### PR TITLE
Fix CIDR block for Public Subnet 1b in VPC configuration

### DIFF
--- a/infra/shared/vpc/vpc.yaml
+++ b/infra/shared/vpc/vpc.yaml
@@ -81,7 +81,7 @@ Resources:
     Condition: IsProdEnvironment
     Properties:
       VpcId: !Ref NagiyuVPC
-      CidrBlock: 10.1.128.0/25
+      CidrBlock: 10.1.0.128/25
       AvailabilityZone: !Sub '${AWS::Region}b'
       MapPublicIpOnLaunch: true
       Tags:


### PR DESCRIPTION
Correct the CIDR block for Public Subnet 1b to ensure proper network configuration in the VPC.