### PR TITLE
v1.0.1

### DIFF
--- a/infra/shared/vpc/vpc.yaml
+++ b/infra/shared/vpc/vpc.yaml
@@ -81,7 +81,7 @@ Resources:
     Condition: IsProdEnvironment
     Properties:
       VpcId: !Ref NagiyuVPC
-      CidrBlock: 10.1.128.0/25
+      CidrBlock: 10.1.0.128/25
       AvailabilityZone: !Sub '${AWS::Region}b'
       MapPublicIpOnLaunch: true
       Tags:


### PR DESCRIPTION
This pull request makes a minor correction to the `infra/shared/vpc/vpc.yaml` file, fixing a typo in the `CidrBlock` property for a subnet resource. The CIDR block was updated to use the correct subnet address. 

* Corrected the `CidrBlock` value from `10.1.128.0/25` to `10.1.0.128/25` in `infra/shared/vpc/vpc.yaml` to ensure the subnet is properly defined.