### PR TITLE
Add CDK Bootstrap role assumption to deploy policy

### DIFF
--- a/infra/shared/iam/policies/deploy-policy-core.yaml
+++ b/infra/shared/iam/policies/deploy-policy-core.yaml
@@ -34,6 +34,17 @@ Resources:
               - cloudformation:ListExports
             Resource: '*'
 
+          # CDK Bootstrap role assumption
+          - Sid: CDKBootstrapRoleAssumption
+            Effect: Allow
+            Action:
+              - sts:AssumeRole
+            Resource:
+              - arn:aws:iam::*:role/cdk-hnb659fds-*
+            Condition:
+              StringEquals:
+                aws:PrincipalAccount: !Ref AWS::AccountId
+
           # ==========================================
           # IAM - ロール・ポリシー管理
           # ==========================================
@@ -98,6 +109,7 @@ Resources:
                   - ecs-tasks.amazonaws.com
                   - events.amazonaws.com
                   - application-autoscaling.amazonaws.com
+                  - cloudformation.amazonaws.com
 
           # ==========================================
           # Network - VPC, EC2


### PR DESCRIPTION
Incorporate role assumption for CDK Bootstrap into the deployment policy to enhance permissions management. This change allows the necessary role to be assumed during the deployment process.