### PR TITLE
Restore branch configuration for push events in workflow

### DIFF
--- a/.github/workflows/root-deploy.yml
+++ b/.github/workflows/root-deploy.yml
@@ -6,8 +6,10 @@ name: Root Domain - CDK Deploy
 
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - develop
+      - integration/**
+      - master
     paths:
       - 'infra/bin/**'
       - 'infra/shared/vpc/**'


### PR DESCRIPTION
Reintroduce the branch configuration for push events in the workflow, allowing pushes to the develop and integration branches alongside master.