### PR TITLE
Add dynamic ECR image tag retrieval for ECS service

### DIFF
--- a/.github/workflows/root-deploy.yml
+++ b/.github/workflows/root-deploy.yml
@@ -97,9 +97,41 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Get latest ECR image tag
+        id: get-image-tag
+        run: |
+          # Get ECR repository name from CloudFormation stack
+          REPOSITORY_NAME=$(aws cloudformation describe-stacks \
+            --stack-name nagiyu-tools-ecr-prod \
+            --query "Stacks[0].Outputs[?OutputKey=='RepositoryName'].OutputValue" \
+            --output text \
+            --region ${{ env.AWS_REGION }})
+
+          if [ -z "$REPOSITORY_NAME" ]; then
+            echo "Warning: Could not find ECR repository, using 'latest' as fallback"
+            echo "image-tag=latest" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get the most recent image tag (sorted by push date)
+          IMAGE_TAG=$(aws ecr describe-images \
+            --repository-name "$REPOSITORY_NAME" \
+            --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' \
+            --output text \
+            --region ${{ env.AWS_REGION }})
+
+          if [ -z "$IMAGE_TAG" ] || [ "$IMAGE_TAG" = "None" ]; then
+            echo "Warning: No images found in ECR repository, using 'latest' as fallback"
+            echo "image-tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found latest image tag: $IMAGE_TAG"
+            echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: CDK Deploy
         env:
           ENVIRONMENT: prod
+          IMAGE_TAG: ${{ steps.get-image-tag.outputs.image-tag }}
         run: npm run deploy --workspace=@nagiyu/infra -- --all --require-approval never
 
       - name: Display deployment summary

--- a/infra/root/ecs-service-stack.ts
+++ b/infra/root/ecs-service-stack.ts
@@ -156,6 +156,9 @@ export class EcsServiceStack extends cdk.Stack {
       `${ecrStackName}-RepositoryUri`
     );
 
+    // Get image tag from environment variable, default to 'latest'
+    const imageTag = process.env.IMAGE_TAG || 'latest';
+
     // Create Task Definition
     this.taskDefinition = new ecs.FargateTaskDefinition(
       this,
@@ -172,7 +175,7 @@ export class EcsServiceStack extends cdk.Stack {
     // Add container to Task Definition
     const container = this.taskDefinition.addContainer('tools-app', {
       containerName: 'tools-app',
-      image: ecs.ContainerImage.fromRegistry(`${ecrRepositoryUri}:latest`),
+      image: ecs.ContainerImage.fromRegistry(`${ecrRepositoryUri}:${imageTag}`),
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'ecs',
         logGroup: logGroup,


### PR DESCRIPTION
Implement a mechanism to retrieve the latest ECR image tag dynamically and update the ECS service stack to use this tag instead of a hardcoded 'latest'. This enhances deployment flexibility and ensures the use of the most recent image.