### PR TITLE
Add curl installation for health checks in Dockerfile

### DIFF
--- a/services/tools/Dockerfile
+++ b/services/tools/Dockerfile
@@ -25,6 +25,9 @@ RUN npm run build --workspace=tools
 FROM base AS runner
 WORKDIR /app
 
+# Install curl for health checks
+RUN apk add --no-cache curl
+
 # Lambda Web Adapter のバイナリをコピー
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
 


### PR DESCRIPTION
Install curl in the Dockerfile to enable health checks.