### PR TITLE
Fix Codec Converter ECR deployment workflow

### DIFF
--- a/.github/workflows/codec-converter-deploy.yml
+++ b/.github/workflows/codec-converter-deploy.yml
@@ -108,22 +108,56 @@ jobs:
           echo "AWS Account ID: $ACCOUNT_ID"
 
       - name: CDK Bootstrap (if needed)
-        working-directory: ./infra/codec-converter
         env:
           ACCOUNT_ID: ${{ steps.get-account-id.outputs.account-id }}
         run: |
           # Bootstrap is idempotent - safe to run on every deployment
-          npx cdk bootstrap aws://$ACCOUNT_ID/${{ env.AWS_REGION }} \
+          npm run bootstrap --workspace=codec-converter -- aws://$ACCOUNT_ID/${{ env.AWS_REGION }} \
             --context env=${{ steps.set-env.outputs.environment }}
 
-      - name: CDK Deploy
-        working-directory: ./infra/codec-converter
+      - name: Check if ECR repository exists
+        id: check-ecr
         env:
           ENVIRONMENT: ${{ steps.set-env.outputs.environment }}
         run: |
-          npx cdk deploy ${{ steps.set-env.outputs.stack-name }} \
+          if aws ecr describe-repositories --repository-names codec-converter-$ENVIRONMENT --region ${{ env.AWS_REGION }} 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: CDK Deploy (Create ECR Repository)
+        if: steps.check-ecr.outputs.exists == 'false'
+        env:
+          ENVIRONMENT: ${{ steps.set-env.outputs.environment }}
+        run: |
+          echo "Creating ECR repository..."
+          npm run deploy --workspace=codec-converter -- ${{ steps.set-env.outputs.stack-name }} \
             --context env=$ENVIRONMENT \
-            --require-approval never \
+            --context useExistingEcrRepository=false \
+            --verbose
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push Docker image to ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: codec-converter-${{ steps.set-env.outputs.environment }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f services/codec-converter/Dockerfile .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: CDK Deploy (Full Stack)
+        env:
+          ENVIRONMENT: ${{ steps.set-env.outputs.environment }}
+        run: |
+          echo "Deploying full stack..."
+          npm run deploy --workspace=codec-converter -- ${{ steps.set-env.outputs.stack-name }} \
+            --context env=$ENVIRONMENT \
+            --context useExistingEcrRepository=true \
             --verbose
 
       - name: Display stack outputs

--- a/infra/codec-converter/package.json
+++ b/infra/codec-converter/package.json
@@ -8,7 +8,9 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "bootstrap": "cdk bootstrap --require-approval never",
+    "deploy": "cdk deploy --require-approval never"
   },
   "devDependencies": {
     "aws-cdk": "2.1100.1"


### PR DESCRIPTION
This commit resolves the deployment failure caused by missing ECR repository by implementing a two-stage deployment approach.

Changes:
- CDK Stack: Add support for creating ECR repository via context flag
  - useExistingEcrRepository=false: Creates new ECR repository with lifecycle rules
  - useExistingEcrRepository=true: References existing ECR repository (default)
- Workflow: Implement two-stage deployment process
  1. Check and create ECR repository if it doesn't exist
  2. Build and push Docker image to ECR
  3. Deploy full stack with Lambda referencing the ECR image
- Package.json: Add bootstrap and deploy scripts for monorepo workspace usage

The deployment now properly handles the chicken-and-egg problem where Lambda requires an ECR image that doesn't exist on first deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>