### PR TITLE
v5.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ Thumbs.db
 cdk.out/
 infra/**/*.js
 infra/**/*.d.ts
+
+# Yarn (このプロジェクトはnpmを使用)
+yarn.lock

--- a/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
+++ b/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
@@ -58,7 +58,10 @@ test.describe('Video List Page', () => {
     ).toBeVisible();
   });
 
-  test('should filter videos by search keyword after debounce', async ({ page, request }) => {
+  test('should filter videos by search keyword after clicking search button', async ({
+    page,
+    request,
+  }) => {
     const startId = 60000000 + Math.floor(Date.now() % 100000);
     await request.post('/api/test/videos', {
       data: {
@@ -72,6 +75,7 @@ test.describe('Video List Page', () => {
 
     const searchKeyword = `${startId + 1}`;
     await page.getByPlaceholder('動画タイトルで検索').fill(searchKeyword);
+    await page.getByRole('button', { name: '検索' }).click();
     await page.waitForResponse(
       (response) =>
         response.url().includes('/api/videos') && response.url().includes(`search=${searchKeyword}`)
@@ -96,6 +100,7 @@ test.describe('Video List Page', () => {
 
     const searchKeyword = 'no-match-keyword';
     await page.getByPlaceholder('動画タイトルで検索').fill(searchKeyword);
+    await page.getByRole('button', { name: '検索' }).click();
     await page.waitForResponse(
       (response) =>
         response.url().includes('/api/videos') && response.url().includes(`search=${searchKeyword}`)
@@ -469,6 +474,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     await page.getByPlaceholder('動画タイトルで検索').fill('test');
+    await page.getByRole('button', { name: '検索' }).click();
 
     await page.waitForResponse(
       (response) => response.url().includes('/api/videos') && response.url().includes('search=test')
@@ -592,6 +598,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     await page.getByPlaceholder('動画タイトルで検索').fill('keyword');
+    await page.getByRole('button', { name: '検索' }).click();
 
     await expect(page).toHaveURL('/mylist?search=keyword');
   });
@@ -678,6 +685,7 @@ test.describe('Video List URL Synchronization', () => {
     const searchKeyword = `${startId + 1}`;
     const searchField = page.getByPlaceholder('動画タイトルで検索');
     await searchField.fill(searchKeyword);
+    await page.getByRole('button', { name: '検索' }).click();
     await page.waitForResponse(
       (response) =>
         response.url().includes('/api/videos') && response.url().includes(`search=${searchKeyword}`)

--- a/services/niconico-mylist-assistant/web/src/components/VideoList.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoList.tsx
@@ -32,7 +32,6 @@ export default function VideoList() {
   const [favoriteFilter, setFavoriteFilter] = useState<string>('all');
   const [skipFilter, setSkipFilter] = useState<string>('all');
   const [searchKeyword, setSearchKeyword] = useState<string>('');
-  const [debouncedSearchKeyword, setDebouncedSearchKeyword] = useState<string>('');
 
   // ページネーション状態
   const [offset, setOffset] = useState(0);
@@ -103,8 +102,8 @@ export default function VideoList() {
         params.append('isSkip', skipFilter);
       }
 
-      if (debouncedSearchKeyword.trim() !== '') {
-        params.append('search', debouncedSearchKeyword.trim());
+      if (searchKeyword.trim() !== '') {
+        params.append('search', searchKeyword.trim());
       }
 
       const response = await fetch(`/api/videos?${params.toString()}`);
@@ -121,7 +120,7 @@ export default function VideoList() {
     } finally {
       setLoading(false);
     }
-  }, [offset, favoriteFilter, skipFilter, debouncedSearchKeyword]);
+  }, [offset, favoriteFilter, skipFilter, searchKeyword]);
 
   // URLクエリパラメータの変更を監視して状態を同期
   useEffect(() => {
@@ -140,39 +139,11 @@ export default function VideoList() {
     }
     if (newSearchKeyword !== stateRef.current.searchKeyword) {
       setSearchKeyword(newSearchKeyword);
-      setDebouncedSearchKeyword(newSearchKeyword);
     }
     if (newOffset !== stateRef.current.offset) {
       setOffset(newOffset);
     }
   }, [searchParams]);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setDebouncedSearchKeyword(searchKeyword);
-    }, 500);
-
-    return () => {
-      clearTimeout(timeoutId);
-    };
-  }, [searchKeyword]);
-
-  useEffect(() => {
-    const currentSearchKeyword = searchParams.get('search') || '';
-    // URLが既に最新値を持つ場合は更新不要
-    if (debouncedSearchKeyword === currentSearchKeyword) {
-      return;
-    }
-    // debouncedSearchKeyword が searchKeyword と異なる場合はデバウンスが未完了か stale な値のため無視する
-    // これにより webkit でナビゲーション中に旧タイムアウトが発火して意図しない router.push が起きることを防ぐ
-    if (debouncedSearchKeyword !== searchKeyword) {
-      return;
-    }
-
-    const currentFavoriteFilter = searchParams.get('favorite') || 'all';
-    const currentSkipFilter = searchParams.get('skip') || 'all';
-    updateURL(currentFavoriteFilter, currentSkipFilter, debouncedSearchKeyword, 0);
-  }, [debouncedSearchKeyword, searchParams, updateURL, searchKeyword]);
 
   // 初回レンダリング時とフィルター・ページネーション変更時に動画を取得
   useEffect(() => {
@@ -241,6 +212,13 @@ export default function VideoList() {
     updateURL(currentFavoriteFilter, value, currentSearchKeyword, 0);
   };
 
+  const handleSearch = (keyword: string) => {
+    // 現在のURLから最新の値を取得（stale closureを回避）
+    const currentFavoriteFilter = searchParams.get('favorite') || 'all';
+    const currentSkipFilter = searchParams.get('skip') || 'all';
+    updateURL(currentFavoriteFilter, currentSkipFilter, keyword, 0);
+  };
+
   const handlePageChange = (newOffset: number) => {
     // 現在のURLから最新の値を取得（stale closureを回避）
     const currentFavoriteFilter = searchParams.get('favorite') || 'all';
@@ -284,7 +262,7 @@ export default function VideoList() {
         searchKeyword={searchKeyword}
         onFavoriteFilterChange={handleFavoriteFilterChange}
         onSkipFilterChange={handleSkipFilterChange}
-        onSearchKeywordChange={setSearchKeyword}
+        onSearch={handleSearch}
       />
 
       {error && (

--- a/services/niconico-mylist-assistant/web/src/components/VideoListFilters.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoListFilters.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import {
   Box,
+  Button,
   FormControl,
   InputLabel,
   Select,
@@ -16,7 +18,7 @@ interface VideoListFiltersProps {
   searchKeyword: string;
   onFavoriteFilterChange: (value: string) => void;
   onSkipFilterChange: (value: string) => void;
-  onSearchKeywordChange: (value: string) => void;
+  onSearch: (value: string) => void;
 }
 
 /**
@@ -30,14 +32,31 @@ export default function VideoListFilters({
   searchKeyword,
   onFavoriteFilterChange,
   onSkipFilterChange,
-  onSearchKeywordChange,
+  onSearch,
 }: VideoListFiltersProps) {
+  const [inputKeyword, setInputKeyword] = useState<string>(searchKeyword);
+
+  // URLからの状態復元（ブラウザバック/フォワード・直接URL入力）時に入力欄を同期する
+  useEffect(() => {
+    setInputKeyword(searchKeyword);
+  }, [searchKeyword]);
+
   const handleFavoriteChange = (event: SelectChangeEvent) => {
     onFavoriteFilterChange(event.target.value);
   };
 
   const handleSkipChange = (event: SelectChangeEvent) => {
     onSkipFilterChange(event.target.value);
+  };
+
+  const handleSearch = () => {
+    onSearch(inputKeyword);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      handleSearch();
+    }
   };
 
   return (
@@ -79,13 +98,19 @@ export default function VideoListFilters({
         </Select>
       </FormControl>
 
-      <TextField
-        size="small"
-        value={searchKeyword}
-        onChange={(event) => onSearchKeywordChange(event.target.value)}
-        placeholder="動画タイトルで検索"
-        sx={{ minWidth: 240 }}
-      />
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <TextField
+          size="small"
+          value={inputKeyword}
+          onChange={(event) => setInputKeyword(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="動画タイトルで検索"
+          sx={{ minWidth: 240 }}
+        />
+        <Button variant="contained" size="small" onClick={handleSearch}>
+          検索
+        </Button>
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
This pull request updates the video list search functionality to trigger searches only when the user clicks the search button or presses Enter, instead of using a debounce on input changes. The changes remove the debounced search logic and refactor related components and tests to support this new behavior.

Search functionality refactor:

* Removed all debounce logic for search keyword updates in `VideoList.tsx`, including the `debouncedSearchKeyword` state and associated effects, so that searches are now triggered explicitly by user action. [[1]](diffhunk://#diff-2fbe289986d08cc58f8b19326ec3b1b78ddf7579ed2969017522d04a6c741217L35) [[2]](diffhunk://#diff-2fbe289986d08cc58f8b19326ec3b1b78ddf7579ed2969017522d04a6c741217L143-L176)
* Refactored the search keyword handling to update the URL and fetch videos only when the search button is clicked or Enter is pressed, using the new `handleSearch` function. [[1]](diffhunk://#diff-2fbe289986d08cc58f8b19326ec3b1b78ddf7579ed2969017522d04a6c741217R215-R221) [[2]](diffhunk://#diff-2fbe289986d08cc58f8b19326ec3b1b78ddf7579ed2969017522d04a6c741217L106-R106) [[3]](diffhunk://#diff-2fbe289986d08cc58f8b19326ec3b1b78ddf7579ed2969017522d04a6c741217L124-R123)

Component interface and UI changes:

* Changed the `VideoListFilters` interface and implementation to accept an `onSearch` prop instead of `onSearchKeywordChange`, and added local state for the input field to synchronize with URL changes. [[1]](diffhunk://#diff-b242bd90f26551c06618d269eaa6d3b2cd63b459642f265dc5cff06bf7297fc5L19-R21) [[2]](diffhunk://#diff-b242bd90f26551c06618d269eaa6d3b2cd63b459642f265dc5cff06bf7297fc5L33-R43)
* Updated `VideoListFilters.tsx` to include a search button and support Enter key for submitting searches, improving accessibility and usability. [[1]](diffhunk://#diff-b242bd90f26551c06618d269eaa6d3b2cd63b459642f265dc5cff06bf7297fc5R52-R61) [[2]](diffhunk://#diff-b242bd90f26551c06618d269eaa6d3b2cd63b459642f265dc5cff06bf7297fc5R101-R113)

Test updates:

* Modified all relevant E2E tests in `video-list.spec.ts` to trigger searches by clicking the search button instead of waiting for debounce, ensuring tests reflect the new user interaction model. [[1]](diffhunk://#diff-7ee2bf8a6f716862151968d98b9a14df1849cb238f9cb5ccda160c22a438cff6L61-R64) [[2]](diffhunk://#diff-7ee2bf8a6f716862151968d98b9a14df1849cb238f9cb5ccda160c22a438cff6R78) [[3]](diffhunk://#diff-7ee2bf8a6f716862151968d98b9a14df1849cb238f9cb5ccda160c22a438cff6R103) [[4]](diffhunk://#diff-7ee2bf8a6f716862151968d98b9a14df1849cb238f9cb5ccda160c22a438cff6R477) [[5]](diffhunk://#diff-7ee2bf8a6f716862151968d98b9a14df1849cb238f9cb5ccda160c22a438cff6R601) [[6]](diffhunk://#diff-7ee2bf8a6f716862151968d98b9a14df1849cb238f9cb5ccda160c22a438cff6R688)