### PR TITLE
v5.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20719,7 +20719,7 @@
     },
     "services/stock-tracker/web": {
       "name": "@nagiyu/stock-tracker-web",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.980.0",
         "@aws-sdk/client-lambda": "^3.980.0",

--- a/services/stock-tracker/core/src/repositories/dynamodb-ticker.repository.ts
+++ b/services/stock-tracker/core/src/repositories/dynamodb-ticker.repository.ts
@@ -12,6 +12,7 @@ import {
   QueryCommand,
   ScanCommand,
   type DynamoDBDocumentClient,
+  type ScanCommandInput,
 } from '@aws-sdk/lib-dynamodb';
 import {
   EntityNotFoundError,
@@ -127,6 +128,43 @@ export class DynamoDBTickerRepository implements TickerRepository {
    */
   public async getAll(options?: PaginationOptions): Promise<PaginatedResult<TickerEntity>> {
     try {
+      const usePagination = options?.limit !== undefined || options?.cursor !== undefined;
+
+      if (!usePagination) {
+        const allItems: TickerEntity[] = [];
+        let exclusiveStartKey: ScanCommandInput['ExclusiveStartKey'];
+
+        do {
+          const result = await this.docClient.send(
+            new ScanCommand({
+              TableName: this.tableName,
+              FilterExpression: '#type = :type',
+              ExpressionAttributeNames: {
+                '#type': 'Type',
+              },
+              ExpressionAttributeValues: {
+                ':type': 'Ticker',
+              },
+              ExclusiveStartKey: exclusiveStartKey,
+            })
+          );
+
+          const pageItems = (result.Items || []).map((item) =>
+            this.mapper.toEntity(item as unknown as DynamoDBItem)
+          );
+          for (const pageItem of pageItems) {
+            allItems.push(pageItem);
+          }
+          exclusiveStartKey = result.LastEvaluatedKey;
+        } while (exclusiveStartKey);
+
+        return {
+          items: allItems,
+          nextCursor: undefined,
+          count: allItems.length,
+        };
+      }
+
       const limit = options?.limit || 50;
       const exclusiveStartKey = options?.cursor
         ? JSON.parse(Buffer.from(options.cursor, 'base64').toString('utf-8'))

--- a/services/stock-tracker/core/src/repositories/in-memory-ticker.repository.ts
+++ b/services/stock-tracker/core/src/repositories/in-memory-ticker.repository.ts
@@ -24,6 +24,7 @@ import { TickerMapper } from '../mappers/ticker.mapper.js';
 const ERROR_MESSAGES = {
   NO_UPDATES_SPECIFIED: '更新するフィールドが指定されていません',
 } as const;
+const FULL_SCAN_PAGE_SIZE = 100;
 
 /**
  * InMemory Ticker Repository
@@ -82,6 +83,34 @@ export class InMemoryTickerRepository implements TickerRepository {
    * 全ティッカー取得
    */
   public async getAll(options?: PaginationOptions): Promise<PaginatedResult<TickerEntity>> {
+    const usePagination = options?.limit !== undefined || options?.cursor !== undefined;
+
+    if (!usePagination) {
+      const items: TickerEntity[] = [];
+      let cursor: string | undefined;
+
+      do {
+        const page = this.store.queryByAttribute(
+          {
+            attributeName: 'Type',
+            attributeValue: 'Ticker',
+          },
+          {
+            limit: FULL_SCAN_PAGE_SIZE,
+            cursor,
+          }
+        );
+        items.push(...page.items.map((item) => this.mapper.toEntity(item)));
+        cursor = page.nextCursor;
+      } while (cursor);
+
+      return {
+        items,
+        nextCursor: undefined,
+        count: items.length,
+      };
+    }
+
     const result = this.store.queryByAttribute(
       {
         attributeName: 'Type',

--- a/services/stock-tracker/core/tests/unit/repositories/dynamodb-ticker.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/dynamodb-ticker.repository.test.ts
@@ -219,6 +219,98 @@ describe('DynamoDBTickerRepository', () => {
 
       await expect(repository.getAll()).rejects.toThrow(DatabaseError);
     });
+
+    it('options未指定時はLastEvaluatedKeyがなくなるまで全ページを取得する', async () => {
+      const page1Items = [
+        {
+          PK: 'TICKER#NSDQ:AAPL',
+          SK: 'METADATA',
+          Type: 'Ticker',
+          TickerID: 'NSDQ:AAPL',
+          Symbol: 'AAPL',
+          Name: 'Apple Inc.',
+          ExchangeID: 'NASDAQ',
+          CreatedAt: 1704067200000,
+          UpdatedAt: 1704067200000,
+        },
+      ];
+      const page2Items = [
+        {
+          PK: 'TICKER#NYSE:IBM',
+          SK: 'METADATA',
+          Type: 'Ticker',
+          TickerID: 'NYSE:IBM',
+          Symbol: 'IBM',
+          Name: 'IBM',
+          ExchangeID: 'NYSE',
+          CreatedAt: 1704067200000,
+          UpdatedAt: 1704067200000,
+        },
+      ];
+
+      mockDocClient.send
+        .mockResolvedValueOnce({
+          Items: page1Items,
+          Count: 1,
+          LastEvaluatedKey: {
+            PK: 'TICKER#NSDQ:AAPL',
+            SK: 'METADATA',
+          },
+        })
+        .mockResolvedValueOnce({
+          Items: page2Items,
+          Count: 1,
+        });
+
+      const result = await repository.getAll();
+
+      expect(result.items).toHaveLength(2);
+      expect(result.count).toBe(2);
+      expect(result.nextCursor).toBeUndefined();
+      expect(mockDocClient.send).toHaveBeenCalledTimes(2);
+
+      const firstScanCommand = mockDocClient.send.mock.calls[0][0];
+      const secondScanCommand = mockDocClient.send.mock.calls[1][0];
+
+      expect(firstScanCommand.input.Limit).toBeUndefined();
+      expect(secondScanCommand.input.ExclusiveStartKey).toEqual({
+        PK: 'TICKER#NSDQ:AAPL',
+        SK: 'METADATA',
+      });
+    });
+
+    it('options指定時は従来どおりページネーション結果を返す', async () => {
+      mockDocClient.send.mockResolvedValueOnce({
+        Items: [
+          {
+            PK: 'TICKER#NSDQ:AAPL',
+            SK: 'METADATA',
+            Type: 'Ticker',
+            TickerID: 'NSDQ:AAPL',
+            Symbol: 'AAPL',
+            Name: 'Apple Inc.',
+            ExchangeID: 'NASDAQ',
+            CreatedAt: 1704067200000,
+            UpdatedAt: 1704067200000,
+          },
+        ],
+        Count: 1,
+        LastEvaluatedKey: {
+          PK: 'TICKER#NSDQ:AAPL',
+          SK: 'METADATA',
+        },
+      });
+
+      const result = await repository.getAll({ limit: 1 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.count).toBe(1);
+      expect(result.nextCursor).toBeDefined();
+      expect(mockDocClient.send).toHaveBeenCalledTimes(1);
+
+      const scanCommand = mockDocClient.send.mock.calls[0][0];
+      expect(scanCommand.input.Limit).toBe(1);
+    });
   });
 
   describe('update', () => {

--- a/services/stock-tracker/core/tests/unit/repositories/in-memory-ticker.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/in-memory-ticker.repository.test.ts
@@ -13,6 +13,8 @@ import {
 } from '@nagiyu/aws';
 import type { CreateTickerInput } from '../../../src/entities/ticker.entity.js';
 
+const ITEMS_EXCEEDING_DEFAULT_LIMIT = 120;
+
 describe('InMemoryTickerRepository', () => {
   let repository: InMemoryTickerRepository;
   let store: InMemorySingleTableStore;
@@ -185,6 +187,42 @@ describe('InMemoryTickerRepository', () => {
       const result = await repository.getAll();
 
       expect(result.items).toHaveLength(0);
+    });
+
+    it('options未指定時は100件を超えていても全件を返す', async () => {
+      const totalCount = ITEMS_EXCEEDING_DEFAULT_LIMIT;
+      for (let i = 0; i < totalCount; i++) {
+        await repository.create({
+          TickerID: `NSDQ:TEST${i}`,
+          Symbol: `TEST${i}`,
+          Name: `Test ${i}`,
+          ExchangeID: 'NASDAQ',
+        });
+      }
+
+      const result = await repository.getAll();
+
+      expect(result.items).toHaveLength(totalCount);
+      expect(result.count).toBe(totalCount);
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('options指定時はページネーションを維持する', async () => {
+      for (let i = 0; i < 5; i++) {
+        await repository.create({
+          TickerID: `NSDQ:PAGED${i}`,
+          Symbol: `PAGED${i}`,
+          Name: `Paged ${i}`,
+          ExchangeID: 'NASDAQ',
+        });
+      }
+
+      const firstPage = await repository.getAll({ limit: 2 });
+      const secondPage = await repository.getAll({ limit: 2, cursor: firstPage.nextCursor });
+
+      expect(firstPage.items).toHaveLength(2);
+      expect(firstPage.nextCursor).toBeDefined();
+      expect(secondPage.items).toHaveLength(2);
     });
   });
 

--- a/services/stock-tracker/web/package.json
+++ b/services/stock-tracker/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/stock-tracker-web",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This pull request enhances the `getAll` method in both `DynamoDBTickerRepository` and `InMemoryTickerRepository` to support fetching all ticker entities when pagination options are not specified. Previously, results were limited by default page sizes even without explicit pagination options. Now, the method retrieves all records across multiple pages if necessary, ensuring complete data retrieval. Comprehensive unit tests have been added to verify this behavior for both repository implementations.

### Repository logic improvements

* Updated `getAll` in `DynamoDBTickerRepository` to fetch all ticker entities across all pages when pagination options are not provided, using repeated scans until all items are retrieved. [[1]](diffhunk://#diff-949828ad49e3285abfeabfe8766b8e6f4b0e27df3ce073f33a90881e7e757aadR15) [[2]](diffhunk://#diff-949828ad49e3285abfeabfe8766b8e6f4b0e27df3ce073f33a90881e7e757aadR131-R167)
* Updated `getAll` in `InMemoryTickerRepository` to fetch all ticker entities across all pages when pagination options are not provided, using repeated queries with a fixed page size until all items are retrieved. [[1]](diffhunk://#diff-687ba570e6ea8c301e0429c0a0d4ce59d516e8638e27db6cc31c4ab1e0290dd3R27) [[2]](diffhunk://#diff-687ba570e6ea8c301e0429c0a0d4ce59d516e8638e27db6cc31c4ab1e0290dd3R86-R113)

### Testing enhancements

* Added unit tests for `DynamoDBTickerRepository` to verify full scan behavior when pagination options are omitted and to confirm pagination is preserved when options are specified.
* Added unit tests for `InMemoryTickerRepository` to verify full scan behavior with more than 100 items and to confirm pagination is preserved when options are specified. [[1]](diffhunk://#diff-ff04b7866a596d1805b5b4cd7fe301ff555740a6d0fa6f5d341eac4036d038f2R16-R17) [[2]](diffhunk://#diff-ff04b7866a596d1805b5b4cd7fe301ff555740a6d0fa6f5d341eac4036d038f2R191-R226)

### Miscellaneous

* Bumped the version in `services/stock-tracker/web/package.json` from 2.0.0 to 2.0.1.