### PR TITLE
v6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13218,6 +13218,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15768,7 +15769,7 @@
     },
     "services/admin/web": {
       "name": "@nagiyu/admin",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@nagiyu/browser": "*",
         "@nagiyu/common": "*",
@@ -15792,7 +15793,7 @@
     },
     "services/auth/web": {
       "name": "@nagiyu/auth-web",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@nagiyu/auth-core": "*",
         "@nagiyu/browser": "*",
@@ -15825,7 +15826,7 @@
     },
     "services/codec-converter/web": {
       "name": "codec-converter-web",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@aws-sdk/client-batch": "^3.980.0",
         "@aws-sdk/client-dynamodb": "^3.980.0",
@@ -15921,7 +15922,7 @@
     },
     "services/niconico-mylist-assistant/web": {
       "name": "@nagiyu/niconico-mylist-assistant-web",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@aws-sdk/client-batch": "^3.980.0",
         "@aws-sdk/client-dynamodb": "^3.980.0",
@@ -15943,7 +15944,7 @@
     },
     "services/share-together/web": {
       "name": "@nagiyu/share-together-web",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@nagiyu/aws": "*",
         "@nagiyu/browser": "*",
@@ -15994,7 +15995,7 @@
     },
     "services/stock-tracker/web": {
       "name": "@nagiyu/stock-tracker-web",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.980.0",
         "@aws-sdk/client-lambda": "^3.980.0",
@@ -16021,7 +16022,7 @@
       }
     },
     "services/tools": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@nagiyu/browser": "*",
         "@nagiyu/common": "*",

--- a/services/admin/web/package.json
+++ b/services/admin/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/admin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/auth/web/package.json
+++ b/services/auth/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/auth-web",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/codec-converter/web/package.json
+++ b/services/codec-converter/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codec-converter-web",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/services/niconico-mylist-assistant/web/package.json
+++ b/services/niconico-mylist-assistant/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/niconico-mylist-assistant-web",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/share-together/web/package.json
+++ b/services/share-together/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/share-together-web",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/stock-tracker/web/package.json
+++ b/services/stock-tracker/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/stock-tracker-web",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/tools/package.json
+++ b/services/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tools",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This pull request updates the version numbers for several web services and packages in the monorepo. These changes are primarily for release management and do not include any functional or code changes.

Version bumps for release management:

* Updated `@nagiyu/share-together-web` to version `1.0.0` in `services/share-together/web/package.json`.
* Updated `@nagiyu/stock-tracker-web` to version `2.3.1` in `services/stock-tracker/web/package.json`.
* Updated `@nagiyu/niconico-mylist-assistant-web` to version `1.3.2` in `services/niconico-mylist-assistant/web/package.json`.
* Updated `codec-converter-web` to version `1.1.2` in `services/codec-converter/web/package.json`.
* Updated `tools` to version `1.1.3` in `services/tools/package.json`.
* Updated `@nagiyu/admin` to version `1.0.2` in `services/admin/web/package.json`.
* Updated `@nagiyu/auth-web` to version `1.0.3` in `services/auth/web/package.json`.