### PR TITLE
v6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15769,7 +15769,7 @@
     },
     "services/admin/web": {
       "name": "@nagiyu/admin",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@nagiyu/browser": "*",
         "@nagiyu/common": "*",
@@ -15793,7 +15793,7 @@
     },
     "services/auth/web": {
       "name": "@nagiyu/auth-web",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@nagiyu/auth-core": "*",
         "@nagiyu/browser": "*",
@@ -15826,7 +15826,7 @@
     },
     "services/codec-converter/web": {
       "name": "codec-converter-web",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "dependencies": {
         "@aws-sdk/client-batch": "^3.980.0",
         "@aws-sdk/client-dynamodb": "^3.980.0",
@@ -15923,7 +15923,7 @@
     },
     "services/niconico-mylist-assistant/web": {
       "name": "@nagiyu/niconico-mylist-assistant-web",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@aws-sdk/client-batch": "^3.980.0",
         "@aws-sdk/client-dynamodb": "^3.980.0",
@@ -15945,7 +15945,7 @@
     },
     "services/share-together/web": {
       "name": "@nagiyu/share-together-web",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@nagiyu/aws": "*",
         "@nagiyu/browser": "*",
@@ -15996,7 +15996,7 @@
     },
     "services/stock-tracker/web": {
       "name": "@nagiyu/stock-tracker-web",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.980.0",
         "@aws-sdk/client-lambda": "^3.980.0",
@@ -16023,7 +16023,7 @@
       }
     },
     "services/tools": {
-      "version": "1.1.4",
+      "version": "1.2.0",
       "dependencies": {
         "@nagiyu/browser": "*",
         "@nagiyu/common": "*",

--- a/services/admin/web/package.json
+++ b/services/admin/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/admin",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/auth/web/package.json
+++ b/services/auth/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/auth-web",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/codec-converter/web/package.json
+++ b/services/codec-converter/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codec-converter-web",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/services/niconico-mylist-assistant/web/package.json
+++ b/services/niconico-mylist-assistant/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/niconico-mylist-assistant-web",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/share-together/web/package.json
+++ b/services/share-together/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/share-together-web",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/stock-tracker/web/package.json
+++ b/services/stock-tracker/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nagiyu/stock-tracker-web",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/services/tools/package.json
+++ b/services/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tools",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This pull request updates the version numbers for several web service packages and the tools package across the repository. These are minor version bumps, likely to reflect recent changes or improvements in each package.

Version updates:

* Admin and authentication services:
  - Bumped `@nagiyu/admin` from 1.0.3 to 1.0.4 (`services/admin/web/package.json`)
  - Bumped `@nagiyu/auth-web` from 1.0.4 to 1.0.5 (`services/auth/web/package.json`)

* Web applications:
  - Bumped `codec-converter-web` from 1.1.3 to 1.1.4 (`services/codec-converter/web/package.json`)
  - Bumped `@nagiyu/niconico-mylist-assistant-web` from 1.3.3 to 1.3.4 (`services/niconico-mylist-assistant/web/package.json`)
  - Bumped `@nagiyu/share-together-web` from 1.0.1 to 1.0.2 (`services/share-together/web/package.json`)
  - Bumped `@nagiyu/stock-tracker-web` from 2.4.0 to 2.5.0 (`services/stock-tracker/web/package.json`)

* Tools package:
  - Bumped `tools` from 1.1.4 to 1.2.0 (`services/tools/package.json`)