### PR TITLE
感情分析のタイムアウトを伸ばす

### DIFF
--- a/services/quick-clip/core/src/libs/emotion-highlight.service.ts
+++ b/services/quick-clip/core/src/libs/emotion-highlight.service.ts
@@ -11,7 +11,7 @@ import type { TranscriptSegment } from './transcription.service.js';
 
 const OPENAI_MODEL = 'gpt-5-mini';
 const MAX_RETRIES = 3;
-const REQUEST_TIMEOUT_MS = 300_000;
+const REQUEST_TIMEOUT_MS = 600_000;
 
 const ERROR_MESSAGES = {
   TIMEOUT: 'OpenAI APIの呼び出しがタイムアウトしました',


### PR DESCRIPTION
## 変更の概要

OpenAI API呼び出しのタイムアウトを600秒に増加させ、安定性を向上させた。
