### PR TITLE
Update Claude action to read agent instructions from file and enhance logging

### DIFF
--- a/.github/workflows/agent-claude.yml
+++ b/.github/workflows/agent-claude.yml
@@ -67,11 +67,6 @@ jobs:
             AGENT_FILE=".github/agents/task.implement.agent.md"
           fi
           echo "agent_file=${AGENT_FILE}" >> "$GITHUB_OUTPUT"
-          {
-            echo "prompt<<AGENT_EOF"
-            cat "${AGENT_FILE}"
-            echo "AGENT_EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: ブランチをチェックアウト（Issue ラベルトリガー時）
         if: github.event_name == 'issues'
@@ -82,12 +77,24 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
           label_trigger: 'agent:claude'
-          prompt: ${{ steps.detect-phase.outputs.prompt }}
+          prompt: |
+            ${{ steps.detect-phase.outputs.agent_file }} に記載されているエージェント指示を読み込み、その内容に従って対象の Issue を処理してください。
+            対象エージェント指示ファイル: ${{ steps.detect-phase.outputs.agent_file }}
 
       - name: Claude を起動（コメントトリガー）
         if: github.event_name == 'issue_comment'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
           trigger_phrase: '@claude'
+
+      - name: 実行ログをアーティファクトとして保存
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-log-${{ github.run_id }}
+          path: /home/runner/work/_temp/claude-execution-output.json
+          if-no-files-found: ignore


### PR DESCRIPTION
## 変更の概要

Claudeアクションがエージェント指示をファイルから読み込むように更新し、実行ログをアーティファクトとして保存する機能を追加しました。

## 関連 Issue

Closes #

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [ ] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [ ] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [ ] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [ ] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [ ] ローカルでテストが全て通ることを確認した
- [ ] ビルドエラーがないことを確認した

## テスト内容

-

## レビューポイント

-

## スクリーンショット（該当する場合）

<!-- UI の変更がある場合はスクリーンショットを添付してください -->

## 補足事項

<!-- その他の補足情報があれば記載してください -->

