### PR TITLE
Add claude_args for specified tools in Claude actions

### DIFF
--- a/.github/workflows/agent-claude.yml
+++ b/.github/workflows/agent-claude.yml
@@ -79,6 +79,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           label_trigger: 'agent:claude'
+          claude_args: '--allowedTools Bash,Read,Edit,Write'
           prompt: |
             ${{ steps.detect-phase.outputs.agent_file }} に記載されているエージェント指示を読み込み、その内容に従って対象の Issue を処理してください。
             対象エージェント指示ファイル: ${{ steps.detect-phase.outputs.agent_file }}
@@ -90,6 +91,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           trigger_phrase: '@claude'
+          claude_args: '--allowedTools Bash,Read,Edit,Write'
 
       - name: 実行ログをアーティファクトとして保存
         if: always()


### PR DESCRIPTION
Implement claude_args to allow the specification of allowed tools in Claude actions, enhancing functionality and flexibility.

## 変更の概要

claude_argsを追加し、Claudeアクションで指定されたツールを許可する機能を実装しました。

## 関連 Issue

Closes #

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [ ] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [ ] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [ ] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [ ] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [ ] ローカルでテストが全て通ることを確認した
- [ ] ビルドエラーがないことを確認した

## テスト内容

-

## レビューポイント

-

## スクリーンショット（該当する場合）

<!-- UI の変更がある場合はスクリーンショットを添付してください -->

## 補足事項

<!-- その他の補足情報があれば記載してください -->

