### PR TITLE
feat(stock-tracker): AIサポート/レジスタンスレベルをアラートの起点として設定可能にする

### DIFF
--- a/services/stock-tracker/web/components/SummaryDetailDialog.tsx
+++ b/services/stock-tracker/web/components/SummaryDetailDialog.tsx
@@ -200,17 +200,11 @@ export default function SummaryDetailDialog({
               </TableContainer>
               <Divider />
               <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                <Button
-                  variant="outlined"
-                  onClick={() => openAlertModal('Buy', summary.close)}
-                >
+                <Button variant="outlined" onClick={() => openAlertModal('Buy', summary.close)}>
                   買いアラート設定
                 </Button>
                 {summary.holding && (
-                  <Button
-                    variant="outlined"
-                    onClick={() => openAlertModal('Sell', summary.close)}
-                  >
+                  <Button variant="outlined" onClick={() => openAlertModal('Sell', summary.close)}>
                     売りアラート設定
                   </Button>
                 )}

--- a/services/stock-tracker/web/components/SummaryDetailDialog.tsx
+++ b/services/stock-tracker/web/components/SummaryDetailDialog.tsx
@@ -10,6 +10,8 @@ import {
   DialogTitle,
   Divider,
   IconButton,
+  Menu,
+  MenuItem,
   Table,
   TableBody,
   TableCell,
@@ -22,6 +24,7 @@ import { Close as CloseIcon } from '@mui/icons-material';
 import AlertSettingsModal from './AlertSettingsModal';
 import StockChart from './StockChart';
 import type { PatternDetail, TickerSummary } from '@/types/stock';
+import type { AlertMode } from '@/types/alert';
 import { ERROR_MESSAGES } from '@/lib/error-messages';
 
 interface SummaryDetailDialogProps {
@@ -62,13 +65,25 @@ export default function SummaryDetailDialog({
   onClose,
   onAlertChanged,
 }: SummaryDetailDialogProps) {
-  const [isBuyAlertOpen, setIsBuyAlertOpen] = useState(false);
-  const [isSellAlertOpen, setIsSellAlertOpen] = useState(false);
+  const [alertModalState, setAlertModalState] = useState<{
+    open: boolean;
+    tradeMode: AlertMode;
+    initialPrice: number;
+  }>({ open: false, tradeMode: 'Buy', initialPrice: 0 });
+  const [chipMenuAnchor, setChipMenuAnchor] = useState<{
+    element: HTMLElement;
+    price: number;
+  } | null>(null);
 
   const handleClose = () => {
-    setIsBuyAlertOpen(false);
-    setIsSellAlertOpen(false);
+    setAlertModalState((s) => ({ ...s, open: false }));
+    setChipMenuAnchor(null);
     onClose();
+  };
+
+  const openAlertModal = (tradeMode: AlertMode, initialPrice: number) => {
+    setChipMenuAnchor(null);
+    setAlertModalState({ open: true, tradeMode, initialPrice });
   };
 
   const buyPatternDetails: PatternDetail[] = (summary?.patternDetails ?? []).filter(
@@ -185,11 +200,17 @@ export default function SummaryDetailDialog({
               </TableContainer>
               <Divider />
               <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                <Button variant="outlined" onClick={() => setIsBuyAlertOpen(true)}>
+                <Button
+                  variant="outlined"
+                  onClick={() => openAlertModal('Buy', summary.close)}
+                >
                   買いアラート設定
                 </Button>
                 {summary.holding && (
-                  <Button variant="outlined" onClick={() => setIsSellAlertOpen(true)}>
+                  <Button
+                    variant="outlined"
+                    onClick={() => openAlertModal('Sell', summary.close)}
+                  >
                     売りアラート設定
                   </Button>
                 )}
@@ -333,7 +354,15 @@ export default function SummaryDetailDialog({
                       </Typography>
                       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                         {summary.aiAnalysisResult.supportLevels.map((level, index) => (
-                          <Chip key={`support-${level}-${index}`} label={`${level}`} size="small" />
+                          <Chip
+                            key={`support-${level}-${index}`}
+                            label={`${level}`}
+                            size="small"
+                            clickable
+                            onClick={(e) =>
+                              setChipMenuAnchor({ element: e.currentTarget, price: level })
+                            }
+                          />
                         ))}
                       </Box>
                     </Box>
@@ -347,6 +376,10 @@ export default function SummaryDetailDialog({
                             key={`resistance-${level}-${index}`}
                             label={`${level}`}
                             size="small"
+                            clickable
+                            onClick={(e) =>
+                              setChipMenuAnchor({ element: e.currentTarget, price: level })
+                            }
                           />
                         ))}
                       </Box>
@@ -394,33 +427,31 @@ export default function SummaryDetailDialog({
           )}
         </DialogContent>
       </Dialog>
+      <Menu
+        anchorEl={chipMenuAnchor?.element ?? null}
+        open={Boolean(chipMenuAnchor)}
+        onClose={() => setChipMenuAnchor(null)}
+      >
+        <MenuItem onClick={() => openAlertModal('Buy', chipMenuAnchor!.price)}>
+          買いアラートを設定
+        </MenuItem>
+        <MenuItem onClick={() => openAlertModal('Sell', chipMenuAnchor!.price)}>
+          売りアラートを設定
+        </MenuItem>
+      </Menu>
       {summary && (
-        <>
-          <AlertSettingsModal
-            open={isBuyAlertOpen}
-            onClose={() => setIsBuyAlertOpen(false)}
-            onSuccess={onAlertChanged}
-            tickerId={summary.tickerId}
-            symbol={summary.symbol}
-            exchangeId={selectedTickerExchangeId}
-            mode="create"
-            tradeMode="Buy"
-            defaultTargetPrice={summary.close}
-            basePrice={summary.close}
-          />
-          <AlertSettingsModal
-            open={isSellAlertOpen}
-            onClose={() => setIsSellAlertOpen(false)}
-            onSuccess={onAlertChanged}
-            tickerId={summary.tickerId}
-            symbol={summary.symbol}
-            exchangeId={selectedTickerExchangeId}
-            mode="create"
-            tradeMode="Sell"
-            defaultTargetPrice={summary.close}
-            basePrice={summary.close}
-          />
-        </>
+        <AlertSettingsModal
+          open={alertModalState.open}
+          onClose={() => setAlertModalState((s) => ({ ...s, open: false }))}
+          onSuccess={onAlertChanged}
+          tickerId={summary.tickerId}
+          symbol={summary.symbol}
+          exchangeId={selectedTickerExchangeId}
+          mode="create"
+          tradeMode={alertModalState.tradeMode}
+          defaultTargetPrice={alertModalState.initialPrice}
+          basePrice={summary.close}
+        />
       )}
     </>
   );

--- a/services/stock-tracker/web/tests/e2e/summary-display.spec.ts
+++ b/services/stock-tracker/web/tests/e2e/summary-display.spec.ts
@@ -447,6 +447,81 @@ test.describe('サマリー画面スモークテスト', () => {
     await expect(dialog.getByText('中立')).toBeVisible();
   });
 
+  test('サポート/レジスタンスチップをクリックして価格プリセット済みアラートを設定できる', async ({
+    page,
+  }) => {
+    await page.route('**/api/summaries', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          exchanges: [
+            {
+              exchangeId: 'test-exchange-id',
+              exchangeName: 'テスト取引所',
+              date: '2026-03-02',
+              summaries: [
+                {
+                  tickerId: 'TEST:AAA',
+                  symbol: 'AAA',
+                  name: 'AAA株式会社',
+                  open: 100,
+                  high: 115,
+                  low: 95,
+                  close: 105,
+                  updatedAt: '2026-03-02T00:00:00.000Z',
+                  buyPatternCount: 0,
+                  sellPatternCount: 0,
+                  patternDetails: [],
+                  aiAnalysisResult: {
+                    priceMovementAnalysis: 'テスト用の値動き分析です。',
+                    patternAnalysis: 'テスト用のパターン分析です。',
+                    supportLevels: [100, 99, 98],
+                    resistanceLevels: [110, 111, 112],
+                    relatedMarketTrend: 'テスト用の市場動向です。',
+                    investmentJudgment: { signal: 'NEUTRAL', reason: '様子見です。' },
+                  },
+                  holding: null,
+                },
+              ],
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('/summaries');
+    await page.locator('tbody tr').first().click();
+
+    const dialog = page.getByRole('dialog');
+
+    // サポートレベルのチップをクリック → Buy/Sell 選択メニューが表示される
+    const supportChip = dialog.getByText('100', { exact: true }).first();
+    await supportChip.click();
+    await expect(page.getByRole('menuitem', { name: '買いアラートを設定' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: '売りアラートを設定' })).toBeVisible();
+
+    // 「買いアラートを設定」を選択 → 買いアラートモーダルが開き、価格 100 がプリセットされる
+    await page.getByRole('menuitem', { name: '買いアラートを設定' }).click();
+    const buyAlertDialog = page.getByRole('dialog', { name: 'アラート設定 (買いアラート)' });
+    await expect(buyAlertDialog).toBeVisible();
+    await expect(buyAlertDialog.getByLabel('目標価格')).toHaveValue('100');
+    await page.keyboard.press('Escape');
+    await expect(buyAlertDialog).toHaveCount(0);
+
+    // レジスタンスレベルのチップをクリック → Buy/Sell 選択メニューが表示される
+    const resistanceChip = dialog.getByText('110', { exact: true }).first();
+    await resistanceChip.click();
+    await expect(page.getByRole('menuitem', { name: '買いアラートを設定' })).toBeVisible();
+
+    // 「売りアラートを設定」を選択 → 売りアラートモーダルが開き、価格 110 がプリセットされる
+    await page.getByRole('menuitem', { name: '売りアラートを設定' }).click();
+    const sellAlertDialog = page.getByRole('dialog', { name: 'アラート設定 (売りアラート)' });
+    await expect(sellAlertDialog).toBeVisible();
+    await expect(sellAlertDialog.getByLabel('目標価格')).toHaveValue('110');
+    await page.keyboard.press('Escape');
+  });
+
   test('詳細ダイアログがモバイル幅で画面内に収まる', async ({ page }) => {
     await page.route('**/api/summaries', async (route) => {
       await route.fulfill({


### PR DESCRIPTION
## 概要

- AI分析で表示されているサポート/レジスタンスチップをクリック可能にし、価格プリセット済みのアラート設定モーダルを開けるようにした
- closes #2863

## 変更内容

### `SummaryDetailDialog.tsx`

- `isBuyAlertOpen` / `isSellAlertOpen` の2つの状態を `alertModalState: { open, tradeMode, initialPrice }` に統合
- チップに `clickable` prop と `onClick` ハンドラを追加し、クリック時に Buy/Sell 選択メニュー（MUI `Menu`）を表示
- メニュー選択後、`AlertSettingsModal` がクリックしたレベルの価格をプリセットした状態で開く
- 2つの `AlertSettingsModal` インスタンスを1つに統合（既存の `defaultTargetPrice` prop を活用）

### `tests/e2e/summary-display.spec.ts`

- サポートチップクリック → Buy/Sell メニュー表示 → モーダルが価格プリセット済みで開くシナリオを追加
- レジスタンスチップ経由で売りアラートモーダルが開くシナリオも追加

## テスト計画

- [ ] E2E: `summary-display.spec.ts` の新規テストが通過すること
- [ ] 既存テスト: `保有情報と買い/売りアラート設定ボタンを条件に応じて表示できる` が引き続き通過すること
- [ ] 手動確認: サポート/レジスタンスチップをクリックして価格プリセット済みアラートモーダルが正しく開くこと

https://claude.ai/code/session_017t6yf5wV6vDJeQPfJLe1kG

---
_Generated by [Claude Code](https://claude.ai/code/session_017t6yf5wV6vDJeQPfJLe1kG)_