### PR TITLE
fix: AbstractDynamoDBRepository.getById の Lambda モジュールインスタンス不一致に対応

### DIFF
--- a/libs/aws/src/dynamodb/abstract-repository.ts
+++ b/libs/aws/src/dynamodb/abstract-repository.ts
@@ -126,7 +126,13 @@ export abstract class AbstractDynamoDBRepository<TEntity, TKey> {
 
       return this.mapToEntity(result.Item);
     } catch (error) {
-      if (error instanceof InvalidEntityDataError) {
+      // モジュールインスタンス差異への対応: instanceof が失敗するケースを name/message で補完
+      if (
+        error instanceof InvalidEntityDataError ||
+        (error instanceof Error &&
+          (error.name === 'InvalidEntityDataError' ||
+            error.message.startsWith('エンティティデータが無効です')))
+      ) {
         throw error;
       }
       throw new DatabaseError(

--- a/libs/aws/tests/unit/dynamodb/abstract-repository.test.ts
+++ b/libs/aws/tests/unit/dynamodb/abstract-repository.test.ts
@@ -1,0 +1,118 @@
+/**
+ * AbstractDynamoDBRepository Unit Tests
+ *
+ * Lambda モジュールインスタンス不一致時の getById エラーハンドリングを検証
+ */
+
+import { AbstractDynamoDBRepository } from '../../../src/dynamodb/abstract-repository.js';
+import {
+  InvalidEntityDataError,
+  DatabaseError,
+} from '../../../src/dynamodb/errors.js';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import type { DynamoDBItem } from '../../../src/dynamodb/types.js';
+
+type TestKey = { id: string };
+type TestEntity = { id: string; name: string; CreatedAt: number; UpdatedAt: number };
+
+class TestRepository extends AbstractDynamoDBRepository<TestEntity, TestKey> {
+  protected buildKeys(key: TestKey): { PK: string; SK: string } {
+    return { PK: `TEST#${key.id}`, SK: 'METADATA' };
+  }
+
+  protected mapToEntity(item: Record<string, unknown>): TestEntity {
+    return {
+      id: item.id as string,
+      name: item.name as string,
+      CreatedAt: item.CreatedAt as number,
+      UpdatedAt: item.UpdatedAt as number,
+    };
+  }
+
+  protected mapToItem(
+    entity: Omit<TestEntity, 'CreatedAt' | 'UpdatedAt'>
+  ): Omit<DynamoDBItem, 'CreatedAt' | 'UpdatedAt'> {
+    const { PK, SK } = this.buildKeys({ id: entity.id });
+    return { PK, SK, Type: 'Test', id: entity.id, name: entity.name };
+  }
+}
+
+describe('AbstractDynamoDBRepository', () => {
+  let repository: TestRepository;
+  let mockDocClient: jest.Mocked<DynamoDBDocumentClient>;
+
+  beforeEach(() => {
+    mockDocClient = { send: jest.fn() } as unknown as jest.Mocked<DynamoDBDocumentClient>;
+    repository = new TestRepository(mockDocClient, { tableName: 'test-table', entityType: 'Test' });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getById', () => {
+    const validItem = { PK: 'TEST#1', SK: 'METADATA', id: '1', name: 'Item', CreatedAt: 1000, UpdatedAt: 1000 };
+
+    it('存在しないアイテムの場合 null を返す', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Item: undefined });
+      const result = await repository.getById({ id: '1' });
+      expect(result).toBeNull();
+    });
+
+    it('正常なアイテムをエンティティとして返す', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
+      const result = await repository.getById({ id: '1' });
+      expect(result).toEqual({ id: '1', name: 'Item', CreatedAt: 1000, UpdatedAt: 1000 });
+    });
+
+    it('InvalidEntityDataError をそのまま re-throw する（instanceof 成功ケース）', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
+      jest.spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity').mockImplementation(() => {
+        throw new InvalidEntityDataError('フィールド "name" が不正');
+      });
+
+      await expect(repository.getById({ id: '1' })).rejects.toBeInstanceOf(InvalidEntityDataError);
+    });
+
+    it('Lambda モジュール不一致: name が InvalidEntityDataError のエラーを re-throw する', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
+      jest.spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity').mockImplementation(() => {
+        // Lambda バンドル環境で instanceof が失敗する場合のシミュレーション
+        const err = new Error('エンティティデータが無効です: フィールド "name" が不正');
+        err.name = 'InvalidEntityDataError';
+        throw err;
+      });
+
+      const rejected = repository.getById({ id: '1' });
+      await expect(rejected).rejects.toMatchObject({ name: 'InvalidEntityDataError' });
+      await expect(rejected).rejects.not.toBeInstanceOf(DatabaseError);
+    });
+
+    it('Lambda モジュール不一致: メッセージプレフィックスが一致するエラーを re-throw する', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
+      jest.spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity').mockImplementation(() => {
+        throw new Error('エンティティデータが無効です: フィールド "CreatedAt" がタイムスタンプではありません');
+      });
+
+      const rejected = repository.getById({ id: '1' });
+      await expect(rejected).rejects.toMatchObject({
+        message: expect.stringContaining('エンティティデータが無効です'),
+      });
+      await expect(rejected).rejects.not.toBeInstanceOf(DatabaseError);
+    });
+
+    it('無関係なエラーは DatabaseError にラップする', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
+      jest.spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity').mockImplementation(() => {
+        throw new Error('Network connection failed');
+      });
+
+      await expect(repository.getById({ id: '1' })).rejects.toBeInstanceOf(DatabaseError);
+    });
+
+    it('DynamoDB 送信エラーは DatabaseError にラップする', async () => {
+      mockDocClient.send.mockRejectedValueOnce(new Error('DynamoDB unavailable'));
+      await expect(repository.getById({ id: '1' })).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+});

--- a/libs/aws/tests/unit/dynamodb/abstract-repository.test.ts
+++ b/libs/aws/tests/unit/dynamodb/abstract-repository.test.ts
@@ -5,10 +5,7 @@
  */
 
 import { AbstractDynamoDBRepository } from '../../../src/dynamodb/abstract-repository.js';
-import {
-  InvalidEntityDataError,
-  DatabaseError,
-} from '../../../src/dynamodb/errors.js';
+import { InvalidEntityDataError, DatabaseError } from '../../../src/dynamodb/errors.js';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import type { DynamoDBItem } from '../../../src/dynamodb/types.js';
 
@@ -51,7 +48,14 @@ describe('AbstractDynamoDBRepository', () => {
   });
 
   describe('getById', () => {
-    const validItem = { PK: 'TEST#1', SK: 'METADATA', id: '1', name: 'Item', CreatedAt: 1000, UpdatedAt: 1000 };
+    const validItem = {
+      PK: 'TEST#1',
+      SK: 'METADATA',
+      id: '1',
+      name: 'Item',
+      CreatedAt: 1000,
+      UpdatedAt: 1000,
+    };
 
     it('存在しないアイテムの場合 null を返す', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Item: undefined });
@@ -67,21 +71,25 @@ describe('AbstractDynamoDBRepository', () => {
 
     it('InvalidEntityDataError をそのまま re-throw する（instanceof 成功ケース）', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
-      jest.spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity').mockImplementation(() => {
-        throw new InvalidEntityDataError('フィールド "name" が不正');
-      });
+      jest
+        .spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity')
+        .mockImplementation(() => {
+          throw new InvalidEntityDataError('フィールド "name" が不正');
+        });
 
       await expect(repository.getById({ id: '1' })).rejects.toBeInstanceOf(InvalidEntityDataError);
     });
 
     it('Lambda モジュール不一致: name が InvalidEntityDataError のエラーを re-throw する', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
-      jest.spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity').mockImplementation(() => {
-        // Lambda バンドル環境で instanceof が失敗する場合のシミュレーション
-        const err = new Error('エンティティデータが無効です: フィールド "name" が不正');
-        err.name = 'InvalidEntityDataError';
-        throw err;
-      });
+      jest
+        .spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity')
+        .mockImplementation(() => {
+          // Lambda バンドル環境で instanceof が失敗する場合のシミュレーション
+          const err = new Error('エンティティデータが無効です: フィールド "name" が不正');
+          err.name = 'InvalidEntityDataError';
+          throw err;
+        });
 
       const rejected = repository.getById({ id: '1' });
       await expect(rejected).rejects.toMatchObject({ name: 'InvalidEntityDataError' });
@@ -90,9 +98,13 @@ describe('AbstractDynamoDBRepository', () => {
 
     it('Lambda モジュール不一致: メッセージプレフィックスが一致するエラーを re-throw する', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
-      jest.spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity').mockImplementation(() => {
-        throw new Error('エンティティデータが無効です: フィールド "CreatedAt" がタイムスタンプではありません');
-      });
+      jest
+        .spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity')
+        .mockImplementation(() => {
+          throw new Error(
+            'エンティティデータが無効です: フィールド "CreatedAt" がタイムスタンプではありません'
+          );
+        });
 
       const rejected = repository.getById({ id: '1' });
       await expect(rejected).rejects.toMatchObject({
@@ -103,9 +115,11 @@ describe('AbstractDynamoDBRepository', () => {
 
     it('無関係なエラーは DatabaseError にラップする', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Item: validItem });
-      jest.spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity').mockImplementation(() => {
-        throw new Error('Network connection failed');
-      });
+      jest
+        .spyOn(repository as unknown as { mapToEntity: () => void }, 'mapToEntity')
+        .mockImplementation(() => {
+          throw new Error('Network connection failed');
+        });
 
       await expect(repository.getById({ id: '1' })).rejects.toBeInstanceOf(DatabaseError);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15438,6 +15438,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15438,7 +15438,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

- `libs/aws/src/dynamodb/abstract-repository.ts` の `getById` catch ブロックが bare `instanceof InvalidEntityDataError` のみで判定していた
- Lambda バンドル環境で `@nagiyu/aws` が複数モジュールインスタンスとして読み込まれると `instanceof` が `false` を返し、`InvalidEntityDataError` が `DatabaseError` にラップされてしまう脆弱性を修正
- `DynamoDBAlertRepository.isInvalidEntityDataError` で採用済みの `||` パターン（`name` または `message` プレフィックスで判定）を同箇所にも適用

## Background

Issue #2329/#2422/#2482 で一時アラート削除バッチが `totalAlerts: 0` でクラッシュしていた問題は `11143c0` (2026-03-30) で `getByFrequency` の `isInvalidEntityDataError` を `||` 演算子に修正することで解消済み。

しかし `4c549a6` (2026-04-12) の Phase 4 移行で `DynamoDBExchangeRepository` が `AbstractDynamoDBRepository` を継承するようになった際、`getById` に同一パターンの bare `instanceof` が混入した。取引所データが不正になった場合に同様の問題が再現しうる構造的欠陥として修正する。

## Test plan

- [x] `libs/aws/tests/unit/dynamodb/abstract-repository.test.ts` を新規追加
  - `instanceof` 成功ケースで `InvalidEntityDataError` が re-throw されること
  - Lambda モジュール不一致シミュレーション（`name` のみ一致）で re-throw されること
  - Lambda モジュール不一致シミュレーション（`message` プレフィックスのみ一致）で re-throw されること
  - 無関係なエラーは `DatabaseError` にラップされること
- [x] `libs/aws` 全テスト (115 件) パス確認済み

https://claude.ai/code/session_01EuPPatrf5sKahEAq2BUffx

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPPatrf5sKahEAq2BUffx)_