### PR TITLE
feat(portal): E-E-A-T 強化と記事メタ表示拡張

### DIFF
--- a/services/portal/web/src/app/about/page.tsx
+++ b/services/portal/web/src/app/about/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import { Container, Typography, Box, Link } from '@mui/material';
+import { AUTHOR } from '@/lib/author';
 
 export const metadata: Metadata = {
   title: 'nagiyu について',
   description:
-    'nagiyu は個人開発者が提供する Web サービス群のポータルサイトです。Tools・Quick Clip・Codec Converter など多彩なサービスを無料で提供しています。開発者プロフィール・技術スタック・サービス一覧をご紹介します。',
+    'nagiyu は個人開発者が提供する Web サービス群のポータルサイトです。Tools・Quick Clip・Codec Converter など多彩なサービスを無料で提供しています。開発者プロフィール・運営方針・編集ポリシー・お問い合わせをご紹介します。',
   alternates: {
     canonical: 'https://nagiyu.com/about',
   },
@@ -37,13 +38,14 @@ export default function AboutPage() {
           開発者プロフィール
         </Typography>
         <Typography variant="body1" paragraph>
-          なぎゆー（個人開発者）
+          {AUTHOR.name}（個人開発者）
         </Typography>
         <Typography variant="body1" paragraph>
           モノレポ構成のプラットフォーム「nagiyu-platform」として複数の Web
           サービスを開発・運用しています。
           AWS（ECS・Lambda・CloudFront・Batch）を活用したサーバーレスアーキテクチャを採用し、
           Next.js・TypeScript を中心としたモダンな技術スタックで構築しています。
+          技術記事は実装した内容を一次情報として執筆しており、すべて自身の運用経験に基づいています。
         </Typography>
         <Typography variant="body2" color="text.secondary">
           GitHub:{' '}
@@ -55,6 +57,36 @@ export default function AboutPage() {
             nagiyu/nagiyu-platform
           </Link>
         </Typography>
+      </Box>
+
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h6" component="h2" gutterBottom sx={{ fontWeight: 600 }}>
+          運営方針
+        </Typography>
+        <Typography variant="body1" paragraph>
+          nagiyu-platform
+          は個人開発のサイドプロジェクトとして長期的な運用を前提に設計しており、サービス・コンテンツともに継続的に更新します。
+          各サービスは無料で公開し、運営費用は AdSense による広告収益で賄うことを目指しています。
+        </Typography>
+        <Box component="ul" sx={{ pl: 3 }}>
+          <Box component="li" sx={{ mb: 1 }}>
+            <Typography variant="body1">
+              <strong>サービスドキュメント</strong> - 機能追加・変更の都度、概要・使い方ガイド・FAQ
+              を更新します
+            </Typography>
+          </Box>
+          <Box component="li" sx={{ mb: 1 }}>
+            <Typography variant="body1">
+              <strong>技術記事</strong> -
+              開発・運用で得た知見をテーマ別に公開します。記事一覧は計画的に拡充していきます
+            </Typography>
+          </Box>
+          <Box component="li" sx={{ mb: 1 }}>
+            <Typography variant="body1">
+              <strong>無料提供</strong> - すべてのサービスは原則無料で利用できます
+            </Typography>
+          </Box>
+        </Box>
       </Box>
 
       <Box sx={{ mb: 4 }}>
@@ -122,7 +154,7 @@ export default function AboutPage() {
         <Box component="ul" sx={{ pl: 3 }}>
           <Box component="li" sx={{ mb: 1 }}>
             <Typography variant="body1">
-              <strong>Next.js 15</strong> - App Router・SSG による高速な静的サイト生成
+              <strong>Next.js 16</strong> - App Router・SSG による高速な静的サイト生成
             </Typography>
           </Box>
           <Box component="li" sx={{ mb: 1 }}>
@@ -148,6 +180,58 @@ export default function AboutPage() {
             </Typography>
           </Box>
         </Box>
+      </Box>
+
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h6" component="h2" gutterBottom sx={{ fontWeight: 600 }}>
+          編集ポリシー
+        </Typography>
+        <Box component="ul" sx={{ pl: 3 }}>
+          <Box component="li" sx={{ mb: 1 }}>
+            <Typography variant="body1">
+              技術記事は、実際に nagiyu-platform
+              で実装・運用した内容に基づいて執筆します。検証していない手法や未検証の構成は記事化しません。
+            </Typography>
+          </Box>
+          <Box component="li" sx={{ mb: 1 }}>
+            <Typography variant="body1">
+              記事の誤りに気づいた場合や、ライブラリ・フレームワークのバージョンアップで内容が古くなった場合は、フロントマターの{' '}
+              <code>updatedAt</code> を更新したうえで本文を改訂します。
+            </Typography>
+          </Box>
+          <Box component="li" sx={{ mb: 1 }}>
+            <Typography variant="body1">
+              生成 AI
+              を執筆補助に用いる場合も、最終的な技術内容は実装・動作確認に基づき責任を持って公開します。
+            </Typography>
+          </Box>
+          <Box component="li" sx={{ mb: 1 }}>
+            <Typography variant="body1">
+              広告は Google AdSense
+              のみを使用し、記事内容と広告配信は分離します。広告主からの編集介入は受けません。
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h6" component="h2" gutterBottom sx={{ fontWeight: 600 }}>
+          お問い合わせ
+        </Typography>
+        <Typography variant="body1" paragraph>
+          記事の誤り報告・サービスの不具合報告・改善要望などは、GitHub Issues
+          からご連絡ください。技術的な質問・議論にも対応します。
+        </Typography>
+        <Typography variant="body2" color="text.secondary" paragraph>
+          Issues:{' '}
+          <Link
+            href="https://github.com/nagiyu/nagiyu-platform/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            github.com/nagiyu/nagiyu-platform/issues
+          </Link>
+        </Typography>
       </Box>
 
       <Box sx={{ mb: 4 }}>

--- a/services/portal/web/src/app/tech/[slug]/page.tsx
+++ b/services/portal/web/src/app/tech/[slug]/page.tsx
@@ -1,10 +1,28 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { Container, Typography, Box, Chip } from '@mui/material';
-import { getAllArticles, getArticle } from '@/lib/content';
+import {
+  Container,
+  Typography,
+  Box,
+  Chip,
+  Card,
+  CardActionArea,
+  CardContent,
+  Divider,
+  Link as MuiLink,
+} from '@mui/material';
+import { getAllArticles, getArticle, getRelatedArticles } from '@/lib/content';
 import MarkdownContent from '@/components/MarkdownContent';
 import { buildBlogPostingJsonLd, buildBreadcrumbJsonLd, jsonLdScript } from '@/lib/jsonLd';
 import { AUTHOR } from '@/lib/author';
+
+/**
+ * 日本語想定で 500 文字 / 分の読了時間を見積もる。HTML タグは除外。
+ */
+function estimateReadingMinutes(html: string): number {
+  const plain = html.replace(/<[^>]+>/g, '').replace(/\s+/g, '');
+  return Math.max(1, Math.ceil(plain.length / 500));
+}
 
 type Params = {
   params: Promise<{ slug: string }>;
@@ -68,6 +86,10 @@ export default async function TechArticlePage({ params }: Params) {
     { name: article.title, url: `https://nagiyu.com/tech/${article.slug}` },
   ]);
 
+  const authorName = article.author ?? AUTHOR.name;
+  const readingMinutes = estimateReadingMinutes(article.content);
+  const relatedArticles = getRelatedArticles(article.slug, article.tags, 3);
+
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
       <script
@@ -83,15 +105,29 @@ export default async function TechArticlePage({ params }: Params) {
       </Typography>
 
       {/* メタ情報 */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1, flexWrap: 'wrap' }}>
+        <Typography variant="caption" color="text.secondary">
+          著者:{' '}
+          <MuiLink href="/about" underline="hover">
+            {authorName}
+          </MuiLink>
+        </Typography>
         <Typography variant="caption" color="text.secondary">
           公開日: {article.publishedAt}
         </Typography>
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-          {article.tags.map((tag) => (
-            <Chip key={tag} label={tag} size="small" variant="outlined" />
-          ))}
-        </Box>
+        {article.updatedAt && article.updatedAt !== article.publishedAt && (
+          <Typography variant="caption" color="text.secondary">
+            最終更新: {article.updatedAt}
+          </Typography>
+        )}
+        <Typography variant="caption" color="text.secondary">
+          読了目安: 約 {readingMinutes} 分
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 3 }}>
+        {article.tags.map((tag) => (
+          <Chip key={tag} label={tag} size="small" variant="outlined" />
+        ))}
       </Box>
 
       {/* 記事概要 */}
@@ -101,6 +137,37 @@ export default async function TechArticlePage({ params }: Params) {
 
       {/* Markdown コンテンツ */}
       <MarkdownContent html={article.content} />
+
+      {/* 関連記事 */}
+      {relatedArticles.length > 0 && (
+        <Box sx={{ mt: 6 }}>
+          <Divider sx={{ mb: 3 }} />
+          <Typography variant="h6" component="h2" gutterBottom>
+            関連記事
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {relatedArticles.map((related) => (
+              <Card key={related.slug} variant="outlined">
+                <CardActionArea href={`/tech/${related.slug}`}>
+                  <CardContent>
+                    <Typography variant="subtitle1" component="h3" gutterBottom>
+                      {related.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      {related.description}
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {related.tags.map((tag) => (
+                        <Chip key={tag} label={tag} size="small" variant="outlined" />
+                      ))}
+                    </Box>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            ))}
+          </Box>
+        </Box>
+      )}
     </Container>
   );
 }

--- a/services/portal/web/src/content/tech/aws-batch-architecture.md
+++ b/services/portal/web/src/content/tech/aws-batch-architecture.md
@@ -3,7 +3,10 @@ title: 'AWS Batchで重い処理をサーバーレス化する構成解説'
 description: '動画変換・画像処理などの重いバッチ処理をAWS Batchでサーバーレス化する構成を解説。ジョブ定義・ジョブキュー・コンピューティング環境・S3トリガー・コスト最適化まで詳しく説明します。'
 slug: 'aws-batch-architecture'
 publishedAt: '2026-04-10'
+updatedAt: '2026-05-01'
+author: 'なぎゆー'
 tags: ['AWS', 'AWS Batch', 'サーバーレス']
+relatedServices: ['quick-clip', 'codec-converter']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/cloudfront-ecs-deployment.md
+++ b/services/portal/web/src/content/tech/cloudfront-ecs-deployment.md
@@ -3,6 +3,8 @@ title: 'CloudFront+ECSでNext.jsをデプロイする構成解説'
 description: 'CloudFront + ECS FargateでNext.jsをデプロイするAWS構成を解説。ECSサービス設定・ALB構成・CloudFrontディストリビューション・キャッシュ設定・GitHub ActionsでのCI/CDまで詳しく説明します。'
 slug: 'cloudfront-ecs-deployment'
 publishedAt: '2026-04-10'
+updatedAt: '2026-05-01'
+author: 'なぎゆー'
 tags: ['AWS', 'CloudFront', 'ECS', 'Next.js']
 ---
 

--- a/services/portal/web/src/content/tech/nextjs-ssg-markdown.md
+++ b/services/portal/web/src/content/tech/nextjs-ssg-markdown.md
@@ -3,6 +3,8 @@ title: 'Next.jsでMarkdownを静的ページに変換する実装方法'
 description: 'Next.jsのSSGとMarkdownファイルを組み合わせた静的サイト生成の実装方法を解説。gray-matterによるフロントマター解析・remark/rehypeによるレンダリング・generateStaticParamsの活用まで詳しく説明します。'
 slug: 'nextjs-ssg-markdown'
 publishedAt: '2026-04-10'
+updatedAt: '2026-05-01'
+author: 'なぎゆー'
 tags: ['Next.js', 'Markdown', 'SSG']
 ---
 

--- a/services/portal/web/src/content/tech/vapid-web-push.md
+++ b/services/portal/web/src/content/tech/vapid-web-push.md
@@ -3,7 +3,10 @@ title: 'Web Push通知をVAPIDキーで実装する方法'
 description: 'VAPIDキーを使ったWeb Push通知の実装方法を解説。サービスワーカーの設定・Push APIのサブスクリプション管理・web-pushライブラリでのサーバーサイド送信・ブラウザサポートまで詳しく説明します。'
 slug: 'vapid-web-push'
 publishedAt: '2026-04-10'
+updatedAt: '2026-05-01'
+author: 'なぎゆー'
 tags: ['Web Push', 'VAPID', '通知']
+relatedServices: ['stock-tracker', 'tools']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/video-codec-comparison.md
+++ b/services/portal/web/src/content/tech/video-codec-comparison.md
@@ -3,7 +3,10 @@ title: 'H.264・VP9・AV1のコーデック比較と使い分け'
 description: '動画コーデックH.264・VP9・AV1の詳細比較。圧縮効率・ブラウザサポート・エンコード速度・画質・用途ごとの使い分けをFFmpegのコマンド例とともに解説します。'
 slug: 'video-codec-comparison'
 publishedAt: '2026-04-10'
+updatedAt: '2026-05-01'
+author: 'なぎゆー'
 tags: ['動画', 'コーデック', 'H.264', 'AV1']
+relatedServices: ['codec-converter']
 ---
 
 ## はじめに

--- a/services/portal/web/src/lib/content.ts
+++ b/services/portal/web/src/lib/content.ts
@@ -118,3 +118,30 @@ export function getAllArticles(): ArticleMeta[] {
     (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
   );
 }
+
+/**
+ * 指定記事に関連する記事を返す（タグ一致数の多い順、同数なら publishedAt 降順）
+ * @param currentSlug - 除外する自記事 slug
+ * @param tags - 比較対象のタグ配列
+ * @param limit - 返す件数（既定 3）
+ */
+export function getRelatedArticles(currentSlug: string, tags: string[], limit = 3): ArticleMeta[] {
+  const tagSet = new Set(tags);
+  const others = getAllArticles().filter((article) => article.slug !== currentSlug);
+
+  const scored = others
+    .map((article) => ({
+      article,
+      score: article.tags.filter((tag) => tagSet.has(tag)).length,
+    }))
+    .filter((entry) => entry.score > 0);
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return new Date(b.article.publishedAt).getTime() - new Date(a.article.publishedAt).getTime();
+  });
+
+  return scored.slice(0, limit).map((entry) => entry.article);
+}


### PR DESCRIPTION
## 概要

AdSense 審査落ち（#2867）対応 PR2/5。著者・更新日・関連記事の表示と About ページの拡充により、**E-E-A-T シグナルを強化**する。

## 変更内容

### コード（`services/portal/web`）

- **`src/lib/content.ts`** — `getRelatedArticles(currentSlug, tags, limit=3)` 追加（タグ一致数の多い順、同数なら publishedAt 降順）
- **`src/app/tech/[slug]/page.tsx`** — 記事メタ表示と関連記事セクションを追加
  - 著者名（`/about` へリンク）
  - `updatedAt`（`publishedAt` と異なる場合のみ表示）
  - 推定読了時間（HTML タグ除外で日本語 500 字/分換算）
  - 記事下部に**関連記事 3 件**のカード一覧（タグマッチで自動選出）
- **`src/app/about/page.tsx`** — E-E-A-T セクション追加
  - 「**運営方針**」: 長期運用・無料提供・更新方針
  - 「**編集ポリシー**」: 一次情報・改訂方針・広告分離
  - 「**お問い合わせ**」: GitHub Issues 経由の連絡窓口
  - 開発者プロフィールに一次情報執筆方針を追記
  - Next.js 15 → 16 表記修正

### コンテンツ（既存 5 本の frontmatter 拡張）

- `author: 'なぎゆー'` を全記事に追加
- `updatedAt: '2026-05-01'` を全記事に追加
- `relatedServices` を関連サービスがある記事に追加:
  - `aws-batch-architecture` → `quick-clip`, `codec-converter`
  - `vapid-web-push` → `stock-tracker`, `tools`
  - `video-codec-comparison` → `codec-converter`

## 検証結果

- [x] `npm run lint` — pass
- [x] `npm run test` — 19 tests pass
- [x] `npm run build` — pass
- [x] `npm run format:check` — pass

ビルド出力で確認:
```
BlogPosting JSON-LD の dateModified が "2026-05-01T00:00:00.000Z" に
author: { @type: "Person", name: "なぎゆー", url: "https://nagiyu.com/about" }
About ページに「運営方針」「編集ポリシー」「お問い合わせ」セクション出力
記事ページに「関連記事」セクション・読了目安表示
```

## 残タスク（後続 PR）

- PR3: 技術記事追加（AWS インフラ + Next.js 編 8 本）
- PR4: 技術記事追加（TypeScript + DevOps 編 8 本）
- PR5: 技術記事追加（バックエンド編 4-8 本）+ トップページ再構成
- 最終 PR: `integration/2867-adsense-compliance` → `develop`

## 関連

- Issue: #2867
- 前 PR: #2868（マージ済み・SEO 基盤整備）

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCxQ5C4c2Yzu7nZj9xBrCT)_