### PR TITLE
fix(portal): タグ名にスペース等を含むタグページの 404 を修正

### DIFF
--- a/services/portal/web/src/app/tech/tags/[tag]/page.tsx
+++ b/services/portal/web/src/app/tech/tags/[tag]/page.tsx
@@ -9,24 +9,23 @@ type Params = { params: Promise<{ tag: string }> };
 export async function generateStaticParams() {
   return getAllTags()
     .filter((entry) => entry.count >= 2)
-    .map((entry) => ({ tag: encodeURIComponent(entry.tag) }));
+    .map((entry) => ({ tag: entry.tag }));
 }
 
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
   const { tag } = await params;
-  const decoded = decodeURIComponent(tag);
-  const url = `https://nagiyu.com/tech/tags/${tag}`;
+  const url = `https://nagiyu.com/tech/tags/${encodeURIComponent(tag)}`;
   return {
-    title: `${decoded} の記事一覧`,
-    description: `nagiyu の技術記事のうち「${decoded}」タグが付いた記事の一覧です。`,
+    title: `${tag} の記事一覧`,
+    description: `nagiyu の技術記事のうち「${tag}」タグが付いた記事の一覧です。`,
     alternates: { canonical: url },
     openGraph: {
       type: 'website',
       url,
-      title: `${decoded} の記事一覧`,
-      description: `nagiyu の技術記事のうち「${decoded}」タグが付いた記事の一覧です。`,
+      title: `${tag} の記事一覧`,
+      description: `nagiyu の技術記事のうち「${tag}」タグが付いた記事の一覧です。`,
       images: ['/og-default.png'],
     },
   };
@@ -34,14 +33,13 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 
 export default async function TagPage({ params }: Params) {
   const { tag } = await params;
-  const decoded = decodeURIComponent(tag);
-  const articles = getArticlesByTag(decoded);
+  const articles = getArticlesByTag(tag);
   if (articles.length === 0) notFound();
 
   const breadcrumb = buildBreadcrumbJsonLd([
     { name: 'ホーム', url: 'https://nagiyu.com/' },
     { name: '技術記事', url: 'https://nagiyu.com/tech' },
-    { name: decoded, url: `https://nagiyu.com/tech/tags/${tag}` },
+    { name: tag, url: `https://nagiyu.com/tech/tags/${encodeURIComponent(tag)}` },
   ]);
 
   return (
@@ -51,7 +49,7 @@ export default async function TagPage({ params }: Params) {
         dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumb) }}
       />
       <Typography variant="h4" component="h1" gutterBottom>
-        {decoded} の記事一覧
+        {tag} の記事一覧
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
         全 {articles.length} 件


### PR DESCRIPTION
## 概要

タグ名にスペース等を含むタグページ（例: `/tech/tags/AWS%20Batch`）が **404 Not Found** になる不具合を修正。

## 不具合の原因

`generateStaticParams` で `encodeURIComponent` 済みの値を返していたため、Next.js が二重エンコード扱いとなり、URL からのリクエスト時にルートマッチに失敗していました。

```typescript
// 修正前: 二重エンコード扱い → 404
return getAllTags().map((entry) => ({ tag: encodeURIComponent(entry.tag) }));

// 修正後: 生のタグ名を渡す
return getAllTags().map((entry) => ({ tag: entry.tag }));
```

Next.js は `params.tag` を URL から自動的にデコードします。事前エンコードは不要で、URL を組み立てるとき（`canonical`、`BreadcrumbList`）にだけ `encodeURIComponent` を使えば OK。

## 修正後の挙動

ビルド出力で確認済み:

```
.next/server/app/tech/tags/AWS Batch.html       ← 空白を含むタグ
.next/server/app/tech/tags/App Router.html
.next/server/app/tech/tags/Web Push.html
.next/server/app/tech/tags/GitHub Actions.html
.next/server/app/tech/tags/CI%2FCD.html         ← `/` 含む（ファイル名安全のため）
.next/server/app/tech/tags/Next.js.html
...
```

`/tech/tags/AWS%20Batch` へのアクセスで `AWS Batch.html` が返るようになります。

## 検証結果

- [x] `npm run lint` — pass
- [x] `npm run test` — 19 tests pass
- [x] `npm run build` — pass（18 タグページ生成、空白含むタグも含む）
- [x] `npm run format:check` — pass

## 関連

- Issue: #2867
- 直前の PR: #2872（このバグを混入してしまった）

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCxQ5C4c2Yzu7nZj9xBrCT)_