### PR TITLE
fix(portal): タグページ URL をスラッグ化し、ASCII タグのみページ化

### DIFF
--- a/services/portal/web/src/app/page.tsx
+++ b/services/portal/web/src/app/page.tsx
@@ -10,7 +10,14 @@ import {
   Button,
   Chip,
 } from '@mui/material';
-import { getAllServiceSlugs, getServiceDocument, getAllArticles, getAllTags } from '@/lib/content';
+import {
+  getAllServiceSlugs,
+  getServiceDocument,
+  getAllArticles,
+  getAllTags,
+  isLinkableTag,
+  tagToSlug,
+} from '@/lib/content';
 import { SERVICE_URLS, SERVICE_NAMES } from '@/lib/services';
 import { buildOrganizationJsonLd, buildWebSiteJsonLd, jsonLdScript } from '@/lib/jsonLd';
 
@@ -27,7 +34,7 @@ export default async function HomePage() {
   const slugs = getAllServiceSlugs();
   const articles = getAllArticles().slice(0, 6);
   const tags = getAllTags()
-    .filter((entry) => entry.count >= 2)
+    .filter((entry) => entry.count >= 2 && isLinkableTag(entry.tag))
     .slice(0, 8);
 
   const serviceCards = await Promise.all(
@@ -122,7 +129,7 @@ export default async function HomePage() {
                 key={entry.tag}
                 label={`${entry.tag} (${entry.count})`}
                 component="a"
-                href={`/tech/tags/${encodeURIComponent(entry.tag)}`}
+                href={`/tech/tags/${tagToSlug(entry.tag)}`}
                 clickable
                 variant="outlined"
               />

--- a/services/portal/web/src/app/sitemap.ts
+++ b/services/portal/web/src/app/sitemap.ts
@@ -1,5 +1,11 @@
 import type { MetadataRoute } from 'next';
-import { getAllArticles, getAllServiceSlugs, getAllTags } from '@/lib/content';
+import {
+  getAllArticles,
+  getAllServiceSlugs,
+  getAllTags,
+  isLinkableTag,
+  tagToSlug,
+} from '@/lib/content';
 
 const SITE_URL = 'https://nagiyu.com';
 
@@ -34,9 +40,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
   }));
 
   const tagEntries: MetadataRoute.Sitemap = getAllTags()
-    .filter((entry) => entry.count >= 2)
+    .filter((entry) => entry.count >= 2 && isLinkableTag(entry.tag))
     .map((entry) => ({
-      url: `${SITE_URL}/tech/tags/${encodeURIComponent(entry.tag)}`,
+      url: `${SITE_URL}/tech/tags/${tagToSlug(entry.tag)}`,
       lastModified: now,
       changeFrequency: 'weekly' as const,
       priority: 0.5,

--- a/services/portal/web/src/app/tech/tags/[tag]/page.tsx
+++ b/services/portal/web/src/app/tech/tags/[tag]/page.tsx
@@ -1,22 +1,29 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { Container, Typography, Box, Card, CardActionArea, CardContent, Chip } from '@mui/material';
-import { getAllTags, getArticlesByTag } from '@/lib/content';
+import {
+  getAllTags,
+  getArticlesByTag,
+  getTagBySlug,
+  isLinkableTag,
+  tagToSlug,
+} from '@/lib/content';
 import { buildBreadcrumbJsonLd, jsonLdScript } from '@/lib/jsonLd';
 
 type Params = { params: Promise<{ tag: string }> };
 
 export async function generateStaticParams() {
   return getAllTags()
-    .filter((entry) => entry.count >= 2)
-    .map((entry) => ({ tag: entry.tag }));
+    .filter((entry) => entry.count >= 2 && isLinkableTag(entry.tag))
+    .map((entry) => ({ tag: tagToSlug(entry.tag) }));
 }
 
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
-  const { tag } = await params;
-  const url = `https://nagiyu.com/tech/tags/${encodeURIComponent(tag)}`;
+  const { tag: slug } = await params;
+  const tag = getTagBySlug(slug) ?? slug;
+  const url = `https://nagiyu.com/tech/tags/${slug}`;
   return {
     title: `${tag} の記事一覧`,
     description: `nagiyu の技術記事のうち「${tag}」タグが付いた記事の一覧です。`,
@@ -32,14 +39,17 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 }
 
 export default async function TagPage({ params }: Params) {
-  const { tag } = await params;
+  const { tag: slug } = await params;
+  const tag = getTagBySlug(slug);
+  if (!tag) notFound();
+
   const articles = getArticlesByTag(tag);
   if (articles.length === 0) notFound();
 
   const breadcrumb = buildBreadcrumbJsonLd([
     { name: 'ホーム', url: 'https://nagiyu.com/' },
     { name: '技術記事', url: 'https://nagiyu.com/tech' },
-    { name: tag, url: `https://nagiyu.com/tech/tags/${encodeURIComponent(tag)}` },
+    { name: tag, url: `https://nagiyu.com/tech/tags/${slug}` },
   ]);
 
   return (

--- a/services/portal/web/src/lib/content.ts
+++ b/services/portal/web/src/lib/content.ts
@@ -165,6 +165,40 @@ export function getAllTags(): { tag: string; count: number }[] {
 }
 
 /**
+ * タグ名を URL 用のスラッグに変換する
+ * - 小文字化
+ * - スペースとスラッシュをハイフンに置換
+ * - 連続するハイフンを 1 つに集約
+ *
+ * 例: "AWS Batch" → "aws-batch" / "Next.js" → "next.js"
+ *
+ * Next.js のルーティングで `%20`（エンコードされたスペース）が prerender-manifest と
+ * 照合されない不具合を回避するため、URL からスペースを排除する目的で導入。
+ */
+export function tagToSlug(tag: string): string {
+  return tag
+    .toLowerCase()
+    .replace(/[\s/]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * 非 ASCII を含むスラッグも Next.js のルーティングで安定しないため、
+ * ページ化対象は ASCII スラッグに収まるタグのみとする。
+ */
+export function isLinkableTag(tag: string): boolean {
+  return /^[a-z0-9.@_-]+$/.test(tagToSlug(tag));
+}
+
+/**
+ * スラッグからオリジナルのタグ名を逆引きする
+ */
+export function getTagBySlug(slug: string): string | null {
+  return getAllTags().find((entry) => tagToSlug(entry.tag) === slug)?.tag ?? null;
+}
+
+/**
  * 指定タグを持つ記事を publishedAt 降順で返す
  */
 export function getArticlesByTag(tag: string): ArticleMeta[] {


### PR DESCRIPTION
## 概要

直前の修正（#2873）後も、URL にスペース・スラッシュ・非 ASCII が含まれるタグページが **404** になる問題が残っていたため再修正。

## 原因

ローカル検証で確認したところ、`/tech/tags/AWS%20Batch` のように URL エンコードされたパス、および `/tech/tags/セキュリティ` のような非 ASCII パスが、Next.js の prerender-manifest と URL デコード後の比較で一部 404 になる挙動でした。エンコード値次第で結果が安定しません。

## 対応

URL から空白・スラッシュ・大文字を排除する `tagToSlug` を導入し、ページ化対象を **ASCII スラッグに収まるタグのみ**に限定します（`isLinkableTag`）。

### 変更点

| ファイル | 内容 |
|---|---|
| `src/lib/content.ts` | `tagToSlug` / `isLinkableTag` / `getTagBySlug` を追加 |
| `src/app/tech/tags/[tag]/page.tsx` | params をスラッグとして受け取り、`getTagBySlug` でタグ名を逆引き |
| `src/app/page.tsx` | ホームのチップは ASCII リンク可能タグのみ。href は `tagToSlug` ベース |
| `src/app/sitemap.ts` | タグ URL もスラッグ化、ASCII タグのみ含める |

### URL の変化

| 変更前 | 変更後 |
|---|---|
| `/tech/tags/AWS%20Batch` | `/tech/tags/aws-batch` |
| `/tech/tags/App%20Router` | `/tech/tags/app-router` |
| `/tech/tags/Web%20Push` | `/tech/tags/web-push` |
| `/tech/tags/GitHub%20Actions` | `/tech/tags/github-actions` |
| `/tech/tags/Next.js` | `/tech/tags/next.js` |
| `/tech/tags/CI%2FCD` | `/tech/tags/ci-cd` |
| `/tech/tags/セキュリティ` | （ページ化対象外） |
| `/tech/tags/通知` | （ページ化対象外） |

非 ASCII（日本語）タグは記事ページのチップとして引き続き表示されますが、専用ページは持ちません。

## 検証結果

- [x] `npm run lint` — pass
- [x] `npm run test` — 19 tests pass
- [x] `npm run build` — pass（14 タグページ生成、すべて ASCII スラッグ）
- [x] `npm run format:check` — pass

ビルド出力でファイル名はすべて `aws-batch.html` のような ASCII。URL エンコードを介さないので Next.js のルーティングが安定します。

## 関連

- Issue: #2867
- 直前の PR: #2873（部分的修正・空白タグの URL エンコード問題が残っていた）

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCxQ5C4c2Yzu7nZj9xBrCT)_