### PR TITLE
fix: 一時アラート失効バッチが getByFrequency で再びクラッシュする問題を解消 (#2866)

### DIFF
--- a/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
@@ -11,12 +11,12 @@ import {
   DeleteCommand,
   QueryCommand,
   type DynamoDBDocumentClient,
+  type QueryCommandOutput,
 } from '@aws-sdk/lib-dynamodb';
 import {
   EntityNotFoundError,
   EntityAlreadyExistsError,
   DatabaseError,
-  InvalidEntityDataError,
   type PaginationOptions,
   type PaginatedResult,
   type DynamoDBItem,
@@ -31,27 +31,6 @@ import { randomUUID } from 'crypto';
 const ERROR_MESSAGES = {
   NO_UPDATES_SPECIFIED: '更新するフィールドが指定されていません',
 } as const;
-
-const INVALID_ENTITY_DATA_ERROR_NAME = 'InvalidEntityDataError';
-const INVALID_ENTITY_DATA_MESSAGE_PREFIX = 'エンティティデータが無効です';
-
-const isInvalidEntityDataError = (error: unknown): error is Error => {
-  if (error instanceof InvalidEntityDataError) {
-    return true;
-  }
-
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  // 実行環境差異により Error のクラス名解決が崩れるケースがあるため、
-  // 「name一致」または「InvalidEntityDataError のメッセージ接頭辞一致」の
-  // どちらかを満たす場合は無効データとして扱う。
-  return (
-    error.message.startsWith(INVALID_ENTITY_DATA_MESSAGE_PREFIX) ||
-    error.name === INVALID_ENTITY_DATA_ERROR_NAME
-  );
-};
 
 /**
  * DynamoDB Alert Repository
@@ -101,13 +80,14 @@ export class DynamoDBAlertRepository implements AlertRepository {
     userId: string,
     options?: PaginationOptions
   ): Promise<PaginatedResult<AlertEntity>> {
+    let result: QueryCommandOutput;
     try {
       const limit = options?.limit || 50;
       const exclusiveStartKey = options?.cursor
         ? JSON.parse(Buffer.from(options.cursor, 'base64').toString('utf-8'))
         : undefined;
 
-      const result = await this.docClient.send(
+      result = await this.docClient.send(
         new QueryCommand({
           TableName: this.tableName,
           IndexName: 'UserIndex',
@@ -124,37 +104,37 @@ export class DynamoDBAlertRepository implements AlertRepository {
           ExclusiveStartKey: exclusiveStartKey,
         })
       );
-
-      const items: AlertEntity[] = [];
-      for (const item of result.Items || []) {
-        try {
-          items.push(this.mapper.toEntity(item as unknown as DynamoDBItem));
-        } catch (error) {
-          if (isInvalidEntityDataError(error)) {
-            const record = item as Record<string, unknown>;
-            logger.warn('無効なアラートデータをスキップしました', {
-              pk: record.PK,
-              sk: record.SK,
-              error: error.message,
-            });
-            continue;
-          }
-          throw error;
-        }
-      }
-      const nextCursor = result.LastEvaluatedKey
-        ? Buffer.from(JSON.stringify(result.LastEvaluatedKey)).toString('base64')
-        : undefined;
-
-      return {
-        items,
-        nextCursor,
-        count: result.Count,
-      };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new DatabaseError(message, error instanceof Error ? error : undefined);
     }
+
+    // mapper.toEntity は同期的なデータ検証であり、ここから投げられるエラーは
+    // 全て個別アイテムの検証失敗。バッチ呼び出し全体を壊さないよう、
+    // エラー種別の判定に依存せず常にスキップ＆警告ログとする。
+    const items: AlertEntity[] = [];
+    for (const item of result.Items || []) {
+      try {
+        items.push(this.mapper.toEntity(item as unknown as DynamoDBItem));
+      } catch (error) {
+        const record = item as Record<string, unknown>;
+        logger.warn('無効なアラートデータをスキップしました', {
+          pk: record.PK,
+          sk: record.SK,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const nextCursor = result.LastEvaluatedKey
+      ? Buffer.from(JSON.stringify(result.LastEvaluatedKey)).toString('base64')
+      : undefined;
+
+    return {
+      items,
+      nextCursor,
+      count: result.Count,
+    };
   }
 
   /**
@@ -164,13 +144,14 @@ export class DynamoDBAlertRepository implements AlertRepository {
     frequency: 'MINUTE_LEVEL' | 'HOURLY_LEVEL',
     options?: PaginationOptions
   ): Promise<PaginatedResult<AlertEntity>> {
+    let result: QueryCommandOutput;
     try {
       const limit = options?.limit || 50;
       const exclusiveStartKey = options?.cursor
         ? JSON.parse(Buffer.from(options.cursor, 'base64').toString('utf-8'))
         : undefined;
 
-      const result = await this.docClient.send(
+      result = await this.docClient.send(
         new QueryCommand({
           TableName: this.tableName,
           IndexName: 'AlertIndex',
@@ -185,37 +166,37 @@ export class DynamoDBAlertRepository implements AlertRepository {
           ExclusiveStartKey: exclusiveStartKey,
         })
       );
-
-      const items: AlertEntity[] = [];
-      for (const item of result.Items || []) {
-        try {
-          items.push(this.mapper.toEntity(item as unknown as DynamoDBItem));
-        } catch (error) {
-          if (isInvalidEntityDataError(error)) {
-            const record = item as Record<string, unknown>;
-            logger.warn('無効なアラートデータをスキップしました', {
-              pk: record.PK,
-              sk: record.SK,
-              error: error.message,
-            });
-            continue;
-          }
-          throw error;
-        }
-      }
-      const nextCursor = result.LastEvaluatedKey
-        ? Buffer.from(JSON.stringify(result.LastEvaluatedKey)).toString('base64')
-        : undefined;
-
-      return {
-        items,
-        nextCursor,
-        count: result.Count,
-      };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new DatabaseError(message, error instanceof Error ? error : undefined);
     }
+
+    // mapper.toEntity は同期的なデータ検証であり、ここから投げられるエラーは
+    // 全て個別アイテムの検証失敗。バッチ呼び出し全体を壊さないよう、
+    // エラー種別の判定に依存せず常にスキップ＆警告ログとする。
+    const items: AlertEntity[] = [];
+    for (const item of result.Items || []) {
+      try {
+        items.push(this.mapper.toEntity(item as unknown as DynamoDBItem));
+      } catch (error) {
+        const record = item as Record<string, unknown>;
+        logger.warn('無効なアラートデータをスキップしました', {
+          pk: record.PK,
+          sk: record.SK,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const nextCursor = result.LastEvaluatedKey
+      ? Buffer.from(JSON.stringify(result.LastEvaluatedKey)).toString('base64')
+      : undefined;
+
+    return {
+      items,
+      nextCursor,
+      count: result.Count,
+    };
   }
 
   /**

--- a/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
@@ -575,6 +575,100 @@ describe('DynamoDBAlertRepository', () => {
         })
       );
     });
+
+    it('toEntity から InvalidEntityDataError 以外のエラーが投げられても、バッチ全体を壊さずにスキップする', async () => {
+      const validItem = {
+        PK: 'USER#user-123',
+        SK: 'ALERT#alert-1',
+        AlertID: 'alert-1',
+        UserID: 'user-123',
+      };
+      const invalidItem = {
+        ...validItem,
+        SK: 'ALERT#invalid-alert',
+        AlertID: 'invalid-alert',
+      };
+
+      const mapperSpy = jest.spyOn(AlertMapper.prototype, 'toEntity').mockImplementation((item) => {
+        const record = item as unknown as { AlertID?: string };
+        if (record.AlertID === 'invalid-alert') {
+          // モジュールインスタンス差異など想定外の経路で `InvalidEntityDataError` 判定が
+          // すり抜けたケースをシミュレート: 名前/メッセージともに合致しない TypeError
+          throw new TypeError('Cannot read properties of undefined');
+        }
+
+        return {
+          AlertID: record.AlertID,
+          UserID: 'user-123',
+        } as unknown as ReturnType<AlertMapper['toEntity']>;
+      });
+
+      mockDocClient.send.mockResolvedValueOnce({
+        Items: [invalidItem, validItem],
+        Count: 2,
+      });
+
+      const result = await repository.getByFrequency('MINUTE_LEVEL');
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.AlertID).toBe('alert-1');
+      expect(logger.warn).toHaveBeenCalledWith(
+        '無効なアラートデータをスキップしました',
+        expect.objectContaining({
+          sk: 'ALERT#invalid-alert',
+          error: 'Cannot read properties of undefined',
+        })
+      );
+      mapperSpy.mockRestore();
+    });
+
+    it('toEntity が DatabaseError でラップされたエラーを投げても、バッチを壊さずにスキップする', async () => {
+      // 本番再現: 何らかの理由で toEntity から DatabaseError 形式のエラーが投げられても
+      // 外側 catch で再ラップされて totalAlerts: 0 でクラッシュすることがあってはならない
+      const validItem = {
+        PK: 'USER#user-123',
+        SK: 'ALERT#alert-1',
+        AlertID: 'alert-1',
+        UserID: 'user-123',
+      };
+      const invalidItem = {
+        ...validItem,
+        SK: 'ALERT#invalid-alert',
+        AlertID: 'invalid-alert',
+      };
+
+      const mapperSpy = jest.spyOn(AlertMapper.prototype, 'toEntity').mockImplementation((item) => {
+        const record = item as unknown as { AlertID?: string };
+        if (record.AlertID === 'invalid-alert') {
+          // すでに DatabaseError 形式に再ラップされたメッセージを持つエラーを擬似的に投げる
+          const wrapped = new Error(
+            'データベースエラーが発生しました: エンティティデータが無効です: フィールド "SubscriptionEndpoint" が文字列ではありません'
+          );
+          wrapped.name = 'DatabaseError';
+          throw wrapped;
+        }
+
+        return {
+          AlertID: record.AlertID,
+          UserID: 'user-123',
+        } as unknown as ReturnType<AlertMapper['toEntity']>;
+      });
+
+      mockDocClient.send.mockResolvedValueOnce({
+        Items: [invalidItem, validItem],
+        Count: 2,
+      });
+
+      const result = await repository.getByFrequency('MINUTE_LEVEL');
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.AlertID).toBe('alert-1');
+      expect(logger.warn).toHaveBeenCalledWith(
+        '無効なアラートデータをスキップしました',
+        expect.objectContaining({ sk: 'ALERT#invalid-alert' })
+      );
+      mapperSpy.mockRestore();
+    });
   });
 
   describe('update', () => {


### PR DESCRIPTION
## Summary

Issue #2866 の再発（2026-05-02 観測ログ）を解消する。

- `DynamoDBAlertRepository.getByFrequency` / `getByUserId` のエラーハンドリング構造を再設計
- `isInvalidEntityDataError` ヘルパーを撤去し、`toEntity` から投げられた全エラーを per-item 検証失敗として無条件スキップ＆警告ログへ変更
- 外側 `try-catch` の対象を DynamoDB API 呼び出しと cursor の base64 デコードのみに限定し、per-item validation エラーが外側 catch で `DatabaseError` に再ラップされる経路自体を排除

これにより、Lambda モジュールインスタンス差異・`instanceof` 破綻・想定外エラー型など、あらゆる条件下で安全にスキップ動作する。

## Test plan

- [x] `services/stock-tracker/core` ユニットテスト 691 件 pass
- [x] `services/stock-tracker/batch` ユニットテスト 92 件 pass
- [x] 新規テスト: `TypeError` / `DatabaseError` 風メッセージが `toEntity` から投げられても `getByFrequency` がクラッシュしないことを確認
- [x] lint / format / build pass

Closes #2866

https://claude.ai/code/session_01EuPPatrf5sKahEAq2BUffx

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPPatrf5sKahEAq2BUffx)_