### PR TITLE
テスト: webkit-mobile でのチェックボックスロケーターをコンテナベースに変更

### DIFF
--- a/services/share-together/web/tests/e2e/group-shared-todo.spec.ts
+++ b/services/share-together/web/tests/e2e/group-shared-todo.spec.ts
@@ -85,7 +85,10 @@ test.describe('グループ共有 ToDo 管理', () => {
     await page.goto(`/lists?scope=shared&groupId=${GROUP_ID}&listId=${LIST_ID}`);
     await page.waitForLoadState('networkidle');
 
-    const checkbox = page.getByRole('checkbox', { name: `${EXISTING_TODO_TITLE}の完了チェック` });
+    const checkbox = page
+      .getByRole('listitem')
+      .filter({ hasText: EXISTING_TODO_TITLE })
+      .getByRole('checkbox');
     await expect(checkbox).not.toBeChecked();
     await checkbox.click();
     await expect(checkbox).toBeChecked();

--- a/services/share-together/web/tests/e2e/personal-todo.spec.ts
+++ b/services/share-together/web/tests/e2e/personal-todo.spec.ts
@@ -49,7 +49,10 @@ test.describe('個人 ToDo 管理', () => {
   });
 
   test('ToDo を完了にできる', async ({ page }) => {
-    const checkbox = page.getByRole('checkbox', { name: 'E2E 未完了 ToDoの完了チェック' });
+    const checkbox = page
+      .getByRole('listitem')
+      .filter({ hasText: 'E2E 未完了 ToDo' })
+      .getByRole('checkbox');
     await expect(checkbox).not.toBeChecked();
     await checkbox.click();
     await expect(checkbox).toBeChecked();


### PR DESCRIPTION
## 変更の概要

webkit-mobile E2E テストでチェックボックスの検索に失敗する問題を修正した。

webkit では `opacity: 0` で配置された native `<input type="checkbox">` に設定した `aria-label` が AX ツリーに正しく公開されず、`getByRole('checkbox', { name: '...' })` による名前ベースのロケーターが失敗する。

`listitem` コンテナ経由で `getByRole('checkbox')` を取得するコンテナベース方式に変更することで、全ブラウザ（chromium-desktop / chromium-mobile / webkit-mobile）で安定して動作するようになった。

## 関連 Issue

<!-- integration → develop PR でのみ Closes # を使用するため、ここでは記載しない -->

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [x] その他（E2E テストのロケーター修正）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [ ] ローカルでテストが全て通ることを確認した（CI で確認）
- [x] ビルドエラーがないことを確認した

## テスト内容

- `services/share-together/web/tests/e2e/personal-todo.spec.ts`
  - 「ToDo を完了にできる」テストのチェックボックスロケーターを変更
  - `getByRole('checkbox', { name: 'E2E 未完了 ToDoの完了チェック' })` → `getByRole('listitem').filter({ hasText: 'E2E 未完了 ToDo' }).getByRole('checkbox')`

- `services/share-together/web/tests/e2e/group-shared-todo.spec.ts`
  - 「共有リストの ToDo を完了にできる」テストのチェックボックスロケーターを変更
  - `getByRole('checkbox', { name: \`${EXISTING_TODO_TITLE}の完了チェック\` })` → `getByRole('listitem').filter({ hasText: EXISTING_TODO_TITLE }).getByRole('checkbox')`

## レビューポイント

- webkit の AX ツリーで `aria-label` が公開されない問題への対応として、コンテナベースロケーターを採用した
- `TodoItem.tsx` 側（コンポーネント）の変更は不要で、テスト側のみの修正

## 補足事項

PR #2894（`integration/2829-npm-update` → `develop`）の Full CI で Share Together webkit-mobile E2E が失敗していた問題の修正。

https://claude.ai/code/session_01R2WS5RRmmoDJEFjeqmMJpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2WS5RRmmoDJEFjeqmMJpj)_