### PR TITLE
fix(ci): stock-tracker デプロイで temporary-alert-expiry Lambda が更新されない問題を修正

### DIFF
--- a/.github/workflows/stock-tracker-deploy.yml
+++ b/.github/workflows/stock-tracker-deploy.yml
@@ -324,6 +324,11 @@ jobs:
             --image-uri "$BATCH_IMAGE_URI" \
             --region ${{ env.AWS_REGION }}
 
+          aws lambda update-function-code \
+            --function-name "nagiyu-stock-tracker-batch-temporary-alert-expiry-$ENVIRONMENT" \
+            --image-uri "$BATCH_IMAGE_URI" \
+            --region ${{ env.AWS_REGION }}
+
           echo "Lambda functions updated with latest images"
 
       - name: Wait for Lambda updates to complete
@@ -349,6 +354,10 @@ jobs:
 
           aws lambda wait function-updated \
             --function-name "nagiyu-stock-tracker-batch-daily-$ENVIRONMENT" \
+            --region ${{ env.AWS_REGION }}
+
+          aws lambda wait function-updated \
+            --function-name "nagiyu-stock-tracker-batch-temporary-alert-expiry-$ENVIRONMENT" \
             --region ${{ env.AWS_REGION }}
 
           echo "All Lambda functions updated successfully"


### PR DESCRIPTION
## 変更の概要

#2897 で実装した一時アラート失効バッチの subscription 非依存化が dev 環境に反映されていなかった原因を修正する。

### 根本原因

`infra/stock-tracker/lib/lambda-stack.ts:242-265` で `nagiyu-stock-tracker-batch-temporary-alert-expiry-${environment}` Lambda は ECR の `latest` タグから作成されている。CDK は同一タグでの再デプロイで Lambda の image を再フェッチさせないため、デプロイワークフローでは別途 `aws lambda update-function-code` を呼んで強制的にイメージを引き直す設計になっている（`stock-tracker-deploy.yml:300-325`）。

しかし、その更新リストに以下 4 つしか含まれていなかった:

- `nagiyu-stock-tracker-web-${env}`
- `nagiyu-stock-tracker-batch-minute-${env}`
- `nagiyu-stock-tracker-batch-hourly-${env}`
- `nagiyu-stock-tracker-batch-summary-${env}`
- `nagiyu-stock-tracker-batch-daily-${env}`

5 番目の Batch Lambda である **`nagiyu-stock-tracker-batch-temporary-alert-expiry-${env}`** が `update-function-code` と `function-updated wait` の両方から漏れていたため、ECR に新しいイメージを push しても Lambda は最初に CDK が作成した古いイメージのまま動き続けていた。

### 修正

`stock-tracker-deploy.yml` の以下 2 箇所に `temporary-alert-expiry` を追加:

- `Update Lambda functions with latest images` ステップの `aws lambda update-function-code` リスト
- `Wait for Lambda updates to complete` ステップの `aws lambda wait function-updated` リスト

## 関連 Issue

短期対応 Issue: #2895（マージ済み PR #2897 の配信完遂のための関連修正）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）→ ワークフロー YAML の修正のためテスト不要
- [ ] 関連ドキュメントを更新した → 該当なし
- [x] CI/CD 設定を追加・更新した
- [ ] ローカルでテストが全て通ることを確認した → 該当なし（YAML 修正のみ）
- [x] ビルドエラーがないことを確認した（YAML 構文上の追記のみ、既存リストへの並列追記）

## テスト内容

- ローカルテスト不可のため、本 PR のマージ → integration 経由で dev 環境に反映 → `nagiyu-stock-tracker-batch-temporary-alert-expiry-dev` Lambda の image digest 更新を CloudWatch Logs / Lambda コンソール上で確認する手順を想定

## レビューポイント

- 追記位置（`update-function-code` と `function-updated wait` の両方）に漏れがないか
- 関数名 `nagiyu-stock-tracker-batch-temporary-alert-expiry-$ENVIRONMENT` が CDK 側 (`infra/stock-tracker/lib/lambda-stack.ts:246`) と一致していること

## 補足事項

- 本 PR は `integration/2895-temporary-alert-batch-redesign` を base とする（短期 Issue #2895 配信の完遂対応）
- 本 PR マージ後の dev 反映確認をもって、integration → develop の Draft PR を作成する想定


---
_Generated by [Claude Code](https://claude.ai/code/session_01VM87F5Sk44RgQTqyNe5N9E)_