### PR TITLE
ドキュメント: Route53 全面移行の計画書を追加

### DIFF
--- a/tasks/route53-migration/dns-inventory.md
+++ b/tasks/route53-migration/dns-inventory.md
@@ -1,0 +1,99 @@
+<!--
+    Phase 0 の棚卸し結果を記録するためのテンプレート。
+    XServer 管理画面で nagiyu.com の全 DNS レコードを確認し、本ファイルに記入する。
+
+    記入後、Phase 2 の CDK 化作業の入力として使用される。
+
+    関連 Issue: #2902
+-->
+
+# nagiyu.com DNS レコード棚卸し（Phase 0）
+
+> 記入者: TBD
+> 記入日: YYYY-MM-DD
+> 取得元: XServer ドメイン管理画面（DNS レコード設定）
+
+## 棚卸し方針
+
+- XServer 管理画面で確認できる **全レコード**を漏れなく転記する
+- レコードタイプ・名前・値・TTL を必ず記録する
+- 不明な用途のレコードがあっても削除せず、そのまま転記し「用途不明」と備考に記載する
+- `dig nagiyu.com ANY +noall +answer @<xserver-ns>` などのコマンドでも併せて確認し、管理画面に表示されない隠れたレコードがないかクロスチェックする
+
+## レコード一覧
+
+### A / AAAA レコード
+
+| 名前 | タイプ | 値 | TTL | 用途・備考 |
+|---|---|---|---|---|
+| | | | | |
+
+### CNAME レコード
+
+| 名前 | タイプ | 値 | TTL | 用途・備考 |
+|---|---|---|---|---|
+| `tools.nagiyu.com` | CNAME | `xxxxxxxx.cloudfront.net` | | tools サービス（推定） |
+| `dev-tools.nagiyu.com` | CNAME | `xxxxxxxx.cloudfront.net` | | tools サービス dev（推定） |
+| ... | | | | |
+
+### MX レコード（メール）
+
+| 名前 | タイプ | 値 | TTL | 用途・備考 |
+|---|---|---|---|---|
+| | | | | |
+
+### TXT レコード（SPF / DKIM / DMARC / 所有権確認 等）
+
+| 名前 | タイプ | 値 | TTL | 用途・備考 |
+|---|---|---|---|---|
+| | | | | |
+
+### NS レコード（サブゾーン委任があれば）
+
+| 名前 | タイプ | 値 | TTL | 用途・備考 |
+|---|---|---|---|---|
+| | | | | |
+
+### SRV / その他
+
+| 名前 | タイプ | 値 | TTL | 用途・備考 |
+|---|---|---|---|---|
+| | | | | |
+
+## ACM DNS 検証 CNAME
+
+ACM 証明書の検証用に登録されている CNAME を別途記録する（Phase 5 で自動化に置換するため）。
+
+| 名前 | タイプ | 値 | TTL | 備考 |
+|---|---|---|---|---|
+| `_xxxxxxxxx.nagiyu.com` | CNAME | `_yyyyyyyy.acm-validations.aws.` | | `*.nagiyu.com` 証明書の検証用 |
+
+`aws acm describe-certificate --certificate-arn <arn> --region us-east-1 --query 'Certificate.DomainValidationOptions[*].ResourceRecord'` で確認可能。
+
+## 確認コマンド例（クロスチェック用）
+
+```bash
+# 主要レコードを XServer NS から直接取得
+NS=ns1.xserver.jp  # XServer のネームサーバ（実際の値に置換）
+
+dig @$NS nagiyu.com SOA +short
+dig @$NS nagiyu.com NS +short
+dig @$NS nagiyu.com MX +short
+dig @$NS nagiyu.com TXT +short
+dig @$NS nagiyu.com A +short
+
+# サブドメイン
+for sub in tools auth admin quick-clip stock-tracker share-together niconico-mylist-assistant codec-converter; do
+  echo "=== $sub.nagiyu.com ==="
+  dig @$NS $sub.nagiyu.com CNAME +short
+  echo "=== dev-$sub.nagiyu.com ==="
+  dig @$NS dev-$sub.nagiyu.com CNAME +short
+done
+```
+
+## 完了条件
+
+- [ ] XServer 管理画面の全レコードを転記済み
+- [ ] `dig` によるクロスチェックで漏れがないことを確認済み
+- [ ] 用途不明レコードの調査・確認済み（消してよいか判断済み）
+- [ ] 本ファイルを Phase 2 担当者に共有済み

--- a/tasks/route53-migration/dns-inventory.md
+++ b/tasks/route53-migration/dns-inventory.md
@@ -30,11 +30,28 @@
 
 ### CNAME レコード
 
-| 名前 | タイプ | 値 | TTL | 用途・備考 |
-|---|---|---|---|---|
-| `tools.nagiyu.com` | CNAME | `xxxxxxxx.cloudfront.net` | | tools サービス（推定） |
-| `dev-tools.nagiyu.com` | CNAME | `xxxxxxxx.cloudfront.net` | | tools サービス dev（推定） |
-| ... | | | | |
+| 名前 | タイプ | 値 | 用途・備考 |
+|---|---|---|---|
+| `_795cd11835618eae1172367526630b7f.nagiyu.com` | CNAME | `_09095adf08f7ad2742324041fb053779.zfyfvmchrl.acm-validations.aws` | |
+| `dev-tools.nagiyu.com` | CNAME | `di5qiqkse31ld.cloudfront.net` | Tools (dev) |
+| `nagiyu.com` | CNAME | `d1k6ec293qn4f7.cloudfront.net` | ルート |
+| `tools.nagiyu.com` | CNAME | `dxsm9dplwcq8k.cloudfront.net` | Tools |
+| `dev-auth.nagiyu.com` | CNAME | `dqwp0hty66uo0.cloudfront.net` | Auth (Dev) |
+| `auth.nagiyu.com` | CNAME | `d34m95nq713g26.cloudfront.net` | Auth |
+| `dev-admin.nagiyu.com` | CNAME | `d20d90d0yxf3hy.cloudfront.net` | Admin (Dev) |
+| `dev-niconico-mylist-assistant.nagiyu.com` | CNAME | `d1m48o6sp5o6j9.cloudfront.net` | Niconico Mylist Assistant (Dev) |
+| `admin.nagiyu.com` | CNAME | `da84amiv79v4m.cloudfront.net` | Admin |
+| `dev-codec-converter.nagiyu.com` | CNAME | `dj528on1g8nw0.cloudfront.net` | Codec Converter (Dev) |
+| `dev-stock-tracker.nagiyu.com` | CNAME | `d1vh86o7kq78ya.cloudfront.net` | Stock Tracker (Dev) |
+| `stock-tracker.nagiyu.com` | CNAME | `d1n3pw1wiam9k0.cloudfront.net` | Stock Tracker |
+| `codec-converter.nagiyu.com` | CNAME | `d1bh7qvatnkglt.cloudfront.net` | Codec Converter |
+| `niconico-mylist-assistant.nagiyu.com` | CNAME | `d2jj4a3zh6zf5h.cloudfront.net` | Niconico Mylist Assistant |
+| `dev-share-together.nagiyu.com` | CNAME | `d3f8lnzpu25qxe.cloudfront.net` | Share Together (Dev) |
+| `share-together.nagiyu.com` | CNAME | `d3vh0c4lc7bae6.cloudfront.net` | Share Together |
+| `dev-quick-clip.nagiyu.com` | CNAME | `dh18sa23cobm6.cloudfront.net` | Quick Clip (Dev9) |
+| `dev.nagiyu.com` | CNAME | `d1p44g973egas4.cloudfront.net` | ルート (Dev) |
+| `hnjg6vgudcwv.nagiyu.com` | CNAME | `gv-d6lr3lnlnk6zbu.dv.googlehosted.com` | |
+| `quick-clip.nagiyu.com` | CNAME | `d1v96dysvz62zc.cloudfront.net` | Quick Clip |
 
 ### MX レコード（メール）
 

--- a/tasks/route53-migration/plan.md
+++ b/tasks/route53-migration/plan.md
@@ -1,0 +1,246 @@
+<!--
+    このドキュメントは開発時のみ使用します。
+    開発完了後に重要な内容を以下に統合し、本ディレクトリを削除します。
+    - docs/infra/shared/route53.md（新規作成 / Phase 6 で対応）
+    - docs/infra/shared/acm.md（DNS 検証手順を Route53 自動化に更新）
+    - docs/infra/shared/cloudfront.md（カスタムドメイン紐付けを ALIAS に更新）
+    - docs/infra/architecture.md（DNS レイヤを Route53 に更新）
+    - docs/infra/setup.md / docs/infra/deploy.md（必要に応じて更新）
+
+    関連 Issue: #2902
+-->
+
+# Route53 全面移行 - 計画書
+
+## 1. 目的
+
+`nagiyu.com` の権威 DNS を XServer から AWS Route53 に全面移行し、新サービス追加・既存サービスのドメイン変更が **CDK のみで完結する状態**にする。
+
+- ドメインレジストラ（XServer 側のドメイン契約）は移管しない
+- Route53 はあくまで権威 DNS としてのみ使用する
+- 既存の運用（ワイルドカード ACM 証明書、CloudFront カスタムドメイン）は維持する
+
+## 2. 現状
+
+### ドメイン・DNS 構成
+
+| 項目 | 現状 |
+|---|---|
+| ドメインレジストラ | XServer (`nagiyu.com`) |
+| 権威 DNS | XServer |
+| ワイルドカード証明書 | `*.nagiyu.com` + `nagiyu.com`（ACM, us-east-1, DNS 検証） |
+| ACM 検証 | XServer 管理画面で手動 CNAME 追加 |
+| サブドメイン → CloudFront | XServer 管理画面で手動 CNAME 追加 |
+
+### サービス一覧（DNS 移行対象）
+
+| サービス | prod ドメイン | dev ドメイン |
+|---|---|---|
+| root | `nagiyu.com` | `dev.nagiyu.com` |
+| tools | `tools.nagiyu.com` | `dev-tools.nagiyu.com` |
+| auth | `auth.nagiyu.com` | `dev-auth.nagiyu.com` |
+| admin | `admin.nagiyu.com` | `dev-admin.nagiyu.com` |
+| quick-clip | `quick-clip.nagiyu.com` | `dev-quick-clip.nagiyu.com` |
+| stock-tracker | `stock-tracker.nagiyu.com` | `dev-stock-tracker.nagiyu.com` |
+| share-together | `share-together.nagiyu.com` | `dev-share-together.nagiyu.com` |
+| niconico-mylist-assistant | `niconico-mylist-assistant.nagiyu.com` | `dev-niconico-mylist-assistant.nagiyu.com` |
+| codec-converter | `codec-converter.nagiyu.com` | `dev-codec-converter.nagiyu.com` |
+
+合計: 9 サービス × 2 環境 = 18 サブドメイン + apex / dev apex。
+
+### 関連実装
+
+- `infra/shared/lib/acm-stack.ts` — ACM 証明書（DNS 検証は現在 `fromDns()` で外部 DNS 委ね）
+- `infra/common/src/stacks/cloudfront-stack-base.ts` — 各サービス CloudFront の共通スタック
+- `infra/root/` 配下 — apex (`nagiyu.com`) 用 CloudFront
+- `infra/shared/libs/utils/ssm.ts` — SSM パラメータ名定義（`ACM_CERTIFICATE_ARN` 等）
+
+## 3. 移行後アーキテクチャ
+
+```
+[利用者]
+   ↓
+[Route53 ホストゾーン nagiyu.com]
+   ├─ NS / SOA（Route53 管理）
+   ├─ A (ALIAS) tools.nagiyu.com → CloudFront
+   ├─ A (ALIAS) dev-tools.nagiyu.com → CloudFront
+   ├─ A (ALIAS) nagiyu.com → CloudFront（apex を ALIAS で直接）
+   ├─ ... 他サービス分
+   ├─ MX / TXT / DKIM 等のメール系レコード（XServer から複製）
+   └─ ACM 検証用 CNAME（自動生成）
+   ↓
+[CloudFront]
+   ↓
+[Lambda Function URL]
+```
+
+### CDK 上の構成方針
+
+- **新規スタック**: `infra/shared/lib/route53-stack.ts` を追加し、`HostedZone` を 1 つ作成
+- **既存 ACM スタック**: 検証方式を `CertificateValidation.fromDns(hostedZone)` に置換
+- **共通 CloudFront スタック**: `aws-route53-targets` の `CloudFrontTarget` を使った `ARecord` を追加
+- **SSM 参照**: ホストゾーン ID を SSM Parameter (`/nagiyu/shared/route53/hosted-zone-id`) に保存し、各サービススタックから参照
+
+## 4. フェーズ計画
+
+各フェーズは **個別の Issue / 個別の PR** として切り、`integration/2902-route53-migration` ブランチに段階的にマージしていく。
+
+### Phase 0: 既存 XServer DNS レコードの棚卸し（人力）
+
+**作業者**: 人力（Claude は XServer に到達不可）  
+**成果物**: `tasks/route53-migration/dns-inventory.md`
+
+XServer 管理画面で `nagiyu.com` の全 DNS レコードを抜き出し、本リポジトリに記録する。
+
+- A / AAAA / CNAME / MX / TXT / SRV / NS（サブゾーン委任があれば）すべて
+- 特に注意:
+    - メール系: MX, SPF (TXT), DKIM (TXT), DMARC (TXT)
+    - 既存 CloudFront 向け CNAME（18 サブドメイン分）
+    - ACM 検証 CNAME（`_xxx.nagiyu.com`）
+    - Google Workspace 等の所有権確認 TXT がある場合
+- TTL も併記する（Phase 3 で短縮するため）
+
+**ブロック条件**: 本フェーズの完了が Phase 2 開始の前提。
+
+### Phase 1: Route53 ホストゾーン作成（CDK）
+
+**作業者**: Claude  
+**ブランチ**: `claude/2902-phase1-hosted-zone`  
+**スタック**: `infra/shared/lib/route53-stack.ts`（新規）
+
+- `HostedZone` リソースを 1 つ作成（`nagiyu.com`）
+- ホストゾーン ID を SSM (`/nagiyu/shared/route53/hosted-zone-id`) と CfnOutput で公開
+- **NS 切替はしない**。この時点ではホストゾーンは未参照状態で AWS 上に存在するだけ
+- Route53 が払い出した 4 つの NS レコードを記録（Phase 4 で使用）
+
+**検証**: CDK deploy 後、`aws route53 list-hosted-zones` でホストゾーンが存在し、`aws route53 get-hosted-zone --id <id>` で 4 つの NS が取得できること。
+
+**リスク**: 極低（既存 DNS には影響しない）
+
+### Phase 2: 既存レコードを Route53 に複製（CDK）
+
+**作業者**: Claude  
+**ブランチ**: `claude/2902-phase2-copy-records`  
+**前提**: Phase 0 の棚卸し完了、Phase 1 のホストゾーン作成完了
+
+- Phase 0 の棚卸し結果を CDK で `route53.RecordSet` として全て定義
+    - メール系（MX / TXT 等）
+    - 既存 CloudFront 向け CNAME（NS 切替後に ALIAS に置換するため、一旦 CNAME のまま複製）
+    - その他カスタムレコード
+- ACM 検証 CNAME は Phase 5 で自動化するためここでは複製しない（既存証明書はそのまま流用）
+- TTL は **300 秒**で統一（NS 切替時の影響時間を最小化）
+
+**検証**: `dig @<route53-ns> nagiyu.com MX +short` 等で Route53 側に正しいレコードが返ることを確認（NS 切替前でも Route53 NS を直接指定すれば確認可能）
+
+**リスク**: 低（NS 切替前なので利用者影響なし）
+
+### Phase 3: XServer 側 TTL 短縮（人力）
+
+**作業者**: 人力（XServer 管理画面）  
+**所要時間**: TTL 短縮後 24h 待機
+
+- XServer の全レコードの TTL を 300 秒に短縮
+- 24h 待機して、世界中のキャッシュが短い TTL を吸収するのを待つ
+- これにより Phase 4 のロールバック時の影響時間を最小化できる
+
+**リスク**: 低
+
+### Phase 4: NS 切替（人力・最大リスクポイント）
+
+**作業者**: 人力（XServer 管理画面 + 監視）  
+**所要時間**: 切替自体は数分。世界中の伝播完了まで TTL 分（300 秒〜数十分）
+
+- XServer のドメイン管理画面で `nagiyu.com` のネームサーバを Route53 のもの（Phase 1 で記録した 4 つ）に変更
+- 切替直後から、世界中の DNS リゾルバが順次 Route53 を参照するようになる
+
+**事前準備**:
+- メンテナンス時間の確保（深夜帯推奨）
+- 切戻し手順の確認（XServer NS に戻すだけ）
+- 監視体制
+    - 全サービスの HTTPS 疎通確認スクリプト
+    - メール送受信テスト
+
+**ロールバック条件**:
+- 主要サービスの HTTPS が一定時間応答しない
+- メール送受信が止まる
+- いずれの場合も XServer の NS を元に戻す
+
+**リスク**: 高（メール・サイト全停止リスク。Phase 0 の棚卸し漏れがここで顕在化する）
+
+### Phase 5: ACM 検証を Route53 自動化に置換（CDK）
+
+**作業者**: Claude  
+**ブランチ**: `claude/2902-phase5-acm-auto-validation`  
+**前提**: Phase 4 完了
+
+- `infra/shared/lib/acm-stack.ts` を改修
+    - `CertificateValidation.fromDns()` → `CertificateValidation.fromDns(hostedZone)`
+    - `route53.IHostedZone` を SSM 経由で参照
+- 既存証明書はそのまま流用可能（検証レコードが Route53 に自動作成されるだけ）
+- 既存の手動 CNAME（XServer から複製したもの）は削除可能（証明書更新前に削除しても、ACM が自動で新しい検証 CNAME を作る）
+
+**検証**: `aws acm describe-certificate` でステータスが `ISSUED` のままであること、証明書更新時に手動操作が不要なことを確認（更新タイミングは有効期限の 60 日前から）
+
+**リスク**: 中（証明書の状態を直接いじるわけではないが、誤って既存証明書を再作成してしまうと一時的に CloudFront が証明書なしになる可能性 → CDK diff で慎重に確認）
+
+### Phase 6: CloudFront 紐付けを ALIAS に置換、ドキュメント更新（CDK）
+
+**作業者**: Claude  
+**ブランチ**: `claude/2902-phase6-alias-records`  
+**前提**: Phase 5 完了
+
+- `infra/common/src/stacks/cloudfront-stack-base.ts` を改修
+    - 各サービスの CloudFront ディストリビューションに対応する `ARecord (ALIAS)` を Route53 ホストゾーンに自動追加
+    - ホストゾーンは SSM 経由で参照（クロススタック参照）
+- `infra/root/` の apex CloudFront も同様に ALIAS で `nagiyu.com` を直接向ける（CNAME では apex に貼れない問題が解消）
+- Phase 2 で複製した CNAME レコードは ALIAS に置き換えるため、CDK で削除する
+- ドキュメント更新:
+    - `docs/infra/shared/route53.md` を新規作成
+    - `docs/infra/shared/acm.md` を Route53 自動検証ベースに更新
+    - `docs/infra/shared/cloudfront.md` のカスタムドメイン手順を更新
+    - `docs/infra/architecture.md` の DNS レイヤを更新
+- `tasks/route53-migration/` を削除
+
+**検証**: 全サービス（prod / dev 計 18 + apex 2）の HTTPS 疎通確認
+
+**リスク**: 中（CDK の差分が大きくなりやすい。サービスごとに小さく PR を分ける案も検討）
+
+## 5. 完了条件
+
+- [ ] `nagiyu.com` の権威 DNS が Route53 に切り替わっている
+- [ ] 全サービス（prod / dev 計 18 サブドメイン + apex 2）が Route53 ALIAS 経由で正常稼働している
+- [ ] メール系（MX 等）が NS 切替後も正常に動作している
+- [ ] ACM 証明書の DNS 検証が Route53 で自動化されている
+- [ ] 新サービス追加時に XServer 管理画面を触る必要がないことが確認できている
+- [ ] `docs/infra/` 配下のドキュメントが Route53 運用に更新されている
+- [ ] `tasks/route53-migration/` が削除されている
+
+## 6. リスク・ロールバック
+
+| リスク | 対策 |
+|---|---|
+| Phase 4 の NS 切替でメール停止 | Phase 0 の棚卸しを徹底。Phase 3 で TTL 短縮。切戻し手順を事前にドリル |
+| Phase 0 の棚卸し漏れ | XServer 管理画面のスクリーンショット + `dig` 系コマンドでクロスチェック |
+| Phase 5 で証明書を誤って再作成 | `cdk diff` で `Certificate` リソースの replacement が発生しないことを確認 |
+| Phase 6 で CloudFront 紐付けが切れる | 1 サービスずつ PR を分け、dev で先行検証してから prod に展開 |
+| Route53 の月額コスト | $0.50/月 + クエリ課金。本件規模では誤差レベル |
+
+## 7. コスト見積もり
+
+- Route53 ホストゾーン: $0.50 / 月
+- Route53 クエリ: $0.40 / 100 万件（本件規模では月数十万件想定 → $0.10 未満）
+- 合計: **概ね $0.60 / 月（≒ 90 円）**
+
+## 8. スコープ外
+
+- ドメインレジストラの Route53 移管（XServer に残す）
+- 別ドメイン（仮にあれば）の Route53 化
+- DNSSEC の導入
+- ヘルスチェック / フェイルオーバー / レイテンシベースルーティング等の高度機能
+
+## 9. 関連 Issue / ドキュメント
+
+- 親 Issue: #2902
+- ACM 現状: [`docs/infra/shared/acm.md`](../../docs/infra/shared/acm.md)
+- CloudFront 現状: [`docs/infra/shared/cloudfront.md`](../../docs/infra/shared/cloudfront.md)
+- アーキテクチャ全体: [`docs/infra/architecture.md`](../../docs/infra/architecture.md)


### PR DESCRIPTION
## 変更の概要

Issue #2902（Route53 全面移行 / パターン C）の事前準備として、6 フェーズに分けた段階的な移行計画を `tasks/route53-migration/plan.md` に文書化した。Phase 0（XServer DNS レコードの人力棚卸し）の受け皿として `dns-inventory.md` テンプレートも併せて追加。

実装変更（CDK 等）は本 PR には含まず、計画ドキュメントのみ。Phase 1 以降は本計画に従って別 Issue / 別 PR で進める。

## 関連 Issue

親 Issue: #2902

<!-- Issue は integration → develop マージ時にクローズするため、本 PR では Closes は使わない -->

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した（ドキュメントのみ）
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）— 本 PR は計画ドキュメントのため対象外
- [x] 関連ドキュメントを更新した（`tasks/route53-migration/` に新規追加）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）— 対象外
- [x] ローカルでテストが全て通ることを確認した（実装変更なし）
- [x] ビルドエラーがないことを確認した（実装変更なし）

## テスト内容

実装変更なし（ドキュメントのみ）のため、テスト対象外。

## レビューポイント

- **フェーズ分割の妥当性**: Phase 0〜6 の粒度・順序が適切か
- **Phase 4 の NS 切替リスク**: 切戻し条件・メンテ時間の確保について事前合意したい
- **スコープ**: ドメインレジストラ移管・DNSSEC・ヘルスチェック等は本計画スコープ外としてよいか
- **Phase 0 の棚卸し**: `dns-inventory.md` テンプレートで網羅されているか（メール系の TXT を特に確認したい）
- **コスト見積もり**: 月額 $0.60 程度の認識で問題ないか

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

- 本計画は Issue #2902 のディスカッションを踏まえて作成
- 各フェーズの実装着手前に、本計画書をベースに子 Issue を起票する
- `tasks/route53-migration/` 配下は移行完了後（Phase 6 末）に削除予定
- 重要な内容は移行完了時に以下へ統合する想定:
  - `docs/infra/shared/route53.md`（新規）
  - `docs/infra/shared/acm.md`（DNS 検証手順を更新）
  - `docs/infra/shared/cloudfront.md`（カスタムドメイン手順を更新）
  - `docs/infra/architecture.md`（DNS レイヤを更新）

---
_Generated by [Claude Code](https://claude.ai/code/session_014bCDuav9LBzoFjhzrdZSUP)_