### PR TITLE
fix: Stock Tracker batch Lambda のハンドラパスを dist/src/ 構造に修正

### DIFF
--- a/infra/stock-tracker/lib/lambda-stack.ts
+++ b/infra/stock-tracker/lib/lambda-stack.ts
@@ -152,7 +152,7 @@ export class LambdaStack extends cdk.Stack {
       runtime: lambda.Runtime.FROM_IMAGE,
       code: lambda.Code.fromEcrImage(batchRepository, {
         tagOrDigest: 'latest',
-        cmd: ['services/stock-tracker/batch/dist/minute.handler'],
+        cmd: ['services/stock-tracker/batch/dist/src/minute.handler'],
       }),
       handler: lambda.Handler.FROM_IMAGE,
       role: batchExecutionRole,
@@ -176,7 +176,7 @@ export class LambdaStack extends cdk.Stack {
       runtime: lambda.Runtime.FROM_IMAGE,
       code: lambda.Code.fromEcrImage(batchRepository, {
         tagOrDigest: 'latest',
-        cmd: ['services/stock-tracker/batch/dist/hourly.handler'],
+        cmd: ['services/stock-tracker/batch/dist/src/hourly.handler'],
       }),
       handler: lambda.Handler.FROM_IMAGE,
       role: batchExecutionRole,
@@ -200,7 +200,7 @@ export class LambdaStack extends cdk.Stack {
       runtime: lambda.Runtime.FROM_IMAGE,
       code: lambda.Code.fromEcrImage(batchRepository, {
         tagOrDigest: 'latest',
-        cmd: ['services/stock-tracker/batch/dist/summary.handler'],
+        cmd: ['services/stock-tracker/batch/dist/src/summary.handler'],
       }),
       handler: lambda.Handler.FROM_IMAGE,
       role: batchExecutionRole,
@@ -222,7 +222,7 @@ export class LambdaStack extends cdk.Stack {
       runtime: lambda.Runtime.FROM_IMAGE,
       code: lambda.Code.fromEcrImage(batchRepository, {
         tagOrDigest: 'latest',
-        cmd: ['services/stock-tracker/batch/dist/daily.handler'],
+        cmd: ['services/stock-tracker/batch/dist/src/daily.handler'],
       }),
       handler: lambda.Handler.FROM_IMAGE,
       role: batchExecutionRole,
@@ -247,7 +247,7 @@ export class LambdaStack extends cdk.Stack {
         runtime: lambda.Runtime.FROM_IMAGE,
         code: lambda.Code.fromEcrImage(batchRepository, {
           tagOrDigest: 'latest',
-          cmd: ['services/stock-tracker/batch/dist/temporary-alert-expiry.handler'],
+          cmd: ['services/stock-tracker/batch/dist/src/temporary-alert-expiry.handler'],
         }),
         handler: lambda.Handler.FROM_IMAGE,
         role: batchExecutionRole,

--- a/services/stock-tracker/batch/Dockerfile
+++ b/services/stock-tracker/batch/Dockerfile
@@ -52,5 +52,5 @@ COPY --from=builder /app/services/stock-tracker/batch/package*.json ./services/s
 COPY --from=builder /app/services/stock-tracker/batch/dist ./services/stock-tracker/batch/dist
 
 # Lambda ハンドラーを指定
-# CMD は CDK の cmd オプションで上書きされる (例: services/stock-tracker/batch/dist/minute.handler)
-CMD ["services/stock-tracker/batch/dist/minute.handler"]
+# CMD は CDK の cmd オプションで上書きされる (例: services/stock-tracker/batch/dist/src/minute.handler)
+CMD ["services/stock-tracker/batch/dist/src/minute.handler"]


### PR DESCRIPTION
## 変更の概要

Stock Tracker batch Lambda 5 関数（minute / hourly / summary / daily / temporary-alert-expiry）が `Runtime.ImportModuleError: Cannot find module 'minute'` で全停止していた不具合を修正する。

PR #2829 の `tsconfig` 修正により batch のビルド出力が `dist/<name>.js` → `dist/src/<name>.js` に変わったが、Lambda の handler 指定（CDK の `cmd` と Dockerfile の `CMD`）が旧パスのまま残っていたのが原因。

## 関連 Issue

Issue 番号は integration → develop のマージ時に閉じる方針のため、本 PR では `Closes #` を付けない。

関連: nagiyu/nagiyu-platform#2917

## 変更種別

- [x] バグ修正
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）
  - 本修正は CDK の `cmd` 文字列と Dockerfile の `CMD` の修正のみで、ロジック変更はない。テスト追加は不要と判断
- [x] 関連ドキュメントを更新した（更新不要）
- [x] CI/CD 設定を追加・更新した（更新不要）
- [ ] ローカルでテストが全て通ることを確認した（CI に委譲）
- [ ] ビルドエラーがないことを確認した（CI に委譲）

## テスト内容

- 自動テストは追加していない（文字列リテラルの 1 対 1 修正のため）
- 検証は dev 環境デプロイ後の CloudWatch Logs で `Runtime.ImportModuleError` が消失することをもって行う

## レビューポイント

### 1. 修正対象の妥当性

- 5 つの batch Lambda の `cmd` を `dist/<name>.handler` → `dist/src/<name>.handler` に修正
- `services/stock-tracker/batch/package.json` の `"main": "dist/src/minute.js"` と整合する
- `tsconfig.json` を再度 `rootDir: "./src"` に戻す案もあるが、PR #2829 で意図的に `"."` に揃えた経緯（CI の verify workflow で `Cannot find module '@nagiyu/...'` を解消）があるため、handler パス側を新構造に合わせる方針を採用した

### 2. Dockerfile の `CMD` 修正

- `CMD` は CDK の `cmd` で上書きされるため動作上は影響しないが、整合性のため新パスに更新した

### 3. 他サービスへの波及

- 同 tsconfig 修正は `codec-converter/batch`, `quick-clip/batch` 等にも適用済み。それらの Lambda 起動状況も別途要確認（本 PR スコープ外）

## スクリーンショット（該当する場合）

なし（UI 変更なし）

## 補足事項

- 本番反映後、CloudWatch Logs `/aws/lambda/nagiyu-stock-tracker-batch-{minute,hourly,summary,daily,temporary-alert-expiry}-prod` でエラー収束を確認すること
- dev 環境では integration ブランチのデプロイ後に同様に確認可能


---
_Generated by [Claude Code](https://claude.ai/code/session_016CVctyuD6SSo9uAFJEdAqC)_