### PR TITLE
share-together: E2E (chromium-mobile) の慢性的な flaky を構造的に解消

### DIFF
--- a/services/share-together/web/playwright.config.ts
+++ b/services/share-together/web/playwright.config.ts
@@ -4,12 +4,24 @@ import { resolve } from 'path';
 
 config({ path: resolve(__dirname, '.env.test') });
 
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
@@ -20,6 +32,8 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
   projects: [
     {
@@ -53,9 +67,9 @@ export default defineConfig({
     return project.name === projectFilter;
   }),
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
     timeout: 2 * 60 * 1000,
   },
 });

--- a/services/share-together/web/src/components/TodoList.tsx
+++ b/services/share-together/web/src/components/TodoList.tsx
@@ -68,23 +68,37 @@ export function TodoList({ scope = 'personal', listId, groupId }: TodoListProps)
     fetchControllerRef.current?.abort();
     const controller = new AbortController();
     fetchControllerRef.current = controller;
+
     void globalThis
       .fetch(createTodosApiPath(scope, targetListId, groupId), { signal: controller.signal })
       .then(async (response) => {
-        fetchControllerRef.current = null;
         if (!response.ok) {
           throw new Error(`status: ${response.status}`);
         }
-        const result = (await response.json()) as TodosResponse;
+        return (await response.json()) as TodosResponse;
+      })
+      .then((result) => {
+        // mutation 等で abort 済みになった場合、レスポンスが先に届いていても state は更新しない。
+        // これにより GET レスポンスが mutation 後の最新 state を上書きする race を防ぐ。
+        if (controller.signal.aborted) {
+          return;
+        }
         setTodos(result.data.todos.map(toDisplayTodo));
       })
       .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
         if (error instanceof Error && error.name === 'AbortError') {
           return;
         }
-        fetchControllerRef.current = null;
         console.error(ERROR_MESSAGES.TODOS_FETCH_FAILED, { error, listId: targetListId });
         setSnackbarMessage(ERROR_MESSAGES.TODOS_FETCH_FAILED_NOTICE);
+      })
+      .finally(() => {
+        if (fetchControllerRef.current === controller) {
+          fetchControllerRef.current = null;
+        }
       });
   };
 

--- a/services/share-together/web/tests/e2e/group-shared-todo.spec.ts
+++ b/services/share-together/web/tests/e2e/group-shared-todo.spec.ts
@@ -72,9 +72,10 @@ test.describe('グループ共有 ToDo 管理', () => {
 
   test('共有リストに ToDo を追加できる', async ({ page }) => {
     await page.goto(`/lists?scope=shared&groupId=${GROUP_ID}&listId=${LIST_ID}`);
-    await page.waitForLoadState('networkidle');
+    const titleField = page.getByRole('textbox', { name: 'タイトル' });
+    await expect(titleField).toBeVisible();
     const todoTitle = `E2E 共有ToDo ${Date.now()}`;
-    await page.getByRole('textbox', { name: 'タイトル' }).fill(todoTitle);
+    await titleField.fill(todoTitle);
     await page.getByRole('button', { name: '追加' }).click();
 
     await expect(page.getByText(todoTitle)).toBeVisible();
@@ -83,7 +84,6 @@ test.describe('グループ共有 ToDo 管理', () => {
 
   test('共有リストの ToDo を完了にできる', async ({ page }) => {
     await page.goto(`/lists?scope=shared&groupId=${GROUP_ID}&listId=${LIST_ID}`);
-    await page.waitForLoadState('networkidle');
     await expect(page.getByText(EXISTING_TODO_TITLE)).toBeVisible();
 
     const checkbox = page
@@ -97,7 +97,6 @@ test.describe('グループ共有 ToDo 管理', () => {
 
   test('共有リストの ToDo を編集できる', async ({ page }) => {
     await page.goto(`/lists?scope=shared&groupId=${GROUP_ID}&listId=${LIST_ID}`);
-    await page.waitForLoadState('networkidle');
     await expect(page.getByText(EXISTING_TODO_TITLE)).toBeVisible();
 
     const updatedTitle = `編集後の共有タスク ${Date.now()}`;
@@ -113,7 +112,6 @@ test.describe('グループ共有 ToDo 管理', () => {
 
   test('共有リストの ToDo を削除できる', async ({ page }) => {
     await page.goto(`/lists?scope=shared&groupId=${GROUP_ID}&listId=${LIST_ID}`);
-    await page.waitForLoadState('networkidle');
     await expect(page.getByText(EXISTING_TODO_TITLE)).toBeVisible();
 
     const todoRow = page.getByRole('listitem').filter({ hasText: EXISTING_TODO_TITLE });
@@ -152,7 +150,6 @@ test.describe('グループ共有 ToDo 管理', () => {
 
   test('他メンバーの変更を更新操作で確認できる', async ({ page }) => {
     await page.goto(`/lists?scope=shared&groupId=${GROUP_ID}&listId=${LIST_ID}`);
-    await page.waitForLoadState('networkidle');
     await expect(page.getByText(EXISTING_TODO_TITLE)).toBeVisible();
   });
 

--- a/services/share-together/web/tests/e2e/personal-lists.spec.ts
+++ b/services/share-together/web/tests/e2e/personal-lists.spec.ts
@@ -272,7 +272,6 @@ test.describe('個人リスト管理', () => {
     });
 
     await page.goto('/lists?listId=list-default');
-    await page.waitForLoadState('networkidle');
     await expect(page.getByText('個人スコープToDo')).toBeVisible();
 
     const scopeSelect = page.getByRole('combobox', { name: '表示範囲' }).first();

--- a/services/share-together/web/tests/e2e/personal-todo.spec.ts
+++ b/services/share-together/web/tests/e2e/personal-todo.spec.ts
@@ -33,7 +33,6 @@ test.describe('個人 ToDo 管理', () => {
     });
 
     await page.goto('/lists?listId=list-default');
-    await page.waitForLoadState('networkidle');
     await expect(page.getByText('E2E 未完了 ToDo')).toBeVisible();
     await expect(page.getByRole('textbox', { name: 'タイトル' })).toBeVisible();
   });


### PR DESCRIPTION
## 変更の概要

share-together の E2E (chromium-mobile) で慢性的に発生していた flaky を、対症療法ではなく構造的に解消する。

最大要因は **E2E が `next dev` モードで実行されていた** こと。HMR / JIT コンパイル / React StrictMode の二重発火 / dev mode の重さがすべて race condition と `networkidle` 不安定化の温床になっていた。本番ビルドに対して `next start` を使うことで、これらをまとめて解消する。

### 対応サマリ

| # | 対応 | 効果 |
|---|---|---|
| A | CI 時の webServer を `npm run start`（本番ビルド済み）に切替 | 最大。HMR / JIT / StrictMode 二重発火を一掃 |
| B | spec から `waitForLoadState('networkidle')` を全廃し、要素単位の `expect(...).toBeVisible()` に置換 | 大。「特定要素の可視化」という意味的な待機に統一 |
| C | CI 用に test/expect/action/navigation の各タイムアウトを明示 | 中。CI 環境変動の吸収 |
| D | `TodoList.tsx` の GET 用 AbortController を整理。`controller.signal.aborted` で mutation 後の state 上書きをガード | 中。本番モードでも稀に起きうる race の根治 |

ローカル開発体験のため、`npm run dev` は `CI` 環境変数が無いときに維持。

## 関連 Issue

<!-- integration → develop の PR でのみ Closes を使う -->

Refs #2926

## 変更種別

- [x] バグ修正
- [x] CI/CD 更新

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存 spec の `networkidle` 削除、TodoList の GET ロジック修正）
- [ ] 関連ドキュメントを更新した（必要なし）
- [ ] CI/CD 設定を追加・更新した（既存ワークフローは build → test:e2e の順序のままで動作）
- [x] ローカルでビルド・lint・format・unit test が全て通ることを確認した
- [x] ローカルで `npm run start`（本番モード）の動作確認を実施

> Sandbox 制約により Playwright の chromium バージョン整合が取れず、ローカルでの E2E 実行は不可。CI 上で動作確認する。

## テスト内容

- ✅ `npm run format:check --workspace=@nagiyu/share-together-web`
- ✅ `npm run lint --workspace=@nagiyu/share-together-web`（既存 warning 1 件、本 PR では新規導入なし）
- ✅ `npm run test --workspace=@nagiyu/share-together-web`（204 passed）
- ✅ `npm run build --workspace=@nagiyu/share-together-web`
- ✅ `CI=true npm run start` で起動 → `/lists` HTTP 200、静的 chunk 200、`/api/test/reset` 200 を確認
- ✅ `npx playwright test --list --project=chromium-mobile` で 36 tests 認識を確認

## レビューポイント

1. **`next start` と `output: 'standalone'` の警告**
   Next.js 16.2.4 は `output: 'standalone'` 設定下で `npm run start` 実行時に「`next start` does not work with standalone」という warning を出すが、実動作は問題なし（HTTP 200 / 静的アセット 200 / API 200 を確認済み）。Docker 本番デプロイは standalone 経由で行われるため、`output: 'standalone'` 自体は維持。warning は CI ログに出るが機能影響なし。
   
2. **TodoList の AbortController 改修**
   レスポンス到着後に `.then` が走るタイミングで mutation により abort されているケースを `controller.signal.aborted` でガードするように変更。これにより GET レスポンスが mutation 後の最新 state を上書きする race を恒久的に防止。

3. **`retries: 2` は維持**
   CI のリソース変動による偶発的失敗の救済として残しているが、**retry に頼らず初回でパスする**状態を目標とする。

## 補足事項

- ローカル開発の `npm run dev` 体験は変更なし（HMR は維持）
- Issue #2926 のゴール「3 連続パス・5 連続 run で flaky 観測なし」の検証は CI 上で実施する
- Issue クローズは integration → develop マージ時に行う


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8j5tvq7RXpEG6BkeTHFaX)_