### PR TITLE
fix(ui): Storybook の JSX を自動ランタイムに明示設定

### DIFF
--- a/libs/ui/.storybook/main.ts
+++ b/libs/ui/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite';
+import { mergeConfig } from 'vite';
 
 /**
  * Storybook 設定
@@ -6,6 +7,11 @@ import type { StorybookConfig } from '@storybook/react-vite';
  * - Vite ビルダーで起動・ビルドを高速化
  * - Stories は src/ 配下のコンポーネント隣接配置を前提とする
  * - addon-themes でライト/ダーク切替、addon-a11y でアクセシビリティチェックを提供
+ *
+ * NOTE: `libs/ui/tsconfig.json` は Next.js 互換のため `jsx: 'preserve'` にして
+ * いる。Storybook（Vite）でビルドする際は React 17+ の自動 JSX ランタイムを
+ * 使うよう viteFinal で esbuild を明示設定し、`React.createElement` への
+ * 変換を回避する（`Can't find variable: React` エラー対策）。
  */
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx|mdx)'],
@@ -16,6 +22,14 @@ const config: StorybookConfig = {
   },
   typescript: {
     reactDocgen: 'react-docgen-typescript',
+  },
+  async viteFinal(config) {
+    return mergeConfig(config, {
+      esbuild: {
+        jsx: 'automatic',
+        jsxImportSource: 'react',
+      },
+    });
   },
 };
 


### PR DESCRIPTION
## 変更の概要

`dev-storybook.nagiyu.com` で Stories を開いた際に **「Can't find variable: React」** エラーで描画が失敗していた問題を修正する。

PR #2913 で deploy したスタックは正常稼働しており、CloudFront・Route53・S3 配信全て OK だが、Storybook 内部のバンドル設定不備でランタイムエラーが出ていた。

## 関連 Issue

Issue #2900 の Phase 0-2 / 0-3 で導入した Storybook の表示不具合修正。

## 変更種別

- [x] バグ修正

## 原因

- `libs/ui/tsconfig.json` は Next.js 互換のため `jsx: 'preserve'` で設定
- `'preserve'` だと TypeScript は JSX を変換せず、ビルドツール（Vite）に委譲する想定
- 本来 `@vitejs/plugin-react` が自動 JSX ランタイム（`react/jsx-runtime`）に変換するはずだが、本ケースでは古いクラシックランタイム（`React.createElement`）にコンパイルされ、`React` グローバルを要求する状態になっていた
- 結果、ブラウザで `Can't find variable: React` 実行時エラー

## 対応

`.storybook/main.ts` の `viteFinal` フックで esbuild に明示的に automatic JSX ランタイムを指定:

```typescript
async viteFinal(config) {
  return mergeConfig(config, {
    esbuild: {
      jsx: 'automatic',
      jsxImportSource: 'react',
    },
  });
},
```

これにより JSX が `_jsx()` / `_jsxs()` に変換され、`React` グローバルへの依存がなくなる。

## 確認内容

- `npm run build-storybook` 成功
- `ErrorAlert.stories` バンドルから `bare React 参照ゼロ`、`createElement` も MUI 内部由来のもの（minify された`re.createElement` で適切に import 済み）のみ
- ストーリー内のコンポーネント呼び出しは全て `jsx()` / `jsxs()` に変換されていることを確認
- 既存テスト 135 件全成功

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（設定変更のため対象外、既存テスト全成功で代替）
- [x] 関連ドキュメントを更新した（コード内コメントで意図を明示）
- [x] ローカルでテストが全て通ることを確認した（135 テスト全成功）
- [x] ビルドエラーがないことを確認した（`npm run build-storybook` 成功）

## レビューポイント

- **viteFinal での esbuild 設定**: `@storybook/react-vite` がデフォルトで automatic ランタイムを使うはずだが、本環境では効かなかったため明示設定。設定の必要性を含めてコメントで意図を残している
- **副作用**: Storybook ビルドのみに影響し、`libs/ui` 本体のビルド・テスト・型は無変更

## デプロイ後の確認

PR マージ後 `integration/2900` にデプロイされると `dev-storybook.nagiyu.com` の Storybook が正しく表示される想定。`Existing/ErrorAlert/Default` で実コンポーネントが描画されればクリア。

## スクリーンショット

修正前: 「Can't find variable: React」エラーボックスが表示される（PR 作成者がスマホで確認済み）

修正後: ローカルビルドで描画問題なし。dev デプロイ後に視覚確認予定。

## 補足事項

- 本 PR は Draft で作成（CLAUDE.md フロー準拠）
- 引き続き Phase 0-4（テスト基盤強化）に進める想定


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_