### PR TITLE
fix(ui): Storybook canvas にデザイントークンの背景色を適用

### DIFF
--- a/libs/ui/.storybook/preview.css
+++ b/libs/ui/.storybook/preview.css
@@ -1,0 +1,32 @@
+/*
+ * Storybook プレビュー専用の CSS
+ *
+ * 目的:
+ *   `tokens.css` で定義した CSS 変数（`--color-bg-canvas` / `--color-fg-default` 等）
+ *   を実際にプレビュー画面に適用し、ライト/ダーク切替が視覚的に確認できる状態に
+ *   する。
+ *
+ * 実装上の注意:
+ *   MUI の `<CssBaseline />` が `body { background: theme.palette.background.default }`
+ *   を適用するため、bare の `body` セレクタでは specificity が同点で打ち勝てない。
+ *   `html[data-theme] body` で specificity を上げ、addon-themes が
+ *   `html[data-theme="..."]` を付与する前提で確実に適用する。
+ *
+ * 配置の意図:
+ *   本ファイルは Storybook プレビュー専用。サービス側の `tokens.css` は変数定義に
+ *   留めて副作用を持たせない方針のため、こちらに切り出している。
+ */
+
+html[data-theme] body {
+  background-color: var(--color-bg-canvas);
+  color: var(--color-fg-default);
+  transition:
+    background-color 200ms ease,
+    color 200ms ease;
+}
+
+/* Storybook の Docs ページ（autodocs）でも canvas トークンを反映させる */
+html[data-theme] .sbdocs.sbdocs-preview {
+  background-color: var(--color-bg-canvas);
+  color: var(--color-fg-default);
+}

--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import theme from '../src/styles/theme';
 
 import '../src/styles/tokens.css';
+import './preview.css';
 
 /**
  * Storybook グローバル設定


### PR DESCRIPTION
## 変更の概要

Storybook ツールバーで light ↔ dark を切り替えたとき、**キャンバス背景色が変わらない**問題を修正する。

PR #2928 で JSX エラーは解消し Stories が描画されるようになったが、視覚的なテーマ切替が確認できない状態だった。

## 関連 Issue

Issue #2900 の Phase 0-1 / 0-2 の補完。

## 変更種別

- [x] バグ修正

## 原因

| 層 | 状態 |
|---|---|
| `tokens.css` | CSS 変数を **定義**するだけ。`[data-theme='dark']` で値が切り替わる仕組みは入っているが、適用する箇所が無い |
| `addon-themes` | `html[data-theme="..."]` を切替する（OK） |
| MUI `<CssBaseline />` | `body { background: theme.palette.background.default }` を適用 → palette は具体値 `#fafafa` 固定 → **トークンの切替が視覚反映されない** |

## 対応

`.storybook/preview.css` を新規追加し、`html[data-theme]` セレクタで CSS 変数をプレビュー画面に適用:

```css
html[data-theme] body {
  background-color: var(--color-bg-canvas);
  color: var(--color-fg-default);
  transition: background-color 200ms ease, color 200ms ease;
}
```

- `html[data-theme]` で specificity を底上げし、CssBaseline の bare `body` より優先される
- `transition` を入れて切替時にスムーズなフェードが見える
- Docs ページ（autodocs）の `.sbdocs-preview` にも同等の rule を適用

## 設計判断の意図

**`tokens.css` 自体には body スタイルを書かない**:
- `tokens.css` は変数定義だけに留めることで「サービス側で使用方法を強制しない」設計を維持
- Storybook プレビュー固有の表示挙動は `.storybook/` 配下に閉じ込め、責務分離を保つ

## 確認内容

- `npm run build-storybook` 成功
- バンドル後の CSS に `html[data-theme] body` ルールが含まれていることを確認
- 既存テスト 135 件全成功

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（プレビュー専用 CSS のため対象外）
- [x] 関連ドキュメントを更新した（CSS 内コメントで設計意図を明示）
- [x] ローカルでテストが全て通ることを確認した（135 テスト全成功）
- [x] ビルドエラーがないことを確認した

## レビューポイント

- **selectors の specificity**: `html[data-theme] body` で CssBaseline の `body` より優先される設計
- **配置場所**: tokens.css ではなく `.storybook/preview.css` に切り出した判断
- **MUI Alert などは依然 dark 切替に追従しない**: これは設計通り（PR 0-1 の MUI palette 制約）。本 PR で対応する範囲はキャンバス背景のみ

## デプロイ後の確認

integration → develop デプロイ後、`https://dev-storybook.nagiyu.com` で Storybook ツールバーから light ↔ dark を切り替えると、**キャンバス背景がグレー ↔ ダークグレーに切り替わる**のが見える想定。

MUI Alert の赤色は引き続き変わらない（これは仕様）。

## 補足事項

- 本 PR は Draft で作成（CLAUDE.md フロー準拠）
- 引き続き Phase 0-4（テスト基盤強化）に進める想定


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_