### PR TITLE
feat(ui): Button コンポーネント追加（PR 1-1-A）

### DIFF
--- a/libs/ui/jest.config.ts
+++ b/libs/ui/jest.config.ts
@@ -20,6 +20,11 @@ const config: Config.InitialOptions = {
   },
   // Setup testing library
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
+  // CSS Modules: クラス名そのものを返すプロキシで `styles.foo === 'foo'` とする。
+  // ユニットテストはクラス名の存在確認に留めるため、ハッシュ化前の値で十分。
+  moduleNameMapper: {
+    '\\.module\\.css$': 'identity-obj-proxy',
+  },
   // Common coverage settings
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -41,10 +41,12 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@nagiyu/browser": "*"
+    "@nagiyu/browser": "*",
+    "@radix-ui/react-slot": "^1.2.4"
   },
   "devDependencies": {
     "@types/jest-axe": "^3.5.9",
+    "identity-obj-proxy": "^3.0.0",
     "jest-axe": "^10.0.0"
   }
 }

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@types/jest-axe": "^3.5.9",
-    "identity-obj-proxy": "^3.0.0",
     "jest-axe": "^10.0.0"
   }
 }

--- a/libs/ui/scripts/copy-assets.mjs
+++ b/libs/ui/scripts/copy-assets.mjs
@@ -1,23 +1,49 @@
 /**
  * tsc 後に CSS 等の非 TypeScript アセットを dist/ に複製するスクリプト。
  *
- * tsc は CSS ファイルを処理しないため、CSS で配布したいトークン定義などは
- * 本スクリプトで明示的に dist/ に複製する必要がある。
+ * tsc は CSS ファイルを処理しないため、CSS で配布したいトークン定義や
+ * コンポーネントの CSS Modules は本スクリプトで明示的に dist/ に複製する。
+ *
+ * - 単発ファイル: tokens.css 等の固定アセット
+ * - パターン: src/ 配下の `*.module.css` を再帰的に検索し、同じ相対パスで dist/ にコピー
  */
 
-import { copyFileSync, mkdirSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { copyFileSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 
-const assets = [{ from: 'src/styles/tokens.css', to: 'dist/src/styles/tokens.css' }];
+const fixedAssets = [{ from: 'src/styles/tokens.css', to: 'dist/src/styles/tokens.css' }];
 
-for (const { from, to } of assets) {
+for (const { from, to } of fixedAssets) {
   const src = resolve(root, from);
   const dest = resolve(root, to);
   mkdirSync(dirname(dest), { recursive: true });
   copyFileSync(src, dest);
   console.log(`copied: ${from} -> ${to}`);
 }
+
+/**
+ * src/ 配下を再帰的に走査し、`*.module.css` を dist/src/ に複製する。
+ */
+function copyModuleCss(currentDir) {
+  const entries = readdirSync(currentDir);
+  for (const entry of entries) {
+    const fullPath = join(currentDir, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      copyModuleCss(fullPath);
+      continue;
+    }
+    if (!entry.endsWith('.module.css')) continue;
+    const rel = relative(root, fullPath);
+    const dest = resolve(root, 'dist', rel);
+    mkdirSync(dirname(dest), { recursive: true });
+    copyFileSync(fullPath, dest);
+    console.log(`copied: ${rel} -> ${relative(root, dest)}`);
+  }
+}
+
+copyModuleCss(resolve(root, 'src'));

--- a/libs/ui/src/components/Button/Button.module.css
+++ b/libs/ui/src/components/Button/Button.module.css
@@ -1,0 +1,216 @@
+/*
+ * Button コンポーネントのスタイル定義。
+ *
+ * - すべての色・余白・角丸は tokens.css の Semantic 変数を参照する。
+ * - MUI 等の特定ライブラリへの依存は持たない（@nagiyu/ui の独立性を保つ）。
+ * - 状態は `:hover` / `:focus-visible` / `:active` / `[aria-disabled]` で表現。
+ */
+
+.button {
+  /* Layout */
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+
+  /* Typography */
+  font-family: var(--font-family-sans);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-tight);
+  text-decoration: none;
+  white-space: nowrap;
+
+  /* Box */
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color var(--duration-fast) var(--easing-out),
+    border-color var(--duration-fast) var(--easing-out),
+    color var(--duration-fast) var(--easing-out),
+    box-shadow var(--duration-fast) var(--easing-out);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-action-primary);
+  outline-offset: 2px;
+}
+
+/* =========================================================================
+ * Size
+ * ========================================================================= */
+
+.size-sm {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  min-height: 32px;
+}
+
+.size-md {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-md);
+  min-height: 40px;
+}
+
+.size-lg {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-size: var(--font-size-lg);
+  min-height: 48px;
+}
+
+/* =========================================================================
+ * Variant × Color
+ *
+ * 色は CSS カスタムプロパティ `--btn-*` に解決し、各 variant でその値を使う。
+ * これにより色追加時は `.color-*` を 1 つ書けばよい構成にする。
+ * ========================================================================= */
+
+.color-primary {
+  --btn-bg: var(--color-action-primary);
+  --btn-bg-hover: var(--color-action-primary-hover);
+  --btn-bg-active: var(--color-action-primary-active);
+  --btn-fg: var(--color-action-primary-fg);
+  --btn-border: var(--color-action-primary);
+}
+
+.color-secondary {
+  --btn-bg: var(--color-action-secondary);
+  --btn-bg-hover: var(--color-action-secondary-hover);
+  --btn-bg-active: var(--color-action-secondary-active);
+  --btn-fg: var(--color-action-secondary-fg);
+  --btn-border: var(--color-action-secondary);
+}
+
+.color-danger {
+  --btn-bg: var(--color-action-danger);
+  --btn-bg-hover: var(--color-action-danger-hover);
+  --btn-bg-active: var(--color-action-danger-active);
+  --btn-fg: var(--color-action-danger-fg);
+  --btn-border: var(--color-action-danger);
+}
+
+.color-success {
+  --btn-bg: var(--color-action-success);
+  --btn-bg-hover: var(--color-action-success-hover);
+  --btn-bg-active: var(--color-action-success-active);
+  --btn-fg: var(--color-action-success-fg);
+  --btn-border: var(--color-action-success);
+}
+
+.color-warning {
+  --btn-bg: var(--color-action-warning);
+  --btn-bg-hover: var(--color-action-warning-hover);
+  --btn-bg-active: var(--color-action-warning-active);
+  --btn-fg: var(--color-action-warning-fg);
+  --btn-border: var(--color-action-warning);
+}
+
+.color-neutral {
+  --btn-bg: var(--color-action-neutral);
+  --btn-bg-hover: var(--color-action-neutral-hover);
+  --btn-bg-active: var(--color-action-neutral-active);
+  --btn-fg: var(--color-action-neutral-fg);
+  --btn-border: var(--color-border-default);
+}
+
+/* solid: 塗りつぶし */
+.variant-solid {
+  background-color: var(--btn-bg);
+  color: var(--btn-fg);
+  border-color: var(--btn-border);
+}
+
+.variant-solid:hover:not([aria-disabled='true']):not(:disabled) {
+  background-color: var(--btn-bg-hover);
+  border-color: var(--btn-bg-hover);
+}
+
+.variant-solid:active:not([aria-disabled='true']):not(:disabled) {
+  background-color: var(--btn-bg-active);
+  border-color: var(--btn-bg-active);
+}
+
+/* outline: 枠線のみ */
+.variant-outline {
+  background-color: transparent;
+  color: var(--btn-bg);
+  border-color: var(--btn-border);
+}
+
+.variant-outline:hover:not([aria-disabled='true']):not(:disabled) {
+  background-color: var(--btn-bg);
+  color: var(--btn-fg);
+}
+
+.variant-outline:active:not([aria-disabled='true']):not(:disabled) {
+  background-color: var(--btn-bg-active);
+  border-color: var(--btn-bg-active);
+  color: var(--btn-fg);
+}
+
+/* ghost: 背景なし */
+.variant-ghost {
+  background-color: transparent;
+  color: var(--btn-bg);
+  border-color: transparent;
+}
+
+.variant-ghost:hover:not([aria-disabled='true']):not(:disabled) {
+  background-color: var(--color-bg-subtle);
+}
+
+.variant-ghost:active:not([aria-disabled='true']):not(:disabled) {
+  background-color: var(--color-bg-subtle);
+  color: var(--btn-bg-active);
+}
+
+/* =========================================================================
+ * Disabled / Loading
+ * ========================================================================= */
+
+.disabled,
+.button:disabled,
+.button[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.loading {
+  cursor: wait;
+}
+
+.content {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.contentHidden {
+  visibility: hidden;
+}
+
+/* スピナー（CSS のみで実装し、SVG / 追加依存を避ける） */
+.spinner {
+  position: absolute;
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: var(--radius-full);
+  animation: button-spin 0.8s linear infinite;
+}
+
+@keyframes button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 2s;
+  }
+}

--- a/libs/ui/src/components/Button/Button.stories.tsx
+++ b/libs/ui/src/components/Button/Button.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import Button from './Button';
+
+/**
+ * `Button` は @nagiyu/ui の最小単位アクション部品。
+ *
+ * - `variant`（solid / outline / ghost）× `color`（6 種）× `size`（sm/md/lg）の直交した API
+ * - `loading` でスピナー、`asChild` で `<a>` 等への変身（Radix Slot）
+ *
+ * MUI への依存は内部で完全に隠蔽されている（Props 型は 100% 独自）。
+ */
+const meta: Meta<typeof Button> = {
+  title: 'Atoms/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'inline-radio',
+      options: ['solid', 'outline', 'ghost'],
+    },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'],
+    },
+    size: {
+      control: 'inline-radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    loading: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    asChild: { control: 'boolean' },
+    children: { control: 'text' },
+  },
+  args: {
+    variant: 'solid',
+    color: 'primary',
+    size: 'md',
+    children: 'ボタン',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  argTypes: { variant: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', gap: 12 }}>
+      <Button {...args} variant="solid">
+        solid
+      </Button>
+      <Button {...args} variant="outline">
+        outline
+      </Button>
+      <Button {...args} variant="ghost">
+        ghost
+      </Button>
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  argTypes: { color: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+      {(['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'] as const).map(
+        (color) => (
+          <Button {...args} key={color} color={color}>
+            {color}
+          </Button>
+        ),
+      )}
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  argTypes: { size: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <Button {...args} size="sm">
+        sm
+      </Button>
+      <Button {...args} size="md">
+        md
+      </Button>
+      <Button {...args} size="lg">
+        lg
+      </Button>
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  args: { loading: true, children: '送信中' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, children: '無効' },
+};
+
+export const AsChildLink: Story = {
+  args: { asChild: true, color: 'primary', variant: 'solid' },
+  render: (args) => (
+    <Button {...args}>
+      <a href="https://example.com" target="_blank" rel="noreferrer">
+        リンクとしてのボタン
+      </a>
+    </Button>
+  ),
+};
+
+/**
+ * variant × color のマトリクス（視覚回帰テスト・カタログ用途）。
+ */
+export const Matrix: Story = {
+  argTypes: { variant: { control: false }, color: { control: false } },
+  render: () => (
+    <div style={{ display: 'grid', gap: 12 }}>
+      {(['solid', 'outline', 'ghost'] as const).map((variant) => (
+        <div key={variant} style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+          {(
+            ['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'] as const
+          ).map((color) => (
+            <Button key={color} variant={variant} color={color}>
+              {variant}/{color}
+            </Button>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/libs/ui/src/components/Button/Button.stories.tsx
+++ b/libs/ui/src/components/Button/Button.stories.tsx
@@ -72,7 +72,7 @@ export const Colors: Story = {
           <Button {...args} key={color} color={color}>
             {color}
           </Button>
-        ),
+        )
       )}
     </div>
   ),
@@ -123,13 +123,13 @@ export const Matrix: Story = {
     <div style={{ display: 'grid', gap: 12 }}>
       {(['solid', 'outline', 'ghost'] as const).map((variant) => (
         <div key={variant} style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
-          {(
-            ['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'] as const
-          ).map((color) => (
-            <Button key={color} variant={variant} color={color}>
-              {variant}/{color}
-            </Button>
-          ))}
+          {(['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'] as const).map(
+            (color) => (
+              <Button key={color} variant={variant} color={color}>
+                {variant}/{color}
+              </Button>
+            )
+          )}
         </div>
       ))}
     </div>

--- a/libs/ui/src/components/Button/Button.tsx
+++ b/libs/ui/src/components/Button/Button.tsx
@@ -17,13 +17,7 @@ export type ButtonVariant = 'solid' | 'outline' | 'ghost';
 /**
  * Button の色（意味）。視覚的な色名（blue 等）ではなく必ず意味で指定する。
  */
-export type ButtonColor =
-  | 'primary'
-  | 'secondary'
-  | 'danger'
-  | 'success'
-  | 'warning'
-  | 'neutral';
+export type ButtonColor = 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'neutral';
 
 /**
  * Button のサイズ。
@@ -36,8 +30,7 @@ export type ButtonSize = 'sm' | 'md' | 'lg';
  * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
  * エスケープハッチは `className` のみ（`sx` / `style` は提供しない）。
  */
-export interface ButtonProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'> {
+export interface ButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'> {
   /**
    * バリアント。既定: `solid`
    */
@@ -85,7 +78,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
     'aria-disabled': ariaDisabled,
     ...rest
   },
-  ref,
+  ref
 ) {
   const Comp: React.ElementType = asChild ? Slot : 'button';
   const isDisabled = disabled || loading;

--- a/libs/ui/src/components/Button/Button.tsx
+++ b/libs/ui/src/components/Button/Button.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+
+import styles from './Button.module.css';
+
+/**
+ * Button のバリアント。
+ *
+ * - `solid`: 塗りつぶし（強調アクション）
+ * - `outline`: 枠線のみ（中位アクション）
+ * - `ghost`: 背景なし（弱い・補助アクション）
+ */
+export type ButtonVariant = 'solid' | 'outline' | 'ghost';
+
+/**
+ * Button の色（意味）。視覚的な色名（blue 等）ではなく必ず意味で指定する。
+ */
+export type ButtonColor =
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'success'
+  | 'warning'
+  | 'neutral';
+
+/**
+ * Button のサイズ。
+ */
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Button のプロパティ。
+ *
+ * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
+ * エスケープハッチは `className` のみ（`sx` / `style` は提供しない）。
+ */
+export interface ButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'> {
+  /**
+   * バリアント。既定: `solid`
+   */
+  variant?: ButtonVariant;
+  /**
+   * 色（意味）。既定: `primary`
+   */
+  color?: ButtonColor;
+  /**
+   * サイズ。既定: `md`
+   */
+  size?: ButtonSize;
+  /**
+   * ローディング中はスピナーを表示し、操作を抑止する。
+   */
+  loading?: boolean;
+  /**
+   * `true` の場合、Radix Slot により子要素に Props をマージする。
+   * 子要素は単一の React 要素である必要がある（`<a>` / `<Link>` 等）。
+   */
+  asChild?: boolean;
+}
+
+/**
+ * 汎用ボタンコンポーネント。
+ *
+ * - `variant` × `color` × `size` の直交した API
+ * - `loading` でスピナー表示（`aria-busy` 自動設定）
+ * - `asChild` でリンク等への変身に対応（Radix Slot パターン）
+ *
+ * @see docs/development/shared-ui-components.md
+ */
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = 'solid',
+    color = 'primary',
+    size = 'md',
+    loading = false,
+    asChild = false,
+    disabled,
+    className,
+    children,
+    type,
+    'aria-busy': ariaBusy,
+    'aria-disabled': ariaDisabled,
+    ...rest
+  },
+  ref,
+) {
+  const Comp: React.ElementType = asChild ? Slot : 'button';
+  const isDisabled = disabled || loading;
+
+  const classes = [
+    styles.button,
+    styles[`variant-${variant}`],
+    styles[`color-${color}`],
+    styles[`size-${size}`],
+    loading ? styles.loading : null,
+    isDisabled ? styles.disabled : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  // asChild の場合、子要素は <button> とは限らないため `disabled` 属性は付与しない。
+  // 代わりに `aria-disabled` と CSS で操作抑止する。
+  const buttonProps = asChild
+    ? {
+        'aria-disabled': ariaDisabled ?? (isDisabled || undefined),
+        'aria-busy': ariaBusy ?? (loading || undefined),
+      }
+    : {
+        type: type ?? 'button',
+        disabled: isDisabled,
+        'aria-busy': ariaBusy ?? (loading || undefined),
+        'aria-disabled': ariaDisabled,
+      };
+
+  // asChild の場合、Radix Slot は単一の React 要素しか受け付けないため、
+  // 子要素をそのまま渡す。スピナー描画は通常モードに限定し、asChild + loading は
+  // `aria-busy` と `[aria-disabled]` 経由の視覚的減光（opacity）で表現する。
+  if (asChild) {
+    return (
+      <Comp ref={ref} className={classes} {...buttonProps} {...rest}>
+        {children}
+      </Comp>
+    );
+  }
+
+  return (
+    <Comp ref={ref} className={classes} {...buttonProps} {...rest}>
+      {loading ? (
+        <span className={styles.spinner} aria-hidden="true" data-testid="button-spinner" />
+      ) : null}
+      <span className={loading ? styles.contentHidden : styles.content}>{children}</span>
+    </Comp>
+  );
+});
+
+export default Button;

--- a/libs/ui/src/components/Button/index.ts
+++ b/libs/ui/src/components/Button/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from './Button';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -2,6 +2,13 @@
 export { default as theme } from './styles/theme';
 export { tokens, breakpoints } from './styles/tokens';
 export type { ThemeMode, ColorRole, Size } from './styles/tokens';
+export { default as Button } from './components/Button';
+export type {
+  ButtonProps,
+  ButtonVariant,
+  ButtonColor,
+  ButtonSize,
+} from './components/Button';
 export { default as Header } from './components/layout/Header';
 export type { HeaderProps, NavigationItem } from './components/layout/Header';
 export { default as Footer } from './components/layout/Footer';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -3,12 +3,7 @@ export { default as theme } from './styles/theme';
 export { tokens, breakpoints } from './styles/tokens';
 export type { ThemeMode, ColorRole, Size } from './styles/tokens';
 export { default as Button } from './components/Button';
-export type {
-  ButtonProps,
-  ButtonVariant,
-  ButtonColor,
-  ButtonSize,
-} from './components/Button';
+export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from './components/Button';
 export { default as Header } from './components/layout/Header';
 export type { HeaderProps, NavigationItem } from './components/layout/Header';
 export { default as Footer } from './components/layout/Footer';

--- a/libs/ui/src/styles/tokens.css
+++ b/libs/ui/src/styles/tokens.css
@@ -223,6 +223,13 @@
   --color-action-info-subtle: var(--primitive-cyan-400);
   --color-action-info-fg: var(--primitive-white);
 
+  /* Action: neutral（淡いグレー基調・補助的アクション用） */
+  --color-action-neutral: var(--primitive-gray-200);
+  --color-action-neutral-hover: var(--primitive-gray-300);
+  --color-action-neutral-active: var(--primitive-gray-400);
+  --color-action-neutral-subtle: var(--primitive-gray-100);
+  --color-action-neutral-fg: var(--color-fg-default);
+
   /* Spacing */
   --spacing-xs: var(--primitive-space-1);
   --spacing-sm: var(--primitive-space-2);
@@ -344,4 +351,11 @@
   --color-action-info-active: var(--primitive-cyan-300);
   --color-action-info-subtle: var(--primitive-cyan-500);
   --color-action-info-fg: var(--primitive-gray-900);
+
+  /* Action: neutral */
+  --color-action-neutral: var(--primitive-gray-700);
+  --color-action-neutral-hover: var(--primitive-gray-600);
+  --color-action-neutral-active: var(--primitive-gray-500);
+  --color-action-neutral-subtle: var(--primitive-gray-800);
+  --color-action-neutral-fg: var(--color-fg-default);
 }

--- a/libs/ui/src/types/css-modules.d.ts
+++ b/libs/ui/src/types/css-modules.d.ts
@@ -1,0 +1,10 @@
+/**
+ * CSS Modules の型宣言。
+ *
+ * `*.module.css` を import すると、クラス名 → ハッシュ化された文字列の
+ * マップが返る。各キーは任意の文字列のため、緩く `Record<string, string>` で扱う。
+ */
+declare module '*.module.css' {
+  const classes: Record<string, string>;
+  export default classes;
+}

--- a/libs/ui/tests/unit/components/Button/Button.test.tsx
+++ b/libs/ui/tests/unit/components/Button/Button.test.tsx
@@ -33,7 +33,7 @@ describe('Button', () => {
       render(
         <Button variant="outline" color="danger" size="lg">
           x
-        </Button>,
+        </Button>
       );
       const btn = screen.getByRole('button');
       expect(btn.className).toContain('variant-outline');
@@ -65,7 +65,7 @@ describe('Button', () => {
       render(
         <Button onClick={onClick} disabled>
           x
-        </Button>,
+        </Button>
       );
       await user.click(screen.getByRole('button'));
       expect(onClick).not.toHaveBeenCalled();
@@ -77,7 +77,7 @@ describe('Button', () => {
       render(
         <Button onClick={onClick} loading>
           x
-        </Button>,
+        </Button>
       );
       await user.click(screen.getByRole('button'));
       expect(onClick).not.toHaveBeenCalled();
@@ -108,7 +108,7 @@ describe('Button', () => {
       render(
         <Button asChild color="primary" variant="solid">
           <a href="/dashboard">go</a>
-        </Button>,
+        </Button>
       );
       const link = screen.getByRole('link', { name: 'go' });
       expect(link.tagName).toBe('A');
@@ -121,7 +121,7 @@ describe('Button', () => {
       render(
         <Button asChild disabled>
           <a href="/x">go</a>
-        </Button>,
+        </Button>
       );
       const link = screen.getByRole('link');
       expect(link).toHaveAttribute('aria-disabled', 'true');
@@ -132,7 +132,7 @@ describe('Button', () => {
       render(
         <Button asChild loading>
           <a href="/x">go</a>
-        </Button>,
+        </Button>
       );
       expect(screen.getByRole('link')).toHaveAttribute('aria-busy', 'true');
     });
@@ -155,14 +155,7 @@ describe('Button', () => {
 
     it('全 variant / color / size の組み合わせで a11y 違反がない', async () => {
       const variants = ['solid', 'outline', 'ghost'] as const;
-      const colors = [
-        'primary',
-        'secondary',
-        'danger',
-        'success',
-        'warning',
-        'neutral',
-      ] as const;
+      const colors = ['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'] as const;
       const sizes = ['sm', 'md', 'lg'] as const;
 
       const { container } = render(
@@ -170,13 +163,18 @@ describe('Button', () => {
           {variants.flatMap((variant) =>
             colors.flatMap((color) =>
               sizes.map((size) => (
-                <Button key={`${variant}-${color}-${size}`} variant={variant} color={color} size={size}>
+                <Button
+                  key={`${variant}-${color}-${size}`}
+                  variant={variant}
+                  color={color}
+                  size={size}
+                >
                   {variant}-{color}-{size}
                 </Button>
-              )),
-            ),
+              ))
+            )
           )}
-        </div>,
+        </div>
       );
       const results = await axe(container);
       expect(results).toHaveNoViolations();

--- a/libs/ui/tests/unit/components/Button/Button.test.tsx
+++ b/libs/ui/tests/unit/components/Button/Button.test.tsx
@@ -1,0 +1,197 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import Button from '../../../../src/components/Button/Button';
+
+describe('Button', () => {
+  describe('rendering', () => {
+    it('children を表示する', () => {
+      render(<Button>保存</Button>);
+      expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument();
+    });
+
+    it('既定で type="button" が付与される（form 内での誤送信防止）', () => {
+      render(<Button>保存</Button>);
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+    });
+
+    it('明示された type を尊重する', () => {
+      render(<Button type="submit">送信</Button>);
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+    });
+
+    it('className を受け付け、内部クラスとマージされる', () => {
+      render(<Button className="custom-class">x</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('custom-class');
+      expect(btn.className).toContain('button');
+    });
+
+    it('variant / color / size の組み合わせをクラスに反映する', () => {
+      render(
+        <Button variant="outline" color="danger" size="lg">
+          x
+        </Button>,
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('variant-outline');
+      expect(btn.className).toContain('color-danger');
+      expect(btn.className).toContain('size-lg');
+    });
+
+    it('既定値（solid / primary / md）が適用される', () => {
+      render(<Button>x</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('variant-solid');
+      expect(btn.className).toContain('color-primary');
+      expect(btn.className).toContain('size-md');
+    });
+  });
+
+  describe('events', () => {
+    it('onClick が発火する', async () => {
+      const onClick = jest.fn();
+      const user = userEvent.setup();
+      render(<Button onClick={onClick}>x</Button>);
+      await user.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('disabled の時は onClick が発火しない', async () => {
+      const onClick = jest.fn();
+      const user = userEvent.setup();
+      render(
+        <Button onClick={onClick} disabled>
+          x
+        </Button>,
+      );
+      await user.click(screen.getByRole('button'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('loading の時は onClick が発火しない', async () => {
+      const onClick = jest.fn();
+      const user = userEvent.setup();
+      render(
+        <Button onClick={onClick} loading>
+          x
+        </Button>,
+      );
+      await user.click(screen.getByRole('button'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loading', () => {
+    it('スピナーを表示し、aria-busy を true にする', () => {
+      render(<Button loading>送信中</Button>);
+      const btn = screen.getByRole('button');
+      expect(btn).toHaveAttribute('aria-busy', 'true');
+      expect(screen.getByTestId('button-spinner')).toBeInTheDocument();
+    });
+
+    it('loading 時は disabled 属性も付与される', () => {
+      render(<Button loading>x</Button>);
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('loading でない時はスピナーを表示しない', () => {
+      render(<Button>x</Button>);
+      expect(screen.queryByTestId('button-spinner')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('asChild', () => {
+    it('子要素のタグをそのまま使い、props をマージする', () => {
+      render(
+        <Button asChild color="primary" variant="solid">
+          <a href="/dashboard">go</a>
+        </Button>,
+      );
+      const link = screen.getByRole('link', { name: 'go' });
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', '/dashboard');
+      expect(link.className).toContain('button');
+      expect(link.className).toContain('color-primary');
+    });
+
+    it('asChild + disabled では aria-disabled を付与し、disabled 属性は付けない', () => {
+      render(
+        <Button asChild disabled>
+          <a href="/x">go</a>
+        </Button>,
+      );
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+      expect(link).not.toHaveAttribute('disabled');
+    });
+
+    it('asChild + loading では aria-busy を付与する', () => {
+      render(
+        <Button asChild loading>
+          <a href="/x">go</a>
+        </Button>,
+      );
+      expect(screen.getByRole('link')).toHaveAttribute('aria-busy', 'true');
+    });
+  });
+
+  describe('ref', () => {
+    it('forwardRef で button 要素にアクセスできる', () => {
+      const ref = React.createRef<HTMLButtonElement>();
+      render(<Button ref={ref}>x</Button>);
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('既定状態で a11y 違反がない', async () => {
+      const { container } = render(<Button>保存</Button>);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('全 variant / color / size の組み合わせで a11y 違反がない', async () => {
+      const variants = ['solid', 'outline', 'ghost'] as const;
+      const colors = [
+        'primary',
+        'secondary',
+        'danger',
+        'success',
+        'warning',
+        'neutral',
+      ] as const;
+      const sizes = ['sm', 'md', 'lg'] as const;
+
+      const { container } = render(
+        <div>
+          {variants.flatMap((variant) =>
+            colors.flatMap((color) =>
+              sizes.map((size) => (
+                <Button key={`${variant}-${color}-${size}`} variant={variant} color={color} size={size}>
+                  {variant}-{color}-{size}
+                </Button>
+              )),
+            ),
+          )}
+        </div>,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('loading 状態でも a11y 違反がない', async () => {
+      const { container } = render(<Button loading>送信中</Button>);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('disabled 状態でも a11y 違反がない', async () => {
+      const { container } = render(<Button disabled>無効</Button>);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,10 +254,12 @@
       "name": "@nagiyu/ui",
       "version": "1.0.0",
       "dependencies": {
-        "@nagiyu/browser": "*"
+        "@nagiyu/browser": "*",
+        "@radix-ui/react-slot": "^1.2.4"
       },
       "devDependencies": {
         "@types/jest-axe": "^3.5.9",
+        "identity-obj-proxy": "^3.0.0",
         "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
@@ -5124,6 +5126,39 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@resvg/resvg-js": {
@@ -11643,6 +11678,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -11904,6 +11946,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ignore": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "dotenv": "^17.4.1",
         "eslint": "^10.2.0",
         "eslint-config-next": "^16.2.3",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
         "prettier": "^3.7.4",
@@ -259,7 +260,6 @@
       },
       "devDependencies": {
         "@types/jest-axe": "^3.5.9",
-        "identity-obj-proxy": "^3.0.0",
         "jest-axe": "^10.0.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dotenv": "^17.4.1",
     "eslint": "^10.2.0",
     "eslint-config-next": "^16.2.3",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
     "prettier": "^3.7.4",

--- a/services/admin/web/jest.config.ts
+++ b/services/admin/web/jest.config.ts
@@ -13,6 +13,8 @@ const config: Config = {
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
+    // @nagiyu/ui の CSS Modules import をスタブ化（クラス名そのものを返す）
+    '\\.module\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/ui$': '<rootDir>/../../../libs/ui/src/index.ts',
     '^@nagiyu/browser$': '<rootDir>/../../../libs/browser/src/index.ts',

--- a/services/auth/web/jest.config.ts
+++ b/services/auth/web/jest.config.ts
@@ -12,6 +12,8 @@ const config: Config = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
+    // @nagiyu/ui の CSS Modules import をスタブ化（クラス名そのものを返す）
+    '\\.module\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/auth-core$': '<rootDir>/../core/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',

--- a/services/portal/web/jest.config.ts
+++ b/services/portal/web/jest.config.ts
@@ -13,6 +13,8 @@ const config: Config = {
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
+    // @nagiyu/ui の CSS Modules import をスタブ化（クラス名そのものを返す）
+    '\\.module\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/ui$': '<rootDir>/../../libs/ui/src/index.ts',
     '^@nagiyu/browser$': '<rootDir>/../../libs/browser/src/index.ts',

--- a/services/quick-clip/web/jest.config.ts
+++ b/services/quick-clip/web/jest.config.ts
@@ -9,6 +9,8 @@ const config: Config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
   moduleNameMapper: {
+    // @nagiyu/ui の CSS Modules import をスタブ化（クラス名そのものを返す）
+    '\\.module\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/nextjs$': '<rootDir>/../../../libs/nextjs/src/index.ts',
     '^@nagiyu/nextjs/(.*)$': '<rootDir>/../../../libs/nextjs/src/$1.ts',

--- a/services/share-together/web/jest.config.ts
+++ b/services/share-together/web/jest.config.ts
@@ -6,6 +6,8 @@ const config: Config = {
   roots: ['<rootDir>/src', '<rootDir>/tests'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   moduleNameMapper: {
+    // @nagiyu/ui の CSS Modules import をスタブ化（クラス名そのものを返す）
+    '\\.module\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/share-together-core$': '<rootDir>/../core/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',

--- a/services/stock-tracker/web/jest.config.ts
+++ b/services/stock-tracker/web/jest.config.ts
@@ -6,6 +6,8 @@ const config: Config = {
   roots: ['<rootDir>/lib', '<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
   moduleNameMapper: {
+    // @nagiyu/ui の CSS Modules import をスタブ化（クラス名そのものを返す）
+    '\\.module\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/$1',
     '^@nagiyu/stock-tracker-core$': '<rootDir>/../core/src/index.ts',
     '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',

--- a/services/tools/jest.config.ts
+++ b/services/tools/jest.config.ts
@@ -13,6 +13,8 @@ const config: Config = {
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
+    // @nagiyu/ui の CSS Modules import をスタブ化（クラス名そのものを返す）
+    '\\.module\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/ui$': '<rootDir>/../../libs/ui/src/index.ts',
     '^@nagiyu/browser$': '<rootDir>/../../libs/browser/src/index.ts',

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -57,9 +57,9 @@
 
 ### Button
 
-- [ ] PR 1-1-A: `libs/ui` に `Button` 実装（variant: solid/outline/ghost、color: 6 種、size: sm/md/lg、`loading`、`asChild`）
-- [ ] PR 1-1-A: Stories 全パターン作成
-- [ ] PR 1-1-A: ユニット + a11y テスト（カバレッジ 90%）
+- [x] PR 1-1-A: `libs/ui` に `Button` 実装（variant: solid/outline/ghost、color: 6 種、size: sm/md/lg、`loading`、`asChild`）
+- [x] PR 1-1-A: Stories 全パターン作成（Default / Variants / Colors / Sizes / Loading / Disabled / AsChildLink / Matrix）
+- [x] PR 1-1-A: ユニット + a11y テスト（Button.tsx は 100% カバレッジ、ライブラリ全体は lines 93.2% / branches 88.37%）
 - [ ] PR 1-1-B: 全サービスで MUI `Button` → `@nagiyu/ui` の `Button` に置換
 - [ ] PR 1-1-C: ESLint で `@mui/material` の `Button` 直接 import を禁止
 


### PR DESCRIPTION
## 変更の概要

Phase 1 の最初のアトミックコンポーネントとして `Button` を `@nagiyu/ui` に実装する（[PR 1-1-A](../tree/integration/2900-shared-ui-components/tasks/shared-ui-components/tasks.md)）。

### API

100% ライブラリ非依存の独自定義。MUI / Radix の Props 型は `extends` していない。

| プロパティ | 型 | 既定 |
| --- | --- | --- |
| `variant` | `'solid' \| 'outline' \| 'ghost'` | `solid` |
| `color` | `'primary' \| 'secondary' \| 'danger' \| 'success' \| 'warning' \| 'neutral'` | `primary` |
| `size` | `'sm' \| 'md' \| 'lg'` | `md` |
| `loading` | `boolean` | `false` |
| `disabled` | `boolean` | `false` |
| `asChild` | `boolean`（Radix Slot） | `false` |
| `className` | `string` | — |

エスケープハッチは `className` のみ。`sx` / `style` Props は受け付けない（仕様準拠）。

### スタイリング

CSS Modules（`Button.module.css`）+ `tokens.css` の Semantic 変数のみ参照する構成。MUI への直接依存はゼロで、将来の Base UI / shadcn/ui 等への差し替えに備える。

`tokens.css` には Button が要求する 6 色目の `neutral` アクションロールを新規追加（ライト/ダーク両対応）。

### ファイル構成

```
libs/ui/src/components/Button/
├── Button.tsx
├── Button.module.css
├── Button.stories.tsx
└── index.ts

libs/ui/tests/unit/components/Button/
└── Button.test.tsx
```

加えて CSS Modules 全般の足回りとして以下を整備:

- `src/types/css-modules.d.ts` — `*.module.css` の型宣言
- `jest.config.ts` — `moduleNameMapper` に `identity-obj-proxy` を設定
- `scripts/copy-assets.mjs` — `*.module.css` を再帰的に `dist/` へ複製

## 関連 Issue

<!-- integration → develop の PR で Closes を付ける運用のため、本 PR では参照のみ -->

#2900

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（`Button.tsx` は **100%** カバレッジ、ライブラリ全体は lines 93.2% / branches 88.37%）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md` の進捗を更新）
- [x] ローカルでテストが全て通ることを確認した（156 件成功）
- [x] ビルドエラーがないことを確認した（`tsc` + `copy-assets` + `build-storybook` 成功）

## テスト内容

`Button.test.tsx` で 20 件のテスト:

- **rendering**: children 表示、`type` 既定値、`className` マージ、variant/color/size のクラス反映
- **events**: `onClick` 発火、`disabled` / `loading` 時の発火抑止
- **loading**: スピナー表示、`aria-busy` 設定、`disabled` 属性付与
- **asChild**: 子要素 `<a>` への props マージ、`disabled` 時の `aria-disabled`、`loading` 時の `aria-busy`
- **ref**: `forwardRef` 動作確認
- **a11y（jest-axe）**: 既定 / 全 variant×color×size マトリクス（54 ケース） / loading / disabled

## レビューポイント

- **6 色目の `neutral` 追加**: 既存の `secondary`（gray-800 ベース）と区別する位置付けで gray-200/gray-700（ライト/ダーク）を追加した。意味付けが妥当か。
- **`asChild` + `loading` の挙動**: Radix `Slot` が単一子要素しか受け付けないため、`asChild` モードではスピナーを描画せず `aria-busy` のみで状態を示す方針とした。
- **CSS Modules 採用**: `libs/ui` のスタイリング手段として CSS Modules を選択した（emotion は MUI の付属で使えるが、ライブラリ非依存性を優先）。今後の全コンポーネントで踏襲予定。
- **CSS の構造**: variant × color の組み合わせを `--btn-*` カスタムプロパティ経由で展開する形にしているため、新色追加は `.color-{name}` を 1 つ書けば済む。

## スクリーンショット

dev 環境の Storybook（`https://dev-storybook.nagiyu.com`）で視覚確認予定。

## 補足事項

PR 1-1-B（サービス側の置換）と PR 1-1-C（ESLint 禁止）は本 PR マージ後に別 PR で対応する。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_