### PR TITLE
refactor(services): MUI Button → @nagiyu/ui Button への置換 + startIcon 拡張（PR 1-1-B）

### DIFF
--- a/libs/ui/src/components/Button/Button.module.css
+++ b/libs/ui/src/components/Button/Button.module.css
@@ -192,6 +192,14 @@
   visibility: hidden;
 }
 
+/* startIcon: ラベル左側のアイコン。currentColor 継承で variant の文字色に追従する */
+.startIcon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: currentColor;
+}
+
 /* スピナー（CSS のみで実装し、SVG / 追加依存を避ける） */
 .spinner {
   position: absolute;

--- a/libs/ui/src/components/Button/Button.stories.tsx
+++ b/libs/ui/src/components/Button/Button.stories.tsx
@@ -3,10 +3,20 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import Button from './Button';
 
 /**
+ * Storybook 用ダミーアイコン（プラス記号）。
+ * 実プロジェクトでは `@mui/icons-material` 等の SVG コンポーネントを渡す。
+ */
+const PlusIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+  </svg>
+);
+
+/**
  * `Button` は @nagiyu/ui の最小単位アクション部品。
  *
  * - `variant`（solid / outline / ghost）× `color`（6 種）× `size`（sm/md/lg）の直交した API
- * - `loading` でスピナー、`asChild` で `<a>` 等への変身（Radix Slot）
+ * - `loading` でスピナー、`startIcon` で左側装飾アイコン、`asChild` で `<a>` 等への変身（Radix Slot）
  *
  * MUI への依存は内部で完全に隠蔽されている（Props 型は 100% 独自）。
  */
@@ -97,6 +107,14 @@ export const Sizes: Story = {
 
 export const Loading: Story = {
   args: { loading: true, children: '送信中' },
+};
+
+export const WithStartIcon: Story = {
+  args: { startIcon: <PlusIcon />, children: '追加' },
+};
+
+export const WithStartIconLoading: Story = {
+  args: { startIcon: <PlusIcon />, loading: true, children: '送信中' },
 };
 
 export const Disabled: Story = {

--- a/libs/ui/src/components/Button/Button.tsx
+++ b/libs/ui/src/components/Button/Button.tsx
@@ -25,12 +25,9 @@ export type ButtonColor = 'primary' | 'secondary' | 'danger' | 'success' | 'warn
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 /**
- * Button のプロパティ。
- *
- * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
- * エスケープハッチは `className` のみ（`sx` / `style` は提供しない）。
+ * Button の共通プロパティ（asChild の有無に依らず使えるもの）。
  */
-export interface ButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'> {
+type ButtonOwnPropsBase = {
   /**
    * バリアント。既定: `solid`
    */
@@ -47,24 +44,57 @@ export interface ButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonE
    * ローディング中はスピナーを表示し、操作を抑止する。
    */
   loading?: boolean;
-  /**
-   * `true` の場合、Radix Slot により子要素に Props をマージする。
-   * 子要素は単一の React 要素である必要がある（`<a>` / `<Link>` 等）。
-   */
-  asChild?: boolean;
-}
+};
+
+type ButtonHtmlProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'>;
+
+/**
+ * 通常モード（`asChild` 未指定または `false`）の Props。
+ * `startIcon` を受け付ける。
+ */
+type ButtonRegularProps = ButtonHtmlProps &
+  ButtonOwnPropsBase & {
+    asChild?: false;
+    /**
+     * ボタン左側に表示する装飾アイコン。`aria-hidden="true"` が自動付与される。
+     * `loading` 中は内部で非表示になり、スピナーに置き換わる。
+     */
+    startIcon?: React.ReactNode;
+  };
+
+/**
+ * `asChild` モードの Props。
+ * Radix `Slot` は単一子要素しか許容しないため、`startIcon` の同時指定は型エラーにする。
+ */
+type ButtonAsChildProps = ButtonHtmlProps &
+  ButtonOwnPropsBase & {
+    asChild: true;
+    /**
+     * `asChild` モードでは利用不可。子要素自身で構造を組み立てること。
+     */
+    startIcon?: never;
+  };
+
+/**
+ * Button のプロパティ。
+ *
+ * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
+ * エスケープハッチは `className` のみ（`sx` / `style` は提供しない）。
+ */
+export type ButtonProps = ButtonRegularProps | ButtonAsChildProps;
 
 /**
  * 汎用ボタンコンポーネント。
  *
  * - `variant` × `color` × `size` の直交した API
  * - `loading` でスピナー表示（`aria-busy` 自動設定）
- * - `asChild` でリンク等への変身に対応（Radix Slot パターン）
+ * - `startIcon` で左側装飾アイコン（`aria-hidden` 自動付与）
+ * - `asChild` でリンク等への変身に対応（Radix Slot パターン、`startIcon` とは排他）
  *
  * @see docs/development/shared-ui-components.md
  */
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  {
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
+  const {
     variant = 'solid',
     color = 'primary',
     size = 'md',
@@ -77,9 +107,14 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
     'aria-busy': ariaBusy,
     'aria-disabled': ariaDisabled,
     ...rest
-  },
-  ref
-) {
+  } = props;
+  // startIcon は asChild と排他のため、通常モード側でのみ取り出す。
+  const startIcon = asChild ? undefined : (props as ButtonRegularProps).startIcon;
+  // asChild と startIcon は型で排他にしているが、実際の rest からも除外する。
+  if ('startIcon' in rest) {
+    delete (rest as { startIcon?: unknown }).startIcon;
+  }
+
   const Comp: React.ElementType = asChild ? Slot : 'button';
   const isDisabled = disabled || loading;
 
@@ -125,7 +160,14 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       {loading ? (
         <span className={styles.spinner} aria-hidden="true" data-testid="button-spinner" />
       ) : null}
-      <span className={loading ? styles.contentHidden : styles.content}>{children}</span>
+      <span className={loading ? styles.contentHidden : styles.content}>
+        {startIcon ? (
+          <span className={styles.startIcon} aria-hidden="true" data-testid="button-start-icon">
+            {startIcon}
+          </span>
+        ) : null}
+        {children}
+      </span>
     </Comp>
   );
 });

--- a/libs/ui/tests/unit/components/Button/Button.test.tsx
+++ b/libs/ui/tests/unit/components/Button/Button.test.tsx
@@ -105,9 +105,7 @@ describe('Button', () => {
 
   describe('startIcon', () => {
     it('startIcon を子要素ラベルの前に表示する', () => {
-      render(
-        <Button startIcon={<span data-testid="my-icon">★</span>}>追加</Button>
-      );
+      render(<Button startIcon={<span data-testid="my-icon">★</span>}>追加</Button>);
       const wrapper = screen.getByTestId('button-start-icon');
       expect(wrapper).toBeInTheDocument();
       expect(wrapper).toContainElement(screen.getByTestId('my-icon'));
@@ -127,7 +125,9 @@ describe('Button', () => {
 
     it('loading 中はスピナーを表示し、startIcon は contentHidden 内に隠れる', () => {
       render(
-        <Button loading startIcon={<span data-testid="my-icon">★</span>}>送信中</Button>
+        <Button loading startIcon={<span data-testid="my-icon">★</span>}>
+          送信中
+        </Button>
       );
       // スピナーは見える
       expect(screen.getByTestId('button-spinner')).toBeInTheDocument();

--- a/libs/ui/tests/unit/components/Button/Button.test.tsx
+++ b/libs/ui/tests/unit/components/Button/Button.test.tsx
@@ -103,6 +103,47 @@ describe('Button', () => {
     });
   });
 
+  describe('startIcon', () => {
+    it('startIcon を子要素ラベルの前に表示する', () => {
+      render(
+        <Button startIcon={<span data-testid="my-icon">★</span>}>追加</Button>
+      );
+      const wrapper = screen.getByTestId('button-start-icon');
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper).toContainElement(screen.getByTestId('my-icon'));
+      // ラベル文字列が同じボタン内に存在する
+      expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
+    });
+
+    it('startIcon ラッパーに aria-hidden が自動付与される', () => {
+      render(<Button startIcon={<span>★</span>}>追加</Button>);
+      expect(screen.getByTestId('button-start-icon')).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('startIcon を渡さなければ wrapper を描画しない', () => {
+      render(<Button>追加</Button>);
+      expect(screen.queryByTestId('button-start-icon')).not.toBeInTheDocument();
+    });
+
+    it('loading 中はスピナーを表示し、startIcon は contentHidden 内に隠れる', () => {
+      render(
+        <Button loading startIcon={<span data-testid="my-icon">★</span>}>送信中</Button>
+      );
+      // スピナーは見える
+      expect(screen.getByTestId('button-spinner')).toBeInTheDocument();
+      // startIcon 自体は DOM に存在するが visibility:hidden の親に包まれている
+      const iconWrapper = screen.getByTestId('button-start-icon');
+      expect(iconWrapper).toBeInTheDocument();
+      expect(iconWrapper.parentElement?.className).toContain('contentHidden');
+    });
+
+    it('startIcon があっても a11y 違反がない', async () => {
+      const { container } = render(<Button startIcon={<span>★</span>}>追加</Button>);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
   describe('asChild', () => {
     it('子要素のタグをそのまま使い、props をマージする', () => {
       render(
@@ -135,6 +176,19 @@ describe('Button', () => {
         </Button>
       );
       expect(screen.getByRole('link')).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('asChild + startIcon は型レベルで禁止される（@ts-expect-error 検証）', () => {
+      render(
+        // @ts-expect-error startIcon は asChild と同時指定不可
+        <Button asChild startIcon={<span data-testid="icon-x">★</span>}>
+          <a href="/x">go</a>
+        </Button>
+      );
+      // 実装としても asChild モードでは startIcon を取り出さないため
+      // 描画されない（DOM に出ない）ことを確認する。
+      expect(screen.queryByTestId('icon-x')).not.toBeInTheDocument();
+      expect(screen.getByRole('link')).toBeInTheDocument();
     });
   });
 

--- a/services/admin/web/src/app/(protected)/dashboard/page.tsx
+++ b/services/admin/web/src/app/(protected)/dashboard/page.tsx
@@ -1,4 +1,5 @@
-import { Box, Card, CardContent, Typography, Button, Chip } from '@mui/material';
+import { Box, Card, CardContent, Typography, Chip } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { hasPermission } from '@nagiyu/common';
 import { getSession } from '@/lib/auth/session';
 import { redirect } from 'next/navigation';
@@ -67,13 +68,8 @@ export default async function DashboardPage() {
       )}
 
       {/* ログアウトボタン */}
-      <Button
-        variant="outlined"
-        color="primary"
-        href={`${process.env.NEXT_PUBLIC_AUTH_URL || ''}/api/auth/signout`}
-        sx={{ mt: 2 }}
-      >
-        ログアウト
+      <Button asChild variant="outline" color="primary">
+        <a href={`${process.env.NEXT_PUBLIC_AUTH_URL || ''}/api/auth/signout`}>ログアウト</a>
       </Button>
     </Box>
   );

--- a/services/admin/web/src/components/notify/NotifyButton.tsx
+++ b/services/admin/web/src/components/notify/NotifyButton.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Button, Alert } from '@mui/material';
+import { Alert } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { urlBase64ToUint8Array } from '@nagiyu/browser';
 
 const ERROR_MESSAGES = {
@@ -92,7 +93,7 @@ export default function NotifyButton() {
 
   return (
     <>
-      <Button variant="contained" onClick={handleEnableNotification} disabled={isLoading}>
+      <Button variant="solid" onClick={handleEnableNotification} loading={isLoading}>
         通知を有効にする
       </Button>
       {message && (

--- a/services/auth/web/src/app/auth/error/page.tsx
+++ b/services/auth/web/src/app/auth/error/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useSearchParams } from 'next/navigation';
-import { Box, Container, Paper, Typography, Button } from '@mui/material';
+import { Box, Container, Paper, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutlined';
 import Link from 'next/link';
 import { Suspense } from 'react';
@@ -45,7 +46,7 @@ function ErrorContent() {
             {errorMessage}
           </Typography>
           <Link href="/signin" style={{ textDecoration: 'none' }}>
-            <Button variant="contained" size="large">
+            <Button variant="solid" size="lg">
               サインインページへ戻る
             </Button>
           </Link>

--- a/services/auth/web/src/app/dashboard/page.tsx
+++ b/services/auth/web/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { hasPermission } from '@nagiyu/common';
-import { Box, Container, Paper, Typography, Card, CardContent, Chip, Button } from '@mui/material';
+import { Box, Container, Paper, Typography, Card, CardContent, Chip } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import Link from 'next/link';
 import { getSession } from '@/lib/auth/session';
 
@@ -56,9 +57,9 @@ export default async function DashboardPage() {
                 管理機能
               </Typography>
               <Box sx={{ mt: 2 }}>
-                <Link href="/dashboard/users" style={{ textDecoration: 'none' }}>
-                  <Button variant="contained">ユーザー管理</Button>
-                </Link>
+                <Button asChild variant="solid">
+                  <Link href="/dashboard/users">ユーザー管理</Link>
+                </Button>
               </Box>
             </CardContent>
           </Card>

--- a/services/auth/web/src/app/dashboard/users/[userId]/edit/user-edit-form.tsx
+++ b/services/auth/web/src/app/dashboard/users/[userId]/edit/user-edit-form.tsx
@@ -146,8 +146,8 @@ export function UserEditForm({ userId }: UserEditFormProps) {
           </FormGroup>
 
           <Box sx={{ mt: 3, display: 'flex', gap: 2 }}>
-            <Button type="submit" variant="solid" loading={saving}>
-              保存
+            <Button type="submit" variant="solid" disabled={saving}>
+              {saving ? '保存中...' : '保存'}
             </Button>
             <Button
               variant="outline"

--- a/services/auth/web/src/app/dashboard/users/[userId]/edit/user-edit-form.tsx
+++ b/services/auth/web/src/app/dashboard/users/[userId]/edit/user-edit-form.tsx
@@ -9,10 +9,10 @@ import {
   FormGroup,
   FormControlLabel,
   Checkbox,
-  Button,
   Alert,
   CircularProgress,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { VALID_ROLES } from '@nagiyu/common';
 import type { User } from '@nagiyu/common';
 
@@ -146,11 +146,11 @@ export function UserEditForm({ userId }: UserEditFormProps) {
           </FormGroup>
 
           <Box sx={{ mt: 3, display: 'flex', gap: 2 }}>
-            <Button type="submit" variant="contained" disabled={saving}>
-              {saving ? '保存中...' : '保存'}
+            <Button type="submit" variant="solid" loading={saving}>
+              保存
             </Button>
             <Button
-              variant="outlined"
+              variant="outline"
               onClick={() => router.push('/dashboard/users')}
               disabled={saving}
             >

--- a/services/auth/web/src/app/dashboard/users/page.tsx
+++ b/services/auth/web/src/app/dashboard/users/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { hasPermission } from '@nagiyu/common';
-import { Box, Container, Typography, Paper, Button } from '@mui/material';
+import { Box, Container, Typography, Paper } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import Link from 'next/link';
 import { UsersTable } from './users-table';
 import { getSession } from '@/lib/auth/session';
@@ -24,9 +25,9 @@ export default async function UsersListPage() {
           <Typography variant="h4" component="h1">
             ユーザー管理
           </Typography>
-          <Link href="/dashboard" style={{ textDecoration: 'none' }}>
-            <Button variant="outlined">ダッシュボードに戻る</Button>
-          </Link>
+          <Button asChild variant="outline">
+            <Link href="/dashboard">ダッシュボードに戻る</Link>
+          </Button>
         </Box>
 
         <Paper sx={{ p: 3 }}>

--- a/services/auth/web/src/app/dashboard/users/users-table.tsx
+++ b/services/auth/web/src/app/dashboard/users/users-table.tsx
@@ -9,11 +9,11 @@ import {
   TableHead,
   TableRow,
   Chip,
-  Button,
   Alert,
   CircularProgress,
   Box,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import Link from 'next/link';
 import type { User } from '@nagiyu/common';
 
@@ -88,14 +88,9 @@ export function UsersTable({ canAssignRoles }: UsersTableProps) {
               </TableCell>
               <TableCell align="right">
                 {canAssignRoles && (
-                  <Link
-                    href={`/dashboard/users/${user.userId}/edit`}
-                    style={{ textDecoration: 'none' }}
-                  >
-                    <Button variant="outlined" size="small">
-                      編集
-                    </Button>
-                  </Link>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/dashboard/users/${user.userId}/edit`}>編集</Link>
+                  </Button>
                 )}
               </TableCell>
             </TableRow>

--- a/services/auth/web/src/app/page.tsx
+++ b/services/auth/web/src/app/page.tsx
@@ -1,4 +1,5 @@
-import { Container, Typography, Button, Box, Paper } from '@mui/material';
+import { Container, Typography, Box, Paper } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import LoginIcon from '@mui/icons-material/Login';
 
 export default function HomePage() {
@@ -23,7 +24,7 @@ export default function HomePage() {
           サインインするには、以下のボタンをクリックしてください。
         </Typography>
 
-        <Button variant="contained" size="large" startIcon={<LoginIcon />} disabled sx={{ mt: 2 }}>
+        <Button variant="solid" size="lg" startIcon={<LoginIcon />} disabled>
           Google でサインイン
         </Button>
 

--- a/services/auth/web/src/app/signin/page.tsx
+++ b/services/auth/web/src/app/signin/page.tsx
@@ -44,12 +44,7 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
             }}
           >
             <Box sx={{ '& > button': { width: '100%' } }}>
-              <Button
-                type="submit"
-                variant="solid"
-                size="lg"
-                startIcon={<GoogleIcon />}
-              >
+              <Button type="submit" variant="solid" size="lg" startIcon={<GoogleIcon />}>
                 Google でサインイン
               </Button>
             </Box>

--- a/services/auth/web/src/app/signin/page.tsx
+++ b/services/auth/web/src/app/signin/page.tsx
@@ -1,5 +1,6 @@
 import { signIn } from '@nagiyu/auth-core';
-import { Box, Button, Container, Paper, Typography } from '@mui/material';
+import { Box, Container, Paper, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import GoogleIcon from '@mui/icons-material/Google';
 
 interface SignInPageProps {
@@ -42,15 +43,16 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
               });
             }}
           >
-            <Button
-              type="submit"
-              variant="contained"
-              size="large"
-              startIcon={<GoogleIcon />}
-              fullWidth
-            >
-              Google でサインイン
-            </Button>
+            <Box sx={{ '& > button': { width: '100%' } }}>
+              <Button
+                type="submit"
+                variant="solid"
+                size="lg"
+                startIcon={<GoogleIcon />}
+              >
+                Google でサインイン
+              </Button>
+            </Box>
           </form>
         </Paper>
       </Box>

--- a/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
+++ b/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
@@ -16,11 +16,11 @@ import {
   Card,
   CardContent,
   Chip,
-  Button,
   Alert,
   Stack,
   Box,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DownloadIcon from '@mui/icons-material/Download';
 import AddIcon from '@mui/icons-material/Add';
@@ -220,7 +220,7 @@ export default function JobDetailsPage({ params }: JobDetailsPageProps) {
         <Alert severity="error" sx={{ mb: 3 }}>
           {error}
         </Alert>
-        <Button variant="contained" startIcon={<AddIcon />} onClick={handleNewConversion}>
+        <Button variant="solid" startIcon={<AddIcon />} onClick={handleNewConversion}>
           新しい動画を変換
         </Button>
       </Container>
@@ -334,12 +334,11 @@ export default function JobDetailsPage({ params }: JobDetailsPageProps) {
         {/* ステータス確認ボタン */}
         {showRefreshButton && (
           <Button
-            variant="contained"
-            size="large"
+            variant="solid"
+            size="lg"
             startIcon={<RefreshIcon />}
             onClick={handleRefresh}
-            disabled={isRefreshing}
-            fullWidth
+            loading={isRefreshing}
             aria-label="ジョブステータスを確認"
           >
             {isRefreshing ? '確認中...' : 'ステータス確認'}
@@ -349,12 +348,11 @@ export default function JobDetailsPage({ params }: JobDetailsPageProps) {
         {/* ダウンロードボタン */}
         {showDownloadButton && (
           <Button
-            variant="contained"
-            size="large"
+            variant="solid"
+            size="lg"
             color="success"
             startIcon={<DownloadIcon />}
             onClick={handleDownload}
-            fullWidth
             aria-label="変換済みファイルをダウンロード"
           >
             ダウンロード
@@ -363,11 +361,10 @@ export default function JobDetailsPage({ params }: JobDetailsPageProps) {
 
         {/* 新規変換ボタン */}
         <Button
-          variant="outlined"
-          size="large"
+          variant="outline"
+          size="lg"
           startIcon={<AddIcon />}
           onClick={handleNewConversion}
-          fullWidth
           aria-label="新しい動画を変換する"
         >
           新しい動画を変換

--- a/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
+++ b/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
@@ -10,16 +10,7 @@ import {
   formatDateTime,
   formatJobId,
 } from '@nagiyu/codec-converter-core';
-import {
-  Container,
-  Typography,
-  Card,
-  CardContent,
-  Chip,
-  Alert,
-  Stack,
-  Box,
-} from '@mui/material';
+import { Container, Typography, Card, CardContent, Chip, Alert, Stack, Box } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DownloadIcon from '@mui/icons-material/Download';

--- a/services/codec-converter/web/src/app/page.tsx
+++ b/services/codec-converter/web/src/app/page.tsx
@@ -7,7 +7,6 @@ import {
   Container,
   Typography,
   Paper,
-  Button,
   Alert,
   FormControl,
   FormLabel,
@@ -16,6 +15,7 @@ import {
   Radio,
   Box,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 
 type UploadError = {
@@ -286,11 +286,10 @@ export default function Home() {
         {/* Submit Button */}
         <Button
           type="submit"
-          variant="contained"
-          size="large"
-          disabled={!file || isUploading}
-          fullWidth
-          sx={{ py: 1.5 }}
+          variant="solid"
+          size="lg"
+          disabled={!file}
+          loading={isUploading}
         >
           {isUploading ? 'アップロード中...' : '変換開始'}
         </Button>

--- a/services/codec-converter/web/src/app/page.tsx
+++ b/services/codec-converter/web/src/app/page.tsx
@@ -284,13 +284,7 @@ export default function Home() {
         </FormControl>
 
         {/* Submit Button */}
-        <Button
-          type="submit"
-          variant="solid"
-          size="lg"
-          disabled={!file}
-          loading={isUploading}
-        >
+        <Button type="submit" variant="solid" size="lg" disabled={!file} loading={isUploading}>
           {isUploading ? 'アップロード中...' : '変換開始'}
         </Button>
       </form>

--- a/services/niconico-mylist-assistant/web/src/app/import/page.tsx
+++ b/services/niconico-mylist-assistant/web/src/app/import/page.tsx
@@ -114,11 +114,7 @@ export default function ImportPage() {
         </Box>
 
         <Box sx={{ mt: 2, display: 'flex', gap: 2 }}>
-          <Button
-            variant="outline"
-            size="lg"
-            onClick={() => setSearchModalOpen(true)}
-          >
+          <Button variant="outline" size="lg" onClick={() => setSearchModalOpen(true)}>
             動画を検索して追加
           </Button>
           <Button

--- a/services/niconico-mylist-assistant/web/src/app/import/page.tsx
+++ b/services/niconico-mylist-assistant/web/src/app/import/page.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Typography,
   TextField,
-  Button,
   Alert,
   Card,
   CardContent,
@@ -19,6 +18,7 @@ import {
   ListItem,
   ListItemText,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useRouter } from 'next/navigation';
 import VideoSearchModal from '@/components/VideoSearchModal';
@@ -113,20 +113,20 @@ export default function ImportPage() {
           />
         </Box>
 
-        <Box sx={{ mt: 2 }}>
+        <Box sx={{ mt: 2, display: 'flex', gap: 2 }}>
           <Button
-            variant="outlined"
-            size="large"
-            sx={{ mr: 2 }}
+            variant="outline"
+            size="lg"
             onClick={() => setSearchModalOpen(true)}
           >
             動画を検索して追加
           </Button>
           <Button
-            variant="contained"
-            size="large"
+            variant="solid"
+            size="lg"
             onClick={handleImport}
-            disabled={loading || !videoIds.trim()}
+            loading={loading}
+            disabled={!videoIds.trim()}
           >
             {loading ? <CircularProgress size={24} /> : 'インポート実行'}
           </Button>
@@ -203,7 +203,7 @@ export default function ImportPage() {
                 )}
 
                 <Box sx={{ mt: 2 }}>
-                  <Button variant="outlined" onClick={() => router.push('/')}>
+                  <Button variant="outline" onClick={() => router.push('/')}>
                     動画一覧を見る
                   </Button>
                 </Box>

--- a/services/niconico-mylist-assistant/web/src/components/HomePageClient.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/HomePageClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Container, Typography, Box, Button } from '@mui/material';
+import { Container, Typography, Box } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import NotificationPermissionDialog from './NotificationPermissionButton';
 import { urlBase64ToUint8Array } from '@nagiyu/browser';
@@ -112,26 +113,25 @@ export default function HomePageClient({ userName, isAuthenticated, appUrl }: Ho
           ニコニコ動画のマイリスト登録を自動化する補助ツールです。
         </Typography>
         {isAuthenticated ? (
-          <Box sx={{ mt: 3 }}>
-            <Typography variant="body1" gutterBottom>
+          <Box sx={{ mt: 3, display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+            <Typography variant="body1" gutterBottom sx={{ width: '100%' }}>
               ようこそ、{userName} さん
             </Typography>
-            <Button href="/register" variant="contained" color="primary" sx={{ mt: 2, mr: 2 }}>
-              マイリスト登録
+            <Button asChild variant="solid" color="primary">
+              <a href="/register">マイリスト登録</a>
             </Button>
-            <Button href="/import" variant="outlined" color="primary" sx={{ mt: 2, mr: 2 }}>
-              動画インポート
+            <Button asChild variant="outline" color="primary">
+              <a href="/import">動画インポート</a>
             </Button>
-            <Button href="/mylist" variant="outlined" color="primary" sx={{ mt: 2, mr: 2 }}>
-              動画管理
+            <Button asChild variant="outline" color="primary">
+              <a href="/mylist">動画管理</a>
             </Button>
             {canUseNotificationApi && (
               <>
                 <Button
-                  variant="outlined"
+                  variant="outline"
                   startIcon={<NotificationsIcon />}
                   onClick={handleOpenNotificationDialog}
-                  sx={{ mt: 2, mr: 2 }}
                 >
                   通知設定
                 </Button>
@@ -149,13 +149,8 @@ export default function HomePageClient({ userName, isAuthenticated, appUrl }: Ho
             <Typography variant="body1" sx={{ mb: 2 }}>
               このサービスを利用するには、ログインが必要です。
             </Typography>
-            <Button
-              href={`${authUrl}/signin?callbackUrl=${encodeURIComponent(appUrl)}`}
-              variant="contained"
-              color="primary"
-              size="large"
-            >
-              ログイン
+            <Button asChild variant="solid" color="primary" size="lg">
+              <a href={`${authUrl}/signin?callbackUrl=${encodeURIComponent(appUrl)}`}>ログイン</a>
             </Button>
           </Box>
         )}

--- a/services/niconico-mylist-assistant/web/src/components/HomePageClient.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/HomePageClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { Container, Typography, Box } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import NotificationsIcon from '@mui/icons-material/Notifications';
@@ -118,13 +119,13 @@ export default function HomePageClient({ userName, isAuthenticated, appUrl }: Ho
               ようこそ、{userName} さん
             </Typography>
             <Button asChild variant="solid" color="primary">
-              <a href="/register">マイリスト登録</a>
+              <Link href="/register">マイリスト登録</Link>
             </Button>
             <Button asChild variant="outline" color="primary">
-              <a href="/import">動画インポート</a>
+              <Link href="/import">動画インポート</Link>
             </Button>
             <Button asChild variant="outline" color="primary">
-              <a href="/mylist">動画管理</a>
+              <Link href="/mylist">動画管理</Link>
             </Button>
             {canUseNotificationApi && (
               <>

--- a/services/niconico-mylist-assistant/web/src/components/JobStatusDisplay.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/JobStatusDisplay.tsx
@@ -12,8 +12,8 @@ import {
   Chip,
   Stack,
   TextField,
-  Button,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import {
   CheckCircle as CheckCircleIcon,
   Error as ErrorIcon,
@@ -343,9 +343,10 @@ export default function JobStatusDisplay({ jobId, onComplete, onError }: JobStat
                   fullWidth
                 />
                 <Button
-                  variant="contained"
+                  variant="solid"
                   onClick={handleSubmit2FA}
-                  disabled={isSubmitting2FA || twoFactorAuthCode.length !== 6}
+                  loading={isSubmitting2FA}
+                  disabled={twoFactorAuthCode.length !== 6}
                 >
                   {isSubmitting2FA ? '送信中...' : 'コードを送信'}
                 </Button>

--- a/services/niconico-mylist-assistant/web/src/components/JobStatusPageClient.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/JobStatusPageClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Container, Typography, Box, Button, Snackbar, Alert } from '@mui/material';
+import { Container, Typography, Box, Snackbar, Alert } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
 import { useRouter } from 'next/navigation';
 import JobStatusDisplay from '@/components/JobStatusDisplay';
@@ -65,7 +66,7 @@ export default function JobStatusPageClient({ jobId }: JobStatusPageClientProps)
       <Box sx={{ my: 4 }}>
         {/* ヘッダー */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
-          <Button variant="outlined" startIcon={<ArrowBackIcon />} onClick={handleBack}>
+          <Button variant="outline" startIcon={<ArrowBackIcon />} onClick={handleBack}>
             登録画面に戻る
           </Button>
           <Typography variant="h4" component="h1">

--- a/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
@@ -8,7 +8,6 @@ import {
   Checkbox,
   Typography,
   Alert,
-  CircularProgress,
   Card,
   CardContent,
   InputAdornment,

--- a/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import {
   Box,
   TextField,
-  Button,
   FormControlLabel,
   Checkbox,
   Typography,
@@ -15,6 +14,7 @@ import {
   InputAdornment,
   IconButton,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import {
@@ -298,10 +298,9 @@ export default function MylistRegisterForm({ onSuccess }: MylistRegisterFormProp
           <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-end' }}>
             <Button
               type="submit"
-              variant="contained"
+              variant="solid"
               color="primary"
-              disabled={loading}
-              startIcon={loading && <CircularProgress size={20} />}
+              loading={loading}
             >
               {loading ? '登録中...' : 'マイリストに登録'}
             </Button>

--- a/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
@@ -296,12 +296,7 @@ export default function MylistRegisterForm({ onSuccess }: MylistRegisterFormProp
 
           {/* 実行ボタン */}
           <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-end' }}>
-            <Button
-              type="submit"
-              variant="solid"
-              color="primary"
-              loading={loading}
-            >
+            <Button type="submit" variant="solid" color="primary" loading={loading}>
               {loading ? '登録中...' : 'マイリストに登録'}
             </Button>
           </Box>

--- a/services/niconico-mylist-assistant/web/src/components/NotificationPermissionButton.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/NotificationPermissionButton.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Typography,
-} from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Typography } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 
 /**
@@ -43,7 +37,9 @@ export default function NotificationPermissionDialog({
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} variant="ghost">キャンセル</Button>
+        <Button onClick={onClose} variant="ghost">
+          キャンセル
+        </Button>
         {!isSubscribed && (
           <Button onClick={onRequestPermission} variant="solid">
             通知を有効にする

--- a/services/niconico-mylist-assistant/web/src/components/NotificationPermissionButton.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/NotificationPermissionButton.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import {
-  Button,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 
 /**
  * 通知許可ダイアログコンポーネント
@@ -43,9 +43,9 @@ export default function NotificationPermissionDialog({
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>キャンセル</Button>
+        <Button onClick={onClose} variant="ghost">キャンセル</Button>
         {!isSubscribed && (
-          <Button onClick={onRequestPermission} variant="contained">
+          <Button onClick={onRequestPermission} variant="solid">
             通知を有効にする
           </Button>
         )}

--- a/services/niconico-mylist-assistant/web/src/components/VideoDetailModal.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoDetailModal.tsx
@@ -6,7 +6,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   TextField,
   Box,
   Typography,
@@ -17,6 +16,7 @@ import {
   Chip,
   Stack,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import {
   Close,
   Favorite,
@@ -309,22 +309,20 @@ export default function VideoDetailModal({
             {/* お気に入り・スキップボタン */}
             <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
               <Button
-                variant={isFavorite ? 'contained' : 'outlined'}
-                color={isFavorite ? 'error' : 'inherit'}
+                variant={isFavorite ? 'solid' : 'outline'}
+                color={isFavorite ? 'danger' : 'neutral'}
                 startIcon={isFavorite ? <Favorite /> : <FavoriteBorder />}
                 onClick={handleToggleFavorite}
                 disabled={isSaving}
-                fullWidth
               >
                 {isFavorite ? 'お気に入り解除' : 'お気に入りに追加'}
               </Button>
               <Button
-                variant={isSkip ? 'contained' : 'outlined'}
-                color={isSkip ? 'warning' : 'inherit'}
+                variant={isSkip ? 'solid' : 'outline'}
+                color={isSkip ? 'warning' : 'neutral'}
                 startIcon={isSkip ? <RemoveCircle /> : <RemoveCircleOutlined />}
                 onClick={handleToggleSkip}
                 disabled={isSaving}
-                fullWidth
               >
                 {isSkip ? 'スキップ解除' : 'スキップに設定'}
               </Button>
@@ -346,9 +344,10 @@ export default function VideoDetailModal({
               />
               <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
                 <Button
-                  variant="contained"
+                  variant="solid"
                   onClick={handleSaveMemo}
-                  disabled={isSaving || memo.length > 1000}
+                  loading={isSaving}
+                  disabled={memo.length > 1000}
                 >
                   メモを保存
                 </Button>
@@ -363,26 +362,18 @@ export default function VideoDetailModal({
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1 }}>
                   <Button
-                    variant="contained"
-                    color="error"
+                    variant="solid"
+                    color="danger"
                     onClick={handleDelete}
-                    disabled={isDeleting}
-                    startIcon={isDeleting ? <CircularProgress size={20} /> : <Delete />}
+                    loading={isDeleting}
+                    startIcon={<Delete />}
                   >
                     削除する
                   </Button>
                   <Button
-                    variant="outlined"
+                    variant="outline"
                     onClick={() => setShowDeleteConfirm(false)}
                     disabled={isDeleting}
-                    sx={{
-                      color: 'error.contrastText',
-                      borderColor: 'error.contrastText',
-                      '&:hover': {
-                        borderColor: 'error.contrastText',
-                        bgcolor: 'rgba(255, 255, 255, 0.1)',
-                      },
-                    }}
                   >
                     キャンセル
                   </Button>
@@ -391,8 +382,8 @@ export default function VideoDetailModal({
             ) : (
               <Box sx={{ display: 'flex', justifyContent: 'center' }}>
                 <Button
-                  variant="outlined"
-                  color="error"
+                  variant="outline"
+                  color="danger"
                   startIcon={<Delete />}
                   onClick={() => setShowDeleteConfirm(true)}
                   disabled={isSaving || isDeleting}
@@ -406,7 +397,7 @@ export default function VideoDetailModal({
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={onClose} disabled={isSaving || isDeleting}>
+        <Button onClick={onClose} variant="ghost" disabled={isSaving || isDeleting}>
           閉じる
         </Button>
       </DialogActions>

--- a/services/niconico-mylist-assistant/web/src/components/VideoListFilters.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoListFilters.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import {
   Box,
-  Button,
   FormControl,
   InputLabel,
   Select,
@@ -11,6 +10,7 @@ import {
   SelectChangeEvent,
   TextField,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 
 interface VideoListFiltersProps {
   favoriteFilter: string;
@@ -107,7 +107,7 @@ export default function VideoListFilters({
           placeholder="動画タイトルで検索"
           sx={{ minWidth: 240 }}
         />
-        <Button variant="contained" size="small" onClick={handleSearch}>
+        <Button variant="solid" size="sm" onClick={handleSearch}>
           検索
         </Button>
       </Box>

--- a/services/niconico-mylist-assistant/web/src/components/VideoSearchModal.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoSearchModal.tsx
@@ -114,8 +114,7 @@ export default function VideoSearchModal({ open, onClose }: VideoSearchModalProp
             onClick={handleSearch}
             loading={loading}
             disabled={
-              !keyword.trim() ||
-              keyword.trim().length > VALIDATION_LIMITS.SEARCH_KEYWORD_MAX_LENGTH
+              !keyword.trim() || keyword.trim().length > VALIDATION_LIMITS.SEARCH_KEYWORD_MAX_LENGTH
             }
           >
             検索
@@ -173,7 +172,9 @@ export default function VideoSearchModal({ open, onClose }: VideoSearchModalProp
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} variant="ghost">閉じる</Button>
+        <Button onClick={onClose} variant="ghost">
+          閉じる
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/services/niconico-mylist-assistant/web/src/components/VideoSearchModal.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoSearchModal.tsx
@@ -5,7 +5,6 @@ import type { NiconicoVideoInfo } from '@nagiyu/niconico-mylist-assistant-core';
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   CardMedia,
@@ -17,6 +16,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { ERROR_MESSAGES, VALIDATION_LIMITS } from '@/lib/constants/errors';
 
 interface VideoSearchModalProps {
@@ -110,10 +110,10 @@ export default function VideoSearchModal({ open, onClose }: VideoSearchModalProp
             }}
           />
           <Button
-            variant="contained"
+            variant="solid"
             onClick={handleSearch}
+            loading={loading}
             disabled={
-              loading ||
               !keyword.trim() ||
               keyword.trim().length > VALIDATION_LIMITS.SEARCH_KEYWORD_MAX_LENGTH
             }
@@ -154,7 +154,7 @@ export default function VideoSearchModal({ open, onClose }: VideoSearchModalProp
                         </Typography>
                       </Box>
                       <Button
-                        variant={addStatus ? 'outlined' : 'contained'}
+                        variant={addStatus ? 'outline' : 'solid'}
                         disabled={Boolean(addStatus)}
                         onClick={() => handleAddVideo(video.videoId)}
                       >
@@ -173,7 +173,7 @@ export default function VideoSearchModal({ open, onClose }: VideoSearchModalProp
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>閉じる</Button>
+        <Button onClick={onClose} variant="ghost">閉じる</Button>
       </DialogActions>
     </Dialog>
   );

--- a/services/portal/web/src/app/page.tsx
+++ b/services/portal/web/src/app/page.tsx
@@ -7,9 +7,9 @@ import {
   Card,
   CardContent,
   CardActions,
-  Button,
   Chip,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import {
   getAllServiceSlugs,
   getServiceDocument,
@@ -101,8 +101,8 @@ export default async function HomePage() {
                     </Box>
                   </CardContent>
                   <CardActions>
-                    <Button size="small" href={`/tech/${article.slug}`}>
-                      記事を読む
+                    <Button asChild size="sm" variant="ghost">
+                      <a href={`/tech/${article.slug}`}>記事を読む</a>
                     </Button>
                   </CardActions>
                 </Card>
@@ -110,8 +110,8 @@ export default async function HomePage() {
             ))}
           </Grid>
           <Box sx={{ mt: 2, textAlign: 'center' }}>
-            <Button href="/tech" variant="outlined">
-              すべての技術記事を見る
+            <Button asChild variant="outline">
+              <a href="/tech">すべての技術記事を見る</a>
             </Button>
           </Box>
         </Box>
@@ -157,11 +157,13 @@ export default async function HomePage() {
                     </Typography>
                   </CardContent>
                   <CardActions>
-                    <Button size="small" href={`/services/${card.slug}`}>
-                      ドキュメント
+                    <Button asChild size="sm" variant="ghost">
+                      <a href={`/services/${card.slug}`}>ドキュメント</a>
                     </Button>
-                    <Button size="small" href={card.url} target="_blank" rel="noopener noreferrer">
-                      サービスを開く
+                    <Button asChild size="sm" variant="ghost">
+                      <a href={card.url} target="_blank" rel="noopener noreferrer">
+                        サービスを開く
+                      </a>
                     </Button>
                   </CardActions>
                 </Card>
@@ -176,8 +178,8 @@ export default async function HomePage() {
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           開発者プロフィール・運営方針・編集ポリシーは About ページをご覧ください。
         </Typography>
-        <Button href="/about" variant="text">
-          nagiyu について
+        <Button asChild variant="ghost">
+          <a href="/about">nagiyu について</a>
         </Button>
       </Box>
     </Container>

--- a/services/portal/web/src/app/page.tsx
+++ b/services/portal/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import {
   Container,
   Typography,
@@ -102,7 +103,7 @@ export default async function HomePage() {
                   </CardContent>
                   <CardActions>
                     <Button asChild size="sm" variant="ghost">
-                      <a href={`/tech/${article.slug}`}>記事を読む</a>
+                      <Link href={`/tech/${article.slug}`}>記事を読む</Link>
                     </Button>
                   </CardActions>
                 </Card>
@@ -111,7 +112,7 @@ export default async function HomePage() {
           </Grid>
           <Box sx={{ mt: 2, textAlign: 'center' }}>
             <Button asChild variant="outline">
-              <a href="/tech">すべての技術記事を見る</a>
+              <Link href="/tech">すべての技術記事を見る</Link>
             </Button>
           </Box>
         </Box>

--- a/services/portal/web/src/app/services/[slug]/page.tsx
+++ b/services/portal/web/src/app/services/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { Container, Typography, Box, Button } from '@mui/material';
+import { Container, Typography, Box } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { getAllServiceSlugs, getServiceDocument } from '@/lib/content';
 import { SERVICE_URLS, SERVICE_NAMES } from '@/lib/services';
 import MarkdownContent from '@/components/MarkdownContent';
@@ -67,8 +68,10 @@ export default async function ServicePage({ params }: Params) {
       {/* 外部リンク */}
       {serviceUrl && (
         <Box sx={{ mb: 3 }}>
-          <Button variant="contained" href={serviceUrl} target="_blank" rel="noopener noreferrer">
-            {serviceName} を開く
+          <Button asChild variant="solid">
+            <a href={serviceUrl} target="_blank" rel="noopener noreferrer">
+              {serviceName} を開く
+            </a>
           </Button>
         </Box>
       )}

--- a/services/portal/web/src/app/services/page.tsx
+++ b/services/portal/web/src/app/services/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { Container, Typography, Grid, Card, CardContent, CardActions } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import { getAllServiceSlugs, getServiceDocument } from '@/lib/content';
@@ -59,7 +60,7 @@ export default async function ServicesPage() {
               </CardContent>
               <CardActions>
                 <Button asChild size="sm" variant="ghost">
-                  <a href={`/services/${card.slug}`}>ドキュメント</a>
+                  <Link href={`/services/${card.slug}`}>ドキュメント</Link>
                 </Button>
                 <Button asChild size="sm" variant="ghost">
                   <a href={card.url} target="_blank" rel="noopener noreferrer">

--- a/services/portal/web/src/app/services/page.tsx
+++ b/services/portal/web/src/app/services/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
-import { Container, Typography, Grid, Card, CardContent, CardActions, Button } from '@mui/material';
+import { Container, Typography, Grid, Card, CardContent, CardActions } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { getAllServiceSlugs, getServiceDocument } from '@/lib/content';
 import { SERVICE_URLS, SERVICE_NAMES } from '@/lib/services';
 
@@ -57,11 +58,13 @@ export default async function ServicesPage() {
                 </Typography>
               </CardContent>
               <CardActions>
-                <Button size="small" href={`/services/${card.slug}`}>
-                  ドキュメント
+                <Button asChild size="sm" variant="ghost">
+                  <a href={`/services/${card.slug}`}>ドキュメント</a>
                 </Button>
-                <Button size="small" href={card.url} target="_blank" rel="noopener noreferrer">
-                  サービスを開く
+                <Button asChild size="sm" variant="ghost">
+                  <a href={card.url} target="_blank" rel="noopener noreferrer">
+                    サービスを開く
+                  </a>
                 </Button>
               </CardActions>
             </Card>

--- a/services/portal/web/src/app/tech/page.tsx
+++ b/services/portal/web/src/app/tech/page.tsx
@@ -7,9 +7,9 @@ import {
   Card,
   CardContent,
   CardActions,
-  Button,
   Chip,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { getAllArticles } from '@/lib/content';
 
 export const metadata: Metadata = {
@@ -64,8 +64,8 @@ export default function TechPage() {
                   </Box>
                 </CardContent>
                 <CardActions>
-                  <Button size="small" href={`/tech/${article.slug}`}>
-                    記事を読む
+                  <Button asChild size="sm" variant="ghost">
+                    <a href={`/tech/${article.slug}`}>記事を読む</a>
                   </Button>
                 </CardActions>
               </Card>

--- a/services/portal/web/src/app/tech/page.tsx
+++ b/services/portal/web/src/app/tech/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import {
   Container,
   Typography,
@@ -65,7 +66,7 @@ export default function TechPage() {
                 </CardContent>
                 <CardActions>
                   <Button asChild size="sm" variant="ghost">
-                    <a href={`/tech/${article.slug}`}>記事を読む</a>
+                    <Link href={`/tech/${article.slug}`}>記事を読む</Link>
                   </Button>
                 </CardActions>
               </Card>

--- a/services/quick-clip/web/jest.config.ts
+++ b/services/quick-clip/web/jest.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
     '^@nagiyu/nextjs$': '<rootDir>/../../../libs/nextjs/src/index.ts',
     '^@nagiyu/nextjs/(.*)$': '<rootDir>/../../../libs/nextjs/src/$1.ts',
     '^@nagiyu/ui$': '<rootDir>/../../../libs/ui/src/index.ts',
+    '^@nagiyu/browser$': '<rootDir>/../../../libs/browser/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/quick-clip-core$': '<rootDir>/../core/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/services/quick-clip/web/src/app/jobs/[jobId]/highlights/page.tsx
+++ b/services/quick-clip/web/src/app/jobs/[jobId]/highlights/page.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Box,
-  Button,
   Chip,
   CircularProgress,
   Container,
@@ -22,6 +21,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ReplayIcon from '@mui/icons-material/Replay';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutlined';
 import type { Highlight } from '@/types/quick-clip';
@@ -581,8 +581,8 @@ export default function HighlightsPage({ params }: HighlightsPageProps) {
                   {/* リトライボタン (FAILED 時のみ) */}
                   {selectedHighlight.clipStatus === 'FAILED' && (
                     <Button
-                      variant="outlined"
-                      color="error"
+                      variant="outline"
+                      color="danger"
                       startIcon={<ReplayIcon />}
                       onClick={() => void onRegenerate(selectedHighlight)}
                     >
@@ -673,9 +673,10 @@ export default function HighlightsPage({ params }: HighlightsPageProps) {
                 </Typography>
 
                 <Button
-                  variant="contained"
+                  variant="solid"
                   onClick={onDownload}
-                  disabled={acceptedCount === 0 || hasUngeneratedAcceptedClip || isDownloading}
+                  loading={isDownloading}
+                  disabled={acceptedCount === 0 || hasUngeneratedAcceptedClip}
                 >
                   {isDownloading ? 'ダウンロード準備中...' : 'ZIP ダウンロード'}
                 </Button>

--- a/services/quick-clip/web/src/app/jobs/[jobId]/page.tsx
+++ b/services/quick-clip/web/src/app/jobs/[jobId]/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
   Alert,
-  Button,
   Chip,
   CircularProgress,
   Container,
@@ -15,6 +14,7 @@ import {
   Stepper,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import WarningIcon from '@mui/icons-material/Warning';
 import type { BatchStage, JobStatus } from '@/types/quick-clip';
@@ -271,14 +271,14 @@ export default function JobPage({ params }: JobPageProps) {
             )}
 
             {canMoveToHighlights && (
-              <Button href={`/jobs/${job.jobId}/highlights`} component={Link} variant="contained">
-                見どころを確認する
+              <Button asChild variant="solid">
+                <Link href={`/jobs/${job.jobId}/highlights`}>見どころを確認する</Link>
               </Button>
             )}
 
             {job.status === 'FAILED' && (
-              <Button href="/" component={Link} variant="outlined">
-                再アップロードする
+              <Button asChild variant="outline">
+                <Link href="/">再アップロードする</Link>
               </Button>
             )}
           </Stack>

--- a/services/quick-clip/web/src/app/page.tsx
+++ b/services/quick-clip/web/src/app/page.tsx
@@ -2,7 +2,8 @@
 
 import { useRef, useState, type ChangeEvent, type DragEvent, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
-import { Alert, Box, Button, Container, LinearProgress, Paper, Typography } from '@mui/material';
+import { Alert, Box, Container, LinearProgress, Paper, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 
 const ERROR_MESSAGES = {
@@ -338,7 +339,7 @@ export default function Home() {
             </Box>
           )}
 
-          <Button type="submit" variant="contained" disabled={!file || isSubmitting}>
+          <Button type="submit" variant="solid" loading={isSubmitting} disabled={!file}>
             {!isSubmitting
               ? 'アップロードして処理開始'
               : (uploadProgress ?? 0) < 100

--- a/services/share-together/web/src/app/groups/page.tsx
+++ b/services/share-together/web/src/app/groups/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Box, Button, Snackbar, Stack, Typography } from '@mui/material';
+import { Box, Snackbar, Stack, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { GroupCard } from '@/components/GroupCard';
 import { CreateItemDialog } from '@/components/CreateItemDialog';
 import { GroupDetailClient } from '@/components/GroupDetailClient';
@@ -145,7 +146,7 @@ export default function GroupsPage() {
           <Typography variant="h5" component="h1">
             グループ
           </Typography>
-          <Button variant="contained" onClick={() => setCreateDialogOpen(true)}>
+          <Button variant="solid" onClick={() => setCreateDialogOpen(true)}>
             グループを作成
           </Button>
         </Stack>

--- a/services/share-together/web/src/app/invitations/page.tsx
+++ b/services/share-together/web/src/app/invitations/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import {
   Box,
-  Button,
   Card,
   CardActions,
   CardContent,
@@ -14,6 +13,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import type { InvitationSummary, InvitationsResponse } from '@/types';
 
 export default function InvitationsPage() {
@@ -131,15 +131,15 @@ export default function InvitationsPage() {
                 <CardActions sx={{ px: 2, pb: 2 }}>
                   <Box sx={{ display: 'flex', gap: 1 }}>
                     <Button
-                      variant="contained"
+                      variant="solid"
                       color="primary"
                       onClick={() => handleAccept(invitation.groupId, invitation.groupName)}
                     >
                       承認
                     </Button>
                     <Button
-                      variant="outlined"
-                      color="inherit"
+                      variant="outline"
+                      color="neutral"
                       onClick={() => handleRejectRequest(invitation.groupId, invitation.groupName)}
                     >
                       拒否

--- a/services/share-together/web/src/app/page.tsx
+++ b/services/share-together/web/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Box, Stack, Typography } from '@mui/material';
 import { Button } from '@nagiyu/ui';
@@ -27,10 +28,10 @@ export default function Home() {
         </Typography>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
           <Button asChild variant="solid">
-            <a href="/lists">リストを開く</a>
+            <Link href="/lists">リストを開く</Link>
           </Button>
           <Button asChild variant="outline">
-            <a href="/groups">グループを管理</a>
+            <Link href="/groups">グループを管理</Link>
           </Button>
         </Stack>
       </Box>

--- a/services/share-together/web/src/app/page.tsx
+++ b/services/share-together/web/src/app/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Box, Button, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { isPersistablePath, loadLastVisitedPath } from '@/lib/lastVisitedPath';
 
 export default function Home() {
@@ -25,11 +26,11 @@ export default function Home() {
           個人リストと共有リストの ToDo を、用途に応じて切り替えながら管理できます。
         </Typography>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-          <Button variant="contained" href="/lists">
-            リストを開く
+          <Button asChild variant="solid">
+            <a href="/lists">リストを開く</a>
           </Button>
-          <Button variant="outlined" href="/groups">
-            グループを管理
+          <Button asChild variant="outline">
+            <a href="/groups">グループを管理</a>
           </Button>
         </Stack>
       </Box>

--- a/services/share-together/web/src/components/ConfirmDialog.tsx
+++ b/services/share-together/web/src/components/ConfirmDialog.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import {
-  Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 
 type ConfirmDialogProps = {
   open: boolean;
@@ -35,8 +35,8 @@ export function ConfirmDialog({
         <DialogContentText>{description}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>{cancelLabel}</Button>
-        <Button onClick={onConfirm} color="error" variant="contained">
+        <Button onClick={onCancel} variant="ghost">{cancelLabel}</Button>
+        <Button onClick={onConfirm} color="danger" variant="solid">
           {confirmLabel}
         </Button>
       </DialogActions>

--- a/services/share-together/web/src/components/ConfirmDialog.tsx
+++ b/services/share-together/web/src/components/ConfirmDialog.tsx
@@ -35,7 +35,9 @@ export function ConfirmDialog({
         <DialogContentText>{description}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel} variant="ghost">{cancelLabel}</Button>
+        <Button onClick={onCancel} variant="ghost">
+          {cancelLabel}
+        </Button>
         <Button onClick={onConfirm} color="danger" variant="solid">
           {confirmLabel}
         </Button>

--- a/services/share-together/web/src/components/CreateItemDialog.tsx
+++ b/services/share-together/web/src/components/CreateItemDialog.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from 'react';
 import {
-  Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   TextField,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 
 type CreateItemDialogProps = {
   open: boolean;
@@ -48,8 +48,8 @@ export function CreateItemDialog({ open, title, label, onClose, onCreate }: Crea
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose}>キャンセル</Button>
-        <Button onClick={handleCreate} variant="contained" disabled={!name.trim()}>
+        <Button onClick={handleClose} variant="ghost">キャンセル</Button>
+        <Button onClick={handleCreate} variant="solid" disabled={!name.trim()}>
           作成
         </Button>
       </DialogActions>

--- a/services/share-together/web/src/components/CreateItemDialog.tsx
+++ b/services/share-together/web/src/components/CreateItemDialog.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  TextField,
-} from '@mui/material';
+import { Dialog, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 
 type CreateItemDialogProps = {
@@ -48,7 +42,9 @@ export function CreateItemDialog({ open, title, label, onClose, onCreate }: Crea
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} variant="ghost">キャンセル</Button>
+        <Button onClick={handleClose} variant="ghost">
+          キャンセル
+        </Button>
         <Button onClick={handleCreate} variant="solid" disabled={!name.trim()}>
           作成
         </Button>

--- a/services/share-together/web/src/components/GroupDetailClient.tsx
+++ b/services/share-together/web/src/components/GroupDetailClient.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   IconButton,
@@ -17,6 +16,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { InviteForm } from '@/components/InviteForm';
@@ -247,11 +247,11 @@ export function GroupDetailClient({
             </List>
             <Box sx={{ mt: 2, display: 'flex', gap: 1 }}>
               {isOwner ? (
-                <Button variant="outlined" color="error" onClick={handleDeleteGroupRequest}>
+                <Button variant="outline" color="danger" onClick={handleDeleteGroupRequest}>
                   グループを削除
                 </Button>
               ) : (
-                <Button variant="outlined" color="warning" onClick={handleLeaveGroupRequest}>
+                <Button variant="outline" color="warning" onClick={handleLeaveGroupRequest}>
                   グループを脱退
                 </Button>
               )}
@@ -267,8 +267,8 @@ export function GroupDetailClient({
             <List>
               {groupLists.map((list) => (
                 <ListItem key={list.listId} disablePadding>
-                  <Button component={Link} href={createSharedListHref(list.listId)}>
-                    {list.name}
+                  <Button asChild variant="ghost">
+                    <Link href={createSharedListHref(list.listId)}>{list.name}</Link>
                   </Button>
                 </ListItem>
               ))}
@@ -285,8 +285,8 @@ export function GroupDetailClient({
                 onChange={(event) => setListName(event.target.value)}
               />
               <Button
-                variant="contained"
-                disabled={isCreatingList}
+                variant="solid"
+                loading={isCreatingList}
                 onClick={() => {
                   if (!isCreatingList) {
                     void handleCreateGroupList();

--- a/services/share-together/web/src/components/InvitationBadge.tsx
+++ b/services/share-together/web/src/components/InvitationBadge.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Badge, Button } from '@mui/material';
+import { Badge } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import type { InvitationsResponse } from '@/types';
 
 const ERROR_MESSAGES = {
@@ -36,10 +37,12 @@ export function InvitationBadge() {
   }, []);
 
   return (
-    <Button color="inherit" href="/invitations">
-      <Badge badgeContent={pendingInvitations} color="secondary" showZero>
-        招待
-      </Badge>
+    <Button asChild variant="ghost" color="neutral">
+      <a href="/invitations">
+        <Badge badgeContent={pendingInvitations} color="secondary" showZero>
+          招待
+        </Badge>
+      </a>
     </Button>
   );
 }

--- a/services/share-together/web/src/components/InvitationBadge.tsx
+++ b/services/share-together/web/src/components/InvitationBadge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Badge } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import type { InvitationsResponse } from '@/types';
@@ -38,11 +39,11 @@ export function InvitationBadge() {
 
   return (
     <Button asChild variant="ghost" color="neutral">
-      <a href="/invitations">
+      <Link href="/invitations">
         <Badge badgeContent={pendingInvitations} color="secondary" showZero>
           招待
         </Badge>
-      </a>
+      </Link>
     </Button>
   );
 }

--- a/services/share-together/web/src/components/InviteForm.tsx
+++ b/services/share-together/web/src/components/InviteForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Button, Stack, TextField, Typography } from '@mui/material';
+import { Box, Stack, TextField, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 
 type InviteFormProps = {
@@ -95,8 +96,9 @@ export function InviteForm({ groupId, isOwner, memberCount }: InviteFormProps) {
           />
           <Button
             type="button"
-            variant="contained"
-            disabled={!isOwner || isSubmitting || isMemberLimitReached}
+            variant="solid"
+            loading={isSubmitting}
+            disabled={!isOwner || isMemberLimitReached}
             onClick={handleSubmit}
           >
             招待を送信

--- a/services/share-together/web/src/components/ListSidebar.tsx
+++ b/services/share-together/web/src/components/ListSidebar.tsx
@@ -7,7 +7,6 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import {
   Box,
-  Button,
   IconButton,
   List,
   ListItem,
@@ -18,6 +17,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import type { ApiErrorResponse, PersonalListResponse, PersonalListsResponse } from '@/types';
 import { ERROR_MESSAGES as COMMON_ERROR_MESSAGES } from '@/lib/constants/errors';
 
@@ -221,10 +221,9 @@ export function ListSidebar({
       <Typography variant="h6" component="h3" gutterBottom>
         {heading}
       </Typography>
-      <Box sx={{ mb: 2 }}>
+      <Box sx={{ mb: 2, '& > button': { width: '100%' } }}>
         <Button
-          variant="contained"
-          fullWidth
+          variant="solid"
           onClick={handleCreateList}
           disabled={isPersonalListLimitReached}
         >

--- a/services/share-together/web/src/components/ListSidebar.tsx
+++ b/services/share-together/web/src/components/ListSidebar.tsx
@@ -222,11 +222,7 @@ export function ListSidebar({
         {heading}
       </Typography>
       <Box sx={{ mb: 2, '& > button': { width: '100%' } }}>
-        <Button
-          variant="solid"
-          onClick={handleCreateList}
-          disabled={isPersonalListLimitReached}
-        >
+        <Button variant="solid" onClick={handleCreateList} disabled={isPersonalListLimitReached}>
           {createButtonLabel}
         </Button>
         {isPersonalListLimitReached ? (

--- a/services/share-together/web/src/components/TodoForm.tsx
+++ b/services/share-together/web/src/components/TodoForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Button, TextField } from '@mui/material';
+import { Box, TextField } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 
 type TodoFormProps = {
   onAdd?: (title: string) => void;
@@ -29,7 +30,7 @@ export function TodoForm({ onAdd }: TodoFormProps) {
         size="small"
         fullWidth
       />
-      <Button type="submit" variant="contained" disabled={isTitleEmpty}>
+      <Button type="submit" variant="solid" disabled={isTitleEmpty}>
         追加
       </Button>
     </Box>

--- a/services/share-together/web/src/components/TodoItem.tsx
+++ b/services/share-together/web/src/components/TodoItem.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Button, Checkbox, ListItem, TextField, Typography } from '@mui/material';
+import { Box, Checkbox, ListItem, TextField, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import type { TodoItem as TodoItemType } from '@/types';
 
 type TodoItemProps = {

--- a/services/share-together/web/src/components/TodoItem.tsx
+++ b/services/share-together/web/src/components/TodoItem.tsx
@@ -68,15 +68,19 @@ export function TodoItem({ todo, onToggleComplete, onDelete, onUpdate }: TodoIte
         )}
         {isEditing ? (
           <>
-            <Button onClick={handleEditCancel}>キャンセル</Button>
-            <Button variant="contained" onClick={handleEditSave} disabled={isEditingTitleEmpty}>
+            <Button variant="ghost" onClick={handleEditCancel}>
+              キャンセル
+            </Button>
+            <Button variant="solid" onClick={handleEditSave} disabled={isEditingTitleEmpty}>
               保存
             </Button>
           </>
         ) : (
-          <Button onClick={handleEditStart}>編集</Button>
+          <Button variant="ghost" onClick={handleEditStart}>
+            編集
+          </Button>
         )}
-        <Button color="error" onClick={() => onDelete?.(todo.todoId)}>
+        <Button variant="ghost" color="danger" onClick={() => onDelete?.(todo.todoId)}>
           削除
         </Button>
       </Box>

--- a/services/stock-tracker/web/app/alerts/page.tsx
+++ b/services/stock-tracker/web/app/alerts/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, Suspense, useMemo } from 'react';
 import {
   Container,
   Box,
-  Button,
   Typography,
   Table,
   TableBody,
@@ -21,6 +20,7 @@ import {
   Select,
   MenuItem,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import {
   Edit as EditIcon,
   Delete as DeleteIcon,
@@ -286,7 +286,7 @@ function AlertsPageContent() {
       {/* ヘッダー */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <Button startIcon={<ArrowBackIcon />} onClick={() => router.back()} variant="outlined">
+          <Button startIcon={<ArrowBackIcon />} onClick={() => router.back()} variant="outline">
             戻る
           </Button>
           <Typography variant="h5" component="h1" sx={{ fontWeight: 'bold' }}>
@@ -333,7 +333,7 @@ function AlertsPageContent() {
         </FormControl>
 
         <Button
-          variant="outlined"
+          variant="outline"
           onClick={handleClearFilters}
           disabled={!filterExchangeKey && !filterMode}
         >
@@ -429,18 +429,18 @@ function AlertsPageContent() {
                       <TableCell align="center">
                         <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center' }}>
                           <Button
-                            variant="contained"
+                            variant="solid"
                             color="warning"
-                            size="small"
+                            size="sm"
                             startIcon={<EditIcon />}
                             onClick={() => handleOpenEditModal(alert)}
                           >
                             編集
                           </Button>
                           <Button
-                            variant="contained"
-                            color="error"
-                            size="small"
+                            variant="solid"
+                            color="danger"
+                            size="sm"
                             startIcon={<DeleteIcon />}
                             onClick={() => handleOpenDeleteDialog(alert)}
                           >

--- a/services/stock-tracker/web/app/exchanges/page.tsx
+++ b/services/stock-tracker/web/app/exchanges/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   Container,
   Box,
-  Button,
   Paper,
   Table,
   TableBody,
@@ -26,6 +25,7 @@ import {
   FormControl,
   InputLabel,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import {
   Add as AddIcon,
   Edit as EditIcon,
@@ -396,12 +396,7 @@ export default function ExchangesPage() {
       {/* ヘッダー */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <Button
-            variant="outlined"
-            startIcon={<ArrowBackIcon />}
-            onClick={() => router.push('/')}
-            sx={{ minWidth: 120 }}
-          >
+          <Button variant="outline" startIcon={<ArrowBackIcon />} onClick={() => router.push('/')}>
             戻る
           </Button>
           <Typography variant="h4" component="h1">
@@ -409,7 +404,7 @@ export default function ExchangesPage() {
           </Typography>
         </Box>
         <Button
-          variant="contained"
+          variant="solid"
           color="primary"
           startIcon={<AddIcon />}
           onClick={handleCreateOpen}
@@ -475,21 +470,18 @@ export default function ExchangesPage() {
                     <TableCell align="center">
                       <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center' }}>
                         <Button
-                          variant="contained"
-                          size="small"
+                          variant="solid"
+                          color="warning"
+                          size="sm"
                           startIcon={<EditIcon />}
                           onClick={() => handleEditOpen(exchange)}
-                          sx={{
-                            backgroundColor: '#ffc107',
-                            '&:hover': { backgroundColor: '#ffa000' },
-                          }}
                         >
                           編集
                         </Button>
                         <Button
-                          variant="contained"
-                          size="small"
-                          color="error"
+                          variant="solid"
+                          size="sm"
+                          color="danger"
                           startIcon={<DeleteIcon />}
                           onClick={() => handleDeleteOpen(exchange)}
                         >
@@ -658,16 +650,11 @@ export default function ExchangesPage() {
           </Box>
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 3 }}>
-          <Button onClick={handleCloseModals} disabled={submitting} sx={{ minWidth: 100 }}>
+          <Button onClick={handleCloseModals} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
-          <Button
-            variant="contained"
-            onClick={handleCreate}
-            disabled={submitting}
-            sx={{ minWidth: 100 }}
-          >
-            {submitting ? <CircularProgress size={24} /> : '保存'}
+          <Button variant="solid" onClick={handleCreate} loading={submitting}>
+            保存
           </Button>
         </DialogActions>
       </Dialog>
@@ -817,16 +804,11 @@ export default function ExchangesPage() {
           </Box>
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 3 }}>
-          <Button onClick={handleCloseModals} disabled={submitting} sx={{ minWidth: 100 }}>
+          <Button onClick={handleCloseModals} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
-          <Button
-            variant="contained"
-            onClick={handleUpdate}
-            disabled={submitting}
-            sx={{ minWidth: 100 }}
-          >
-            {submitting ? <CircularProgress size={24} /> : '保存'}
+          <Button variant="solid" onClick={handleUpdate} loading={submitting}>
+            保存
           </Button>
         </DialogActions>
       </Dialog>
@@ -841,17 +823,11 @@ export default function ExchangesPage() {
           </Typography>
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 3 }}>
-          <Button onClick={handleCloseModals} disabled={submitting} sx={{ minWidth: 100 }}>
+          <Button onClick={handleCloseModals} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
-          <Button
-            variant="contained"
-            color="error"
-            onClick={handleDelete}
-            disabled={submitting}
-            sx={{ minWidth: 100 }}
-          >
-            {submitting ? <CircularProgress size={24} /> : '削除'}
+          <Button variant="solid" color="danger" onClick={handleDelete} loading={submitting}>
+            削除
           </Button>
         </DialogActions>
       </Dialog>

--- a/services/stock-tracker/web/app/holdings/page.tsx
+++ b/services/stock-tracker/web/app/holdings/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import {
   Container,
   Box,
-  Button,
   Typography,
   Table,
   TableBody,
@@ -25,6 +24,7 @@ import {
   Select,
   MenuItem,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import {
   Add as AddIcon,
   Edit as EditIcon,
@@ -603,7 +603,7 @@ export default function HoldingsPage() {
       {/* ヘッダー */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <Button startIcon={<ArrowBackIcon />} onClick={() => router.push('/')} variant="outlined">
+          <Button startIcon={<ArrowBackIcon />} onClick={() => router.push('/')} variant="outline">
             戻る
           </Button>
           <Typography variant="h5" component="h1" sx={{ fontWeight: 'bold' }}>
@@ -612,7 +612,7 @@ export default function HoldingsPage() {
         </Box>
         <Button
           startIcon={<AddIcon />}
-          variant="contained"
+          variant="solid"
           color="primary"
           onClick={handleOpenCreateModal}
         >
@@ -707,12 +707,11 @@ export default function HoldingsPage() {
                       <TableCell>{holding.currency}</TableCell>
                       <TableCell align="center">
                         <Button
-                          variant="contained"
+                          variant="solid"
                           color={hasAlert ? 'primary' : 'success'}
-                          size="small"
+                          size="sm"
                           startIcon={hasAlert ? <CheckCircleIcon /> : <NotificationsNoneIcon />}
                           onClick={() => handleOpenAlertModal(holding)}
-                          sx={{ minWidth: 140 }}
                         >
                           {hasAlert ? 'アラート設定済' : '売りアラート'}
                         </Button>
@@ -720,18 +719,18 @@ export default function HoldingsPage() {
                       <TableCell align="center">
                         <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center' }}>
                           <Button
-                            variant="contained"
+                            variant="solid"
                             color="warning"
-                            size="small"
+                            size="sm"
                             startIcon={<EditIcon />}
                             onClick={() => handleOpenEditModal(holding)}
                           >
                             編集
                           </Button>
                           <Button
-                            variant="contained"
-                            color="error"
-                            size="small"
+                            variant="solid"
+                            color="danger"
+                            size="sm"
                             startIcon={<DeleteIcon />}
                             onClick={() => handleOpenDeleteDialog(holding)}
                             disabled={submitting || deleteDialogLoading}
@@ -872,11 +871,11 @@ export default function HoldingsPage() {
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseCreateModal} disabled={submitting}>
+          <Button onClick={handleCloseCreateModal} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
-          <Button onClick={handleCreate} variant="contained" color="primary" disabled={submitting}>
-            {submitting ? <CircularProgress size={24} /> : '保存'}
+          <Button onClick={handleCreate} variant="solid" color="primary" loading={submitting}>
+            保存
           </Button>
         </DialogActions>
       </Dialog>
@@ -949,11 +948,11 @@ export default function HoldingsPage() {
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseEditModal} disabled={submitting}>
+          <Button onClick={handleCloseEditModal} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
-          <Button onClick={handleUpdate} variant="contained" color="primary" disabled={submitting}>
-            {submitting ? <CircularProgress size={24} /> : '保存'}
+          <Button onClick={handleUpdate} variant="solid" color="primary" loading={submitting}>
+            保存
           </Button>
         </DialogActions>
       </Dialog>
@@ -1007,11 +1006,11 @@ export default function HoldingsPage() {
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseDeleteDialog} disabled={submitting}>
+          <Button onClick={handleCloseDeleteDialog} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
-          <Button onClick={handleDelete} variant="contained" color="error" disabled={submitting}>
-            {submitting ? <CircularProgress size={24} /> : '削除'}
+          <Button onClick={handleDelete} variant="solid" color="danger" loading={submitting}>
+            削除
           </Button>
         </DialogActions>
       </Dialog>

--- a/services/stock-tracker/web/app/summaries/page.tsx
+++ b/services/stock-tracker/web/app/summaries/page.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   FormControl,
@@ -21,6 +20,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { useSession } from 'next-auth/react';
 import { hasPermission } from '@nagiyu/common';
 import type { SummariesResponse, TickerSummary } from '@/types/stock';
@@ -165,7 +165,7 @@ export default function SummariesPage() {
           </Select>
         </FormControl>
         {hasManageDataPermission && (
-          <Button variant="contained" onClick={handleRefresh} disabled={isRefreshing}>
+          <Button variant="solid" onClick={handleRefresh} loading={isRefreshing}>
             サマリー更新
           </Button>
         )}

--- a/services/stock-tracker/web/app/tickers/page.tsx
+++ b/services/stock-tracker/web/app/tickers/page.tsx
@@ -5,7 +5,6 @@ import {
   Container,
   Box,
   Typography,
-  Button,
   Paper,
   Table,
   TableBody,
@@ -27,6 +26,7 @@ import {
   CircularProgress,
   SelectChangeEvent,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { Add as AddIcon, Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material';
 
 // エラーメッセージ定数
@@ -312,7 +312,7 @@ export default function TickersPage() {
           ティッカー管理
         </Typography>
         <Button
-          variant="contained"
+          variant="solid"
           color="primary"
           startIcon={<AddIcon />}
           onClick={openCreateModal}
@@ -459,10 +459,12 @@ export default function TickersPage() {
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={closeModals}>キャンセル</Button>
+          <Button onClick={closeModals} variant="ghost">
+            キャンセル
+          </Button>
           <Button
             onClick={handleCreate}
-            variant="contained"
+            variant="solid"
             color="primary"
             disabled={!formData.symbol || !formData.name || !formData.exchangeId}
           >
@@ -511,13 +513,10 @@ export default function TickersPage() {
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={closeModals}>キャンセル</Button>
-          <Button
-            onClick={handleUpdate}
-            variant="contained"
-            color="primary"
-            disabled={!formData.name}
-          >
+          <Button onClick={closeModals} variant="ghost">
+            キャンセル
+          </Button>
+          <Button onClick={handleUpdate} variant="solid" color="primary" disabled={!formData.name}>
             更新
           </Button>
         </DialogActions>
@@ -536,8 +535,10 @@ export default function TickersPage() {
           </Alert>
         </DialogContent>
         <DialogActions>
-          <Button onClick={closeModals}>キャンセル</Button>
-          <Button onClick={handleDelete} variant="contained" color="error">
+          <Button onClick={closeModals} variant="ghost">
+            キャンセル
+          </Button>
+          <Button onClick={handleDelete} variant="solid" color="danger">
             削除
           </Button>
         </DialogActions>

--- a/services/stock-tracker/web/components/AlertDeleteConfirmDialog.tsx
+++ b/services/stock-tracker/web/components/AlertDeleteConfirmDialog.tsx
@@ -1,13 +1,6 @@
 'use client';
 
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Typography,
-  Box,
-} from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Typography, Box } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import type { AlertResponse } from '../types/alert';
 

--- a/services/stock-tracker/web/components/AlertDeleteConfirmDialog.tsx
+++ b/services/stock-tracker/web/components/AlertDeleteConfirmDialog.tsx
@@ -5,11 +5,10 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   Typography,
   Box,
-  CircularProgress,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import type { AlertResponse } from '../types/alert';
 
 interface AlertDeleteConfirmDialogProps {
@@ -96,11 +95,11 @@ export default function AlertDeleteConfirmDialog({
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={submitting}>
+        <Button onClick={onClose} disabled={submitting} variant="ghost">
           キャンセル
         </Button>
-        <Button onClick={onConfirm} variant="contained" color="error" disabled={submitting}>
-          {submitting ? <CircularProgress size={24} /> : '削除'}
+        <Button onClick={onConfirm} variant="solid" color="danger" loading={submitting}>
+          削除
         </Button>
       </DialogActions>
     </Dialog>

--- a/services/stock-tracker/web/components/AlertSettingsModal.tsx
+++ b/services/stock-tracker/web/components/AlertSettingsModal.tsx
@@ -12,7 +12,6 @@ import {
   Select,
   MenuItem,
   Alert,
-  CircularProgress,
   Box,
   Typography,
   FormControlLabel,

--- a/services/stock-tracker/web/components/AlertSettingsModal.tsx
+++ b/services/stock-tracker/web/components/AlertSettingsModal.tsx
@@ -6,7 +6,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   TextField,
   FormControl,
   InputLabel,
@@ -19,6 +18,7 @@ import {
   FormControlLabel,
   Switch,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { urlBase64ToUint8Array } from '@nagiyu/browser';
 import { calculateTargetPriceFromPercentage, formatPrice } from '../lib/percentage-helper';
 import type { Timeframe } from '../types/stock';
@@ -1651,7 +1651,7 @@ export default function AlertSettingsModal({
           <Typography variant="subtitle1" sx={{ mt: 1 }}>
             通知設定（任意）
           </Typography>
-          <Button variant="outlined" onClick={() => setNotificationEditDialogOpen(true)}>
+          <Button variant="outline" onClick={() => setNotificationEditDialogOpen(true)}>
             通知設定を編集
           </Button>
           <TextField
@@ -1683,11 +1683,11 @@ export default function AlertSettingsModal({
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={submitting}>
+        <Button onClick={onClose} disabled={submitting} variant="ghost">
           キャンセル
         </Button>
-        <Button onClick={handleSubmit} variant="contained" color="primary" disabled={submitting}>
-          {submitting ? <CircularProgress size={24} /> : '保存'}
+        <Button onClick={handleSubmit} variant="solid" color="primary" loading={submitting}>
+          保存
         </Button>
       </DialogActions>
 

--- a/services/stock-tracker/web/components/ErrorDisplay.tsx
+++ b/services/stock-tracker/web/components/ErrorDisplay.tsx
@@ -7,7 +7,8 @@
  */
 
 import React from 'react';
-import { Box, Alert, Button, Typography } from '@mui/material';
+import { Box, Alert, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { Refresh as RefreshIcon } from '@mui/icons-material';
 import type { APIError } from '@nagiyu/common';
 

--- a/services/stock-tracker/web/components/ErrorDisplay.tsx
+++ b/services/stock-tracker/web/components/ErrorDisplay.tsx
@@ -77,7 +77,7 @@ export function ErrorDisplay({
 
       {showRetry && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <Button variant="contained" startIcon={<RefreshIcon />} onClick={onRetry}>
+          <Button variant="solid" startIcon={<RefreshIcon />} onClick={onRetry}>
             再試行
           </Button>
         </Box>
@@ -106,7 +106,7 @@ export function LoadingError({
         {message}
       </Alert>
       {onRetry && (
-        <Button variant="outlined" startIcon={<RefreshIcon />} onClick={onRetry} sx={{ mt: 2 }}>
+        <Button variant="outline" startIcon={<RefreshIcon />} onClick={onRetry}>
           再読み込み
         </Button>
       )}

--- a/services/stock-tracker/web/components/HoldingCard.tsx
+++ b/services/stock-tracker/web/components/HoldingCard.tsx
@@ -319,8 +319,8 @@ export default function HoldingCard({
             保有株式
           </Typography>
           <Button
-            variant="contained"
-            size="small"
+            variant="solid"
+            size="sm"
             startIcon={<AddIcon />}
             onClick={handleOpenCreateModal}
             disabled={!canAddHolding}
@@ -433,11 +433,11 @@ export default function HoldingCard({
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setCreateModalOpen(false)} disabled={submitting}>
+          <Button onClick={() => setCreateModalOpen(false)} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
-          <Button onClick={() => void handleCreate()} variant="contained" disabled={submitting}>
-            {submitting ? <CircularProgress size={24} /> : '保存'}
+          <Button onClick={() => void handleCreate()} variant="solid" loading={submitting}>
+            保存
           </Button>
         </DialogActions>
       </Dialog>
@@ -472,11 +472,11 @@ export default function HoldingCard({
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setEditModalOpen(false)} disabled={submitting}>
+          <Button onClick={() => setEditModalOpen(false)} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
-          <Button onClick={() => void handleUpdate()} variant="contained" disabled={submitting}>
-            {submitting ? <CircularProgress size={24} /> : '保存'}
+          <Button onClick={() => void handleUpdate()} variant="solid" loading={submitting}>
+            保存
           </Button>
         </DialogActions>
       </Dialog>
@@ -534,16 +534,17 @@ export default function HoldingCard({
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setDeleteDialogOpen(false)} disabled={submitting}>
+          <Button onClick={() => setDeleteDialogOpen(false)} disabled={submitting} variant="ghost">
             キャンセル
           </Button>
           <Button
             onClick={() => void handleDelete()}
-            variant="contained"
-            color="error"
-            disabled={submitting || deleteDialogLoading}
+            variant="solid"
+            color="danger"
+            loading={submitting}
+            disabled={deleteDialogLoading}
           >
-            {submitting ? <CircularProgress size={24} /> : '削除'}
+            削除
           </Button>
         </DialogActions>
       </Dialog>

--- a/services/stock-tracker/web/components/HoldingCard.tsx
+++ b/services/stock-tracker/web/components/HoldingCard.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   CircularProgress,
@@ -22,6 +21,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { Add as AddIcon, Delete as DeleteIcon, Edit as EditIcon } from '@mui/icons-material';
 import type { HoldingResponse } from '@/types/holding';
 import type { AlertResponse } from '@/types/alert';

--- a/services/stock-tracker/web/components/NotificationEditDialog.tsx
+++ b/services/stock-tracker/web/components/NotificationEditDialog.tsx
@@ -1,14 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  TextField,
-} from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, TextField } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 
 interface NotificationEditDialogProps {
   open: boolean;
@@ -52,8 +46,10 @@ export default function NotificationEditDialog({
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>キャンセル</Button>
-        <Button onClick={() => onSave(localTitle, localBody)} variant="contained">
+        <Button onClick={onClose} variant="ghost">
+          キャンセル
+        </Button>
+        <Button onClick={() => onSave(localTitle, localBody)} variant="solid">
           保存
         </Button>
       </DialogActions>

--- a/services/stock-tracker/web/components/NotificationOverwriteConfirmDialog.tsx
+++ b/services/stock-tracker/web/components/NotificationOverwriteConfirmDialog.tsx
@@ -1,13 +1,7 @@
 'use client';
 
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  Typography,
-} from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 
 interface NotificationOverwriteConfirmDialogProps {
   open: boolean;
@@ -29,8 +23,10 @@ export default function NotificationOverwriteConfirmDialog({
         </Typography>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>このまま維持する</Button>
-        <Button onClick={onConfirm} variant="contained">
+        <Button onClick={onCancel} variant="ghost">
+          このまま維持する
+        </Button>
+        <Button onClick={onConfirm} variant="solid">
           上書きする
         </Button>
       </DialogActions>

--- a/services/stock-tracker/web/components/QuickActions.tsx
+++ b/services/stock-tracker/web/components/QuickActions.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Box, Typography, Button } from '@mui/material';
+import Link from 'next/link';
+import { Box, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import {
   TrendingUp as TrendingUpIcon,
   Notifications as NotificationsIcon,
@@ -27,60 +29,45 @@ export default function QuickActions({ hasManageDataPermission }: QuickActionsPr
         }}
       >
         {/* 1. 保有株式管理 */}
-        <Button
-          variant="contained"
-          size="large"
-          href="/holdings"
-          startIcon={<TrendingUpIcon />}
-          sx={{ py: 2 }}
-        >
-          保有株式管理
+        <Button asChild variant="solid" size="lg">
+          <Link href="/holdings">
+            <TrendingUpIcon />
+            保有株式管理
+          </Link>
         </Button>
 
         {/* 2. アラート一覧 */}
-        <Button
-          variant="contained"
-          size="large"
-          href="/alerts"
-          startIcon={<NotificationsIcon />}
-          sx={{ py: 2 }}
-        >
-          アラート一覧
+        <Button asChild variant="solid" size="lg">
+          <Link href="/alerts">
+            <NotificationsIcon />
+            アラート一覧
+          </Link>
         </Button>
 
-        <Button
-          variant="contained"
-          size="large"
-          href="/summaries"
-          startIcon={<SummarizeIcon />}
-          sx={{ py: 2 }}
-        >
-          サマリー
+        <Button asChild variant="solid" size="lg">
+          <Link href="/summaries">
+            <SummarizeIcon />
+            サマリー
+          </Link>
         </Button>
 
         {/* 4. 取引所管理 (stock-admin のみ) */}
         {hasManageDataPermission && (
-          <Button
-            variant="outlined"
-            size="large"
-            href="/exchanges"
-            startIcon={<BusinessIcon />}
-            sx={{ py: 2 }}
-          >
-            取引所管理
+          <Button asChild variant="outline" size="lg">
+            <Link href="/exchanges">
+              <BusinessIcon />
+              取引所管理
+            </Link>
           </Button>
         )}
 
         {/* 5. ティッカー管理 (stock-admin のみ) */}
         {hasManageDataPermission && (
-          <Button
-            variant="outlined"
-            size="large"
-            href="/tickers"
-            startIcon={<ShowChartIcon />}
-            sx={{ py: 2 }}
-          >
-            ティッカー管理
+          <Button asChild variant="outline" size="lg">
+            <Link href="/tickers">
+              <ShowChartIcon />
+              ティッカー管理
+            </Link>
           </Button>
         )}
       </Box>

--- a/services/stock-tracker/web/components/SummaryDetailDialog.tsx
+++ b/services/stock-tracker/web/components/SummaryDetailDialog.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import {
   Box,
-  Button,
   Chip,
   Dialog,
   DialogContent,
@@ -20,6 +19,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { Close as CloseIcon } from '@mui/icons-material';
 import AlertSettingsModal from './AlertSettingsModal';
 import StockChart from './StockChart';
@@ -202,11 +202,11 @@ export default function SummaryDetailDialog({
               </TableContainer>
               <Divider />
               <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                <Button variant="outlined" onClick={() => openAlertModal('Buy', summary.close)}>
+                <Button variant="outline" onClick={() => openAlertModal('Buy', summary.close)}>
                   買いアラート設定
                 </Button>
                 {summary.holding && (
-                  <Button variant="outlined" onClick={() => openAlertModal('Sell', summary.close)}>
+                  <Button variant="outline" onClick={() => openAlertModal('Sell', summary.close)}>
                     売りアラート設定
                   </Button>
                 )}

--- a/services/stock-tracker/web/components/TickerAlertListCard.tsx
+++ b/services/stock-tracker/web/components/TickerAlertListCard.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   Chip,
@@ -14,6 +13,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { Add as AddIcon, Delete as DeleteIcon, Edit as EditIcon } from '@mui/icons-material';
 import type { AlertResponse } from '@/types/alert';
 import AlertSettingsModal from './AlertSettingsModal';
@@ -118,8 +118,8 @@ export default function TickerAlertListCard({
           </Typography>
           <Box sx={{ display: 'flex', gap: 1 }}>
             <Button
-              variant="contained"
-              size="small"
+              variant="solid"
+              size="sm"
               color="success"
               startIcon={<AddIcon />}
               onClick={() => setCreateTradeMode('Buy')}
@@ -128,8 +128,8 @@ export default function TickerAlertListCard({
               買い追加
             </Button>
             <Button
-              variant="contained"
-              size="small"
+              variant="solid"
+              size="sm"
               color="warning"
               startIcon={<AddIcon />}
               onClick={() => setCreateTradeMode('Sell')}

--- a/services/stock-tracker/web/components/TickerSummaryCard.tsx
+++ b/services/stock-tracker/web/components/TickerSummaryCard.tsx
@@ -1,16 +1,8 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Chip,
-  CircularProgress,
-  Grid,
-  Typography,
-} from '@mui/material';
+import { Box, Card, CardContent, Chip, CircularProgress, Grid, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import type { TickerSummary } from '@/types/stock';
 import SummaryDetailDialog from './SummaryDetailDialog';
 
@@ -113,7 +105,7 @@ export default function TickerSummaryCard({
               </Typography>
             </Grid>
             <Grid size={12}>
-              <Button variant="outlined" size="small" onClick={() => setIsDetailDialogOpen(true)}>
+              <Button variant="outline" size="sm" onClick={() => setIsDetailDialogOpen(true)}>
                 詳細
               </Button>
             </Grid>

--- a/services/stock-tracker/web/tests/unit/components/home-page-client-query-selection.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/home-page-client-query-selection.test.ts
@@ -28,6 +28,34 @@ jest.mock('@nagiyu/ui', () => ({
   __esModule: true,
   ErrorAlert: ({ message }: { message: string }) =>
     React.createElement('div', { role: 'alert' }, message),
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    type,
+    asChild,
+    loading,
+    startIcon,
+    ...rest
+  }: {
+    children?: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    type?: 'button' | 'submit' | 'reset';
+    asChild?: boolean;
+    loading?: boolean;
+    startIcon?: React.ReactNode;
+    [key: string]: unknown;
+  }) => {
+    void asChild;
+    void loading;
+    void startIcon;
+    return React.createElement(
+      'button',
+      { onClick, disabled, type: type ?? 'button', ...rest },
+      children
+    );
+  },
 }));
 
 jest.mock('../../../components/EmptyState', () => ({

--- a/services/tools/src/app/base64/Base64Client.tsx
+++ b/services/tools/src/app/base64/Base64Client.tsx
@@ -1,16 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  Alert,
-  Box,
-  Button,
-  Container,
-  Snackbar,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Alert, Box, Container, Snackbar, Stack, TextField, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ClearIcon from '@mui/icons-material/Clear';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
@@ -108,14 +100,14 @@ export default function Base64Client() {
       <Box sx={{ mb: 3 }}>
         <Stack direction="row" spacing={2}>
           <Button
-            variant={mode === 'encode' ? 'contained' : 'outlined'}
+            variant={mode === 'encode' ? 'solid' : 'outline'}
             onClick={() => handleModeChange('encode')}
             aria-label="エンコードモードに切り替える"
           >
             エンコード
           </Button>
           <Button
-            variant={mode === 'decode' ? 'contained' : 'outlined'}
+            variant={mode === 'decode' ? 'solid' : 'outline'}
             onClick={() => handleModeChange('decode')}
             aria-label="デコードモードに切り替える"
           >
@@ -150,7 +142,7 @@ export default function Base64Client() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ContentPasteIcon />}
             onClick={handleReadClipboard}
             aria-label="クリップボードから入力を読み取る"
@@ -158,7 +150,7 @@ export default function Base64Client() {
             クリップボードから読み取り
           </Button>
           <Button
-            variant="contained"
+            variant="solid"
             onClick={handleConvert}
             disabled={!inputText.trim()}
             aria-label={
@@ -194,7 +186,7 @@ export default function Base64Client() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="contained"
+            variant="solid"
             startIcon={<ContentCopyIcon />}
             onClick={handleCopy}
             disabled={!outputText}
@@ -203,7 +195,7 @@ export default function Base64Client() {
             コピー
           </Button>
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ClearIcon />}
             onClick={handleClear}
             disabled={!inputText && !outputText}

--- a/services/tools/src/app/hash-generator/HashGeneratorClient.tsx
+++ b/services/tools/src/app/hash-generator/HashGeneratorClient.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import {
   Alert,
   Box,
-  Button,
   Container,
   MenuItem,
   Snackbar,
@@ -12,6 +11,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ClearIcon from '@mui/icons-material/Clear';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
@@ -133,7 +133,7 @@ export default function HashGeneratorClient() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ContentPasteIcon />}
             onClick={handleReadClipboard}
             aria-label="クリップボードから入力を読み取る"
@@ -141,7 +141,7 @@ export default function HashGeneratorClient() {
             クリップボードから読み取り
           </Button>
           <Button
-            variant="contained"
+            variant="solid"
             onClick={handleGenerate}
             disabled={!inputText.trim()}
             aria-label="入力文字列のハッシュを生成する"
@@ -175,7 +175,7 @@ export default function HashGeneratorClient() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="contained"
+            variant="solid"
             startIcon={<ContentCopyIcon />}
             onClick={handleCopy}
             disabled={!outputText}
@@ -184,7 +184,7 @@ export default function HashGeneratorClient() {
             コピー
           </Button>
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ClearIcon />}
             onClick={handleClear}
             disabled={!inputText && !outputText}

--- a/services/tools/src/app/json-formatter/JsonFormatterClient.tsx
+++ b/services/tools/src/app/json-formatter/JsonFormatterClient.tsx
@@ -5,7 +5,6 @@ import {
   Container,
   Typography,
   TextField,
-  Button,
   Box,
   Snackbar,
   Alert,
@@ -14,6 +13,7 @@ import {
   AccordionSummary,
   AccordionDetails,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ClearIcon from '@mui/icons-material/Clear';
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
@@ -234,7 +234,7 @@ export default function JsonFormatterClient() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ContentPasteIcon />}
             onClick={handleReadClipboard}
             aria-label="クリップボードから JSON を読み取る"
@@ -242,7 +242,7 @@ export default function JsonFormatterClient() {
             クリップボードから読み取り
           </Button>
           <Button
-            variant="contained"
+            variant="solid"
             onClick={handleFormat}
             disabled={!inputText.trim()}
             aria-label="JSON を整形する"
@@ -250,7 +250,7 @@ export default function JsonFormatterClient() {
             整形
           </Button>
           <Button
-            variant="contained"
+            variant="solid"
             onClick={handleMinify}
             disabled={!inputText.trim()}
             aria-label="JSON を圧縮する"
@@ -285,7 +285,7 @@ export default function JsonFormatterClient() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="contained"
+            variant="solid"
             startIcon={<ContentCopyIcon />}
             onClick={handleCopy}
             disabled={!outputText}
@@ -294,7 +294,7 @@ export default function JsonFormatterClient() {
             コピー
           </Button>
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ClearIcon />}
             onClick={handleClear}
             disabled={!inputText && !outputText}

--- a/services/tools/src/app/offline/page.tsx
+++ b/services/tools/src/app/offline/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Box, Container, Typography, Button } from '@mui/material';
+import { Box, Container, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import WifiOffIcon from '@mui/icons-material/WifiOff';
 import RefreshIcon from '@mui/icons-material/Refresh';
 
@@ -31,10 +32,9 @@ export default function OfflinePage() {
         </Typography>
 
         <Button
-          variant="contained"
+          variant="solid"
           startIcon={<RefreshIcon />}
           onClick={() => window.location.reload()}
-          sx={{ mt: 2 }}
         >
           再読み込み
         </Button>

--- a/services/tools/src/app/timestamp-converter/TimestampConverterClient.tsx
+++ b/services/tools/src/app/timestamp-converter/TimestampConverterClient.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import {
   Alert,
   Box,
-  Button,
   Container,
   MenuItem,
   Snackbar,
@@ -12,6 +11,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ClearIcon from '@mui/icons-material/Clear';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { writeToClipboard } from '@nagiyu/browser';
@@ -169,7 +169,7 @@ export default function TimestampConverterClient() {
           sx={{ mb: 2 }}
         />
         <Button
-          variant="contained"
+          variant="solid"
           onClick={handleConvertSeconds}
           disabled={!unixSecondsInput.trim()}
           aria-label="Unix秒を日時に変換する"
@@ -190,7 +190,7 @@ export default function TimestampConverterClient() {
           sx={{ mb: 2 }}
         />
         <Button
-          variant="contained"
+          variant="solid"
           onClick={handleConvertMilliseconds}
           disabled={!unixMillisecondsInput.trim()}
           aria-label="Unixミリ秒を日時に変換する"
@@ -211,7 +211,7 @@ export default function TimestampConverterClient() {
           sx={{ mb: 2 }}
         />
         <Button
-          variant="contained"
+          variant="solid"
           onClick={handleConvertDateTime}
           disabled={!dateTimeInput.trim()}
           aria-label="日時をUnixタイムスタンプに変換する"
@@ -254,7 +254,7 @@ export default function TimestampConverterClient() {
 
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
         <Button
-          variant="contained"
+          variant="solid"
           startIcon={<ContentCopyIcon />}
           onClick={handleCopy}
           disabled={!result}
@@ -263,7 +263,7 @@ export default function TimestampConverterClient() {
           結果をコピー
         </Button>
         <Button
-          variant="outlined"
+          variant="outline"
           startIcon={<ClearIcon />}
           onClick={handleClear}
           disabled={!hasAnyInput}

--- a/services/tools/src/app/transit-converter/page.tsx
+++ b/services/tools/src/app/transit-converter/page.tsx
@@ -5,7 +5,6 @@ import {
   Container,
   Typography,
   TextField,
-  Button,
   Box,
   Snackbar,
   Alert,
@@ -15,6 +14,7 @@ import {
   AccordionSummary,
   AccordionDetails,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ClearIcon from '@mui/icons-material/Clear';
 import SyncIcon from '@mui/icons-material/Sync';
@@ -355,7 +355,7 @@ function TransitConverterContent() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ContentPasteIcon />}
             onClick={handleReadClipboard}
             aria-label="クリップボードから乗り換え案内テキストを読み取る"
@@ -363,12 +363,11 @@ function TransitConverterContent() {
             クリップボードから読み取り
           </Button>
           <Button
-            variant="contained"
-            startIcon={
-              isProcessing ? <CircularProgress size={20} aria-label="変換処理中" /> : <SyncIcon />
-            }
+            variant="solid"
+            startIcon={<SyncIcon />}
             onClick={handleConvert}
-            disabled={isProcessing || !inputText.trim()}
+            loading={isProcessing}
+            disabled={!inputText.trim()}
             aria-label="乗り換え案内テキストを変換する"
           >
             変換
@@ -401,7 +400,7 @@ function TransitConverterContent() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="contained"
+            variant="solid"
             startIcon={<ContentCopyIcon />}
             onClick={handleCopy}
             disabled={!outputText}
@@ -410,7 +409,7 @@ function TransitConverterContent() {
             コピー
           </Button>
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ClearIcon />}
             onClick={handleClear}
             disabled={!inputText && !outputText}

--- a/services/tools/src/app/url-encoder/UrlEncoderClient.tsx
+++ b/services/tools/src/app/url-encoder/UrlEncoderClient.tsx
@@ -1,16 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  Alert,
-  Box,
-  Button,
-  Container,
-  Snackbar,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Alert, Box, Container, Snackbar, Stack, TextField, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ClearIcon from '@mui/icons-material/Clear';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
@@ -105,14 +97,14 @@ export default function UrlEncoderClient() {
       <Box sx={{ mb: 3 }}>
         <Stack direction="row" spacing={2}>
           <Button
-            variant={mode === 'encode' ? 'contained' : 'outlined'}
+            variant={mode === 'encode' ? 'solid' : 'outline'}
             onClick={() => handleModeChange('encode')}
             aria-label="エンコードモードに切り替える"
           >
             エンコード
           </Button>
           <Button
-            variant={mode === 'decode' ? 'contained' : 'outlined'}
+            variant={mode === 'decode' ? 'solid' : 'outline'}
             onClick={() => handleModeChange('decode')}
             aria-label="デコードモードに切り替える"
           >
@@ -147,7 +139,7 @@ export default function UrlEncoderClient() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ContentPasteIcon />}
             onClick={handleReadClipboard}
             aria-label="クリップボードから入力を読み取る"
@@ -155,7 +147,7 @@ export default function UrlEncoderClient() {
             クリップボードから読み取り
           </Button>
           <Button
-            variant="contained"
+            variant="solid"
             onClick={handleConvert}
             disabled={!inputText.trim()}
             aria-label={
@@ -191,7 +183,7 @@ export default function UrlEncoderClient() {
           sx={{ '& > button': { xs: { width: '100%' }, sm: { width: 'auto' } } }}
         >
           <Button
-            variant="contained"
+            variant="solid"
             startIcon={<ContentCopyIcon />}
             onClick={handleCopy}
             disabled={!outputText}
@@ -200,7 +192,7 @@ export default function UrlEncoderClient() {
             コピー
           </Button>
           <Button
-            variant="outlined"
+            variant="outline"
             startIcon={<ClearIcon />}
             onClick={handleClear}
             disabled={!inputText && !outputText}

--- a/services/tools/src/app/vapid-generator/page.tsx
+++ b/services/tools/src/app/vapid-generator/page.tsx
@@ -1,16 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import {
-  Alert,
-  Box,
-  Button,
-  Container,
-  Snackbar,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Alert, Box, Container, Snackbar, Stack, TextField, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import AutorenewIcon from '@mui/icons-material/Autorenew';
 import { writeToClipboard } from '@nagiyu/browser';
@@ -84,10 +76,10 @@ export default function VapidGeneratorPage() {
 
         <Box sx={{ mb: 3, mt: 3 }}>
           <Button
-            variant="contained"
+            variant="solid"
             startIcon={<AutorenewIcon />}
             onClick={handleGenerate}
-            disabled={isGenerating}
+            loading={isGenerating}
             aria-label="VAPIDキーを生成する"
           >
             {isGenerating ? '生成中...' : 'VAPIDキーを生成'}
@@ -109,7 +101,7 @@ export default function VapidGeneratorPage() {
               sx={{ mb: 1.5 }}
             />
             <Button
-              variant="outlined"
+              variant="outline"
               startIcon={<ContentCopyIcon />}
               onClick={() => keys && handleCopy(keys.publicKey)}
               disabled={!keys?.publicKey}
@@ -133,7 +125,7 @@ export default function VapidGeneratorPage() {
               sx={{ mb: 1.5 }}
             />
             <Button
-              variant="outlined"
+              variant="outline"
               startIcon={<ContentCopyIcon />}
               onClick={() => keys && handleCopy(keys.privateKey)}
               disabled={!keys?.privateKey}

--- a/services/tools/src/components/dialogs/MigrationDialog.tsx
+++ b/services/tools/src/components/dialogs/MigrationDialog.tsx
@@ -6,11 +6,11 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
   FormControlLabel,
   Checkbox,
   Typography,
 } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 import { getItem, setItem } from '@nagiyu/browser';
 
 const STORAGE_KEY = 'tools-migration-dialog-shown';
@@ -100,7 +100,7 @@ export default function MigrationDialog() {
           }
           label="今後表示しない"
         />
-        <Button onClick={handleClose} variant="contained" fullWidth>
+        <Button onClick={handleClose} variant="solid">
           閉じる
         </Button>
       </DialogActions>

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -60,8 +60,9 @@
 - [x] PR 1-1-A: `libs/ui` に `Button` 実装（variant: solid/outline/ghost、color: 6 種、size: sm/md/lg、`loading`、`asChild`）
 - [x] PR 1-1-A: Stories 全パターン作成（Default / Variants / Colors / Sizes / Loading / Disabled / AsChildLink / Matrix）
 - [x] PR 1-1-A: ユニット + a11y テスト（Button.tsx は 100% カバレッジ、ライブラリ全体は lines 93.2% / branches 88.37%）
-- [ ] PR 1-1-B: 全サービスで MUI `Button` → `@nagiyu/ui` の `Button` に置換
-- [ ] PR 1-1-C: ESLint で `@mui/material` の `Button` 直接 import を禁止
+- [x] PR 1-1-B: Button に `startIcon` Props を追加（`asChild` と TS 排他、`endIcon` は不採用）
+- [x] PR 1-1-B: 全サービスで MUI `Button` → `@nagiyu/ui` の `Button` に置換（62 ファイル / Navigation 2 ファイルは AppBar 内 `color="inherit"` のため MUI 残置）
+- [ ] PR 1-1-C: ESLint で `@mui/material` の `Button` 直接 import を禁止（Navigation 2 ファイルは例外コメントで対応）
 
 ### TextField
 


### PR DESCRIPTION
## 変更の概要

Phase 1 PR 1-1-B（[tasks.md](../tree/integration/2900-shared-ui-components/tasks/shared-ui-components/tasks.md) 参照）。サービス側の MUI `Button` を `@nagiyu/ui` の `Button` に置換する。

合わせて、サービスでの利用ニーズが高い `startIcon` を Button に追加する API 拡張も含む（24+ ファイルで利用見込み、`endIcon` は既存サービスで未使用のため非対応）。

## API 拡張: `startIcon`

```tsx
<Button startIcon={<RefreshIcon />} onClick={onRetry}>
  再試行
</Button>
```

- `startIcon?: React.ReactNode`
- 内部で `aria-hidden="true"` のラッパー span を自動付与
- `loading` 中は startIcon もスピナー overlay と一緒に視覚的に隠れる
- `asChild` と `startIcon` は **TypeScript の判別共用体で排他**（同時指定はコンパイルエラー）

## 置換ルール（マッピング）

| MUI | @nagiyu/ui |
|---|---|
| `variant="contained"` | `variant="solid"` |
| `variant="outlined"` | `variant="outline"` |
| `variant="text"` | `variant="ghost"` |
| `color="error"` | `color="danger"` |
| `color="info"` | `color="primary"`（近似マッピング） |
| `color="default"` | プロップ削除（既定 = primary） |
| `size="small"`/`"medium"`/`"large"` | `size="sm"`/`"md"`/`"lg"` |
| `disabled={isLoading}` 等 | `loading={...}`（読み込み中の場合） |
| `component={Link} href` | `asChild` + 子要素 `<Link>` |
| `sx={{ mt: 2 }}` | プロップ削除、親 `Stack`/`Box` の `gap`/`spacing` で対応 |

## 例外: AppBar 内の `color="inherit"`

以下 2 ファイルは `color="inherit"` で MUI の AppBar コンテクスト色継承に依存しているため **MUI のまま維持**。後続 PR 1-1-C で ESLint 例外コメント付与:

- `services/share-together/web/src/components/Navigation.tsx`
- `services/niconico-mylist-assistant/web/src/components/Navigation.tsx`

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能（Button.startIcon 追加）
- [x] リファクタリング（サービス側置換）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（Button.tsx は startIcon 関連で 6 件追加。全 26 件）
- [ ] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md` の進捗）— 後続コミット
- [ ] ローカルでテストが全て通ることを確認した — 後続コミットで全サービス確認
- [ ] ビルドエラーがないことを確認した

## テスト内容

`Button.test.tsx` startIcon describe ブロック追加:

- `startIcon` を子要素ラベルの前に表示する
- ラッパーに `aria-hidden="true"` が自動付与される
- `startIcon` 未指定時は wrapper を描画しない
- `loading` 中は startIcon が `contentHidden` 内に隠れ、スピナーが見える
- a11y 違反がない（jest-axe）
- `asChild` + `startIcon` は型レベルで禁止される（`@ts-expect-error` 検証 + DOM 非描画確認）

## レビューポイント

- **`startIcon` 追加の妥当性**: 24+ サービスファイルで MUI の `startIcon` 利用がある実需。同時に `endIcon` は 0 件なので追加せず、API 表面を最小に保った。
- **`asChild` × `startIcon` の TS 排他**: 判別共用体で実装。意外な挙動を防ぐ。
- **AppBar 例外 2 ファイル**: `color="inherit"` の MUI コンテクスト色継承は @nagiyu/ui で再現困難なため MUI 残置。PR 1-1-C で ESLint 例外コメント。
- **`color="info"` → `primary` マッピング**: 1 箇所のみ存在、視覚差は許容範囲と判断。

## スクリーンショット

dev 環境の Storybook（`https://dev-storybook.nagiyu.com`）で WithStartIcon / WithStartIconLoading を視覚確認予定。

## 補足事項

- 現状はリファレンスとして `services/admin/web/src/components/notify/NotifyButton.tsx` のみ置換済み。
- 残り 62 ファイルはバックグラウンド作業中。完了次第追加 push する。
- PR 1-1-C（ESLint 禁止）は本 PR マージ後に別 PR で対応。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_