### PR TITLE
feat(eslint): @mui/material の Button 直接 import を禁止（PR 1-1-C）

### DIFF
--- a/configs/eslint.config.no-restricted-mui.mjs
+++ b/configs/eslint.config.no-restricted-mui.mjs
@@ -1,0 +1,32 @@
+/**
+ * `@mui/material` の共通ラップ済みコンポーネントを直接 import するのを禁止する設定。
+ *
+ * 各サービスの `eslint.config.mjs` から spread して使うことで、`services/*` 配下のみに
+ * 適用され、`libs/ui` 内部（MUI を直接利用する必要がある）には影響しない。
+ *
+ * 対象を増やす場合（PR 1-2-C 以降）は `paths.importNames` と `patterns.group` の両方に
+ * コンポーネント名を追加すること。例外的に MUI を直接使いたい場合は、当該行に
+ * `// eslint-disable-next-line no-restricted-imports -- 理由` を付与すること。
+ */
+export default {
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: '@mui/material',
+            importNames: ['Button'],
+            message: '共通コンポーネントは @nagiyu/ui から import してください',
+          },
+        ],
+        patterns: [
+          {
+            group: ['@mui/material/Button', '@mui/material/Button/*'],
+            message: '共通コンポーネントは @nagiyu/ui から import してください',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/services/admin/web/eslint.config.mjs
+++ b/services/admin/web/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { fixupConfigRules } from '@eslint/compat';
 import baseConfig from '../../../configs/eslint.config.base.mjs';
+import noRestrictedMui from '../../../configs/eslint.config.no-restricted-mui.mjs';
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import tseslint from 'typescript-eslint';
 
@@ -25,6 +26,7 @@ const eslintConfig = defineConfig([
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ]);
 
 export default eslintConfig;

--- a/services/auth/web/eslint.config.mjs
+++ b/services/auth/web/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { fixupConfigRules } from '@eslint/compat';
 import baseConfig from '../../../configs/eslint.config.base.mjs';
+import noRestrictedMui from '../../../configs/eslint.config.no-restricted-mui.mjs';
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import tseslint from 'typescript-eslint';
 
@@ -16,6 +17,7 @@ const eslintConfig = defineConfig([
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ]);
 
 export default eslintConfig;

--- a/services/codec-converter/web/eslint.config.mjs
+++ b/services/codec-converter/web/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { fixupConfigRules } from '@eslint/compat';
 import nextConfig from 'eslint-config-next';
+import noRestrictedMui from '../../../configs/eslint.config.no-restricted-mui.mjs';
 import tseslint from 'typescript-eslint';
 
 const eslintConfig = [
@@ -12,6 +13,7 @@ const eslintConfig = [
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ];
 
 export default eslintConfig;

--- a/services/niconico-mylist-assistant/web/eslint.config.mjs
+++ b/services/niconico-mylist-assistant/web/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { fixupConfigRules } from '@eslint/compat';
 import baseConfig from '../../../configs/eslint.config.base.mjs';
+import noRestrictedMui from '../../../configs/eslint.config.no-restricted-mui.mjs';
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import tseslint from 'typescript-eslint';
 
@@ -16,6 +17,7 @@ const eslintConfig = defineConfig([
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ]);
 
 export default eslintConfig;

--- a/services/niconico-mylist-assistant/web/src/components/Navigation.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/Navigation.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+// eslint-disable-next-line no-restricted-imports -- AppBar 内で color="inherit" によるコンテクスト色継承が必要なため、@nagiyu/ui ではなく MUI の Button をそのまま利用する
 import { AppBar, Toolbar, Typography, Button } from '@mui/material';
 import { useRouter } from 'next/navigation';
 

--- a/services/portal/web/eslint.config.mjs
+++ b/services/portal/web/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { fixupConfigRules } from '@eslint/compat';
 import baseConfig from '../../../configs/eslint.config.base.mjs';
+import noRestrictedMui from '../../../configs/eslint.config.no-restricted-mui.mjs';
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import tseslint from 'typescript-eslint';
 
@@ -25,6 +26,7 @@ const eslintConfig = defineConfig([
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ]);
 
 export default eslintConfig;

--- a/services/quick-clip/web/eslint.config.mjs
+++ b/services/quick-clip/web/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { fixupConfigRules } from '@eslint/compat';
 import nextConfig from 'eslint-config-next';
+import noRestrictedMui from '../../../configs/eslint.config.no-restricted-mui.mjs';
 import tseslint from 'typescript-eslint';
 
 const eslintConfig = [
@@ -12,6 +13,7 @@ const eslintConfig = [
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ];
 
 export default eslintConfig;

--- a/services/share-together/web/eslint.config.mjs
+++ b/services/share-together/web/eslint.config.mjs
@@ -1,4 +1,5 @@
 import baseConfig from '../../../configs/eslint.config.base.mjs';
+import noRestrictedMui from '../../../configs/eslint.config.no-restricted-mui.mjs';
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { fixupConfigRules } from '@eslint/compat';
 import nextVitals from 'eslint-config-next/core-web-vitals';
@@ -16,6 +17,7 @@ const eslintConfig = defineConfig([
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ]);
 
 export default eslintConfig;

--- a/services/share-together/web/src/components/Navigation.tsx
+++ b/services/share-together/web/src/components/Navigation.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+// eslint-disable-next-line no-restricted-imports -- AppBar 内で color="inherit" によるコンテクスト色継承が必要なため、@nagiyu/ui ではなく MUI の Button をそのまま利用する
 import { AppBar, Button, Toolbar, Typography } from '@mui/material';
 import Link from 'next/link';
 import { InvitationBadge } from '@/components/InvitationBadge';

--- a/services/stock-tracker/web/eslint.config.mjs
+++ b/services/stock-tracker/web/eslint.config.mjs
@@ -1,4 +1,5 @@
 import baseConfig from '../../../configs/eslint.config.base.mjs';
+import noRestrictedMui from '../../../configs/eslint.config.no-restricted-mui.mjs';
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { fixupConfigRules } from '@eslint/compat';
 import nextVitals from 'eslint-config-next/core-web-vitals';
@@ -23,6 +24,7 @@ const eslintConfig = defineConfig([
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ]);
 
 export default eslintConfig;

--- a/services/tools/eslint.config.mjs
+++ b/services/tools/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { fixupConfigRules } from '@eslint/compat';
 import baseConfig from '../../configs/eslint.config.base.mjs';
+import noRestrictedMui from '../../configs/eslint.config.no-restricted-mui.mjs';
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import tseslint from 'typescript-eslint';
 
@@ -28,6 +29,7 @@ const eslintConfig = defineConfig([
       'react-hooks/immutability': 'off',
     },
   },
+  noRestrictedMui,
 ]);
 
 export default eslintConfig;

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -62,7 +62,7 @@
 - [x] PR 1-1-A: ユニット + a11y テスト（Button.tsx は 100% カバレッジ、ライブラリ全体は lines 93.2% / branches 88.37%）
 - [x] PR 1-1-B: Button に `startIcon` Props を追加（`asChild` と TS 排他、`endIcon` は不採用）
 - [x] PR 1-1-B: 全サービスで MUI `Button` → `@nagiyu/ui` の `Button` に置換（62 ファイル / Navigation 2 ファイルは AppBar 内 `color="inherit"` のため MUI 残置）
-- [ ] PR 1-1-C: ESLint で `@mui/material` の `Button` 直接 import を禁止（Navigation 2 ファイルは例外コメントで対応）
+- [x] PR 1-1-C: ESLint で `@mui/material` の `Button` 直接 import を禁止（共有 config `configs/eslint.config.no-restricted-mui.mjs` を 9 サービスから spread。Navigation 2 ファイルは `// eslint-disable-next-line no-restricted-imports -- 理由` で例外）
 
 ### TextField
 


### PR DESCRIPTION
## 変更の概要

`@mui/material` の `Button` を**サービス側から直接 import するのを ESLint で禁止**する（PR 1-1-C）。

これにより:
- 新規コード・既存コードへの加筆で MUI Button を誤って使うとビルド失敗で検出可能
- 共通コンポーネントの利用が強制され、Button のスタイル統一性が保たれる
- 将来 MUI 以外への差し替え時にも grep 一発で残置箇所を検出できる

## 実装方針

### 共有 ESLint config（新規）

`configs/eslint.config.no-restricted-mui.mjs` を新規作成:

```js
{
  rules: {
    'no-restricted-imports': ['error', {
      paths: [{ name: '@mui/material', importNames: ['Button'], message: '...' }],
      patterns: [{ group: ['@mui/material/Button', '@mui/material/Button/*'], message: '...' }],
    }],
  },
}
```

PR 1-2-C 以降で対象を増やす場合は `paths.importNames` と `patterns.group` の両方に追加するだけで良い。

### スコープ設計

- **`libs/ui/` には適用しない**（MUI を直接利用する必要がある側のため）
- **適用は `services/*` 配下のみ**：base config ではなく各サービスの `eslint.config.mjs` から個別 spread する形にした

更新したサービス（9 ファイル）:
- `services/admin/web/eslint.config.mjs`
- `services/auth/web/eslint.config.mjs`
- `services/codec-converter/web/eslint.config.mjs`
- `services/niconico-mylist-assistant/web/eslint.config.mjs`
- `services/portal/web/eslint.config.mjs`
- `services/quick-clip/web/eslint.config.mjs`
- `services/share-together/web/eslint.config.mjs`
- `services/stock-tracker/web/eslint.config.mjs`
- `services/tools/eslint.config.mjs`

### 例外運用（2 ファイル）

AppBar 内で `color="inherit"` によるコンテクスト色継承が必要な箇所は MUI のまま残置:
- `services/share-together/web/src/components/Navigation.tsx`
- `services/niconico-mylist-assistant/web/src/components/Navigation.tsx`

両ファイルの import 行に下記コメントを付与:

```ts
// eslint-disable-next-line no-restricted-imports -- AppBar 内で color="inherit" によるコンテクスト色継承が必要なため、@nagiyu/ui ではなく MUI の Button をそのまま利用する
import { AppBar, Button, Toolbar, Typography } from '@mui/material';
```

`docs/development/shared-ui-components.md` の例外運用ルール（理由必須）に準拠。

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能（ESLint ルール追加）
- [ ] バグ修正
- [x] リファクタリング（複数 eslint config の更新）
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（ルールの動作を一時違反ファイル injection で確認、Navigation 例外動作確認済）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] CI/CD 設定を追加・更新した（ESLint config 追加）
- [x] ローカルでテストが全て通ることを確認した（9 サービスの lint pass / share-together は既存 useEffect warning 1 件のみ、本変更と無関係）
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカルで以下を確認:

1. **9 サービス全て `npm run lint` pass**（既存 share-together TodoList warning 1 件のみ、本変更と無関係）
2. **ルール発火確認**: `services/admin/web/src/test-violation.tsx` に `import { Button } from '@mui/material'` を一時注入 → `error 'Button' import from '@mui/material' is restricted. 共通コンポーネントは @nagiyu/ui から import してください` を確認 → 削除
3. **Navigation 例外コメントの動作確認**: 2 ファイルとも `color="inherit"` Button が `// eslint-disable-next-line` でエラーにならない

## レビューポイント

- **ルール定義場所**: 共有 config を `configs/` に新規追加し、各サービス側で spread する形にしました。base に入れると libs/ui まで影響するため避けています。
- **例外コメントの粒度**: import 行単位（`// eslint-disable-next-line`）で付与し、`// eslint-disable` でファイル全体無効にはしていません。例外箇所をピンポイントで把握できる形を維持。
- **将来拡張**: PR 1-2-C 以降で `TextField` 等を追加する際は、`importNames` と `patterns.group` に名前を足すだけで増やせる構成です。

## スクリーンショット

該当なし（UI 変更なし）。

## 補足事項

- マージ後、ESLint で `@mui/material` の `Button` 直接利用が新規 PR で発生すると CI 失敗するため、レビュー観点が安定します。
- 例外コメントを後続 PR で消すかどうかは、AppBar 自体の置換（共通 Header / Navigation 部品化）と合わせて検討予定。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_