### PR TITLE
feat(ui): TextField コンポーネント追加（PR 1-2-A）

### DIFF
--- a/libs/ui/src/components/TextField/TextField.module.css
+++ b/libs/ui/src/components/TextField/TextField.module.css
@@ -1,0 +1,139 @@
+/*
+ * TextField コンポーネントのスタイル定義。
+ *
+ * - すべての色・余白・角丸は tokens.css の Semantic 変数を参照する。
+ * - MUI 等の特定ライブラリへの依存は持たない。
+ * - 状態は `:hover` / `:focus-visible` / `[aria-invalid='true']` / `:disabled` で表現。
+ */
+
+.wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  font-family: var(--font-family-sans);
+  /* デフォルトは内容に応じた幅。fullWidth で 100% に */
+}
+
+.fullWidth {
+  display: flex;
+  width: 100%;
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-default);
+  line-height: var(--line-height-normal);
+}
+
+.requiredMark {
+  color: var(--color-action-danger);
+}
+
+.input {
+  /* Box */
+  appearance: none;
+  width: 100%;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-surface);
+  color: var(--color-fg-default);
+
+  /* Typography */
+  font-family: inherit;
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+
+  /* Transition */
+  transition:
+    border-color var(--duration-fast) var(--easing-out),
+    box-shadow var(--duration-fast) var(--easing-out);
+}
+
+.input::placeholder {
+  color: var(--color-fg-muted);
+}
+
+.input:hover:not(:disabled):not(:read-only) {
+  border-color: var(--color-border-strong);
+}
+
+.input:focus-visible {
+  outline: none;
+  border-color: var(--color-action-primary);
+  box-shadow: 0 0 0 3px var(--color-action-primary-subtle);
+}
+
+.input:disabled {
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+}
+
+.input:read-only {
+  background-color: var(--color-bg-subtle);
+  cursor: default;
+}
+
+textarea.input {
+  resize: vertical;
+  min-height: 4rem;
+}
+
+.helperText {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  line-height: var(--line-height-normal);
+}
+
+/* =========================================================================
+ * Size
+ * ========================================================================= */
+
+.size-sm .input {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  min-height: 32px;
+}
+
+.size-md .input {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-md);
+  min-height: 40px;
+}
+
+.size-lg .input {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-lg);
+  min-height: 48px;
+}
+
+/* =========================================================================
+ * Error state
+ * ========================================================================= */
+
+.error .input {
+  border-color: var(--color-action-danger);
+}
+
+.error .input:hover:not(:disabled):not(:read-only) {
+  border-color: var(--color-action-danger-hover);
+}
+
+.error .input:focus-visible {
+  border-color: var(--color-action-danger);
+  box-shadow: 0 0 0 3px var(--color-action-danger-subtle);
+}
+
+.error .helperText {
+  color: var(--color-action-danger);
+}
+
+/* =========================================================================
+ * Disabled wrapper（label もディム化）
+ * ========================================================================= */
+
+.disabled .label {
+  color: var(--color-fg-disabled);
+}

--- a/libs/ui/src/components/TextField/TextField.stories.tsx
+++ b/libs/ui/src/components/TextField/TextField.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import TextField from './TextField';
+
+/**
+ * `TextField` は @nagiyu/ui のテキスト入力部品。
+ *
+ * - `label` を渡せば `useId` で input と自動関連付け（a11y 必須対応）
+ * - `multiline` で textarea に切替
+ * - `error` で危険色の境界線・helperText、`aria-invalid` 自動付与
+ * - `readOnly` / `maxLength` を top-level Props として提供
+ *
+ * MUI への依存は内部で完全に隠蔽されている。
+ */
+const meta: Meta<typeof TextField> = {
+  title: 'Atoms/TextField',
+  component: TextField,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['text', 'password', 'email', 'number', 'search', 'tel', 'url'],
+    },
+    size: {
+      control: 'inline-radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    fullWidth: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    required: { control: 'boolean' },
+    readOnly: { control: 'boolean' },
+    error: { control: 'boolean' },
+    multiline: { control: 'boolean' },
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    helperText: { control: 'text' },
+  },
+  args: {
+    label: '名前',
+    placeholder: '山田 太郎',
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextField>;
+
+export const Default: Story = {};
+
+export const WithHelperText: Story = {
+  args: {
+    label: 'メールアドレス',
+    placeholder: 'example@nagiyu.com',
+    helperText: '通知の送信先として使われます',
+    type: 'email',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: 'パスワード',
+    type: 'password',
+    required: true,
+    helperText: '8 文字以上',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: 'メールアドレス',
+    value: 'invalid',
+    error: true,
+    helperText: 'メールアドレスの形式が正しくありません',
+  },
+};
+
+export const Disabled: Story = {
+  args: { label: '取引所', value: 'NASDAQ', disabled: true },
+};
+
+export const ReadOnly: Story = {
+  args: { label: 'ティッカー', value: 'AAPL', readOnly: true },
+};
+
+export const FullWidth: Story = {
+  args: { label: '備考', fullWidth: true, placeholder: '何か入力してください' },
+};
+
+export const Sizes: Story = {
+  argTypes: { size: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16, width: 320 }}>
+      <TextField {...args} size="sm" label="sm" />
+      <TextField {...args} size="md" label="md" />
+      <TextField {...args} size="lg" label="lg" />
+    </div>
+  ),
+};
+
+export const Multiline: Story = {
+  args: {
+    label: 'コメント',
+    multiline: true,
+    minRows: 3,
+    placeholder: 'コメントを入力',
+    fullWidth: true,
+  },
+};
+
+export const Number: Story = {
+  args: {
+    label: '数量',
+    type: 'number',
+    placeholder: '0',
+    helperText: '半角数字のみ',
+  },
+};
+
+export const MaxLength: Story = {
+  args: {
+    label: '通知タイトル',
+    maxLength: 12,
+    helperText: '最大 12 文字',
+    fullWidth: true,
+  },
+};

--- a/libs/ui/src/components/TextField/TextField.tsx
+++ b/libs/ui/src/components/TextField/TextField.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import * as React from 'react';
+
+import styles from './TextField.module.css';
+
+/**
+ * TextField のサイズ。
+ */
+export type TextFieldSize = 'sm' | 'md' | 'lg';
+
+/**
+ * TextField の入力種別。HTML `type` 属性のうち、テキスト入力として意味のある値に絞る。
+ */
+export type TextFieldType = 'text' | 'password' | 'email' | 'number' | 'search' | 'tel' | 'url';
+
+/**
+ * TextField のプロパティ。
+ *
+ * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
+ * エスケープハッチは `className` のみ。
+ */
+export interface TextFieldProps {
+  // ---- 値・イベント ----
+  value?: string;
+  defaultValue?: string;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onBlur?: (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+
+  // ---- 表示 ----
+  /**
+   * フォームラベル。`<label htmlFor>` で input/textarea と関連付ける。
+   * 関連付けは内部で `useId` により自動生成（`id` を渡せばそれを尊重）。
+   */
+  label?: React.ReactNode;
+  /**
+   * プレースホルダー。
+   */
+  placeholder?: string;
+  /**
+   * 入力欄の下に表示される補助テキスト。`error` が true なら危険色で描画される。
+   */
+  helperText?: React.ReactNode;
+
+  // ---- 種別 ----
+  /**
+   * 入力種別。既定: `text`
+   */
+  type?: TextFieldType;
+
+  // ---- 状態 ----
+  disabled?: boolean;
+  required?: boolean;
+  /**
+   * MUI の `slotProps.input.readOnly` 相当。読み取り専用フィールド。
+   */
+  readOnly?: boolean;
+  /**
+   * エラー状態。境界線・helperText が危険色になり、`aria-invalid` が付与される。
+   */
+  error?: boolean;
+
+  // ---- レイアウト ----
+  /**
+   * 親要素の幅いっぱいに広げる。既定: `false`
+   */
+  fullWidth?: boolean;
+  /**
+   * サイズ。既定: `md`
+   */
+  size?: TextFieldSize;
+
+  // ---- 複数行 ----
+  /**
+   * `true` の場合、`<textarea>` として描画する。
+   */
+  multiline?: boolean;
+  rows?: number;
+  minRows?: number;
+  maxRows?: number;
+
+  // ---- 制約 ----
+  /**
+   * MUI の `slotProps.htmlInput.maxLength` 相当。HTML `maxlength` 属性を付与。
+   */
+  maxLength?: number;
+
+  // ---- その他 HTML ----
+  id?: string;
+  name?: string;
+  autoFocus?: boolean;
+  autoComplete?: string;
+  inputMode?: 'text' | 'numeric' | 'decimal' | 'tel' | 'email' | 'search' | 'url' | 'none';
+
+  // ---- a11y ----
+  /**
+   * `label` 以外で名前を提供する場合に使用する。`label` が指定されている場合は不要。
+   */
+  'aria-label'?: string;
+
+  // ---- エスケープハッチ ----
+  className?: string;
+
+  // ---- ref ----
+  /**
+   * 内部の `<input>` または `<textarea>` 要素への ref。
+   */
+  inputRef?: React.Ref<HTMLInputElement | HTMLTextAreaElement>;
+}
+
+/**
+ * テキスト入力コンポーネント。
+ *
+ * - `label` と入力要素を `useId` 経由で自動関連付け（a11y 必須対応）
+ * - `multiline` で `<textarea>` に切替
+ * - `error` で危険色の境界線・helperText、`aria-invalid` 自動付与
+ * - `readOnly` / `maxLength` を top-level Props として提供（MUI の slotProps を直接露出しない）
+ *
+ * @see docs/development/shared-ui-components.md
+ */
+const TextField = React.forwardRef<HTMLDivElement, TextFieldProps>(function TextField(
+  {
+    value,
+    defaultValue,
+    onChange,
+    onBlur,
+    onFocus,
+    onKeyDown,
+    label,
+    placeholder,
+    helperText,
+    type = 'text',
+    disabled = false,
+    required = false,
+    readOnly = false,
+    error = false,
+    fullWidth = false,
+    size = 'md',
+    multiline = false,
+    rows,
+    minRows,
+    maxRows,
+    maxLength,
+    id,
+    name,
+    autoFocus,
+    autoComplete,
+    inputMode,
+    'aria-label': ariaLabel,
+    className,
+    inputRef,
+  },
+  ref
+) {
+  const generatedId = React.useId();
+  const inputId = id ?? generatedId;
+  const helperTextId = `${inputId}-helper-text`;
+
+  const wrapperClasses = [
+    styles.wrapper,
+    fullWidth ? styles.fullWidth : null,
+    disabled ? styles.disabled : null,
+    error ? styles.error : null,
+    styles[`size-${size}`],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const sharedProps = {
+    id: inputId,
+    name,
+    value,
+    defaultValue,
+    onChange,
+    onBlur,
+    onFocus,
+    onKeyDown,
+    placeholder,
+    disabled,
+    required,
+    readOnly,
+    autoFocus,
+    autoComplete,
+    inputMode,
+    maxLength,
+    'aria-label': ariaLabel,
+    'aria-invalid': error || undefined,
+    'aria-describedby': helperText ? helperTextId : undefined,
+    className: styles.input,
+  };
+
+  return (
+    <div ref={ref} className={wrapperClasses}>
+      {label ? (
+        <label htmlFor={inputId} className={styles.label}>
+          {label}
+          {required ? (
+            <span aria-hidden="true" className={styles.requiredMark}>
+              {' '}
+              *
+            </span>
+          ) : null}
+        </label>
+      ) : null}
+      {multiline ? (
+        <textarea
+          {...sharedProps}
+          ref={inputRef as React.Ref<HTMLTextAreaElement>}
+          rows={rows}
+          // HTML の textarea は minRows/maxRows を直接サポートしないため、rows のみ反映する。
+          // より高度な auto-resize は将来必要になれば追加する。
+          {...(minRows && !rows ? { rows: minRows } : {})}
+          {...(maxRows ? { 'data-max-rows': maxRows } : {})}
+        />
+      ) : (
+        <input {...sharedProps} ref={inputRef as React.Ref<HTMLInputElement>} type={type} />
+      )}
+      {helperText ? (
+        <p id={helperTextId} className={styles.helperText}>
+          {helperText}
+        </p>
+      ) : null}
+    </div>
+  );
+});
+
+export default TextField;

--- a/libs/ui/src/components/TextField/index.ts
+++ b/libs/ui/src/components/TextField/index.ts
@@ -1,0 +1,2 @@
+export { default } from './TextField';
+export type { TextFieldProps, TextFieldSize, TextFieldType } from './TextField';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -4,6 +4,8 @@ export { tokens, breakpoints } from './styles/tokens';
 export type { ThemeMode, ColorRole, Size } from './styles/tokens';
 export { default as Button } from './components/Button';
 export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from './components/Button';
+export { default as TextField } from './components/TextField';
+export type { TextFieldProps, TextFieldSize, TextFieldType } from './components/TextField';
 export { default as Header } from './components/layout/Header';
 export type { HeaderProps, NavigationItem } from './components/layout/Header';
 export { default as Footer } from './components/layout/Footer';

--- a/libs/ui/tests/unit/components/TextField/TextField.test.tsx
+++ b/libs/ui/tests/unit/components/TextField/TextField.test.tsx
@@ -1,0 +1,192 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import TextField from '../../../../src/components/TextField/TextField';
+
+describe('TextField', () => {
+  describe('rendering', () => {
+    it('既定で input[type=text] を描画する', () => {
+      render(<TextField label="名前" />);
+      const input = screen.getByLabelText('名前');
+      expect(input.tagName).toBe('INPUT');
+      expect(input).toHaveAttribute('type', 'text');
+    });
+
+    it('label を渡すと <label> が描画され、input と htmlFor で関連付けられる', () => {
+      render(<TextField label="メールアドレス" />);
+      const input = screen.getByLabelText('メールアドレス');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('id を明示すれば尊重される（label htmlFor も対応する）', () => {
+      render(<TextField id="my-input" label="名前" />);
+      const input = screen.getByLabelText('名前');
+      expect(input).toHaveAttribute('id', 'my-input');
+    });
+
+    it('helperText を渡すと p 要素に描画され、aria-describedby で関連付けられる', () => {
+      render(<TextField label="メール" helperText="example@example.com の形式" />);
+      const input = screen.getByLabelText('メール');
+      const helperId = input.getAttribute('aria-describedby');
+      expect(helperId).toBeTruthy();
+      const helper = document.getElementById(helperId!);
+      expect(helper).toHaveTextContent('example@example.com の形式');
+    });
+
+    it('placeholder が反映される', () => {
+      render(<TextField label="名前" placeholder="山田 太郎" />);
+      expect(screen.getByPlaceholderText('山田 太郎')).toBeInTheDocument();
+    });
+
+    it('type を反映する', () => {
+      render(<TextField label="数量" type="number" />);
+      expect(screen.getByLabelText('数量')).toHaveAttribute('type', 'number');
+    });
+
+    it('既定値（md / no fullWidth）が適用される', () => {
+      const { container } = render(<TextField label="x" />);
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.className).toContain('size-md');
+      expect(wrapper.className).not.toContain('fullWidth');
+    });
+  });
+
+  describe('events', () => {
+    it('onChange が発火し、入力値が伝わる', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(<TextField label="名前" onChange={onChange} />);
+      const input = screen.getByLabelText('名前');
+      await user.type(input, 'abc');
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('disabled の時は入力できない', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(<TextField label="名前" disabled onChange={onChange} />);
+      await user.type(screen.getByLabelText('名前'), 'x');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('readOnly の時は入力が反映されない', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(<TextField label="名前" readOnly value="固定" onChange={onChange} />);
+      await user.type(screen.getByLabelText('名前'), 'x');
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByLabelText('名前')).toHaveValue('固定');
+    });
+  });
+
+  describe('states', () => {
+    it('error=true で aria-invalid と error クラスが付与される', () => {
+      const { container } = render(<TextField label="x" error helperText="ng" />);
+      expect(screen.getByLabelText('x')).toHaveAttribute('aria-invalid', 'true');
+      expect((container.firstChild as HTMLElement).className).toContain('error');
+    });
+
+    it('required=true でラベルにアスタリスクと required 属性が付く', () => {
+      const { container } = render(<TextField label="名前" required />);
+      expect(screen.getByLabelText(/名前/)).toBeRequired();
+      expect(container.textContent).toContain('*');
+    });
+
+    it('disabled=true で input に disabled 属性、wrapper に disabled クラス', () => {
+      const { container } = render(<TextField label="x" disabled />);
+      expect(screen.getByLabelText('x')).toBeDisabled();
+      expect((container.firstChild as HTMLElement).className).toContain('disabled');
+    });
+
+    it('readOnly=true で input に readonly 属性が付く', () => {
+      render(<TextField label="x" readOnly value="ro" />);
+      expect(screen.getByLabelText('x')).toHaveAttribute('readonly');
+    });
+
+    it('fullWidth=true で wrapper に fullWidth クラス', () => {
+      const { container } = render(<TextField label="x" fullWidth />);
+      expect((container.firstChild as HTMLElement).className).toContain('fullWidth');
+    });
+  });
+
+  describe('multiline', () => {
+    it('multiline=true で textarea に切り替わる', () => {
+      render(<TextField label="本文" multiline />);
+      const node = screen.getByLabelText('本文');
+      expect(node.tagName).toBe('TEXTAREA');
+    });
+
+    it('rows を反映する', () => {
+      render(<TextField label="x" multiline rows={5} />);
+      expect(screen.getByLabelText('x')).toHaveAttribute('rows', '5');
+    });
+
+    it('rows 未指定で minRows のみ指定すると minRows が rows として反映される', () => {
+      render(<TextField label="x" multiline minRows={3} />);
+      expect(screen.getByLabelText('x')).toHaveAttribute('rows', '3');
+    });
+  });
+
+  describe('constraints', () => {
+    it('maxLength が input に反映される', () => {
+      render(<TextField label="x" maxLength={5} />);
+      expect(screen.getByLabelText('x')).toHaveAttribute('maxlength', '5');
+    });
+  });
+
+  describe('size', () => {
+    it.each(['sm', 'md', 'lg'] as const)('size=%s で対応するクラスが付与される', (size) => {
+      const { container } = render(<TextField label="x" size={size} />);
+      expect((container.firstChild as HTMLElement).className).toContain(`size-${size}`);
+    });
+  });
+
+  describe('inputRef', () => {
+    it('inputRef で input 要素にアクセスできる', () => {
+      const ref = React.createRef<HTMLInputElement>();
+      render(<TextField label="x" inputRef={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
+
+    it('multiline の inputRef は textarea を受け取る', () => {
+      const ref = React.createRef<HTMLTextAreaElement>();
+      render(<TextField label="x" multiline inputRef={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('label がある既定状態で a11y 違反がない', async () => {
+      const { container } = render(<TextField label="メールアドレス" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('error 状態で a11y 違反がない', async () => {
+      const { container } = render(<TextField label="x" error helperText="ng" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('disabled 状態で a11y 違反がない', async () => {
+      const { container } = render(<TextField label="x" disabled />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('multiline 状態で a11y 違反がない', async () => {
+      const { container } = render(<TextField label="本文" multiline />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('label なしでも aria-label があれば a11y 違反がない', async () => {
+      const { container } = render(<TextField aria-label="検索" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -66,8 +66,8 @@
 
 ### TextField
 
-- [ ] PR 1-2-A: `libs/ui` に `TextField` 実装
-- [ ] PR 1-2-A: Stories + テスト
+- [x] PR 1-2-A: `libs/ui` に `TextField` 実装（label 自動関連付け / multiline / error / readOnly / maxLength / fullWidth / size sm/md/lg）
+- [x] PR 1-2-A: Stories + ユニット + a11y テスト（TextField.tsx は statements/lines/functions 100%、branches 97.05%）
 - [ ] PR 1-2-B: 全サービスで置換
 - [ ] PR 1-2-C: ESLint 禁止追加
 


### PR DESCRIPTION
## 変更の概要

`@nagiyu/ui` に **`TextField` コンポーネント**を追加する（PR 1-2-A）。

- `label` を `React.useId` で `<label htmlFor>` と自動関連付け（a11y 必須対応、MUI と同パターン）
- `multiline` で `<textarea>` に切替
- `error` で危険色の境界線・helperText、`aria-invalid` 自動付与
- `readOnly` / `maxLength` を **top-level Props** として提供（MUI の `slotProps` を露出させない）
- `fullWidth` / `size` (sm/md/lg)
- `type`: text / password / email / number / search / tel / url

## API

```ts
export interface TextFieldProps {
  // 値・イベント
  value?: string;
  defaultValue?: string;
  onChange?, onBlur?, onFocus?, onKeyDown?;

  // 表示
  label?: React.ReactNode;
  placeholder?: string;
  helperText?: React.ReactNode;

  // 種別
  type?: 'text' | 'password' | 'email' | 'number' | 'search' | 'tel' | 'url';

  // 状態
  disabled?, required?, readOnly?, error?: boolean;

  // レイアウト
  fullWidth?: boolean;
  size?: 'sm' | 'md' | 'lg';

  // 複数行
  multiline?: boolean;
  rows?, minRows?, maxRows?: number;

  // 制約
  maxLength?: number;

  // その他 HTML
  id?, name?, autoComplete?, autoFocus?, inputMode?;

  // a11y
  'aria-label'?: string;

  // エスケープハッチ
  className?: string;

  // ref
  inputRef?: React.Ref<HTMLInputElement | HTMLTextAreaElement>;
}
```

## 採用しなかった機能と理由

| 機能 | 判断 | 理由 |
|---|---|---|
| `variant` | 不採用（単一視覚スタイル） | サービスの実利用は MUI 既定の outlined のみ |
| `color` | 不採用（`error` boolean のみ） | MUI でも実利用なし |
| `slotProps` | 不採用、必要なものを top-level に昇格 | MUI 固有 API を漏らさないため |
| `select` 化 | 不採用 | Select は PR 2-1-A で別コンポーネントとして実装する方針（spec 準拠） |
| `asChild` | 不採用 | フォーム制御は単独 leaf として動作 |

## ファイル構成

```
libs/ui/src/components/TextField/
├── TextField.tsx
├── TextField.module.css
├── TextField.stories.tsx
└── index.ts

libs/ui/tests/unit/components/TextField/
└── TextField.test.tsx
```

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（**29 件 pass / TextField.tsx は statements・lines・functions 100%、branches 97.05%**）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した（ライブラリ全体: 191 件 pass / lines 93.75% / branches 90.53%）
- [x] ビルドエラーがないことを確認した（`tsc` + `copy-assets` + `build-storybook` 成功）

## テスト内容

`TextField.test.tsx` で 29 件のテスト:

- **rendering**: input/textarea 切替、label 自動関連付け、`id` 明示の尊重、`aria-describedby`、`placeholder`、`type`、既定値
- **events**: `onChange` 発火、`disabled` / `readOnly` 時の入力抑止
- **states**: `error` で `aria-invalid`、`required` でアスタリスク表示、`disabled` / `readOnly` / `fullWidth` クラス
- **multiline**: `<textarea>` 切替、`rows` / `minRows` 反映
- **constraints**: `maxLength` HTML 属性反映
- **size**: sm/md/lg 全パターン
- **inputRef**: input/textarea 両方への ref 動作
- **a11y（jest-axe）**: 既定 / error / disabled / multiline / `aria-label` 単独

## レビューポイント

- **`useId` による label 自動関連付け**: 利用側が明示 `id` を渡せばそれを尊重、未指定なら React の `useId` でユニーク id を生成して `<label htmlFor>` と input の id を合わせる。a11y 違反を防ぎつつ DX を保つ。
- **`readOnly` / `maxLength` の top-level 昇格**: MUI では `slotProps={{ input: { readOnly: true } }}` `slotProps={{ htmlInput: { maxLength: 12 } }}` として書かれていたものを、@nagiyu/ui ではフラットに渡せる。サービス側調査で 23 箇所が `slotProps` 利用しており、移行先として top-level Props のほうが書きやすい。
- **`multiline` の rows ハンドリング**: `rows` 明示を最優先、未指定で `minRows` のみ指定された場合は `minRows` を `rows` として反映。`maxRows` は現状 `data-max-rows` 属性に反映するのみ（auto-resize は将来必要なら追加）。
- **エラー状態の視覚的差異**: 境界線色・helperText の文字色を `--color-action-danger` 系に変更。`error=true` のときに `aria-invalid="true"` と CSS クラスの両方を付与する。

## スクリーンショット

dev 環境の Storybook で視覚確認予定。

## 補足事項

PR 1-2-B（サービス側の置換）と PR 1-2-C（ESLint 禁止）は本 PR マージ後に別 PR で対応する。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_