### PR TITLE
feat(eslint): @mui/material の TextField 直接 import を禁止（PR 1-2-C）

### DIFF
--- a/configs/eslint.config.no-restricted-mui.mjs
+++ b/configs/eslint.config.no-restricted-mui.mjs
@@ -16,13 +16,18 @@ export default {
         paths: [
           {
             name: '@mui/material',
-            importNames: ['Button'],
+            importNames: ['Button', 'TextField'],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },
         ],
         patterns: [
           {
-            group: ['@mui/material/Button', '@mui/material/Button/*'],
+            group: [
+              '@mui/material/Button',
+              '@mui/material/Button/*',
+              '@mui/material/TextField',
+              '@mui/material/TextField/*',
+            ],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },
         ],

--- a/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import {
   Box,
+  // eslint-disable-next-line no-restricted-imports -- パスワード表示切替の endAdornment（IconButton）を使うため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する
   TextField,
   FormControlLabel,
   Checkbox,

--- a/services/stock-tracker/web/app/exchanges/page.tsx
+++ b/services/stock-tracker/web/app/exchanges/page.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  // eslint-disable-next-line no-restricted-imports -- 編集モーダル内 TextField の sx={{ backgroundColor: '#f5f5f5' }} で背景色指定が必要なため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する
   TextField,
   Snackbar,
   Select,

--- a/services/stock-tracker/web/app/holdings/page.tsx
+++ b/services/stock-tracker/web/app/holdings/page.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  // eslint-disable-next-line no-restricted-imports -- 数値入力の HTML 制約 step/min/max（slotProps.htmlInput）が必要なため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する
   TextField,
   FormControl,
   InputLabel,

--- a/services/stock-tracker/web/components/AlertSettingsModal.tsx
+++ b/services/stock-tracker/web/components/AlertSettingsModal.tsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  // eslint-disable-next-line no-restricted-imports -- 数値入力の HTML 制約 step/min/max（slotProps.htmlInput）が必要なため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する
   TextField,
   FormControl,
   InputLabel,

--- a/services/stock-tracker/web/components/HoldingCard.tsx
+++ b/services/stock-tracker/web/components/HoldingCard.tsx
@@ -17,6 +17,7 @@ import {
   IconButton,
   Select,
   Stack,
+  // eslint-disable-next-line no-restricted-imports -- 数値入力の HTML 制約 step/min/max（slotProps.htmlInput）が必要なため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する
   TextField,
   Tooltip,
   Typography,

--- a/services/tools/src/app/hash-generator/HashGeneratorClient.tsx
+++ b/services/tools/src/app/hash-generator/HashGeneratorClient.tsx
@@ -8,6 +8,7 @@ import {
   MenuItem,
   Snackbar,
   Stack,
+  // eslint-disable-next-line no-restricted-imports -- アルゴリズム選択で TextField の select プロップ（dropdown 化）を使うため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する（Select は PR 2-1-A で別実装予定）
   TextField,
   Typography,
 } from '@mui/material';

--- a/services/tools/src/app/timestamp-converter/TimestampConverterClient.tsx
+++ b/services/tools/src/app/timestamp-converter/TimestampConverterClient.tsx
@@ -8,6 +8,7 @@ import {
   MenuItem,
   Snackbar,
   Stack,
+  // eslint-disable-next-line no-restricted-imports -- タイムゾーン選択で TextField の select プロップ（dropdown 化）を使うため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する（Select は PR 2-1-A で別実装予定）
   TextField,
   Typography,
 } from '@mui/material';

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -69,7 +69,7 @@
 - [x] PR 1-2-A: `libs/ui` に `TextField` 実装（label 自動関連付け / multiline / error / readOnly / maxLength / fullWidth / size sm/md/lg）
 - [x] PR 1-2-A: Stories + ユニット + a11y テスト（TextField.tsx は statements/lines/functions 100%、branches 97.05%）
 - [x] PR 1-2-B: 全サービスで MUI `TextField` → `@nagiyu/ui` の `TextField` に置換（18 ファイル / API ギャップにより 7 ファイル MUI 残置：endAdornment 1・sx カラー指定 1・number step/min/max 3・select 化 2、PR 1-2-C で ESLint 例外コメント）
-- [ ] PR 1-2-C: ESLint 禁止追加（保留 7 ファイルは例外コメントで対応）
+- [x] PR 1-2-C: ESLint 禁止追加（共有 config の `importNames` / `patterns.group` に `TextField` を追加。保留 7 ファイルは複数行 import 内の `TextField` 直前に `// eslint-disable-next-line no-restricted-imports -- 理由` を付与）
 
 ### Checkbox
 


### PR DESCRIPTION
## 変更の概要

サービス側で MUI の `TextField` を直接 import するのを ESLint で禁止する（PR 1-2-C）。Button (PR 1-1-C) と同じ仕組みに `TextField` を追加。

## 実装

### 共有 ESLint config の更新

`configs/eslint.config.no-restricted-mui.mjs` の `importNames` / `patterns.group` に `TextField` を追加:

```diff
  paths: [
    {
      name: '@mui/material',
-     importNames: ['Button'],
+     importNames: ['Button', 'TextField'],
      message: '共通コンポーネントは @nagiyu/ui から import してください',
    },
  ],
  patterns: [
    {
      group: [
        '@mui/material/Button',
        '@mui/material/Button/*',
+       '@mui/material/TextField',
+       '@mui/material/TextField/*',
      ],
      ...
    },
  ],
```

### 例外運用（7 ファイル）

PR 1-2-B で API ギャップにより MUI 残置とした 7 ファイルに `// eslint-disable-next-line no-restricted-imports -- 理由` を付与:

| ファイル | 理由 |
|---|---|
| `niconico-mylist-assistant/MylistRegisterForm.tsx` | パスワード表示切替の `endAdornment` IconButton |
| `stock-tracker/exchanges/page.tsx` | `sx={{ backgroundColor: '#f5f5f5' }}` |
| `stock-tracker/holdings/page.tsx` | 数値入力の HTML 制約 step/min/max |
| `stock-tracker/AlertSettingsModal.tsx` | 同上 |
| `stock-tracker/HoldingCard.tsx` | 同上 |
| `tools/hash-generator/HashGeneratorClient.tsx` | `select` プロップ（dropdown 化） |
| `tools/timestamp-converter/TimestampConverterClient.tsx` | 同上 |

### 複数行 import の例外コメント配置

Button (PR 1-1-C) では単一行 import に `eslint-disable-next-line` を import 文の直前に置く形だった。**TextField の保留 7 ファイルはすべて複数行 import** で、`import {` 行に置くと中身の `TextField` 行（実際の違反箇所）に届かないため、**`TextField` 直前の行に配置**する方式とした:

```ts
import {
  Box,
  // eslint-disable-next-line no-restricted-imports -- 理由
  TextField,
  ...
} from '@mui/material';
```

これで `TextField` の違反のみ抑止し、他のメンバー（Box 等）には影響しない。

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能（ESLint ルール拡張）
- [ ] バグ修正
- [x] リファクタリング（保留ファイルへの例外コメント付与）
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存テストの回帰確認は不要、ESLint ルール変更のみ）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] CI/CD 設定を追加・更新した（共有 ESLint config 拡張）
- [x] ローカルでテストが全て通ることを確認した（9 サービスの lint pass / share-together は既存 useEffect warning 1 件のみ）
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカルで以下を確認:

1. **9 サービス全て `npm run lint` pass**（既存 share-together TodoList warning 1 件のみ、本変更と無関係）
2. **ルール発火確認**: 例外コメントを外して 7 ファイルそれぞれで `'TextField' import from '@mui/material' is restricted` エラーが出ることを確認 → 例外コメント付与で解消
3. **複数行 import の例外コメント配置**: import 文先頭に置くと違反箇所（TextField 行）に届かない → 個別の `TextField` 行直前に置く方式で動作確認

## レビューポイント

- **複数行 import 内のコメント配置**: 単一行 import（Button の Navigation 例外）と異なり、TextField の保留 7 ファイルは複数行 import なので **個別に `TextField` 直前** にコメントを置いている。grep で例外箇所を後追いしやすく、他のメンバーには影響しない最小スコープの抑止。
- **ESLint config の今後拡張**: 同 config の `importNames` / `patterns.group` に名前を追加するだけで対象を増やせる。Phase 1 残り（Checkbox / Chip / Link）も同パターンで進める。

## スクリーンショット

該当なし（UI 変更なし）。

## 補足事項

- マージ後、サービス側で MUI の `TextField` を直接利用する新規コードは CI 失敗するため、レビュー観点が安定。
- 例外コメントを後続 PR で消すかどうかは、@nagiyu/ui TextField への機能追加（adornment / step,min,max）と Select 実装（PR 2-1-A）と合わせて検討。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_