### PR TITLE
feat(ui): Checkbox コンポーネント追加（PR 1-3-A）

### DIFF
--- a/libs/ui/src/components/Checkbox/Checkbox.module.css
+++ b/libs/ui/src/components/Checkbox/Checkbox.module.css
@@ -1,0 +1,158 @@
+/*
+ * Checkbox コンポーネントのスタイル定義。
+ *
+ * - native input を視覚的に隠して、`.box` を CSS で描画する。
+ * - 状態は `:checked` / `:indeterminate` / `:focus-visible` / `:disabled` で表現。
+ * - すべての色・余白・角丸は tokens.css の Semantic 変数を参照する。
+ */
+
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-family: var(--font-family-sans);
+  cursor: pointer;
+  color: var(--color-fg-default);
+}
+
+.wrapper.disabled {
+  cursor: not-allowed;
+  color: var(--color-fg-disabled);
+}
+
+/* input + box をスタックする小さなコンテナ */
+.root {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* native input を視覚的に隠すが、フォーカス可能・操作可能な状態は維持する */
+.input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  cursor: inherit;
+  z-index: 1;
+}
+
+/* 視覚的なチェックボックスのボックス */
+.box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-surface);
+  transition:
+    background-color var(--duration-fast) var(--easing-out),
+    border-color var(--duration-fast) var(--easing-out),
+    box-shadow var(--duration-fast) var(--easing-out);
+}
+
+/* hover （wrapper レベルで判定） */
+.wrapper:hover:not(.disabled) .input:not(:disabled) ~ .box {
+  border-color: var(--color-action-primary);
+}
+
+/* focus-visible リング */
+.input:focus-visible ~ .box {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--color-action-primary-subtle);
+}
+
+/* checked 状態 */
+.input:checked ~ .box {
+  background-color: var(--color-action-primary);
+  border-color: var(--color-action-primary);
+}
+
+/* indeterminate 状態 */
+.input:indeterminate ~ .box {
+  background-color: var(--color-action-primary);
+  border-color: var(--color-action-primary);
+}
+
+/* disabled 状態 */
+.input:disabled ~ .box {
+  background-color: var(--color-bg-subtle);
+  border-color: var(--color-border-default);
+  opacity: 0.6;
+}
+
+.input:disabled:checked ~ .box,
+.input:disabled:indeterminate ~ .box {
+  background-color: var(--color-action-primary-subtle);
+  border-color: var(--color-action-primary-subtle);
+}
+
+/* アイコン（チェックマーク・横棒）。既定は非表示 */
+.checkIcon,
+.dashIcon {
+  width: 100%;
+  height: 100%;
+  fill: var(--color-action-primary-fg);
+  display: none;
+}
+
+/* checked のときチェックマーク表示 */
+.input:checked:not(:indeterminate) ~ .box .checkIcon {
+  display: block;
+}
+
+/* indeterminate のとき横棒表示（checked より優先） */
+.input:indeterminate ~ .box .dashIcon {
+  display: block;
+}
+
+/* indeterminate のときチェックマークは隠す */
+.input:indeterminate ~ .box .checkIcon {
+  display: none;
+}
+
+.labelText {
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+  user-select: none;
+}
+
+.requiredMark {
+  color: var(--color-action-danger);
+}
+
+/* =========================================================================
+ * Size
+ * ========================================================================= */
+
+.size-sm .root {
+  width: 16px;
+  height: 16px;
+}
+
+.size-sm .labelText {
+  font-size: var(--font-size-sm);
+}
+
+.size-md .root {
+  width: 20px;
+  height: 20px;
+}
+
+.size-md .labelText {
+  font-size: var(--font-size-md);
+}
+
+.size-lg .root {
+  width: 24px;
+  height: 24px;
+}
+
+.size-lg .labelText {
+  font-size: var(--font-size-lg);
+}

--- a/libs/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/libs/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
+
+import Checkbox from './Checkbox';
+
+/**
+ * `Checkbox` は @nagiyu/ui のチェックボックス部品。
+ *
+ * - `label` を渡せば `<label>` で input と自動関連付け（a11y 必須対応）
+ * - `indeterminate` で部分選択状態（DOM プロパティ + 視覚は横棒）
+ * - 視覚的に隠した native `<input type="checkbox">` を CSS で再描画
+ *
+ * MUI への依存は内部で完全に隠蔽されている。
+ */
+const meta: Meta<typeof Checkbox> = {
+  title: 'Atoms/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'inline-radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    required: { control: 'boolean' },
+    indeterminate: { control: 'boolean' },
+    label: { control: 'text' },
+  },
+  args: {
+    label: '同意します',
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+  args: { checked: true },
+};
+
+export const Indeterminate: Story = {
+  args: { indeterminate: true, label: '部分選択' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const DisabledChecked: Story = {
+  args: { disabled: true, checked: true },
+};
+
+export const Required: Story = {
+  args: { required: true, label: '必須項目' },
+};
+
+export const NoLabel: Story = {
+  args: { label: undefined, 'aria-label': '通知を受け取る' },
+};
+
+export const Sizes: Story = {
+  argTypes: { size: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <Checkbox {...args} size="sm" label="sm" />
+      <Checkbox {...args} size="md" label="md" />
+      <Checkbox {...args} size="lg" label="lg" />
+    </div>
+  ),
+};
+
+/**
+ * 制御コンポーネントの動作確認用ストーリー。
+ */
+export const Controlled: Story = {
+  render: function ControlledRender(args) {
+    const [checked, setChecked] = React.useState(false);
+    return (
+      <Checkbox
+        {...args}
+        checked={checked}
+        onChange={(e) => setChecked(e.target.checked)}
+        label={`チェック状態: ${checked ? 'on' : 'off'}`}
+      />
+    );
+  },
+};

--- a/libs/ui/src/components/Checkbox/Checkbox.tsx
+++ b/libs/ui/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import * as React from 'react';
+
+import styles from './Checkbox.module.css';
+
+/**
+ * Checkbox のサイズ。
+ */
+export type CheckboxSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Checkbox のプロパティ。
+ *
+ * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
+ * エスケープハッチは `className` のみ。
+ */
+export interface CheckboxProps {
+  // ---- 値・イベント ----
+  checked?: boolean;
+  defaultChecked?: boolean;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+
+  // ---- 表示 ----
+  /**
+   * チェックボックス右側に表示するラベル。
+   * 渡すと `<label>` で input と関連付けて 1 コンポーネントで完結する
+   * （MUI の `<FormControlLabel control={<Checkbox/>} label="..."/>` 相当）。
+   */
+  label?: React.ReactNode;
+
+  // ---- 状態 ----
+  disabled?: boolean;
+  required?: boolean;
+  /**
+   * 部分選択状態。`true` のとき、HTML の `indeterminate` DOM プロパティを設定し、
+   * 視覚的にも横棒（ダッシュ）アイコンを表示する。
+   */
+  indeterminate?: boolean;
+
+  // ---- サイズ ----
+  /**
+   * サイズ。既定: `md`
+   */
+  size?: CheckboxSize;
+
+  // ---- その他 HTML ----
+  id?: string;
+  name?: string;
+  value?: string;
+  autoFocus?: boolean;
+
+  // ---- a11y ----
+  /**
+   * `label` 以外で名前を提供する場合に使用する。`label` が指定されている場合は不要。
+   */
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+
+  // ---- エスケープハッチ ----
+  className?: string;
+
+  // ---- ref ----
+  /**
+   * 内部の `<input type="checkbox">` 要素への ref。
+   */
+  inputRef?: React.Ref<HTMLInputElement>;
+}
+
+/**
+ * チェックボックスコンポーネント。
+ *
+ * - `label` を渡せば `<label>` で input と自動関連付け（a11y 必須対応）
+ * - `indeterminate` で DOM プロパティと視覚（横棒アイコン）を同期
+ * - 視覚的に隠した native `<input type="checkbox">` を CSS で再描画
+ *
+ * @see docs/development/shared-ui-components.md
+ */
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  {
+    checked,
+    defaultChecked,
+    onChange,
+    label,
+    disabled = false,
+    required = false,
+    indeterminate = false,
+    size = 'md',
+    id,
+    name,
+    value,
+    autoFocus,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    className,
+    inputRef,
+  },
+  ref
+) {
+  const generatedId = React.useId();
+  const inputId = id ?? generatedId;
+
+  // 内部 ref を作り、外部から渡された ref とマージする。
+  // indeterminate は HTML 属性ではなく DOM プロパティなので useEffect で同期。
+  const internalRef = React.useRef<HTMLInputElement | null>(null);
+  React.useEffect(() => {
+    if (internalRef.current) {
+      internalRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  const setRefs = React.useCallback(
+    (node: HTMLInputElement | null) => {
+      internalRef.current = node;
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLInputElement | null>).current = node;
+      }
+      if (typeof inputRef === 'function') {
+        inputRef(node);
+      } else if (inputRef) {
+        (inputRef as React.MutableRefObject<HTMLInputElement | null>).current = node;
+      }
+    },
+    [ref, inputRef]
+  );
+
+  const wrapperClasses = [
+    styles.wrapper,
+    disabled ? styles.disabled : null,
+    styles[`size-${size}`],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const inputElement = (
+    <span className={styles.root}>
+      <input
+        ref={setRefs}
+        id={inputId}
+        type="checkbox"
+        name={name}
+        value={value}
+        checked={checked}
+        defaultChecked={defaultChecked}
+        onChange={onChange}
+        disabled={disabled}
+        required={required}
+        autoFocus={autoFocus}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        className={styles.input}
+      />
+      <span className={styles.box} aria-hidden="true">
+        {/* チェックマーク（checked 時に表示） */}
+        <svg className={styles.checkIcon} viewBox="0 0 24 24" focusable="false">
+          <path d="M9 16.17 4.83 12l-1.41 1.41L9 19 21 7l-1.41-1.41z" />
+        </svg>
+        {/* 横棒（indeterminate 時に表示） */}
+        <svg className={styles.dashIcon} viewBox="0 0 24 24" focusable="false">
+          <path d="M19 13H5v-2h14v2z" />
+        </svg>
+      </span>
+    </span>
+  );
+
+  if (label) {
+    return (
+      <label htmlFor={inputId} className={wrapperClasses}>
+        {inputElement}
+        <span className={styles.labelText}>
+          {label}
+          {required ? (
+            <span aria-hidden="true" className={styles.requiredMark}>
+              {' '}
+              *
+            </span>
+          ) : null}
+        </span>
+      </label>
+    );
+  }
+
+  return <span className={wrapperClasses}>{inputElement}</span>;
+});
+
+export default Checkbox;

--- a/libs/ui/src/components/Checkbox/index.ts
+++ b/libs/ui/src/components/Checkbox/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Checkbox';
+export type { CheckboxProps, CheckboxSize } from './Checkbox';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -6,6 +6,8 @@ export { default as Button } from './components/Button';
 export type { ButtonProps, ButtonVariant, ButtonColor, ButtonSize } from './components/Button';
 export { default as TextField } from './components/TextField';
 export type { TextFieldProps, TextFieldSize, TextFieldType } from './components/TextField';
+export { default as Checkbox } from './components/Checkbox';
+export type { CheckboxProps, CheckboxSize } from './components/Checkbox';
 export { default as Header } from './components/layout/Header';
 export type { HeaderProps, NavigationItem } from './components/layout/Header';
 export { default as Footer } from './components/layout/Footer';

--- a/libs/ui/tests/unit/components/Checkbox/Checkbox.test.tsx
+++ b/libs/ui/tests/unit/components/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,206 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import Checkbox from '../../../../src/components/Checkbox/Checkbox';
+
+describe('Checkbox', () => {
+  describe('rendering', () => {
+    it('input[type=checkbox] を描画する', () => {
+      render(<Checkbox aria-label="テスト" />);
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+
+    it('label を渡すと <label> でラップされ、input と関連付けられる', () => {
+      render(<Checkbox label="同意します" />);
+      const checkbox = screen.getByLabelText('同意します');
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toHaveAttribute('type', 'checkbox');
+    });
+
+    it('id を明示すれば尊重される', () => {
+      render(<Checkbox id="my-cb" label="x" />);
+      expect(screen.getByLabelText('x')).toHaveAttribute('id', 'my-cb');
+    });
+
+    it('label なしでも aria-label があれば指定できる', () => {
+      render(<Checkbox aria-label="検索" />);
+      expect(screen.getByRole('checkbox', { name: '検索' })).toBeInTheDocument();
+    });
+
+    it('既定値（md / unchecked）が適用される', () => {
+      const { container } = render(<Checkbox label="x" />);
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.className).toContain('size-md');
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+  });
+
+  describe('events', () => {
+    it('クリックで onChange が発火し、checked の値が伝わる', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(<Checkbox label="x" onChange={onChange} />);
+      await user.click(screen.getByLabelText('x'));
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const event = onChange.mock.calls[0][0];
+      expect(event.target.checked).toBe(true);
+    });
+
+    it('label テキストをクリックでも input にフォーカス・状態変化が起きる', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(<Checkbox label="同意します" onChange={onChange} />);
+      // label テキスト要素をクリック
+      await user.click(screen.getByText('同意します'));
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('disabled の時は onChange が発火しない', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(<Checkbox label="x" disabled onChange={onChange} />);
+      await user.click(screen.getByLabelText('x'));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('Space キーでも onChange が発火する', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(<Checkbox label="x" onChange={onChange} />);
+      const checkbox = screen.getByLabelText('x');
+      checkbox.focus();
+      await user.keyboard(' ');
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('controlled', () => {
+    it('checked を渡せば制御コンポーネントとして動作する', () => {
+      const { rerender } = render(<Checkbox label="x" checked={false} onChange={() => {}} />);
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+      rerender(<Checkbox label="x" checked={true} onChange={() => {}} />);
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('defaultChecked で初期値を設定できる', () => {
+      render(<Checkbox label="x" defaultChecked />);
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+  });
+
+  describe('states', () => {
+    it('disabled=true で input に disabled 属性、wrapper に disabled クラス', () => {
+      const { container } = render(<Checkbox label="x" disabled />);
+      expect(screen.getByRole('checkbox')).toBeDisabled();
+      expect((container.firstChild as HTMLElement).className).toContain('disabled');
+    });
+
+    it('required=true で input に required 属性、ラベルにアスタリスク', () => {
+      const { container } = render(<Checkbox label="同意" required />);
+      expect(screen.getByRole('checkbox')).toBeRequired();
+      expect(container.textContent).toContain('*');
+    });
+
+    it('indeterminate=true で DOM プロパティが設定される', () => {
+      render(<Checkbox label="x" indeterminate />);
+      const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+      expect(checkbox.indeterminate).toBe(true);
+    });
+
+    it('indeterminate=false に切り替えると DOM プロパティも解除される', () => {
+      const { rerender } = render(<Checkbox label="x" indeterminate />);
+      const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+      expect(checkbox.indeterminate).toBe(true);
+      rerender(<Checkbox label="x" indeterminate={false} />);
+      expect(checkbox.indeterminate).toBe(false);
+    });
+  });
+
+  describe('size', () => {
+    it.each(['sm', 'md', 'lg'] as const)('size=%s で対応するクラスが付与される', (size) => {
+      const { container } = render(<Checkbox label="x" size={size} />);
+      expect((container.firstChild as HTMLElement).className).toContain(`size-${size}`);
+    });
+  });
+
+  describe('refs', () => {
+    it('forwardRef で input 要素にアクセスできる', () => {
+      const ref = React.createRef<HTMLInputElement>();
+      render(<Checkbox label="x" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+      expect(ref.current?.type).toBe('checkbox');
+    });
+
+    it('inputRef でも input 要素にアクセスできる', () => {
+      const ref = React.createRef<HTMLInputElement>();
+      render(<Checkbox label="x" inputRef={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    });
+
+    it('ref と inputRef を同時に渡しても両方に値がセットされる', () => {
+      const ref1 = React.createRef<HTMLInputElement>();
+      const ref2 = React.createRef<HTMLInputElement>();
+      render(<Checkbox label="x" ref={ref1} inputRef={ref2} />);
+      expect(ref1.current).toBeInstanceOf(HTMLInputElement);
+      expect(ref2.current).toBeInstanceOf(HTMLInputElement);
+      expect(ref1.current).toBe(ref2.current);
+    });
+
+    it('ref コールバック関数も呼ばれる', () => {
+      const refFn = jest.fn();
+      render(<Checkbox label="x" ref={refFn} />);
+      expect(refFn).toHaveBeenCalled();
+      expect(refFn.mock.calls[0][0]).toBeInstanceOf(HTMLInputElement);
+    });
+
+    it('inputRef コールバック関数も呼ばれる', () => {
+      const refFn = jest.fn();
+      render(<Checkbox label="x" inputRef={refFn} />);
+      expect(refFn).toHaveBeenCalled();
+      expect(refFn.mock.calls[0][0]).toBeInstanceOf(HTMLInputElement);
+    });
+  });
+
+  describe('html attributes', () => {
+    it('name / value が input に反映される', () => {
+      render(<Checkbox label="x" name="agree" value="yes" />);
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('name', 'agree');
+      expect(checkbox).toHaveAttribute('value', 'yes');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('label を持つ既定状態で a11y 違反がない', async () => {
+      const { container } = render(<Checkbox label="同意します" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('checked 状態で a11y 違反がない', async () => {
+      const { container } = render(<Checkbox label="x" defaultChecked />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('disabled 状態で a11y 違反がない', async () => {
+      const { container } = render(<Checkbox label="x" disabled />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('indeterminate 状態で a11y 違反がない', async () => {
+      const { container } = render(<Checkbox label="x" indeterminate />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('label なし aria-label のみでも a11y 違反がない', async () => {
+      const { container } = render(<Checkbox aria-label="検索" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -73,7 +73,7 @@
 
 ### Checkbox
 
-- [ ] PR 1-3-A: 実装 + Stories + テスト
+- [x] PR 1-3-A: 実装 + Stories + テスト（label 自動関連付け / indeterminate / size sm/md/lg、native input + CSS で再描画。Checkbox.tsx は statements/lines/functions 100%、branches 95.45%）
 - [ ] PR 1-3-B: 置換
 - [ ] PR 1-3-C: ESLint 禁止追加
 


### PR DESCRIPTION
## 変更の概要

`@nagiyu/ui` に **`Checkbox` コンポーネント**を追加する（PR 1-3-A）。

- `label` を渡せば `<label>` で input と自動関連付け（MUI の `FormControlLabel + Checkbox` を 1 コンポーネントで完結）
- `indeterminate` を `useEffect` で DOM プロパティに同期 + 視覚的に横棒アイコン
- 視覚的に隠した native `<input type="checkbox">` を CSS で再描画（accent-color 系より細かく theming 可能）

## API

```ts
export interface CheckboxProps {
  // 値・イベント
  checked?: boolean;
  defaultChecked?: boolean;
  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;

  // 表示
  label?: React.ReactNode;

  // 状態
  disabled?: boolean;
  required?: boolean;
  indeterminate?: boolean;

  // サイズ
  size?: 'sm' | 'md' | 'lg';

  // その他 HTML
  id?, name?, value?, autoFocus?;

  // a11y
  'aria-label'?, 'aria-labelledby'?: string;

  // エスケープハッチ
  className?: string;

  // ref（forwardRef・inputRef どちらでも）
  inputRef?: React.Ref<HTMLInputElement>;
}
```

## 採用しなかった機能と理由

| 機能 | 判断 | 理由 |
|---|---|---|
| `color` | 不採用（チェック時は primary 固定） | サービスの実利用は color 指定なし（0/17 箇所） |
| `variant` | 不採用 | チェックボックスにバリエーション不要 |
| `slotProps` | 不採用、必要なものを top-level に昇格 | MUI 固有 API を漏らさないため |
| `asChild` | 不採用 | フォーム制御は単独 leaf として動作 |
| `error` | 不採用 | TextField と異なり、チェックボックスの error 状態は実利用パターンに乏しい |

## ファイル構成

```
libs/ui/src/components/Checkbox/
├── Checkbox.tsx
├── Checkbox.module.css
├── Checkbox.stories.tsx
└── index.ts

libs/ui/tests/unit/components/Checkbox/
└── Checkbox.test.tsx
```

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（**29 件 pass / Checkbox.tsx は statements・lines・functions 100%、branches 95.45%**）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した（ライブラリ全体: 220 件 pass）
- [x] ビルドエラーがないことを確認した（`tsc` + `copy-assets` + `build-storybook` 成功）

## テスト内容

`Checkbox.test.tsx` で 29 件のテスト:

- **rendering**: input[type=checkbox] 描画、label 自動関連付け、id 明示の尊重、aria-label 単独、既定値
- **events**: クリック / Space キーで onChange 発火、event.target.checked 反映、label テキストクリックでも反応、disabled 時の発火抑止
- **controlled**: `checked` での制御モード、`defaultChecked` での非制御モード
- **states**: `disabled` で `disabled` 属性 + クラス、`required` で属性 + アスタリスク、`indeterminate` の DOM プロパティ反映と切替
- **size**: sm/md/lg 全パターン
- **refs**: `forwardRef`、`inputRef`、両方同時、コールバック関数も対応
- **html attributes**: `name` / `value` 反映
- **a11y（jest-axe）**: 既定 / checked / disabled / indeterminate / aria-label 単独

## レビューポイント

- **`<FormControlLabel control={<Checkbox/>}>` パターンの統合**: MUI ではラベルと checkbox が分かれていたが、@nagiyu/ui では `<Checkbox label="..." />` で完結。可読性と DX が向上。
- **`indeterminate` の同期方法**: HTML 属性ではなく DOM プロパティのため `useEffect` で `inputRef.current.indeterminate = true` を反映。`indeterminate=false` への切替も正しく解除される（テスト確認済）。
- **ref 統合**: `forwardRef` の `ref` と top-level Props の `inputRef` を両方サポートし、内部で `useCallback` ベースのコールバック ref を作って統合。両方を同時に渡しても安全。
- **視覚再描画方式**: native input を `position: absolute; opacity: 0` で隠し、隣接 sibling の `.box` と SVG アイコンを CSS で描画。`:checked` / `:indeterminate` / `:focus-visible` / `:disabled` 各擬似クラスで状態変化。

## スクリーンショット

dev 環境で視覚確認予定。

## 補足事項

PR 1-3-B（サービス側の置換、6 ファイル）と PR 1-3-C（ESLint 禁止）は本 PR マージ後に別 PR で対応する。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_