### PR TITLE
feat(libs): ErrorEvent 共通型と DynamoDB 書き込み SDK を追加

### DIFF
--- a/libs/aws/package.json
+++ b/libs/aws/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/client-batch": "^3.1024.0",
     "@aws-sdk/client-dynamodb": "^3.1024.0",
     "@aws-sdk/client-s3": "^3.1024.0",
-    "@aws-sdk/lib-dynamodb": "^3.1024.0"
+    "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@nagiyu/common": "*"
   }
 }

--- a/libs/aws/src/error-events/dynamodb-writer.ts
+++ b/libs/aws/src/error-events/dynamodb-writer.ts
@@ -1,0 +1,78 @@
+/**
+ * DynamoDB 実装の ErrorEventWriter
+ *
+ * Single Table Design の規約に従い、エラーイベントを既定のキー設計で書き込む。
+ */
+
+import { PutCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import type { ErrorEvent } from '@nagiyu/common';
+import {
+  buildErrorEventPK,
+  buildErrorEventSK,
+  computeErrorEventTtl,
+  ERROR_EVENT_ENTITY_TYPE,
+  ERROR_EVENT_GSI1_PK,
+  type ErrorEventWriter,
+} from './writer.js';
+
+const ERROR_MESSAGES = {
+  INVALID_EVENT_ID: 'eventId は空文字にできません',
+  INVALID_SERVICE_ID: 'serviceId は空文字にできません',
+  INVALID_OCCURRED_AT: 'occurredAt は空文字にできません',
+  INVALID_TITLE: 'title は空文字にできません',
+} as const;
+
+/**
+ * DynamoDB をバックエンドとする ErrorEventWriter 実装。
+ */
+export class DynamoDBErrorEventWriter implements ErrorEventWriter {
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+
+  constructor(docClient: DynamoDBDocumentClient, tableName: string) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+  }
+
+  public async put(event: ErrorEvent): Promise<void> {
+    if (!event.eventId) {
+      throw new Error(ERROR_MESSAGES.INVALID_EVENT_ID);
+    }
+    if (!event.serviceId) {
+      throw new Error(ERROR_MESSAGES.INVALID_SERVICE_ID);
+    }
+    if (!event.occurredAt) {
+      throw new Error(ERROR_MESSAGES.INVALID_OCCURRED_AT);
+    }
+    if (!event.title) {
+      throw new Error(ERROR_MESSAGES.INVALID_TITLE);
+    }
+
+    const sortKey = buildErrorEventSK(event.occurredAt, event.eventId);
+    const now = Date.now();
+
+    await this.docClient.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          PK: buildErrorEventPK(event.serviceId),
+          SK: sortKey,
+          Type: ERROR_EVENT_ENTITY_TYPE,
+          GSI1PK: ERROR_EVENT_GSI1_PK,
+          GSI1SK: sortKey,
+          eventId: event.eventId,
+          serviceId: event.serviceId,
+          source: event.source,
+          severity: event.severity,
+          title: event.title,
+          message: event.message,
+          context: event.context,
+          occurredAt: event.occurredAt,
+          ttl: computeErrorEventTtl(event.occurredAt),
+          CreatedAt: now,
+          UpdatedAt: now,
+        },
+      })
+    );
+  }
+}

--- a/libs/aws/src/error-events/factory.ts
+++ b/libs/aws/src/error-events/factory.ts
@@ -1,0 +1,59 @@
+/**
+ * ErrorEventWriter Factory
+ *
+ * 環境変数 `USE_IN_MEMORY_DB` に応じて in-memory / DynamoDB の実装を切り替える。
+ */
+
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { createRepositoryFactory } from '../dynamodb/repository-factory.js';
+import { DynamoDBErrorEventWriter } from './dynamodb-writer.js';
+import { InMemoryErrorEventWriter } from './in-memory-writer.js';
+import type { ErrorEventWriter } from './writer.js';
+
+const ERROR_MESSAGES = {
+  DYNAMODB_PARAMS_REQUIRED: 'DynamoDB 実装には docClient と tableName が必要です',
+} as const;
+
+function requireDynamoParams(
+  docClient: DynamoDBDocumentClient | undefined,
+  tableName: string | undefined
+): { docClient: DynamoDBDocumentClient; tableName: string } {
+  if (!docClient || !tableName) {
+    throw new Error(ERROR_MESSAGES.DYNAMODB_PARAMS_REQUIRED);
+  }
+  return { docClient, tableName };
+}
+
+const errorEventWriterFactory = createRepositoryFactory<
+  ErrorEventWriter,
+  [DynamoDBDocumentClient | undefined, string | undefined]
+>({
+  createInMemoryRepository: () => new InMemoryErrorEventWriter(),
+  createDynamoDBRepository: (docClient, tableName) => {
+    const params = requireDynamoParams(docClient, tableName);
+    return new DynamoDBErrorEventWriter(params.docClient, params.tableName);
+  },
+});
+
+/**
+ * `ErrorEventWriter` を生成する。
+ *
+ * - `USE_IN_MEMORY_DB=true` のとき in-memory 実装
+ * - それ以外は DynamoDB 実装（docClient / tableName 必須）
+ *
+ * 一度生成されたインスタンスはシングルトンとして再利用される。
+ * テストで状態分離が必要な場合は `resetErrorEventWriter()` を呼んでから再生成すること。
+ */
+export function createErrorEventWriter(
+  docClient?: DynamoDBDocumentClient,
+  tableName?: string
+): ErrorEventWriter {
+  return errorEventWriterFactory.createRepository(docClient, tableName);
+}
+
+/**
+ * 内部のシングルトンインスタンスを破棄する。テスト用。
+ */
+export function resetErrorEventWriter(): void {
+  errorEventWriterFactory.resetRepository();
+}

--- a/libs/aws/src/error-events/in-memory-writer.ts
+++ b/libs/aws/src/error-events/in-memory-writer.ts
@@ -1,0 +1,36 @@
+/**
+ * in-memory 実装の ErrorEventWriter
+ *
+ * テスト・ローカル開発用。永続化は行わずプロセスメモリ上に保持する。
+ */
+
+import type { ErrorEvent } from '@nagiyu/common';
+import type { ErrorEventWriter } from './writer.js';
+
+/**
+ * in-memory 実装。
+ *
+ * `getRecords()` で書き込まれたイベントを参照でき、
+ * テストで書き込み内容のアサーションに使用する。
+ */
+export class InMemoryErrorEventWriter implements ErrorEventWriter {
+  private readonly records: ErrorEvent[] = [];
+
+  public async put(event: ErrorEvent): Promise<void> {
+    this.records.push({ ...event });
+  }
+
+  /**
+   * 書き込まれたイベントの一覧（書き込み順）を取得する。テスト用。
+   */
+  public getRecords(): readonly ErrorEvent[] {
+    return [...this.records];
+  }
+
+  /**
+   * 内部状態をクリアする。テスト用。
+   */
+  public reset(): void {
+    this.records.length = 0;
+  }
+}

--- a/libs/aws/src/error-events/index.ts
+++ b/libs/aws/src/error-events/index.ts
@@ -1,0 +1,20 @@
+/**
+ * ErrorEvents モジュール
+ *
+ * プラットフォーム共通のエラーイベントを DynamoDB に書き込むための SDK。
+ */
+
+export type { ErrorEventWriter, ErrorEventKey } from './writer.js';
+export {
+  ERROR_EVENT_ENTITY_TYPE,
+  ERROR_EVENT_GSI1_PK,
+  ERROR_EVENT_TTL_DAYS,
+  ERROR_EVENT_PK_PREFIX,
+  ERROR_EVENT_SK_PREFIX,
+  buildErrorEventPK,
+  buildErrorEventSK,
+  computeErrorEventTtl,
+} from './writer.js';
+export { DynamoDBErrorEventWriter } from './dynamodb-writer.js';
+export { InMemoryErrorEventWriter } from './in-memory-writer.js';
+export { createErrorEventWriter, resetErrorEventWriter } from './factory.js';

--- a/libs/aws/src/error-events/writer.ts
+++ b/libs/aws/src/error-events/writer.ts
@@ -1,0 +1,84 @@
+/**
+ * ErrorEventWriter インタフェース定義
+ *
+ * プラットフォーム上で発生したエラーイベントを永続化する書き込み専用 API。
+ * DynamoDB / in-memory の両方の実装を切り替え可能にするため抽象化する。
+ */
+
+import type { ErrorEvent } from '@nagiyu/common';
+
+/**
+ * エラーイベント書き込み API
+ */
+export interface ErrorEventWriter {
+  /**
+   * エラーイベントを 1 件書き込む。
+   *
+   * @param event - 永続化するエラーイベント
+   * @throws データベース書き込みに失敗した場合
+   */
+  put(event: ErrorEvent): Promise<void>;
+}
+
+/**
+ * エラーイベントテーブルの DynamoDB キー
+ */
+export type ErrorEventKey = {
+  serviceId: string;
+  occurredAt: string;
+  eventId: string;
+};
+
+/**
+ * DynamoDB Item の Type 値
+ */
+export const ERROR_EVENT_ENTITY_TYPE = 'ErrorEvent';
+
+/**
+ * 全件横断クエリ用 GSI1 のパーティションキー値（固定）
+ */
+export const ERROR_EVENT_GSI1_PK = 'ERROR_EVENT_ALL';
+
+/**
+ * TTL の保持期間（日数）
+ */
+export const ERROR_EVENT_TTL_DAYS = 180;
+
+/**
+ * PK プレフィックス
+ */
+export const ERROR_EVENT_PK_PREFIX = 'ERROR_EVENT#';
+
+/**
+ * SK プレフィックス
+ */
+export const ERROR_EVENT_SK_PREFIX = 'OCCURRED#';
+
+/**
+ * PK を構築する。
+ */
+export function buildErrorEventPK(serviceId: string): string {
+  return `${ERROR_EVENT_PK_PREFIX}${serviceId}`;
+}
+
+/**
+ * SK を構築する。
+ */
+export function buildErrorEventSK(occurredAt: string, eventId: string): string {
+  return `${ERROR_EVENT_SK_PREFIX}${occurredAt}#${eventId}`;
+}
+
+/**
+ * occurredAt（ISO-8601）から TTL の Unix epoch 秒を計算する。
+ *
+ * @param occurredAt - ISO-8601 文字列
+ * @returns occurredAt + 180 日後の Unix epoch 秒
+ */
+export function computeErrorEventTtl(occurredAt: string): number {
+  const occurredAtMillis = Date.parse(occurredAt);
+  if (Number.isNaN(occurredAtMillis)) {
+    throw new Error(`occurredAt が ISO-8601 として解釈できません: ${occurredAt}`);
+  }
+  const ttlMillis = occurredAtMillis + ERROR_EVENT_TTL_DAYS * 24 * 60 * 60 * 1000;
+  return Math.floor(ttlMillis / 1000);
+}

--- a/libs/aws/src/index.ts
+++ b/libs/aws/src/index.ts
@@ -11,3 +11,4 @@ export * from './clients.js';
 export * from './dynamodb/index.js';
 export * from './s3/index.js';
 export * from './batch/index.js';
+export * from './error-events/index.js';

--- a/libs/aws/tests/unit/error-events/dynamodb-writer.test.ts
+++ b/libs/aws/tests/unit/error-events/dynamodb-writer.test.ts
@@ -1,0 +1,104 @@
+/**
+ * DynamoDBErrorEventWriter の単体テスト
+ */
+
+import { PutCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import type { ErrorEvent } from '@nagiyu/common';
+import { DynamoDBErrorEventWriter } from '../../../src/error-events/dynamodb-writer.js';
+import {
+  buildErrorEventPK,
+  buildErrorEventSK,
+  computeErrorEventTtl,
+  ERROR_EVENT_ENTITY_TYPE,
+  ERROR_EVENT_GSI1_PK,
+} from '../../../src/error-events/writer.js';
+
+const baseEvent: ErrorEvent = {
+  eventId: 'evt-1',
+  serviceId: 'stock-tracker',
+  source: 'cloudwatch-alarm',
+  severity: 'error',
+  title: 'stock-tracker-web-error-rate-prod (ALARM)',
+  message: 'Threshold Crossed',
+  context: '{"raw":true}',
+  occurredAt: '2026-05-06T01:32:11.000Z',
+};
+
+describe('DynamoDBErrorEventWriter', () => {
+  let mockDocClient: jest.Mocked<DynamoDBDocumentClient>;
+  let writer: DynamoDBErrorEventWriter;
+
+  beforeEach(() => {
+    mockDocClient = { send: jest.fn() } as unknown as jest.Mocked<DynamoDBDocumentClient>;
+    writer = new DynamoDBErrorEventWriter(mockDocClient, 'test-error-events');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('put', () => {
+    it('PutCommand を Single Table Design のキーで送信する', async () => {
+      mockDocClient.send.mockResolvedValueOnce({} as never);
+
+      await writer.put(baseEvent);
+
+      expect(mockDocClient.send).toHaveBeenCalledTimes(1);
+      const sentCommand = mockDocClient.send.mock.calls[0][0] as PutCommand;
+      expect(sentCommand).toBeInstanceOf(PutCommand);
+
+      const input = sentCommand.input;
+      expect(input.TableName).toBe('test-error-events');
+      const expectedSk = buildErrorEventSK(baseEvent.occurredAt, baseEvent.eventId);
+      expect(input.Item).toMatchObject({
+        PK: buildErrorEventPK(baseEvent.serviceId),
+        SK: expectedSk,
+        Type: ERROR_EVENT_ENTITY_TYPE,
+        GSI1PK: ERROR_EVENT_GSI1_PK,
+        GSI1SK: expectedSk,
+        eventId: baseEvent.eventId,
+        serviceId: baseEvent.serviceId,
+        source: baseEvent.source,
+        severity: baseEvent.severity,
+        title: baseEvent.title,
+        message: baseEvent.message,
+        context: baseEvent.context,
+        occurredAt: baseEvent.occurredAt,
+        ttl: computeErrorEventTtl(baseEvent.occurredAt),
+      });
+      expect(typeof input.Item?.CreatedAt).toBe('number');
+      expect(typeof input.Item?.UpdatedAt).toBe('number');
+    });
+
+    it('eventId が空の場合は例外を投げる', async () => {
+      await expect(writer.put({ ...baseEvent, eventId: '' })).rejects.toThrow(
+        'eventId は空文字にできません'
+      );
+      expect(mockDocClient.send).not.toHaveBeenCalled();
+    });
+
+    it('serviceId が空の場合は例外を投げる', async () => {
+      await expect(writer.put({ ...baseEvent, serviceId: '' })).rejects.toThrow(
+        'serviceId は空文字にできません'
+      );
+    });
+
+    it('occurredAt が空の場合は例外を投げる', async () => {
+      await expect(writer.put({ ...baseEvent, occurredAt: '' })).rejects.toThrow(
+        'occurredAt は空文字にできません'
+      );
+    });
+
+    it('title が空の場合は例外を投げる', async () => {
+      await expect(writer.put({ ...baseEvent, title: '' })).rejects.toThrow(
+        'title は空文字にできません'
+      );
+    });
+
+    it('DynamoDB エラーはそのまま伝播する', async () => {
+      mockDocClient.send.mockRejectedValueOnce(new Error('AWS down'));
+
+      await expect(writer.put(baseEvent)).rejects.toThrow('AWS down');
+    });
+  });
+});

--- a/libs/aws/tests/unit/error-events/factory.test.ts
+++ b/libs/aws/tests/unit/error-events/factory.test.ts
@@ -1,0 +1,75 @@
+/**
+ * createErrorEventWriter の単体テスト
+ */
+
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  createErrorEventWriter,
+  resetErrorEventWriter,
+} from '../../../src/error-events/factory.js';
+import { DynamoDBErrorEventWriter } from '../../../src/error-events/dynamodb-writer.js';
+import { InMemoryErrorEventWriter } from '../../../src/error-events/in-memory-writer.js';
+
+describe('createErrorEventWriter', () => {
+  const originalUseInMemory = process.env.USE_IN_MEMORY_DB;
+
+  beforeEach(() => {
+    resetErrorEventWriter();
+  });
+
+  afterEach(() => {
+    if (originalUseInMemory === undefined) {
+      delete process.env.USE_IN_MEMORY_DB;
+    } else {
+      process.env.USE_IN_MEMORY_DB = originalUseInMemory;
+    }
+    resetErrorEventWriter();
+  });
+
+  it('USE_IN_MEMORY_DB=true のとき in-memory 実装を返す', () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+
+    const writer = createErrorEventWriter();
+
+    expect(writer).toBeInstanceOf(InMemoryErrorEventWriter);
+  });
+
+  it('USE_IN_MEMORY_DB が未設定で docClient と tableName が揃っているとき DynamoDB 実装を返す', () => {
+    delete process.env.USE_IN_MEMORY_DB;
+    const mockClient = { send: jest.fn() } as unknown as DynamoDBDocumentClient;
+
+    const writer = createErrorEventWriter(mockClient, 'tbl');
+
+    expect(writer).toBeInstanceOf(DynamoDBErrorEventWriter);
+  });
+
+  it('USE_IN_MEMORY_DB が未設定で docClient が欠けているときは例外を投げる', () => {
+    delete process.env.USE_IN_MEMORY_DB;
+    expect(() => createErrorEventWriter(undefined, 'tbl')).toThrow(
+      'DynamoDB 実装には docClient と tableName が必要です'
+    );
+  });
+
+  it('USE_IN_MEMORY_DB が未設定で tableName が欠けているときは例外を投げる', () => {
+    delete process.env.USE_IN_MEMORY_DB;
+    const mockClient = { send: jest.fn() } as unknown as DynamoDBDocumentClient;
+    expect(() => createErrorEventWriter(mockClient, undefined)).toThrow(
+      'DynamoDB 実装には docClient と tableName が必要です'
+    );
+  });
+
+  it('生成された Writer はシングルトンとして再利用される', () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const first = createErrorEventWriter();
+    const second = createErrorEventWriter();
+    expect(first).toBe(second);
+  });
+
+  it('resetErrorEventWriter 後は新規インスタンスを返す', () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const first = createErrorEventWriter();
+    resetErrorEventWriter();
+    const second = createErrorEventWriter();
+    expect(first).not.toBe(second);
+  });
+});

--- a/libs/aws/tests/unit/error-events/in-memory-writer.test.ts
+++ b/libs/aws/tests/unit/error-events/in-memory-writer.test.ts
@@ -1,0 +1,69 @@
+/**
+ * InMemoryErrorEventWriter の単体テスト
+ */
+
+import type { ErrorEvent } from '@nagiyu/common';
+import { InMemoryErrorEventWriter } from '../../../src/error-events/in-memory-writer.js';
+
+const sampleEvent = (overrides: Partial<ErrorEvent> = {}): ErrorEvent => ({
+  eventId: 'evt-1',
+  serviceId: 'stock-tracker',
+  source: 'cloudwatch-alarm',
+  severity: 'error',
+  title: 'sample',
+  message: 'sample message',
+  context: '{}',
+  occurredAt: '2026-05-06T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('InMemoryErrorEventWriter', () => {
+  let writer: InMemoryErrorEventWriter;
+
+  beforeEach(() => {
+    writer = new InMemoryErrorEventWriter();
+  });
+
+  it('put したイベントを getRecords で取得できる', async () => {
+    const event = sampleEvent();
+    await writer.put(event);
+
+    const records = writer.getRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]).toEqual(event);
+  });
+
+  it('複数 put すると書き込み順で保持される', async () => {
+    await writer.put(sampleEvent({ eventId: 'a' }));
+    await writer.put(sampleEvent({ eventId: 'b' }));
+    await writer.put(sampleEvent({ eventId: 'c' }));
+
+    const records = writer.getRecords();
+    expect(records.map((r) => r.eventId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('内部状態を変更しても getRecords の戻り値は影響を受けない', async () => {
+    await writer.put(sampleEvent());
+    const snapshot = writer.getRecords();
+
+    await writer.put(sampleEvent({ eventId: 'evt-2' }));
+
+    expect(snapshot).toHaveLength(1);
+    expect(writer.getRecords()).toHaveLength(2);
+  });
+
+  it('put された ErrorEvent はコピーされ、後続の変更の影響を受けない', async () => {
+    const event = sampleEvent();
+    await writer.put(event);
+
+    event.title = 'mutated';
+
+    expect(writer.getRecords()[0].title).toBe('sample');
+  });
+
+  it('reset で内部状態をクリアできる', async () => {
+    await writer.put(sampleEvent());
+    writer.reset();
+    expect(writer.getRecords()).toHaveLength(0);
+  });
+});

--- a/libs/aws/tests/unit/error-events/writer.test.ts
+++ b/libs/aws/tests/unit/error-events/writer.test.ts
@@ -1,0 +1,59 @@
+/**
+ * ErrorEvents Writer 共通ヘルパーの単体テスト
+ */
+
+import {
+  buildErrorEventPK,
+  buildErrorEventSK,
+  computeErrorEventTtl,
+  ERROR_EVENT_GSI1_PK,
+  ERROR_EVENT_PK_PREFIX,
+  ERROR_EVENT_SK_PREFIX,
+  ERROR_EVENT_TTL_DAYS,
+} from '../../../src/error-events/writer.js';
+
+describe('buildErrorEventPK', () => {
+  it('プレフィックス付きの PK を構築する', () => {
+    expect(buildErrorEventPK('stock-tracker')).toBe(`${ERROR_EVENT_PK_PREFIX}stock-tracker`);
+  });
+});
+
+describe('buildErrorEventSK', () => {
+  it('occurredAt と eventId を結合した SK を構築する', () => {
+    const sk = buildErrorEventSK('2026-05-06T01:32:11Z', 'evt-1');
+    expect(sk).toBe(`${ERROR_EVENT_SK_PREFIX}2026-05-06T01:32:11Z#evt-1`);
+  });
+});
+
+describe('computeErrorEventTtl', () => {
+  it('occurredAt から TTL_DAYS 日後の Unix epoch 秒を返す', () => {
+    const occurredAt = '2026-05-06T00:00:00Z';
+    const expected = Math.floor(
+      (Date.parse(occurredAt) + ERROR_EVENT_TTL_DAYS * 24 * 60 * 60 * 1000) / 1000
+    );
+    expect(computeErrorEventTtl(occurredAt)).toBe(expected);
+  });
+
+  it('TTL は occurredAt より TTL_DAYS 日後である', () => {
+    const occurredAt = '2026-01-01T00:00:00Z';
+    const ttlSeconds = computeErrorEventTtl(occurredAt);
+    const occurredAtSeconds = Math.floor(Date.parse(occurredAt) / 1000);
+    expect(ttlSeconds - occurredAtSeconds).toBe(ERROR_EVENT_TTL_DAYS * 24 * 60 * 60);
+  });
+
+  it('不正な occurredAt は例外を投げる', () => {
+    expect(() => computeErrorEventTtl('not-a-date')).toThrow(
+      /occurredAt が ISO-8601 として解釈できません/
+    );
+  });
+});
+
+describe('定数', () => {
+  it('GSI1PK は固定文字列', () => {
+    expect(ERROR_EVENT_GSI1_PK).toBe('ERROR_EVENT_ALL');
+  });
+
+  it('TTL_DAYS は 180 日', () => {
+    expect(ERROR_EVENT_TTL_DAYS).toBe(180);
+  });
+});

--- a/libs/aws/tsconfig.json
+++ b/libs/aws/tsconfig.json
@@ -11,5 +11,6 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../common" }]
 }

--- a/libs/common/src/error-event/event-id.ts
+++ b/libs/common/src/error-event/event-id.ts
@@ -5,16 +5,15 @@
  * 形式は実装非依存（呼び出し側は文字列としてのみ扱うこと）。
  */
 
-import { randomUUID } from 'node:crypto';
-
 /**
  * 新しい eventId を生成する。
  *
- * 現在の実装は UUID v4 を使用するが、将来の変更に備えて呼び出し側は
- * 形式に依存しないこと。
+ * 現在の実装は `globalThis.crypto.randomUUID()` を使用する。
+ * Node.js 19 以降と最新ブラウザの双方で動作するため、
+ * クライアント / サーバ両方の環境にバンドルされる場合でも問題ない。
  *
  * @returns 一意な eventId 文字列
  */
 export function generateEventId(): string {
-  return randomUUID();
+  return globalThis.crypto.randomUUID();
 }

--- a/libs/common/src/error-event/event-id.ts
+++ b/libs/common/src/error-event/event-id.ts
@@ -1,0 +1,20 @@
+/**
+ * ErrorEvent の eventId 生成ヘルパー
+ *
+ * 同一プラットフォーム内で衝突しない一意な ID を生成する。
+ * 形式は実装非依存（呼び出し側は文字列としてのみ扱うこと）。
+ */
+
+import { randomUUID } from 'node:crypto';
+
+/**
+ * 新しい eventId を生成する。
+ *
+ * 現在の実装は UUID v4 を使用するが、将来の変更に備えて呼び出し側は
+ * 形式に依存しないこと。
+ *
+ * @returns 一意な eventId 文字列
+ */
+export function generateEventId(): string {
+  return randomUUID();
+}

--- a/libs/common/src/error-event/index.ts
+++ b/libs/common/src/error-event/index.ts
@@ -1,0 +1,8 @@
+/**
+ * ErrorEvent モジュール
+ *
+ * プラットフォーム共通のエラーイベント型と関連ヘルパーを提供する。
+ */
+
+export type { ErrorEvent, ErrorSeverity, ErrorSource } from './types.js';
+export { generateEventId } from './event-id.js';

--- a/libs/common/src/error-event/types.ts
+++ b/libs/common/src/error-event/types.ts
@@ -1,0 +1,42 @@
+/**
+ * ErrorEvent ドメイン型定義
+ *
+ * プラットフォーム上で発生したエラー通知を表す共通型。
+ * フレームワーク非依存。
+ */
+
+/**
+ * エラーの重大度
+ */
+export type ErrorSeverity = 'info' | 'warning' | 'error' | 'critical';
+
+/**
+ * エラーの発生源種別
+ *
+ * - `cloudwatch-alarm`: CloudWatch Alarm 由来（SNS 経由で取り込まれる）
+ * - `application`: アプリケーション層からの直接レポート（将来拡張）
+ * - `manual`: 運用者による手動投入（将来拡張）
+ */
+export type ErrorSource = 'cloudwatch-alarm' | 'application' | 'manual';
+
+/**
+ * 永続化される 1 件のエラーイベント
+ */
+export type ErrorEvent = {
+  /** イベントの一意識別子 */
+  eventId: string;
+  /** 発生元サービス ID（例: stock-tracker） */
+  serviceId: string;
+  /** 発生源種別 */
+  source: ErrorSource;
+  /** 重大度 */
+  severity: ErrorSeverity;
+  /** 一覧表示用の見出し */
+  title: string;
+  /** 詳細本文 */
+  message: string;
+  /** 生ペイロードを保持する JSON 文字列 */
+  context: string;
+  /** 発生時刻（ISO-8601 UTC） */
+  occurredAt: string;
+};

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -31,3 +31,6 @@ export type { ErrorCode } from './constants/error-codes.js';
 export { COMMON_ERROR_MESSAGES } from './constants/error-messages.js';
 export type { CommonErrorMessageKey } from './constants/error-messages.js';
 export { HTTP_STATUS } from './constants/http-status.js';
+
+// ErrorEvent module - プラットフォーム共通のエラー通知型
+export * from './error-event/index.js';

--- a/libs/common/tests/unit/error-event/event-id.test.ts
+++ b/libs/common/tests/unit/error-event/event-id.test.ts
@@ -1,0 +1,21 @@
+/**
+ * generateEventId の単体テスト
+ */
+
+import { generateEventId } from '../../../src/error-event/event-id.js';
+
+describe('generateEventId', () => {
+  it('文字列を返す', () => {
+    const id = generateEventId();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('呼び出すたびに異なる ID を返す', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateEventId());
+    }
+    expect(ids.size).toBe(100);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,7 +199,8 @@
         "@aws-sdk/client-batch": "^3.1024.0",
         "@aws-sdk/client-dynamodb": "^3.1024.0",
         "@aws-sdk/client-s3": "^3.1024.0",
-        "@aws-sdk/lib-dynamodb": "^3.1024.0"
+        "@aws-sdk/lib-dynamodb": "^3.1024.0",
+        "@nagiyu/common": "*"
       }
     },
     "libs/browser": {


### PR DESCRIPTION
## 変更の概要

#2940 の **Phase 1（PR-impl-1: ライブラリ基盤）**。
プラットフォーム共通の `ErrorEvent` 型と DynamoDB 書き込み SDK を追加する。
後続 PR の Lambda（alarm-ingest, stream-handler）と Admin Web がこれを使ってエラー永続化機能を構築する。

## 関連 Issue

本 PR ではクローズしない（integration → develop の PR で `Closes #2940` を付ける）。

- #2940

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（新規ファイルはすべて 100% カバレッジ）
- [x] 関連ドキュメント（`tasks/persist-error-notifications/design.md`）と整合
- [ ] CI/CD 設定を追加・更新した（Phase 1 では不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## 追加内容

### `libs/common/error-event/`

| ファイル | 内容 |
| --- | --- |
| `types.ts` | `ErrorEvent` / `ErrorSeverity` / `ErrorSource` の型定義（フレームワーク非依存） |
| `event-id.ts` | `generateEventId()` — 一意な eventId 生成（現在は UUID v4、形式非依存） |
| `index.ts` | barrel export |

### `libs/aws/error-events/`

| ファイル | 内容 |
| --- | --- |
| `writer.ts` | `ErrorEventWriter` インタフェース、Single Table キー構築ヘルパー（`buildErrorEventPK`, `buildErrorEventSK`, `computeErrorEventTtl`）、各種定数 |
| `dynamodb-writer.ts` | `DynamoDBErrorEventWriter` — `PutCommand` で永続化、入力バリデーション付き |
| `in-memory-writer.ts` | `InMemoryErrorEventWriter` — テスト・ローカル開発用 |
| `factory.ts` | `createErrorEventWriter` — `USE_IN_MEMORY_DB` 環境変数で実装切替（既存 `createRepositoryFactory` を活用） |
| `index.ts` | barrel export |

### 関連変更

- `libs/aws/package.json`: `@nagiyu/common` 依存追加
- `libs/aws/tsconfig.json`: TypeScript project references 追加
- `libs/common/src/index.ts` / `libs/aws/src/index.ts`: 新モジュールを re-export

## テスト内容

- `libs/common/tests/unit/error-event/event-id.test.ts`: 一意性・型の検証
- `libs/aws/tests/unit/error-events/writer.test.ts`: キー構築 / TTL 計算 / 不正入力例外
- `libs/aws/tests/unit/error-events/dynamodb-writer.test.ts`: `PutCommand` の正しい構築 / バリデーション / DynamoDB 例外伝播
- `libs/aws/tests/unit/error-events/in-memory-writer.test.ts`: put / getRecords / reset / 入力コピーによる副作用防止
- `libs/aws/tests/unit/error-events/factory.test.ts`: in-memory / DynamoDB 切替 / シングルトン / reset

実行結果:
- `libs/common`: 16 suites, 231 tests, **all pass**, 全カバレッジ閾値クリア
- `libs/aws`: 15 suites, 139 tests, **all pass**, 新規 4 ファイルすべて 100% カバレッジ

## レビューポイント

- **Single Table Design 規約への準拠**: PK/SK/GSI1 の命名・TTL 属性
- **入力バリデーション**: `dynamodb-writer.ts` 冒頭のバリデーション位置（DAO 層に置く判断）
- **Factory の責務分担**: 既存 `createRepositoryFactory` を再利用するか専用実装するかは前者を採用

## スクリーンショット（該当する場合）

なし（ライブラリ追加のみ）

## 補足事項

- **本 PR にはランタイム動作の変更はありません**。後続の PR-impl-2（インフラ + Lambda + UI）でこの SDK を使ってエラー永続化機能を実装する。
- Draft で進める。Ready 化は人力で実施。


---
_Generated by [Claude Code](https://claude.ai/code/session_016hjRjYUmbWuNfXgqNxA78s)_