### PR TITLE
refactor(services): MUI Checkbox → @nagiyu/ui Checkbox 置換（PR 1-3-B）

### DIFF
--- a/services/auth/web/src/app/dashboard/users/[userId]/edit/user-edit-form.tsx
+++ b/services/auth/web/src/app/dashboard/users/[userId]/edit/user-edit-form.tsx
@@ -2,17 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  Box,
-  Typography,
-  Paper,
-  FormGroup,
-  FormControlLabel,
-  Checkbox,
-  Alert,
-  CircularProgress,
-} from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Box, Typography, Paper, FormGroup, Alert, CircularProgress } from '@mui/material';
+import { Button, Checkbox } from '@nagiyu/ui';
 import { VALID_ROLES } from '@nagiyu/common';
 import type { User } from '@nagiyu/common';
 
@@ -131,16 +122,12 @@ export function UserEditForm({ userId }: UserEditFormProps) {
 
           <FormGroup>
             {VALID_ROLES.map((role) => (
-              <FormControlLabel
+              <Checkbox
                 key={role}
-                control={
-                  <Checkbox
-                    checked={selectedRoles.includes(role)}
-                    onChange={() => handleRoleToggle(role)}
-                    disabled={saving}
-                  />
-                }
                 label={role}
+                checked={selectedRoles.includes(role)}
+                onChange={() => handleRoleToggle(role)}
+                disabled={saving}
               />
             ))}
           </FormGroup>

--- a/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx
@@ -5,8 +5,6 @@ import {
   Box,
   // eslint-disable-next-line no-restricted-imports -- パスワード表示切替の endAdornment（IconButton）を使うため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する
   TextField,
-  FormControlLabel,
-  Checkbox,
   Typography,
   Alert,
   Card,
@@ -14,7 +12,7 @@ import {
   InputAdornment,
   IconButton,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Checkbox } from '@nagiyu/ui';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import {
@@ -196,34 +194,26 @@ export default function MylistRegisterForm({ onSuccess }: MylistRegisterFormProp
             helperText="1〜100の範囲で指定してください"
           />
 
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={formData.favoriteOnly}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    favoriteOnly: e.target.checked,
-                  })
-                }
-              />
-            }
+          <Checkbox
             label="お気に入りのみを対象にする"
+            checked={formData.favoriteOnly}
+            onChange={(e) =>
+              setFormData({
+                ...formData,
+                favoriteOnly: e.target.checked,
+              })
+            }
           />
 
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={formData.excludeSkip}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    excludeSkip: e.target.checked,
-                  })
-                }
-              />
-            }
+          <Checkbox
             label="スキップ動画を除外する"
+            checked={formData.excludeSkip}
+            onChange={(e) =>
+              setFormData({
+                ...formData,
+                excludeSkip: e.target.checked,
+              })
+            }
           />
 
           {/* マイリスト名 */}

--- a/services/quick-clip/web/src/components/highlights/ColumnVisibilityButton.tsx
+++ b/services/quick-clip/web/src/components/highlights/ColumnVisibilityButton.tsx
@@ -1,15 +1,8 @@
 'use client';
 
 import { type MouseEvent, useState } from 'react';
-import {
-  Checkbox,
-  FormControlLabel,
-  FormGroup,
-  IconButton,
-  Paper,
-  Popover,
-  Tooltip,
-} from '@mui/material';
+import { FormGroup, IconButton, Paper, Popover, Tooltip } from '@mui/material';
+import { Checkbox } from '@nagiyu/ui';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import type { ColumnDefinition } from '../../constants/highlightTableColumns';
 import type { ColumnVisibilityMap } from '../../hooks/useColumnVisibility';
@@ -64,16 +57,12 @@ export function ColumnVisibilityButton({
         <Paper sx={{ p: 1 }}>
           <FormGroup>
             {columns.map((col) => (
-              <FormControlLabel
+              <Checkbox
                 key={col.id}
-                control={
-                  <Checkbox
-                    size="small"
-                    checked={visibilityMap[col.id] ?? false}
-                    onChange={() => onToggle(col.id)}
-                  />
-                }
+                size="sm"
                 label={col.label}
+                checked={visibilityMap[col.id] ?? false}
+                onChange={() => onToggle(col.id)}
               />
             ))}
           </FormGroup>

--- a/services/share-together/web/src/components/TodoItem.tsx
+++ b/services/share-together/web/src/components/TodoItem.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Checkbox, ListItem, Typography } from '@mui/material';
-import { Button, TextField } from '@nagiyu/ui';
+import { Box, ListItem, Typography } from '@mui/material';
+import { Button, Checkbox, TextField } from '@nagiyu/ui';
 import type { TodoItem as TodoItemType } from '@/types';
 
 type TodoItemProps = {
@@ -44,7 +44,7 @@ export function TodoItem({ todo, onToggleComplete, onDelete, onUpdate }: TodoIte
         <Checkbox
           checked={todo.isCompleted}
           onChange={() => onToggleComplete?.(todo.todoId)}
-          slotProps={{ input: { 'aria-label': `${todo.title}の完了チェック` } }}
+          aria-label={`${todo.title}の完了チェック`}
         />
         {isEditing ? (
           <TextField

--- a/services/tools/src/components/dialogs/MigrationDialog.tsx
+++ b/services/tools/src/components/dialogs/MigrationDialog.tsx
@@ -1,16 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  FormControlLabel,
-  Checkbox,
-  Typography,
-} from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Typography } from '@mui/material';
+import { Button, Checkbox } from '@nagiyu/ui';
 import { getItem, setItem } from '@nagiyu/browser';
 
 const STORAGE_KEY = 'tools-migration-dialog-shown';
@@ -91,14 +83,10 @@ export default function MigrationDialog() {
         </Typography>
       </DialogContent>
       <DialogActions sx={{ flexDirection: 'column', alignItems: 'stretch', gap: 1, px: 3, pb: 2 }}>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={dontShowAgain}
-              onChange={(e) => setDontShowAgain(e.target.checked)}
-            />
-          }
+        <Checkbox
           label="今後表示しない"
+          checked={dontShowAgain}
+          onChange={(e) => setDontShowAgain(e.target.checked)}
         />
         <Button onClick={handleClose} variant="solid">
           閉じる

--- a/services/tools/src/components/tools/DisplaySettingsSection.tsx
+++ b/services/tools/src/components/tools/DisplaySettingsSection.tsx
@@ -1,12 +1,5 @@
-import {
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  FormControlLabel,
-  Checkbox,
-  Typography,
-  Box,
-} from '@mui/material';
+import { Accordion, AccordionSummary, AccordionDetails, Typography, Box } from '@mui/material';
+import { Checkbox } from '@nagiyu/ui';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { DisplaySettings } from '@/types/tools';
 
@@ -51,99 +44,64 @@ export default function DisplaySettingsSection({
       </AccordionSummary>
       <AccordionDetails>
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          <FormControlLabel
-            control={
-              <Checkbox checked={settings.showDate} onChange={() => handleChange('showDate')} />
-            }
+          <Checkbox
             label="日付を表示"
+            checked={settings.showDate}
+            onChange={() => handleChange('showDate')}
           />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={settings.showDepartureArrival}
-                onChange={() => handleChange('showDepartureArrival')}
-              />
-            }
+          <Checkbox
             label="出発地・到着地を表示"
+            checked={settings.showDepartureArrival}
+            onChange={() => handleChange('showDepartureArrival')}
           />
-          <FormControlLabel
-            control={
-              <Checkbox checked={settings.showTime} onChange={() => handleChange('showTime')} />
-            }
+          <Checkbox
             label="出発時刻・到着時刻を表示"
+            checked={settings.showTime}
+            onChange={() => handleChange('showTime')}
           />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={settings.showDuration}
-                onChange={() => handleChange('showDuration')}
-              />
-            }
+          <Checkbox
             label="所要時間を表示"
+            checked={settings.showDuration}
+            onChange={() => handleChange('showDuration')}
           />
-          <FormControlLabel
-            control={
-              <Checkbox checked={settings.showFare} onChange={() => handleChange('showFare')} />
-            }
+          <Checkbox
             label="運賃を表示"
+            checked={settings.showFare}
+            onChange={() => handleChange('showFare')}
           />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={settings.showTransferCount}
-                onChange={() => handleChange('showTransferCount')}
-              />
-            }
+          <Checkbox
             label="乗換回数を表示"
+            checked={settings.showTransferCount}
+            onChange={() => handleChange('showTransferCount')}
           />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={settings.showDistance}
-                onChange={() => handleChange('showDistance')}
-              />
-            }
+          <Checkbox
             label="距離を表示"
+            checked={settings.showDistance}
+            onChange={() => handleChange('showDistance')}
           />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={settings.showRouteDetails}
-                onChange={() => handleChange('showRouteDetails')}
-              />
-            }
+          <Checkbox
             label="ルート詳細を表示"
+            checked={settings.showRouteDetails}
+            onChange={() => handleChange('showRouteDetails')}
           />
           <Box sx={{ pl: 4, display: 'flex', flexDirection: 'column' }}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={settings.showTimeRange}
-                  onChange={() => handleChange('showTimeRange')}
-                  disabled={!settings.showRouteDetails}
-                />
-              }
+            <Checkbox
               label="時刻範囲を表示"
+              checked={settings.showTimeRange}
+              onChange={() => handleChange('showTimeRange')}
+              disabled={!settings.showRouteDetails}
             />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={settings.showLineName}
-                  onChange={() => handleChange('showLineName')}
-                  disabled={!settings.showRouteDetails}
-                />
-              }
+            <Checkbox
               label="路線名を表示"
+              checked={settings.showLineName}
+              onChange={() => handleChange('showLineName')}
+              disabled={!settings.showRouteDetails}
             />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={settings.showPlatform}
-                  onChange={() => handleChange('showPlatform')}
-                  disabled={!settings.showRouteDetails}
-                />
-              }
+            <Checkbox
               label="番線情報を表示"
+              checked={settings.showPlatform}
+              onChange={() => handleChange('showPlatform')}
+              disabled={!settings.showRouteDetails}
             />
           </Box>
         </Box>

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -74,7 +74,7 @@
 ### Checkbox
 
 - [x] PR 1-3-A: 実装 + Stories + テスト（label 自動関連付け / indeterminate / size sm/md/lg、native input + CSS で再描画。Checkbox.tsx は statements/lines/functions 100%、branches 95.45%）
-- [ ] PR 1-3-B: 置換
+- [x] PR 1-3-B: 置換（6 ファイル全置換完了。`<FormControlLabel control={<Checkbox/>} label=>` → `<Checkbox label=>` で 1 部品化、`slotProps.input.aria-label` → `aria-label`）
 - [ ] PR 1-3-C: ESLint 禁止追加
 
 ### Chip


### PR DESCRIPTION
## 変更の概要

サービス側で MUI の `Checkbox` を `@nagiyu/ui` の `Checkbox` に置換する（PR 1-3-B）。

- **6 ファイル全置換完了**（保留 0）
- `<FormControlLabel control={<Checkbox/>} label="..."/>` パターンを `<Checkbox label="..."/>` の 1 部品化

## 主な変換マッピング

| MUI | @nagiyu/ui |
|---|---|
| `<FormControlLabel control={<Checkbox checked onChange/>} label="X"/>` | `<Checkbox label="X" checked onChange/>` |
| `slotProps={{ input: { 'aria-label': '...' } }}` | `aria-label="..."` |
| `size="small"` | `size="sm"` |
| 親 import から `FormControlLabel` 削除 | (Checkbox の label 機能で不要に) |

## 置換完了ファイル（6）

- `services/auth/web/src/app/dashboard/users/[userId]/edit/user-edit-form.tsx` — ロール選択（VALID_ROLES.map で複数生成）
- `services/niconico-mylist-assistant/web/src/components/MylistRegisterForm.tsx` — 「お気に入りのみ」「スキップ動画除外」の 2 箇所（TextField の MUI 残置はそのまま、Checkbox のみ置換）
- `services/quick-clip/web/src/components/highlights/ColumnVisibilityButton.tsx` — 列表示切り替えポップオーバー（`size="small"` → `size="sm"`）
- `services/share-together/web/src/components/TodoItem.tsx` — TODO 完了チェック（`slotProps.input.aria-label` → `aria-label`）
- `services/tools/src/components/dialogs/MigrationDialog.tsx` — 「今後表示しない」
- `services/tools/src/components/tools/DisplaySettingsSection.tsx` — 表示設定アコーディオン（11 個のチェックボックス）

## 関連 Issue

#2900

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存テストの回帰確認）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカルで以下を確認:

| ワークスペース | 結果 |
|---|---|
| `@nagiyu/auth-web` | 22/22 pass |
| `@nagiyu/share-together-web` | 204/204 pass |
| `@nagiyu/quick-clip-web` / `@nagiyu/tools` / `@nagiyu/niconico-mylist-assistant-web` | lint pass（テスト未実装は既存どおり） |
| 全サービス lint OK（share-together の既存 useEffect warning 1 件のみ、本変更と無関係） | ✅ |

## レビューポイント

- **`<FormControlLabel control={<Checkbox/>}>` パターンの統合**: MUI ではラベルとチェックボックスが分離していたが、`@nagiyu/ui Checkbox` の `label` Props で統合したため、`FormControlLabel` が不要に。コード量も大幅減（DisplaySettingsSection で 11 箇所 → 1 行記述に）。
- **`slotProps.input.aria-label` → `aria-label`**: TodoItem.tsx で MUI 固有 API を使っていた箇所を、@nagiyu/ui の top-level Props で代替。
- **保留ゼロ**: TextField (PR 1-2-B) と異なり、Checkbox は API ギャップがなく全 6 ファイル置換できた。

## スクリーンショット

dev 環境で視覚確認予定。

## 補足事項

PR 1-3-C で ESLint 禁止追加（保留ファイルがないので例外コメント不要）。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_