### PR TITLE
feat(eslint): @mui/material の Checkbox 直接 import を禁止（PR 1-3-C）

### DIFF
--- a/configs/eslint.config.no-restricted-mui.mjs
+++ b/configs/eslint.config.no-restricted-mui.mjs
@@ -16,7 +16,7 @@ export default {
         paths: [
           {
             name: '@mui/material',
-            importNames: ['Button', 'TextField'],
+            importNames: ['Button', 'TextField', 'Checkbox'],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },
         ],
@@ -27,6 +27,8 @@ export default {
               '@mui/material/Button/*',
               '@mui/material/TextField',
               '@mui/material/TextField/*',
+              '@mui/material/Checkbox',
+              '@mui/material/Checkbox/*',
             ],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -75,7 +75,7 @@
 
 - [x] PR 1-3-A: 実装 + Stories + テスト（label 自動関連付け / indeterminate / size sm/md/lg、native input + CSS で再描画。Checkbox.tsx は statements/lines/functions 100%、branches 95.45%）
 - [x] PR 1-3-B: 置換（6 ファイル全置換完了。`<FormControlLabel control={<Checkbox/>} label=>` → `<Checkbox label=>` で 1 部品化、`slotProps.input.aria-label` → `aria-label`）
-- [ ] PR 1-3-C: ESLint 禁止追加
+- [x] PR 1-3-C: ESLint 禁止追加（共有 config の `importNames` / `patterns.group` に `Checkbox` を追加。保留ファイルゼロのため例外コメント不要）
 
 ### Chip
 


### PR DESCRIPTION
## 変更の概要

サービス側で MUI の `Checkbox` を直接 import するのを ESLint で禁止する（PR 1-3-C）。Button (PR 1-1-C) / TextField (PR 1-2-C) と同じ仕組みに `Checkbox` を追加。

## 実装

`configs/eslint.config.no-restricted-mui.mjs` の `importNames` / `patterns.group` に `Checkbox` を追加:

```diff
  paths: [
    {
      name: '@mui/material',
-     importNames: ['Button', 'TextField'],
+     importNames: ['Button', 'TextField', 'Checkbox'],
      message: '共通コンポーネントは @nagiyu/ui から import してください',
    },
  ],
  patterns: [
    {
      group: [
        '@mui/material/Button',
        '@mui/material/Button/*',
        '@mui/material/TextField',
        '@mui/material/TextField/*',
+       '@mui/material/Checkbox',
+       '@mui/material/Checkbox/*',
      ],
      ...
    },
  ],
```

## 例外運用

**保留ファイルゼロ**のため、例外コメントの付与なし（PR 1-3-B で 6 ファイル全置換完了）。Button・TextField で必要だった `// eslint-disable-next-line` の付与作業がなく、シンプルな PR となる。

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能（ESLint ルール拡張）
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存テストの回帰確認は不要、ESLint ルール変更のみ）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] CI/CD 設定を追加・更新した（共有 ESLint config 拡張）
- [x] ローカルでテストが全て通ることを確認した（9 サービス lint pass、share-together の既存 useEffect warning のみ）
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカルで以下を確認:

1. **9 サービス全て `npm run lint` pass**（既存 share-together TodoList warning 1 件のみ、本変更と無関係）
2. **ルール発火確認**: `services/admin/web/src/cb-violation.tsx` に `import { Checkbox } from '@mui/material'` を一時注入 → `error 'Checkbox' import from '@mui/material' is restricted` を確認 → 削除

## レビューポイント

- **保留ゼロのシンプル PR**: Checkbox 置換時に API ギャップが発生しなかったため、この PR は config 1 ファイル + tasks.md のみの変更。
- **次フェーズへの移植性**: 同 config の `importNames` / `patterns.group` にコンポーネント名を追加するだけで対象を増やせる構成。Phase 1 残り（Chip / Link）も同パターンで進める。

## スクリーンショット

該当なし（UI 変更なし）。

## 補足事項

これで Phase 1 の Checkbox セクション完了。次は Chip → Link で Phase 1 アトミックコンポーネントが完了する。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_