### PR TITLE
feat(admin): エラー永続化基盤の本流経路（インフラ・Lambda・UI）

### DIFF
--- a/infra/admin/bin/admin.ts
+++ b/infra/admin/bin/admin.ts
@@ -2,7 +2,9 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { ECRStack } from '../lib/ecr-stack';
+import { BatchEcrStack } from '../lib/batch-ecr-stack';
 import { LambdaStack } from '../lib/lambda-stack';
+import { BatchLambdaStack } from '../lib/batch-lambda-stack';
 import { CloudFrontStack } from '../lib/cloudfront-stack';
 import { AdminStack } from '../lib/admin-stack';
 
@@ -50,6 +52,23 @@ new AdminStack(app, `NagiyuAdminInfra${envSuffix}`, {
   environment: env,
   env: stackEnv,
   description: `Admin Service Infra - ${env} environment`,
+});
+
+// Admin Batch (alarm-ingest / stream-handler Lambda) ECR スタック
+new BatchEcrStack(app, `NagiyuAdminBatchECR${envSuffix}`, {
+  environment: env,
+  env: stackEnv,
+  description: `Admin Batch ECR - ${env} environment`,
+});
+
+// Admin Batch Lambda スタック
+// - alarm-ingest: SNS (admin alarms) → DynamoDB (error-events)
+// - stream-handler: error-events DynamoDB Streams → Web Push fan-out
+new BatchLambdaStack(app, `NagiyuAdminBatchLambda${envSuffix}`, {
+  environment: env as 'dev' | 'prod',
+  batchEcrRepositoryName: `nagiyu-admin-batch-ecr-${env}`,
+  env: stackEnv,
+  description: `Admin Batch Lambda - ${env} environment`,
 });
 
 // CloudFront スタックを作成

--- a/infra/admin/lib/batch-ecr-stack.ts
+++ b/infra/admin/lib/batch-ecr-stack.ts
@@ -1,0 +1,26 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { EcrStackBase, EcrStackBaseProps } from '@nagiyu/infra-common';
+
+export interface BatchEcrStackProps extends cdk.StackProps {
+  environment: string;
+}
+
+/**
+ * Admin Batch サービス用の ECR スタック
+ *
+ * alarm-ingest / stream-handler Lambda 用のコンテナイメージを保管する。
+ */
+export class BatchEcrStack extends EcrStackBase {
+  constructor(scope: Construct, id: string, props: BatchEcrStackProps) {
+    const { environment, ...stackProps } = props;
+
+    const baseProps: EcrStackBaseProps = {
+      ...stackProps,
+      serviceName: 'admin-batch',
+      environment: environment as 'dev' | 'prod',
+    };
+
+    super(scope, id, baseProps);
+  }
+}

--- a/infra/admin/lib/batch-lambda-stack.ts
+++ b/infra/admin/lib/batch-lambda-stack.ts
@@ -1,0 +1,212 @@
+import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import { SnsEventSource, DynamoEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { Construct } from 'constructs';
+
+export interface BatchLambdaStackProps extends cdk.StackProps {
+  environment: 'dev' | 'prod';
+  /**
+   * Admin Batch ECR リポジトリ名（同一スタック内の依存）
+   */
+  batchEcrRepositoryName: string;
+}
+
+/**
+ * Admin Batch Lambda Stack
+ *
+ * - alarm-ingest: SNS (admin alarms) → DynamoDB (error-events) への取り込み
+ * - stream-handler: error-events DynamoDB Streams → Web Push fan-out
+ *
+ * 既存リソース (admin の SNS / DynamoDB、error-events テーブル) は ARN / 名前で
+ * 参照する。各 Lambda の IAM 権限はこのスタック内で最小限に絞って付与する。
+ */
+export class BatchLambdaStack extends cdk.Stack {
+  public readonly alarmIngestFunction: lambda.Function;
+  public readonly streamHandlerFunction: lambda.Function;
+  public readonly streamHandlerDeadLetterQueue: sqs.Queue;
+
+  constructor(scope: Construct, id: string, props: BatchLambdaStackProps) {
+    super(scope, id, props);
+
+    const { environment, batchEcrRepositoryName } = props;
+
+    // 既存 ECR リポジトリの参照
+    const batchRepository = ecr.Repository.fromRepositoryName(
+      this,
+      'BatchEcrRepository',
+      batchEcrRepositoryName
+    );
+
+    // 既存テーブル / トピックの ARN
+    const region = cdk.Stack.of(this).region;
+    const account = cdk.Stack.of(this).account;
+    const adminTableName = `nagiyu-admin-main-${environment}`;
+    const errorEventsTableName = `nagiyu-error-events-${environment}`;
+    const errorEventsTableArn = `arn:aws:dynamodb:${region}:${account}:table/${errorEventsTableName}`;
+    const adminTableArn = `arn:aws:dynamodb:${region}:${account}:table/${adminTableName}`;
+    const adminAlarmTopicArn = `arn:aws:sns:${region}:${account}:nagiyu-admin-alarms-${environment}`;
+
+    // Admin Web の URL（自分自身、Push 通知の遷移先）
+    const adminUrl =
+      environment === 'prod'
+        ? 'https://admin.nagiyu.com'
+        : `https://${environment}-admin.nagiyu.com`;
+
+    // VAPID キー（CDK context から渡される。未指定時はプレースホルダー）
+    const vapidPublicKey = scope.node.tryGetContext('vapidPublicKey') || 'PLACEHOLDER';
+    const vapidPrivateKey = scope.node.tryGetContext('vapidPrivateKey') || 'PLACEHOLDER';
+
+    // ─────────────────────────────────────────
+    // alarm-ingest Lambda
+    // ─────────────────────────────────────────
+    const alarmIngestRole = new iam.Role(this, 'AlarmIngestExecutionRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      description: `Execution role for alarm-ingest Lambda (${environment})`,
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+      ],
+    });
+    alarmIngestRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['dynamodb:PutItem'],
+        resources: [errorEventsTableArn],
+      })
+    );
+
+    this.alarmIngestFunction = new lambda.Function(this, 'AlarmIngestFunction', {
+      functionName: `nagiyu-admin-alarm-ingest-${environment}`,
+      runtime: lambda.Runtime.FROM_IMAGE,
+      handler: lambda.Handler.FROM_IMAGE,
+      code: lambda.Code.fromEcrImage(batchRepository, {
+        tagOrDigest: 'latest',
+        cmd: ['services/admin/batch/dist/src/alarm-ingest.handler'],
+      }),
+      role: alarmIngestRole,
+      memorySize: 256,
+      timeout: cdk.Duration.seconds(30),
+      environment: {
+        NODE_ENV: environment,
+        ERROR_EVENTS_TABLE_NAME: errorEventsTableName,
+      },
+      tracing: lambda.Tracing.ACTIVE,
+      logRetention: logs.RetentionDays.ONE_MONTH,
+      description: 'SNS (admin alarms) → DynamoDB (error-events) を仲介するイベント取り込み Lambda',
+    });
+
+    // 既存の admin alarm Topic を SNS Subscription で接続する
+    const adminAlarmTopic = sns.Topic.fromTopicArn(this, 'AdminAlarmTopic', adminAlarmTopicArn);
+    this.alarmIngestFunction.addEventSource(new SnsEventSource(adminAlarmTopic));
+
+    // ─────────────────────────────────────────
+    // stream-handler Lambda
+    // ─────────────────────────────────────────
+    this.streamHandlerDeadLetterQueue = new sqs.Queue(this, 'StreamHandlerDLQ', {
+      queueName: `nagiyu-admin-stream-handler-dlq-${environment}`,
+      retentionPeriod: cdk.Duration.days(14),
+    });
+
+    const streamHandlerRole = new iam.Role(this, 'StreamHandlerExecutionRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      description: `Execution role for stream-handler Lambda (${environment})`,
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+      ],
+    });
+    // DynamoDB Streams の購読権限
+    streamHandlerRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'dynamodb:DescribeStream',
+          'dynamodb:GetRecords',
+          'dynamodb:GetShardIterator',
+          'dynamodb:ListStreams',
+        ],
+        resources: [`${errorEventsTableArn}/stream/*`],
+      })
+    );
+    // Push 購読情報の Read（Admin DynamoDB）
+    streamHandlerRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['dynamodb:Query', 'dynamodb:Scan', 'dynamodb:DeleteItem'],
+        resources: [adminTableArn, `${adminTableArn}/index/*`],
+      })
+    );
+    // DLQ への送信権限
+    this.streamHandlerDeadLetterQueue.grantSendMessages(streamHandlerRole);
+
+    this.streamHandlerFunction = new lambda.Function(this, 'StreamHandlerFunction', {
+      functionName: `nagiyu-admin-stream-handler-${environment}`,
+      runtime: lambda.Runtime.FROM_IMAGE,
+      handler: lambda.Handler.FROM_IMAGE,
+      code: lambda.Code.fromEcrImage(batchRepository, {
+        tagOrDigest: 'latest',
+        cmd: ['services/admin/batch/dist/src/stream-handler.handler'],
+      }),
+      role: streamHandlerRole,
+      memorySize: 256,
+      timeout: cdk.Duration.seconds(30),
+      environment: {
+        NODE_ENV: environment,
+        DYNAMODB_TABLE_NAME: adminTableName,
+        VAPID_PUBLIC_KEY: vapidPublicKey,
+        VAPID_PRIVATE_KEY: vapidPrivateKey,
+        APP_URL: adminUrl,
+      },
+      deadLetterQueue: this.streamHandlerDeadLetterQueue,
+      tracing: lambda.Tracing.ACTIVE,
+      logRetention: logs.RetentionDays.ONE_MONTH,
+      description: 'error-events DynamoDB Streams を契機に Web Push を fan-out する Lambda',
+    });
+
+    // 既存 error-events テーブルの Streams ARN を CFN Import で取得
+    const errorEventsStreamArn = cdk.Fn.importValue(
+      `nagiyu-error-events-table-stream-arn-${environment}`
+    );
+
+    const errorEventsTable = dynamodb.Table.fromTableAttributes(this, 'ErrorEventsTable', {
+      tableArn: errorEventsTableArn,
+      tableStreamArn: errorEventsStreamArn,
+    });
+
+    this.streamHandlerFunction.addEventSource(
+      new DynamoEventSource(errorEventsTable, {
+        startingPosition: lambda.StartingPosition.LATEST,
+        batchSize: 100,
+        maxBatchingWindow: cdk.Duration.seconds(5),
+        retryAttempts: 2,
+        bisectBatchOnError: true,
+      })
+    );
+
+    // ─────────────────────────────────────────
+    // タグ・Outputs
+    // ─────────────────────────────────────────
+    [this.alarmIngestFunction, this.streamHandlerFunction].forEach((fn) => {
+      cdk.Tags.of(fn).add('Application', 'nagiyu');
+      cdk.Tags.of(fn).add('Service', 'admin-batch');
+      cdk.Tags.of(fn).add('Environment', environment);
+    });
+
+    new cdk.CfnOutput(this, 'AlarmIngestFunctionArn', {
+      value: this.alarmIngestFunction.functionArn,
+      description: 'alarm-ingest Lambda Function ARN',
+    });
+    new cdk.CfnOutput(this, 'StreamHandlerFunctionArn', {
+      value: this.streamHandlerFunction.functionArn,
+      description: 'stream-handler Lambda Function ARN',
+    });
+    new cdk.CfnOutput(this, 'StreamHandlerDLQUrl', {
+      value: this.streamHandlerDeadLetterQueue.queueUrl,
+      description: 'stream-handler DLQ URL',
+    });
+  }
+}

--- a/infra/admin/lib/lambda-stack.ts
+++ b/infra/admin/lib/lambda-stack.ts
@@ -58,6 +58,15 @@ export class LambdaStack extends LambdaStackBase {
           `arn:aws:dynamodb:*:*:table/nagiyu-admin-main-${environment}/index/*`,
         ],
       }),
+      // 共通エラーイベントテーブルへの読み取り権限（/errors UI / API 用）
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['dynamodb:GetItem', 'dynamodb:Query'],
+        resources: [
+          `arn:aws:dynamodb:*:*:table/nagiyu-error-events-${environment}`,
+          `arn:aws:dynamodb:*:*:table/nagiyu-error-events-${environment}/index/*`,
+        ],
+      }),
     ];
 
     const baseProps: LambdaStackBaseProps = {
@@ -71,6 +80,8 @@ export class LambdaStack extends LambdaStackBase {
           NODE_ENV: environment,
           APP_VERSION: appVersion,
           DYNAMODB_TABLE_NAME: `nagiyu-admin-main-${environment}`,
+          // 共通エラーイベントテーブル（/errors UI / API で読み取り）
+          ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
           // NextAuth v5 で使用される環境変数
           AUTH_SECRET: nextAuthSecret,
           // 自サービスのベース URL（callbackUrl 生成などに使用）

--- a/infra/shared/bin/shared.ts
+++ b/infra/shared/bin/shared.ts
@@ -11,6 +11,7 @@ import { IamContainerPolicyStack } from '../lib/iam/iam-container-policy-stack';
 import { IamIntegrationPolicyStack } from '../lib/iam/iam-integration-policy-stack';
 import { IamUsersStack } from '../lib/iam/iam-users-stack';
 import { DockerBuildLockStack } from '../lib/docker-build-lock-stack';
+import { ErrorEventsTableStack } from '../lib/error-events-table-stack';
 
 const app = new cdk.App();
 
@@ -103,5 +104,17 @@ new DockerBuildLockStack(app, 'NagiyuDockerBuildLock', {
   env: stackEnv,
   description: 'S3 bucket for Docker build lock semaphore',
 });
+
+// プラットフォーム共通のエラーイベント永続化テーブル
+// 各サービスから直接 PutItem され、Admin が読み取る共有リソース
+new ErrorEventsTableStack(
+  app,
+  `NagiyuErrorEventsTable${env.charAt(0).toUpperCase() + env.slice(1)}`,
+  {
+    environment: env as 'dev' | 'prod',
+    env: stackEnv,
+    description: `Platform Error Events DynamoDB Table - ${env} environment`,
+  }
+);
 
 app.synth();

--- a/infra/shared/lib/error-events-table-stack.ts
+++ b/infra/shared/lib/error-events-table-stack.ts
@@ -1,0 +1,80 @@
+import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+
+export interface ErrorEventsTableStackProps extends cdk.StackProps {
+  environment: 'dev' | 'prod';
+}
+
+/**
+ * プラットフォーム共通のエラーイベント永続化テーブルを管理するスタック。
+ *
+ * このテーブルは複数サービスから書き込まれ、Admin から読み取られる共有リソース。
+ * Admin の既存テーブル (nagiyu-admin-main-{env}) とは分離し、
+ * 時系列・TTL・Streams の運用要件に最適化したスキーマで構築する。
+ */
+export class ErrorEventsTableStack extends cdk.Stack {
+  public readonly table: dynamodb.Table;
+
+  constructor(scope: Construct, id: string, props: ErrorEventsTableStackProps) {
+    super(scope, id, props);
+
+    const { environment } = props;
+
+    this.table = new dynamodb.Table(this, 'ErrorEventsTable', {
+      tableName: `nagiyu-error-events-${environment}`,
+      partitionKey: {
+        name: 'PK',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'SK',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true,
+      timeToLiveAttribute: 'ttl',
+      stream: dynamodb.StreamViewType.NEW_IMAGE,
+      removalPolicy:
+        environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    // 全サービス横断の時系列クエリ用 GSI
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'AllByOccurredAt',
+      partitionKey: {
+        name: 'GSI1PK',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'GSI1SK',
+        type: dynamodb.AttributeType.STRING,
+      },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    cdk.Tags.of(this.table).add('Application', 'nagiyu');
+    cdk.Tags.of(this.table).add('Service', 'platform');
+    cdk.Tags.of(this.table).add('Component', 'error-events');
+    cdk.Tags.of(this.table).add('Environment', environment);
+
+    new cdk.CfnOutput(this, 'TableName', {
+      value: this.table.tableName,
+      description: 'Error Events DynamoDB Table Name',
+      exportName: `nagiyu-error-events-table-name-${environment}`,
+    });
+
+    new cdk.CfnOutput(this, 'TableArn', {
+      value: this.table.tableArn,
+      description: 'Error Events DynamoDB Table ARN',
+      exportName: `nagiyu-error-events-table-arn-${environment}`,
+    });
+
+    new cdk.CfnOutput(this, 'TableStreamArn', {
+      value: this.table.tableStreamArn ?? '',
+      description: 'Error Events DynamoDB Table Stream ARN',
+      exportName: `nagiyu-error-events-table-stream-arn-${environment}`,
+    });
+  }
+}

--- a/infra/shared/tests/unit/error-events-table-stack.test.js
+++ b/infra/shared/tests/unit/error-events-table-stack.test.js
@@ -1,0 +1,140 @@
+const cdk = require('aws-cdk-lib');
+const { Template } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { ErrorEventsTableStack } = require('../../lib/error-events-table-stack');
+
+describe('ErrorEventsTableStack', () => {
+  it('環境名を含むテーブル名で DynamoDB テーブルを作成する', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      TableName: 'nagiyu-error-events-dev',
+    });
+  });
+
+  it('PK/SK のキースキーマを設定する', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      KeySchema: [
+        { AttributeName: 'PK', KeyType: 'HASH' },
+        { AttributeName: 'SK', KeyType: 'RANGE' },
+      ],
+    });
+  });
+
+  it('GSI AllByOccurredAt を作成する', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: 'AllByOccurredAt',
+          KeySchema: [
+            { AttributeName: 'GSI1PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI1SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+        },
+      ],
+    });
+  });
+
+  it('TTL 属性 ttl を有効化する', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      TimeToLiveSpecification: {
+        AttributeName: 'ttl',
+        Enabled: true,
+      },
+    });
+  });
+
+  it('Streams を NEW_IMAGE で有効化する', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      StreamSpecification: {
+        StreamViewType: 'NEW_IMAGE',
+      },
+    });
+  });
+
+  it('PAY_PER_REQUEST モードで作成する', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      BillingMode: 'PAY_PER_REQUEST',
+    });
+  });
+
+  it('prod 環境では RemovalPolicy = RETAIN', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'prod',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResource('AWS::DynamoDB::Table', {
+      DeletionPolicy: 'Retain',
+      UpdateReplacePolicy: 'Retain',
+    });
+  });
+
+  it('dev 環境では RemovalPolicy = DESTROY', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResource('AWS::DynamoDB::Table', {
+      DeletionPolicy: 'Delete',
+      UpdateReplacePolicy: 'Delete',
+    });
+  });
+
+  it('テーブル名・ARN・Stream ARN の Output を生成する', () => {
+    const app = new cdk.App();
+    const stack = new ErrorEventsTableStack(app, 'TestErrorEventsTable', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasOutput('TableName', {
+      Export: { Name: 'nagiyu-error-events-table-name-dev' },
+    });
+    template.hasOutput('TableArn', {
+      Export: { Name: 'nagiyu-error-events-table-arn-dev' },
+    });
+    template.hasOutput('TableStreamArn', {
+      Export: { Name: 'nagiyu-error-events-table-stream-arn-dev' },
+    });
+  });
+});

--- a/libs/common/src/auth/roles.ts
+++ b/libs/common/src/auth/roles.ts
@@ -33,7 +33,13 @@ export const ROLES = {
     id: 'admin',
     name: '管理者',
     description: 'Phase 1 ではユーザー管理とロール割り当ての全権限を持つ',
-    permissions: ['users:read', 'users:write', 'roles:assign', 'notifications:write'],
+    permissions: [
+      'users:read',
+      'users:write',
+      'roles:assign',
+      'notifications:write',
+      'errors:read',
+    ],
   },
   'user-manager': {
     id: 'user-manager',

--- a/libs/common/src/auth/types.ts
+++ b/libs/common/src/auth/types.ts
@@ -59,6 +59,7 @@ export type Permission =
   | 'users:write'
   | 'roles:assign'
   | 'notifications:write'
+  | 'errors:read'
   | 'stocks:read'
   | 'stocks:write-own'
   | 'stocks:manage-data'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4036,6 +4036,10 @@
       "resolved": "services/admin/web",
       "link": true
     },
+    "node_modules/@nagiyu/admin-batch": {
+      "resolved": "services/admin/batch",
+      "link": true
+    },
     "node_modules/@nagiyu/admin-core": {
       "resolved": "services/admin/core",
       "link": true
@@ -17772,6 +17776,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "services/admin/batch": {
+      "name": "@nagiyu/admin-batch",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1024.0",
+        "@aws-sdk/lib-dynamodb": "^3.1024.0",
+        "@aws-sdk/util-dynamodb": "^3.996.2",
+        "@nagiyu/admin-core": "*",
+        "@nagiyu/aws": "*",
+        "@nagiyu/common": "*"
       }
     },
     "services/admin/core": {

--- a/services/admin/batch/Dockerfile
+++ b/services/admin/batch/Dockerfile
@@ -1,0 +1,56 @@
+# Multi-stage build for Admin Batch Lambda (alarm-ingest, stream-handler)
+# AWS Lambda 公式 Node.js 24 ベースイメージを使用
+
+FROM public.ecr.aws/lambda/nodejs:24 AS base
+
+# ビルドステージ
+FROM base AS builder
+WORKDIR /app
+
+# モノレポ全体の package.json とソースをコピー
+COPY package*.json ./
+COPY configs ./configs/
+COPY libs ./libs/
+COPY services/admin ./services/admin/
+
+# 依存関係をインストール（ソースコード存在下で実行）
+RUN npm ci
+
+# 共通ライブラリ → admin-core → admin-batch の順にビルド
+RUN npm run build --workspace=@nagiyu/common
+RUN npm run build --workspace=@nagiyu/aws
+RUN npm run build --workspace=@nagiyu/admin-core
+RUN npm run build --workspace=@nagiyu/admin-batch
+
+# 実行ステージ
+FROM base AS runner
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+ENV NODE_ENV=production
+
+# モノレポのルート node_modules をコピー（ホイスティング対応）
+COPY --from=builder /app/node_modules ./node_modules
+
+# 必要なビルド成果物と package.json をコピー
+COPY --from=builder /app/package*.json ./
+
+# 共通ライブラリ
+COPY --from=builder /app/libs/common/package*.json ./libs/common/
+COPY --from=builder /app/libs/common/dist ./libs/common/dist
+
+# AWS ライブラリ
+COPY --from=builder /app/libs/aws/package*.json ./libs/aws/
+COPY --from=builder /app/libs/aws/dist ./libs/aws/dist
+
+# Admin Core
+COPY --from=builder /app/services/admin/core/package*.json ./services/admin/core/
+COPY --from=builder /app/services/admin/core/dist ./services/admin/core/dist
+
+# Admin Batch
+COPY --from=builder /app/services/admin/batch/package*.json ./services/admin/batch/
+COPY --from=builder /app/services/admin/batch/dist ./services/admin/batch/dist
+
+# Lambda ハンドラーは CDK 側で個別の `cmd` で上書きする
+# - alarm-ingest:    services/admin/batch/dist/src/alarm-ingest.handler
+# - stream-handler:  services/admin/batch/dist/src/stream-handler.handler
+CMD ["services/admin/batch/dist/src/alarm-ingest.handler"]

--- a/services/admin/batch/eslint.config.mjs
+++ b/services/admin/batch/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '../../../configs/eslint.config.base.mjs';
+
+export default baseConfig;

--- a/services/admin/batch/jest.config.ts
+++ b/services/admin/batch/jest.config.ts
@@ -1,0 +1,40 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/admin-core$': '<rootDir>/../core/src/index.ts',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
+    '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
+    '^@nagiyu/common/push$': '<rootDir>/../../../libs/common/src/push/index.ts',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: {
+          moduleResolution: 'node',
+          esModuleInterop: true,
+        },
+      },
+    ],
+  },
+  testMatch: ['<rootDir>/tests/**/*.test.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  coverageDirectory: 'coverage',
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  modulePathIgnorePatterns: ['<rootDir>/../../package.json'],
+};
+
+export default config;

--- a/services/admin/batch/package.json
+++ b/services/admin/batch/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@nagiyu/admin-batch",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/src/alarm-ingest.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts tests/**/*.ts",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1024.0",
+    "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@aws-sdk/util-dynamodb": "^3.996.2",
+    "@nagiyu/admin-core": "*",
+    "@nagiyu/aws": "*",
+    "@nagiyu/common": "*"
+  }
+}

--- a/services/admin/batch/src/alarm-ingest.ts
+++ b/services/admin/batch/src/alarm-ingest.ts
@@ -1,0 +1,162 @@
+/**
+ * alarm-ingest Lambda Handler
+ *
+ * SNS 経由で届いた CloudWatch Alarm 通知を ErrorEvent として
+ * DynamoDB（error-events テーブル）に永続化する。
+ *
+ * 後段では DynamoDB Streams が起動して stream-handler が
+ * Web Push を発火する（このハンドラ自身は Push を送らない）。
+ */
+
+import { generateEventId, type ErrorEvent, type ErrorSeverity } from '@nagiyu/common';
+import { getDynamoDBDocumentClient, createErrorEventWriter } from '@nagiyu/aws';
+
+const ERROR_MESSAGES = {
+  ERROR_EVENTS_TABLE_NAME_REQUIRED: 'ERROR_EVENTS_TABLE_NAME が設定されていません',
+} as const;
+
+/**
+ * SNS Lambda Event の Record（必要な部分のみ）
+ */
+type SnsRecord = {
+  EventSource: 'aws:sns';
+  Sns: {
+    Type: string;
+    Subject?: string;
+    Message: string;
+    Timestamp: string;
+  };
+};
+
+/**
+ * Lambda が受け取る SNS イベント
+ */
+export type AlarmIngestEvent = {
+  Records: SnsRecord[];
+};
+
+export type HandlerResponse = {
+  processed: number;
+  skipped: number;
+};
+
+/**
+ * CloudWatch Alarm の SNS メッセージ本文形式
+ */
+type CloudWatchAlarmPayload = {
+  AlarmName?: string;
+  AlarmDescription?: string;
+  NewStateValue?: string;
+  NewStateReason?: string;
+  StateChangeTime?: string;
+  Region?: string;
+  AlarmArn?: string;
+};
+
+function getWriter() {
+  const tableName = process.env.ERROR_EVENTS_TABLE_NAME;
+  if (!tableName) {
+    throw new Error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);
+  }
+  const docClient =
+    process.env.USE_IN_MEMORY_DB === 'true' ? undefined : getDynamoDBDocumentClient();
+  return createErrorEventWriter(docClient, tableName);
+}
+
+/**
+ * AlarmName からサービス ID を推定する。
+ *
+ * 既存の命名規約 `{service}-{component}-{metric}-{env}` を前提に、
+ * 先頭 2 セグメント（例: `stock-tracker`）を抽出する。
+ * 該当しない場合は最初のセグメントを返し、それも空なら 'unknown'。
+ */
+export function inferServiceIdFromAlarmName(alarmName: string): string {
+  if (!alarmName) {
+    return 'unknown';
+  }
+  const segments = alarmName.split('-').filter((s) => s.length > 0);
+  if (segments.length === 0) {
+    return 'unknown';
+  }
+  if (segments.length >= 2) {
+    return `${segments[0]}-${segments[1]}`;
+  }
+  return segments[0];
+}
+
+/**
+ * CloudWatch Alarm から重大度を推定する。
+ * CloudWatch Alarm 自体には severity の概念がないため、
+ * 今回は一律 `error` とする（将来 AlarmDescription などからの推定に拡張する）。
+ */
+export function inferSeverityFromAlarm(): ErrorSeverity {
+  return 'error';
+}
+
+/**
+ * ALARM 遷移の SNS Notification を ErrorEvent に変換する。
+ * 対象外（OK 通知 / 解析不能）の場合は null を返す。
+ */
+export function buildErrorEventFromSns(record: SnsRecord): ErrorEvent | null {
+  if (record.Sns.Type !== 'Notification') {
+    return null;
+  }
+
+  let payload: CloudWatchAlarmPayload;
+  try {
+    payload = JSON.parse(record.Sns.Message) as CloudWatchAlarmPayload;
+  } catch {
+    return null;
+  }
+
+  // OK / INSUFFICIENT_DATA は Phase 1 では永続化しない
+  if (payload.NewStateValue !== 'ALARM') {
+    return null;
+  }
+
+  if (!payload.AlarmName) {
+    return null;
+  }
+
+  const serviceId = inferServiceIdFromAlarmName(payload.AlarmName);
+  const occurredAt = payload.StateChangeTime
+    ? new Date(payload.StateChangeTime).toISOString()
+    : new Date(record.Sns.Timestamp).toISOString();
+
+  return {
+    eventId: generateEventId(),
+    serviceId,
+    source: 'cloudwatch-alarm',
+    severity: inferSeverityFromAlarm(),
+    title: `${payload.AlarmName} (${payload.NewStateValue})`,
+    message: payload.NewStateReason ?? '',
+    context: record.Sns.Message,
+    occurredAt,
+  };
+}
+
+/**
+ * Lambda エントリポイント。
+ */
+export async function handler(event: AlarmIngestEvent): Promise<HandlerResponse> {
+  const writer = getWriter();
+
+  let processed = 0;
+  let skipped = 0;
+
+  for (const record of event.Records ?? []) {
+    if (record.EventSource !== 'aws:sns') {
+      skipped += 1;
+      continue;
+    }
+    const errorEvent = buildErrorEventFromSns(record);
+    if (!errorEvent) {
+      skipped += 1;
+      continue;
+    }
+    await writer.put(errorEvent);
+    processed += 1;
+  }
+
+  return { processed, skipped };
+}

--- a/services/admin/batch/src/stream-handler.ts
+++ b/services/admin/batch/src/stream-handler.ts
@@ -1,0 +1,182 @@
+/**
+ * stream-handler Lambda Handler
+ *
+ * error-events DynamoDB Streams を受け、INSERT イベントごとに
+ * Web Push を全購読者へ fan-out する。
+ *
+ * - MODIFY / REMOVE は無視
+ * - Push 送信は既存の WebPushSender を流用（購読は admin の DynamoDB にある）
+ * - data.url は `/errors/{eventId}?at={occurredAt}&serviceId={serviceId}` を指す
+ */
+
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+import type { ErrorEvent, ErrorSeverity, ErrorSource } from '@nagiyu/common';
+import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import {
+  createPushSubscriptionRepository,
+  WebPushSender,
+  type PushNotificationPayload,
+} from '@nagiyu/admin-core';
+
+const ERROR_MESSAGES = {
+  ADMIN_DYNAMODB_TABLE_NAME_REQUIRED: 'DYNAMODB_TABLE_NAME が設定されていません',
+  VAPID_KEYS_REQUIRED: 'VAPID キーが設定されていません',
+  APP_URL_REQUIRED: 'APP_URL が設定されていません',
+} as const;
+
+/**
+ * DynamoDB Streams Event の最小定義
+ */
+type StreamRecord = {
+  eventName: 'INSERT' | 'MODIFY' | 'REMOVE';
+  dynamodb?: {
+    NewImage?: Record<string, unknown>;
+  };
+};
+
+export type StreamHandlerEvent = {
+  Records: StreamRecord[];
+};
+
+export type HandlerResponse = {
+  notified: number;
+  skipped: number;
+};
+
+function getSubscriptionRepository() {
+  const tableName = process.env.DYNAMODB_TABLE_NAME;
+  if (!tableName) {
+    throw new Error(ERROR_MESSAGES.ADMIN_DYNAMODB_TABLE_NAME_REQUIRED);
+  }
+  const docClient =
+    process.env.USE_IN_MEMORY_DB === 'true' ? undefined : getDynamoDBDocumentClient();
+  return createPushSubscriptionRepository(docClient, tableName);
+}
+
+function getWebPushSender(): WebPushSender {
+  const vapidPublicKey = process.env.VAPID_PUBLIC_KEY;
+  const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY;
+  if (!vapidPublicKey || !vapidPrivateKey) {
+    throw new Error(ERROR_MESSAGES.VAPID_KEYS_REQUIRED);
+  }
+
+  return new WebPushSender({
+    repository: getSubscriptionRepository(),
+    vapidPublicKey,
+    vapidPrivateKey,
+  });
+}
+
+const VALID_SEVERITIES: ReadonlySet<ErrorSeverity> = new Set([
+  'info',
+  'warning',
+  'error',
+  'critical',
+]);
+
+const VALID_SOURCES: ReadonlySet<ErrorSource> = new Set([
+  'cloudwatch-alarm',
+  'application',
+  'manual',
+]);
+
+function isErrorSeverity(value: unknown): value is ErrorSeverity {
+  return typeof value === 'string' && VALID_SEVERITIES.has(value as ErrorSeverity);
+}
+
+function isErrorSource(value: unknown): value is ErrorSource {
+  return typeof value === 'string' && VALID_SOURCES.has(value as ErrorSource);
+}
+
+/**
+ * Streams の NewImage（DynamoDB AttributeValue 形式）から ErrorEvent を復元する。
+ * 必須フィールドが欠けている場合は null。
+ */
+export function unmarshallErrorEvent(newImage: Record<string, unknown>): ErrorEvent | null {
+  const item = unmarshall(newImage as Parameters<typeof unmarshall>[0]);
+
+  if (
+    typeof item.eventId !== 'string' ||
+    typeof item.serviceId !== 'string' ||
+    typeof item.title !== 'string' ||
+    typeof item.message !== 'string' ||
+    typeof item.context !== 'string' ||
+    typeof item.occurredAt !== 'string' ||
+    !isErrorSource(item.source) ||
+    !isErrorSeverity(item.severity)
+  ) {
+    return null;
+  }
+
+  return {
+    eventId: item.eventId,
+    serviceId: item.serviceId,
+    source: item.source,
+    severity: item.severity,
+    title: item.title,
+    message: item.message,
+    context: item.context,
+    occurredAt: item.occurredAt,
+  };
+}
+
+/**
+ * ErrorEvent から Web Push の Payload を組み立てる。
+ */
+export function buildPushPayload(event: ErrorEvent, appUrl: string): PushNotificationPayload {
+  const params = new URLSearchParams({
+    at: event.occurredAt,
+    serviceId: event.serviceId,
+  });
+  const detailPath = `/errors/${encodeURIComponent(event.eventId)}?${params.toString()}`;
+  const url = appUrl ? `${appUrl}${detailPath}` : detailPath;
+
+  return {
+    title: event.title,
+    body: event.message || 'エラー通知を受信しました',
+    icon: '/icon-192x192.png',
+    data: {
+      url,
+      eventId: event.eventId,
+      tag: event.eventId,
+    },
+  };
+}
+
+/**
+ * Lambda エントリポイント。
+ */
+export async function handler(event: StreamHandlerEvent): Promise<HandlerResponse> {
+  const appUrl = process.env.APP_URL;
+  if (!appUrl) {
+    throw new Error(ERROR_MESSAGES.APP_URL_REQUIRED);
+  }
+
+  const sender = getWebPushSender();
+
+  let notified = 0;
+  let skipped = 0;
+
+  for (const record of event.Records ?? []) {
+    if (record.eventName !== 'INSERT') {
+      skipped += 1;
+      continue;
+    }
+    const newImage = record.dynamodb?.NewImage;
+    if (!newImage) {
+      skipped += 1;
+      continue;
+    }
+    const errorEvent = unmarshallErrorEvent(newImage);
+    if (!errorEvent) {
+      skipped += 1;
+      continue;
+    }
+
+    const payload = buildPushPayload(errorEvent, appUrl);
+    await sender.sendAll(payload);
+    notified += 1;
+  }
+
+  return { notified, skipped };
+}

--- a/services/admin/batch/tests/unit/alarm-ingest.test.ts
+++ b/services/admin/batch/tests/unit/alarm-ingest.test.ts
@@ -1,0 +1,217 @@
+/**
+ * alarm-ingest Lambda の単体テスト
+ */
+
+import { resetErrorEventWriter } from '@nagiyu/aws';
+import {
+  buildErrorEventFromSns,
+  inferServiceIdFromAlarmName,
+  handler,
+  type AlarmIngestEvent,
+} from '../../src/alarm-ingest.js';
+
+const buildSnsRecord = (
+  message: Record<string, unknown>,
+  type = 'Notification'
+): {
+  EventSource: 'aws:sns';
+  Sns: { Type: string; Subject?: string; Message: string; Timestamp: string };
+} => ({
+  EventSource: 'aws:sns',
+  Sns: {
+    Type: type,
+    Message: JSON.stringify(message),
+    Timestamp: '2026-05-06T01:00:00.000Z',
+  },
+});
+
+describe('inferServiceIdFromAlarmName', () => {
+  it('2 セグメント以上なら最初の 2 セグメントを連結する', () => {
+    expect(inferServiceIdFromAlarmName('stock-tracker-web-error-rate-prod')).toBe(
+      'stock-tracker'
+    );
+  });
+
+  it('1 セグメントならそのまま返す', () => {
+    expect(inferServiceIdFromAlarmName('admin')).toBe('admin');
+  });
+
+  it('空文字なら unknown', () => {
+    expect(inferServiceIdFromAlarmName('')).toBe('unknown');
+  });
+
+  it('ハイフンだけなら unknown', () => {
+    expect(inferServiceIdFromAlarmName('---')).toBe('unknown');
+  });
+});
+
+describe('buildErrorEventFromSns', () => {
+  it('ALARM 遷移の Notification を ErrorEvent に変換する', () => {
+    const record = buildSnsRecord({
+      AlarmName: 'stock-tracker-web-error-rate-prod',
+      NewStateValue: 'ALARM',
+      NewStateReason: 'Threshold Crossed: 0.6 > 0.05',
+      StateChangeTime: '2026-05-06T01:32:11.123+0000',
+    });
+
+    const event = buildErrorEventFromSns(record);
+
+    expect(event).not.toBeNull();
+    expect(event!.serviceId).toBe('stock-tracker');
+    expect(event!.severity).toBe('error');
+    expect(event!.source).toBe('cloudwatch-alarm');
+    expect(event!.title).toBe('stock-tracker-web-error-rate-prod (ALARM)');
+    expect(event!.message).toBe('Threshold Crossed: 0.6 > 0.05');
+    expect(event!.context).toBe(record.Sns.Message);
+    expect(event!.eventId).toBeTruthy();
+    expect(event!.occurredAt).toBe('2026-05-06T01:32:11.123Z');
+  });
+
+  it('OK 遷移は null を返す', () => {
+    const record = buildSnsRecord({
+      AlarmName: 'stock-tracker-web-error-rate-prod',
+      NewStateValue: 'OK',
+      NewStateReason: 'Recovered',
+    });
+    expect(buildErrorEventFromSns(record)).toBeNull();
+  });
+
+  it('SubscriptionConfirmation など Type が異なる場合は null', () => {
+    const record = buildSnsRecord({}, 'SubscriptionConfirmation');
+    expect(buildErrorEventFromSns(record)).toBeNull();
+  });
+
+  it('Message が JSON でないとき null', () => {
+    const record = {
+      EventSource: 'aws:sns' as const,
+      Sns: {
+        Type: 'Notification',
+        Message: 'not-json-payload',
+        Timestamp: '2026-05-06T01:00:00.000Z',
+      },
+    };
+    expect(buildErrorEventFromSns(record)).toBeNull();
+  });
+
+  it('AlarmName が無いとき null', () => {
+    const record = buildSnsRecord({
+      NewStateValue: 'ALARM',
+      NewStateReason: 'reason',
+    });
+    expect(buildErrorEventFromSns(record)).toBeNull();
+  });
+
+  it('StateChangeTime 不在のときは Sns.Timestamp を occurredAt に使う', () => {
+    const record = buildSnsRecord({
+      AlarmName: 'svc-component',
+      NewStateValue: 'ALARM',
+      NewStateReason: 'reason',
+    });
+    const event = buildErrorEventFromSns(record);
+    expect(event!.occurredAt).toBe('2026-05-06T01:00:00.000Z');
+  });
+});
+
+describe('handler', () => {
+  const originalEnv = process.env.USE_IN_MEMORY_DB;
+  const originalTable = process.env.ERROR_EVENTS_TABLE_NAME;
+
+  beforeEach(() => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    process.env.ERROR_EVENTS_TABLE_NAME = 'test-error-events';
+    resetErrorEventWriter();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.USE_IN_MEMORY_DB;
+    } else {
+      process.env.USE_IN_MEMORY_DB = originalEnv;
+    }
+    if (originalTable === undefined) {
+      delete process.env.ERROR_EVENTS_TABLE_NAME;
+    } else {
+      process.env.ERROR_EVENTS_TABLE_NAME = originalTable;
+    }
+    resetErrorEventWriter();
+  });
+
+  it('ALARM 通知 1 件 → processed=1', async () => {
+    const event: AlarmIngestEvent = {
+      Records: [
+        buildSnsRecord({
+          AlarmName: 'stock-tracker-web-error-rate-prod',
+          NewStateValue: 'ALARM',
+          NewStateReason: 'Threshold',
+          StateChangeTime: '2026-05-06T01:00:00Z',
+        }),
+      ],
+    };
+
+    const result = await handler(event);
+    expect(result).toEqual({ processed: 1, skipped: 0 });
+  });
+
+  it('OK 通知は skip', async () => {
+    const event: AlarmIngestEvent = {
+      Records: [
+        buildSnsRecord({
+          AlarmName: 'stock-tracker-web-error-rate-prod',
+          NewStateValue: 'OK',
+          NewStateReason: 'Recovered',
+        }),
+      ],
+    };
+
+    const result = await handler(event);
+    expect(result).toEqual({ processed: 0, skipped: 1 });
+  });
+
+  it('複数レコードが混在する場合、ALARM のみ processed', async () => {
+    const event: AlarmIngestEvent = {
+      Records: [
+        buildSnsRecord({
+          AlarmName: 'stock-tracker-web-error-rate-prod',
+          NewStateValue: 'ALARM',
+          NewStateReason: 'Threshold',
+        }),
+        buildSnsRecord({
+          AlarmName: 'stock-tracker-web-error-rate-prod',
+          NewStateValue: 'OK',
+          NewStateReason: 'Recovered',
+        }),
+      ],
+    };
+
+    const result = await handler(event);
+    expect(result).toEqual({ processed: 1, skipped: 1 });
+  });
+
+  it('Records が空でもエラーにならない', async () => {
+    const result = await handler({ Records: [] });
+    expect(result).toEqual({ processed: 0, skipped: 0 });
+  });
+
+  it('ERROR_EVENTS_TABLE_NAME 未設定で例外を投げる', async () => {
+    delete process.env.ERROR_EVENTS_TABLE_NAME;
+    delete process.env.USE_IN_MEMORY_DB;
+    resetErrorEventWriter();
+
+    await expect(
+      handler({ Records: [buildSnsRecord({ NewStateValue: 'ALARM' })] })
+    ).rejects.toThrow('ERROR_EVENTS_TABLE_NAME が設定されていません');
+  });
+
+  it('aws:sns 以外のイベントソースは skip', async () => {
+    const event: AlarmIngestEvent = {
+      Records: [
+        {
+          EventSource: 'aws:sqs' as 'aws:sns',
+          Sns: { Type: 'Notification', Message: '{}', Timestamp: '2026-05-06T01:00:00Z' },
+        },
+      ],
+    };
+    const result = await handler(event);
+    expect(result).toEqual({ processed: 0, skipped: 1 });
+  });
+});

--- a/services/admin/batch/tests/unit/stream-handler.test.ts
+++ b/services/admin/batch/tests/unit/stream-handler.test.ts
@@ -1,0 +1,168 @@
+/**
+ * stream-handler Lambda の単体テスト
+ */
+
+import { marshall } from '@aws-sdk/util-dynamodb';
+import type { ErrorEvent } from '@nagiyu/common';
+import { resetPushSubscriptionRepository } from '@nagiyu/admin-core';
+import {
+  buildPushPayload,
+  unmarshallErrorEvent,
+  handler,
+  type StreamHandlerEvent,
+} from '../../src/stream-handler.js';
+
+const sampleEvent: ErrorEvent = {
+  eventId: 'evt-1',
+  serviceId: 'stock-tracker',
+  source: 'cloudwatch-alarm',
+  severity: 'error',
+  title: 'sample-alarm (ALARM)',
+  message: 'Threshold Crossed',
+  context: '{}',
+  occurredAt: '2026-05-06T01:00:00.000Z',
+};
+
+const buildStreamRecord = (
+  errorEvent: ErrorEvent | null,
+  eventName: 'INSERT' | 'MODIFY' | 'REMOVE' = 'INSERT'
+) => ({
+  eventName,
+  dynamodb: errorEvent
+    ? {
+        NewImage: marshall({
+          ...errorEvent,
+          PK: `ERROR_EVENT#${errorEvent.serviceId}`,
+          SK: `OCCURRED#${errorEvent.occurredAt}#${errorEvent.eventId}`,
+          ttl: 1234567890,
+        }),
+      }
+    : undefined,
+});
+
+describe('unmarshallErrorEvent', () => {
+  it('正常な NewImage を ErrorEvent に変換する', () => {
+    const newImage = marshall({
+      ...sampleEvent,
+      PK: 'ERROR_EVENT#stock-tracker',
+      SK: 'OCCURRED#2026-05-06T01:00:00.000Z#evt-1',
+    });
+
+    const result = unmarshallErrorEvent(newImage as Record<string, unknown>);
+
+    expect(result).toEqual(sampleEvent);
+  });
+
+  it('必須フィールドが無いと null', () => {
+    const newImage = marshall({ eventId: 'x' });
+    expect(unmarshallErrorEvent(newImage as Record<string, unknown>)).toBeNull();
+  });
+
+  it('severity が不正なら null', () => {
+    const newImage = marshall({ ...sampleEvent, severity: 'unknown-severity' });
+    expect(unmarshallErrorEvent(newImage as Record<string, unknown>)).toBeNull();
+  });
+
+  it('source が不正なら null', () => {
+    const newImage = marshall({ ...sampleEvent, source: 'invalid-source' });
+    expect(unmarshallErrorEvent(newImage as Record<string, unknown>)).toBeNull();
+  });
+});
+
+describe('buildPushPayload', () => {
+  it('title / body / icon / data.url を持つ payload を返す', () => {
+    const payload = buildPushPayload(sampleEvent, 'https://admin.example.com');
+
+    expect(payload.title).toBe(sampleEvent.title);
+    expect(payload.body).toBe(sampleEvent.message);
+    expect(payload.icon).toBe('/icon-192x192.png');
+    expect(payload.data?.url).toBe(
+      'https://admin.example.com/errors/evt-1?at=2026-05-06T01%3A00%3A00.000Z&serviceId=stock-tracker'
+    );
+    expect(payload.data?.eventId).toBe('evt-1');
+    expect(payload.data?.tag).toBe('evt-1');
+  });
+
+  it('appUrl が空文字なら相対パスで data.url を生成する', () => {
+    const payload = buildPushPayload(sampleEvent, '');
+    expect(payload.data?.url).toBe(
+      '/errors/evt-1?at=2026-05-06T01%3A00%3A00.000Z&serviceId=stock-tracker'
+    );
+  });
+
+  it('message が空でもデフォルト本文を入れる', () => {
+    const payload = buildPushPayload({ ...sampleEvent, message: '' }, 'https://x');
+    expect(payload.body).toBe('エラー通知を受信しました');
+  });
+});
+
+describe('handler', () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    originalEnv.USE_IN_MEMORY_DB = process.env.USE_IN_MEMORY_DB;
+    originalEnv.DYNAMODB_TABLE_NAME = process.env.DYNAMODB_TABLE_NAME;
+    originalEnv.VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY;
+    originalEnv.VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
+    originalEnv.APP_URL = process.env.APP_URL;
+
+    process.env.USE_IN_MEMORY_DB = 'true';
+    process.env.DYNAMODB_TABLE_NAME = 'admin-table';
+    process.env.VAPID_PUBLIC_KEY = 'public';
+    process.env.VAPID_PRIVATE_KEY = 'private';
+    process.env.APP_URL = 'https://admin.example.com';
+    resetPushSubscriptionRepository();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    resetPushSubscriptionRepository();
+  });
+
+  it('INSERT イベント 1 件 → notified=1', async () => {
+    const event: StreamHandlerEvent = {
+      Records: [buildStreamRecord(sampleEvent)],
+    };
+    const result = await handler(event);
+    expect(result).toEqual({ notified: 1, skipped: 0 });
+  });
+
+  it('MODIFY と REMOVE は skip', async () => {
+    const event: StreamHandlerEvent = {
+      Records: [
+        buildStreamRecord(sampleEvent, 'MODIFY'),
+        buildStreamRecord(sampleEvent, 'REMOVE'),
+      ],
+    };
+    const result = await handler(event);
+    expect(result).toEqual({ notified: 0, skipped: 2 });
+  });
+
+  it('NewImage が無いと skip', async () => {
+    const event: StreamHandlerEvent = {
+      Records: [{ eventName: 'INSERT' }],
+    };
+    const result = await handler(event);
+    expect(result).toEqual({ notified: 0, skipped: 1 });
+  });
+
+  it('VAPID キー未設定で例外', async () => {
+    delete process.env.VAPID_PUBLIC_KEY;
+    await expect(
+      handler({ Records: [buildStreamRecord(sampleEvent)] })
+    ).rejects.toThrow('VAPID キーが設定されていません');
+  });
+
+  it('APP_URL 未設定で例外', async () => {
+    delete process.env.APP_URL;
+    await expect(
+      handler({ Records: [buildStreamRecord(sampleEvent)] })
+    ).rejects.toThrow('APP_URL が設定されていません');
+  });
+});

--- a/services/admin/batch/tsconfig.json
+++ b/services/admin/batch/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../configs/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/services/admin/core/src/errors/dynamodb-reader.ts
+++ b/services/admin/core/src/errors/dynamodb-reader.ts
@@ -1,0 +1,142 @@
+/**
+ * DynamoDB をバックエンドとする ErrorEventReader 実装
+ */
+
+import { QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import type { ErrorEvent, ErrorSeverity, ErrorSource } from '@nagiyu/common';
+import {
+  buildErrorEventPK,
+  buildErrorEventSK,
+  ERROR_EVENT_GSI1_PK,
+  ERROR_EVENT_SK_PREFIX,
+} from '@nagiyu/aws';
+import {
+  decodeCursor,
+  encodeCursor,
+  normalizeLimit,
+  type ErrorEventReader,
+  type ListErrorEventsQuery,
+  type ListErrorEventsResult,
+} from './reader.js';
+
+const ERROR_MESSAGES = {
+  INVALID_RANGE: 'from は to よりも前の時刻である必要があります',
+} as const;
+
+const ALL_BY_OCCURRED_AT_INDEX = 'AllByOccurredAt';
+
+type ItemRecord = Record<string, unknown>;
+
+function toErrorEvent(item: ItemRecord): ErrorEvent {
+  return {
+    eventId: item.eventId as string,
+    serviceId: item.serviceId as string,
+    source: item.source as ErrorSource,
+    severity: item.severity as ErrorSeverity,
+    title: item.title as string,
+    message: item.message as string,
+    context: item.context as string,
+    occurredAt: item.occurredAt as string,
+  };
+}
+
+/**
+ * DynamoDB をバックエンドとする ErrorEventReader 実装。
+ */
+export class DynamoDBErrorEventReader implements ErrorEventReader {
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+
+  constructor(docClient: DynamoDBDocumentClient, tableName: string) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+  }
+
+  public async list(query: ListErrorEventsQuery): Promise<ListErrorEventsResult> {
+    if (query.from && query.to && Date.parse(query.from) > Date.parse(query.to)) {
+      throw new Error(ERROR_MESSAGES.INVALID_RANGE);
+    }
+
+    const limit = normalizeLimit(query.limit);
+    const exclusiveStartKey = query.cursor ? decodeCursor(query.cursor) : undefined;
+
+    const useGsi = !query.serviceId;
+    const partitionKeyName = useGsi ? 'GSI1PK' : 'PK';
+    const sortKeyName = useGsi ? 'GSI1SK' : 'SK';
+    const partitionKeyValue = useGsi ? ERROR_EVENT_GSI1_PK : buildErrorEventPK(query.serviceId!);
+
+    const expressionAttributeNames: Record<string, string> = {
+      '#pk': partitionKeyName,
+    };
+    const expressionAttributeValues: Record<string, unknown> = {
+      ':pk': partitionKeyValue,
+    };
+
+    const conditions: string[] = ['#pk = :pk'];
+
+    if (query.from && query.to) {
+      conditions.push('#sk BETWEEN :from AND :to');
+      expressionAttributeNames['#sk'] = sortKeyName;
+      expressionAttributeValues[':from'] = `${ERROR_EVENT_SK_PREFIX}${query.from}`;
+      expressionAttributeValues[':to'] = `${ERROR_EVENT_SK_PREFIX}${query.to}￿`;
+    } else if (query.from) {
+      conditions.push('#sk >= :from');
+      expressionAttributeNames['#sk'] = sortKeyName;
+      expressionAttributeValues[':from'] = `${ERROR_EVENT_SK_PREFIX}${query.from}`;
+    } else if (query.to) {
+      conditions.push('#sk <= :to');
+      expressionAttributeNames['#sk'] = sortKeyName;
+      expressionAttributeValues[':to'] = `${ERROR_EVENT_SK_PREFIX}${query.to}￿`;
+    } else {
+      conditions.push('begins_with(#sk, :prefix)');
+      expressionAttributeNames['#sk'] = sortKeyName;
+      expressionAttributeValues[':prefix'] = ERROR_EVENT_SK_PREFIX;
+    }
+
+    const result = await this.docClient.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        IndexName: useGsi ? ALL_BY_OCCURRED_AT_INDEX : undefined,
+        KeyConditionExpression: conditions.join(' AND '),
+        ExpressionAttributeNames: expressionAttributeNames,
+        ExpressionAttributeValues: expressionAttributeValues,
+        Limit: limit,
+        ScanIndexForward: false,
+        ExclusiveStartKey: exclusiveStartKey,
+      })
+    );
+
+    const items = (result.Items ?? []) as ItemRecord[];
+    const nextCursor = result.LastEvaluatedKey ? encodeCursor(result.LastEvaluatedKey) : null;
+
+    return {
+      items: items.map(toErrorEvent),
+      nextCursor,
+    };
+  }
+
+  public async findById(
+    eventId: string,
+    occurredAt: string,
+    serviceId: string
+  ): Promise<ErrorEvent | null> {
+    const result = await this.docClient.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: '#pk = :pk AND #sk = :sk',
+        ExpressionAttributeNames: {
+          '#pk': 'PK',
+          '#sk': 'SK',
+        },
+        ExpressionAttributeValues: {
+          ':pk': buildErrorEventPK(serviceId),
+          ':sk': buildErrorEventSK(occurredAt, eventId),
+        },
+        Limit: 1,
+      })
+    );
+
+    const item = result.Items?.[0] as ItemRecord | undefined;
+    return item ? toErrorEvent(item) : null;
+  }
+}

--- a/services/admin/core/src/errors/factory.ts
+++ b/services/admin/core/src/errors/factory.ts
@@ -1,0 +1,54 @@
+/**
+ * ErrorEventReader Factory
+ */
+
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { createRepositoryFactory } from '@nagiyu/aws';
+import { DynamoDBErrorEventReader } from './dynamodb-reader.js';
+import { InMemoryErrorEventReader } from './in-memory-reader.js';
+import type { ErrorEventReader } from './reader.js';
+
+const ERROR_MESSAGES = {
+  DYNAMODB_PARAMS_REQUIRED: 'DynamoDB 実装には docClient と tableName が必要です',
+} as const;
+
+function requireDynamoParams(
+  docClient: DynamoDBDocumentClient | undefined,
+  tableName: string | undefined
+): { docClient: DynamoDBDocumentClient; tableName: string } {
+  if (!docClient || !tableName) {
+    throw new Error(ERROR_MESSAGES.DYNAMODB_PARAMS_REQUIRED);
+  }
+  return { docClient, tableName };
+}
+
+const errorEventReaderFactory = createRepositoryFactory<
+  ErrorEventReader,
+  [DynamoDBDocumentClient | undefined, string | undefined]
+>({
+  createInMemoryRepository: () => new InMemoryErrorEventReader(),
+  createDynamoDBRepository: (docClient, tableName) => {
+    const params = requireDynamoParams(docClient, tableName);
+    return new DynamoDBErrorEventReader(params.docClient, params.tableName);
+  },
+});
+
+/**
+ * `ErrorEventReader` を生成する。
+ *
+ * - `USE_IN_MEMORY_DB=true` のとき in-memory 実装
+ * - それ以外は DynamoDB 実装（docClient / tableName 必須）
+ */
+export function createErrorEventReader(
+  docClient?: DynamoDBDocumentClient,
+  tableName?: string
+): ErrorEventReader {
+  return errorEventReaderFactory.createRepository(docClient, tableName);
+}
+
+/**
+ * 内部のシングルトンインスタンスを破棄する。テスト用。
+ */
+export function resetErrorEventReader(): void {
+  errorEventReaderFactory.resetRepository();
+}

--- a/services/admin/core/src/errors/in-memory-reader.ts
+++ b/services/admin/core/src/errors/in-memory-reader.ts
@@ -1,0 +1,73 @@
+/**
+ * in-memory 実装の ErrorEventReader
+ *
+ * テスト・ローカル開発用。put した順に保持し、occurredAt で降順ソートして返す。
+ */
+
+import type { ErrorEvent } from '@nagiyu/common';
+import {
+  normalizeLimit,
+  type ErrorEventReader,
+  type ListErrorEventsQuery,
+  type ListErrorEventsResult,
+} from './reader.js';
+
+/**
+ * in-memory 実装。
+ *
+ * `put` で書き込みできるテスト用ヘルパーを兼ねており、
+ * Reader / Writer の両方として使える簡易ストア。
+ */
+export class InMemoryErrorEventReader implements ErrorEventReader {
+  private readonly records: ErrorEvent[] = [];
+
+  /**
+   * テスト用に 1 件追加する。
+   */
+  public put(event: ErrorEvent): void {
+    this.records.push({ ...event });
+  }
+
+  public reset(): void {
+    this.records.length = 0;
+  }
+
+  public async list(query: ListErrorEventsQuery): Promise<ListErrorEventsResult> {
+    const limit = normalizeLimit(query.limit);
+
+    let filtered = [...this.records];
+
+    if (query.serviceId) {
+      filtered = filtered.filter((e) => e.serviceId === query.serviceId);
+    }
+    if (query.from) {
+      filtered = filtered.filter((e) => e.occurredAt >= query.from!);
+    }
+    if (query.to) {
+      filtered = filtered.filter((e) => e.occurredAt <= query.to!);
+    }
+
+    filtered.sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
+
+    const offset = query.cursor ? Number.parseInt(query.cursor, 10) : 0;
+    const start = Number.isFinite(offset) && offset >= 0 ? offset : 0;
+    const sliced = filtered.slice(start, start + limit);
+    const nextOffset = start + sliced.length;
+    const nextCursor = nextOffset < filtered.length ? String(nextOffset) : null;
+
+    return { items: sliced, nextCursor };
+  }
+
+  public async findById(
+    eventId: string,
+    occurredAt: string,
+    serviceId: string
+  ): Promise<ErrorEvent | null> {
+    return (
+      this.records.find(
+        (e) =>
+          e.eventId === eventId && e.occurredAt === occurredAt && e.serviceId === serviceId
+      ) ?? null
+    );
+  }
+}

--- a/services/admin/core/src/errors/index.ts
+++ b/services/admin/core/src/errors/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Errors モジュール
+ *
+ * Admin の永続化済みエラーイベント参照のためのドメインロジック。
+ */
+
+export type {
+  ErrorEventReader,
+  ListErrorEventsQuery,
+  ListErrorEventsResult,
+} from './reader.js';
+export {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+  encodeCursor,
+  decodeCursor,
+  normalizeLimit,
+} from './reader.js';
+export { DynamoDBErrorEventReader } from './dynamodb-reader.js';
+export { InMemoryErrorEventReader } from './in-memory-reader.js';
+export { createErrorEventReader, resetErrorEventReader } from './factory.js';

--- a/services/admin/core/src/errors/reader.ts
+++ b/services/admin/core/src/errors/reader.ts
@@ -1,0 +1,103 @@
+/**
+ * ErrorEventReader インタフェース定義
+ *
+ * Admin Web で永続化済みエラーイベントを参照するための読み取り専用 API。
+ */
+
+import type { ErrorEvent } from '@nagiyu/common';
+
+/**
+ * 一覧取得時のクエリパラメータ
+ */
+export type ListErrorEventsQuery = {
+  /** サービス ID で絞り込み（未指定なら全サービス） */
+  serviceId?: string;
+  /** 開始時刻（ISO-8601、含む） */
+  from?: string;
+  /** 終了時刻（ISO-8601、含む） */
+  to?: string;
+  /** 1 ページの最大件数（既定 50、最大 100） */
+  limit?: number;
+  /** ページング cursor（前回の応答で受け取った nextCursor） */
+  cursor?: string;
+};
+
+/**
+ * 一覧取得の結果
+ */
+export type ListErrorEventsResult = {
+  items: ErrorEvent[];
+  /** 次ページがある場合の cursor、なければ null */
+  nextCursor: string | null;
+};
+
+/**
+ * エラーイベント参照 API
+ */
+export interface ErrorEventReader {
+  /**
+   * 条件に合致するエラーイベントを時系列降順で取得する。
+   */
+  list(query: ListErrorEventsQuery): Promise<ListErrorEventsResult>;
+
+  /**
+   * eventId と occurredAt を指定して 1 件取得する。
+   * 該当が無い、もしくは TTL で削除済みの場合は null を返す。
+   */
+  findById(eventId: string, occurredAt: string, serviceId: string): Promise<ErrorEvent | null>;
+}
+
+/**
+ * 既定の最大取得件数
+ */
+export const DEFAULT_LIST_LIMIT = 50;
+
+/**
+ * 上限となる最大取得件数
+ */
+export const MAX_LIST_LIMIT = 100;
+
+const ERROR_MESSAGES = {
+  INVALID_CURSOR: 'cursor が不正な形式です',
+} as const;
+
+/**
+ * 不透明な cursor 文字列に DynamoDB の LastEvaluatedKey をエンコードする。
+ */
+export function encodeCursor(lastEvaluatedKey: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(lastEvaluatedKey), 'utf-8').toString('base64url');
+}
+
+/**
+ * cursor 文字列から DynamoDB の LastEvaluatedKey をデコードする。
+ *
+ * @throws cursor が不正な場合
+ */
+export function decodeCursor(cursor: string): Record<string, unknown> {
+  try {
+    const json = Buffer.from(cursor, 'base64url').toString('utf-8');
+    const parsed = JSON.parse(json);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('parsed result is not an object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new Error(ERROR_MESSAGES.INVALID_CURSOR);
+  }
+}
+
+/**
+ * limit を既定値・上限に丸める。
+ */
+export function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) {
+    return DEFAULT_LIST_LIMIT;
+  }
+  if (limit < 1) {
+    return 1;
+  }
+  if (limit > MAX_LIST_LIMIT) {
+    return MAX_LIST_LIMIT;
+  }
+  return Math.floor(limit);
+}

--- a/services/admin/core/src/index.ts
+++ b/services/admin/core/src/index.ts
@@ -14,3 +14,20 @@ export {
 
 export type { PushNotificationPayload, SendAllResult } from './notify/web-push-sender.js';
 export { WebPushSender } from './notify/web-push-sender.js';
+
+export type {
+  ErrorEventReader,
+  ListErrorEventsQuery,
+  ListErrorEventsResult,
+} from './errors/index.js';
+export {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+  encodeCursor,
+  decodeCursor,
+  normalizeLimit,
+  DynamoDBErrorEventReader,
+  InMemoryErrorEventReader,
+  createErrorEventReader,
+  resetErrorEventReader,
+} from './errors/index.js';

--- a/services/admin/core/tests/unit/errors/dynamodb-reader.test.ts
+++ b/services/admin/core/tests/unit/errors/dynamodb-reader.test.ts
@@ -1,0 +1,147 @@
+/**
+ * DynamoDBErrorEventReader の単体テスト
+ */
+
+import { QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import type { ErrorEvent } from '@nagiyu/common';
+import {
+  buildErrorEventPK,
+  buildErrorEventSK,
+  ERROR_EVENT_GSI1_PK,
+} from '@nagiyu/aws';
+import { DynamoDBErrorEventReader } from '../../../src/errors/dynamodb-reader.js';
+import { encodeCursor } from '../../../src/errors/reader.js';
+
+const sampleEvent: ErrorEvent = {
+  eventId: 'evt-1',
+  serviceId: 'stock-tracker',
+  source: 'cloudwatch-alarm',
+  severity: 'error',
+  title: 'sample',
+  message: 'sample',
+  context: '{}',
+  occurredAt: '2026-05-06T00:00:00.000Z',
+};
+
+const itemFor = (event: ErrorEvent): Record<string, unknown> => ({
+  PK: buildErrorEventPK(event.serviceId),
+  SK: buildErrorEventSK(event.occurredAt, event.eventId),
+  ...event,
+});
+
+describe('DynamoDBErrorEventReader', () => {
+  let mockDocClient: jest.Mocked<DynamoDBDocumentClient>;
+  let reader: DynamoDBErrorEventReader;
+
+  beforeEach(() => {
+    mockDocClient = { send: jest.fn() } as unknown as jest.Mocked<DynamoDBDocumentClient>;
+    reader = new DynamoDBErrorEventReader(mockDocClient, 'test-error-events');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('list', () => {
+    it('serviceId 未指定なら GSI1 にクエリし、全件横断する', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Items: [itemFor(sampleEvent)] } as never);
+
+      const result = await reader.list({});
+
+      const cmd = mockDocClient.send.mock.calls[0][0] as QueryCommand;
+      expect(cmd.input.IndexName).toBe('AllByOccurredAt');
+      expect(cmd.input.ExpressionAttributeValues?.[':pk']).toBe(ERROR_EVENT_GSI1_PK);
+      expect(cmd.input.ScanIndexForward).toBe(false);
+      expect(result.items).toEqual([sampleEvent]);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('serviceId 指定なら main table の PK にクエリする', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Items: [] } as never);
+
+      await reader.list({ serviceId: 'stock-tracker' });
+
+      const cmd = mockDocClient.send.mock.calls[0][0] as QueryCommand;
+      expect(cmd.input.IndexName).toBeUndefined();
+      expect(cmd.input.ExpressionAttributeValues?.[':pk']).toBe('ERROR_EVENT#stock-tracker');
+    });
+
+    it('from / to 両方ある場合は SK BETWEEN になる', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Items: [] } as never);
+
+      await reader.list({
+        serviceId: 'stock-tracker',
+        from: '2026-05-01T00:00:00Z',
+        to: '2026-05-31T23:59:59Z',
+      });
+
+      const cmd = mockDocClient.send.mock.calls[0][0] as QueryCommand;
+      expect(cmd.input.KeyConditionExpression).toContain('BETWEEN');
+    });
+
+    it('from のみなら >= で絞る', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Items: [] } as never);
+      await reader.list({ from: '2026-05-01T00:00:00Z' });
+      const cmd = mockDocClient.send.mock.calls[0][0] as QueryCommand;
+      expect(cmd.input.KeyConditionExpression).toContain('>=');
+    });
+
+    it('to のみなら <= で絞る', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Items: [] } as never);
+      await reader.list({ to: '2026-05-31T00:00:00Z' });
+      const cmd = mockDocClient.send.mock.calls[0][0] as QueryCommand;
+      expect(cmd.input.KeyConditionExpression).toContain('<=');
+    });
+
+    it('from > to のとき例外', async () => {
+      await expect(
+        reader.list({ from: '2026-05-31T00:00:00Z', to: '2026-05-01T00:00:00Z' })
+      ).rejects.toThrow('from は to よりも前の時刻');
+      expect(mockDocClient.send).not.toHaveBeenCalled();
+    });
+
+    it('LastEvaluatedKey がある場合 nextCursor を返す', async () => {
+      mockDocClient.send.mockResolvedValueOnce({
+        Items: [itemFor(sampleEvent)],
+        LastEvaluatedKey: { PK: 'ERROR_EVENT#stock-tracker', SK: 'OCCURRED#x#y' },
+      } as never);
+
+      const result = await reader.list({});
+      expect(result.nextCursor).not.toBeNull();
+    });
+
+    it('cursor が指定されていれば ExclusiveStartKey に渡す', async () => {
+      const lastKey = { PK: 'ERROR_EVENT#stock-tracker', SK: 'OCCURRED#x#y' };
+      const cursor = encodeCursor(lastKey);
+      mockDocClient.send.mockResolvedValueOnce({ Items: [] } as never);
+
+      await reader.list({ cursor });
+
+      const cmd = mockDocClient.send.mock.calls[0][0] as QueryCommand;
+      expect(cmd.input.ExclusiveStartKey).toEqual(lastKey);
+    });
+  });
+
+  describe('findById', () => {
+    it('PK + SK で 1 件取得できる', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Items: [itemFor(sampleEvent)] } as never);
+
+      const result = await reader.findById(
+        sampleEvent.eventId,
+        sampleEvent.occurredAt,
+        sampleEvent.serviceId
+      );
+
+      const cmd = mockDocClient.send.mock.calls[0][0] as QueryCommand;
+      expect(cmd.input.KeyConditionExpression).toBe('#pk = :pk AND #sk = :sk');
+      expect(cmd.input.ExpressionAttributeValues?.[':pk']).toBe('ERROR_EVENT#stock-tracker');
+      expect(result).toEqual(sampleEvent);
+    });
+
+    it('該当無しなら null', async () => {
+      mockDocClient.send.mockResolvedValueOnce({ Items: [] } as never);
+      const result = await reader.findById('x', '2026-05-06T00:00:00Z', 'stock-tracker');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/services/admin/core/tests/unit/errors/factory.test.ts
+++ b/services/admin/core/tests/unit/errors/factory.test.ts
@@ -1,0 +1,66 @@
+/**
+ * createErrorEventReader の単体テスト
+ */
+
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  createErrorEventReader,
+  resetErrorEventReader,
+} from '../../../src/errors/factory.js';
+import { DynamoDBErrorEventReader } from '../../../src/errors/dynamodb-reader.js';
+import { InMemoryErrorEventReader } from '../../../src/errors/in-memory-reader.js';
+
+describe('createErrorEventReader', () => {
+  const original = process.env.USE_IN_MEMORY_DB;
+
+  beforeEach(() => {
+    resetErrorEventReader();
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.USE_IN_MEMORY_DB;
+    } else {
+      process.env.USE_IN_MEMORY_DB = original;
+    }
+    resetErrorEventReader();
+  });
+
+  it('USE_IN_MEMORY_DB=true で in-memory 実装', () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    expect(createErrorEventReader()).toBeInstanceOf(InMemoryErrorEventReader);
+  });
+
+  it('docClient + tableName で DynamoDB 実装', () => {
+    delete process.env.USE_IN_MEMORY_DB;
+    const mockClient = { send: jest.fn() } as unknown as DynamoDBDocumentClient;
+    expect(createErrorEventReader(mockClient, 'tbl')).toBeInstanceOf(DynamoDBErrorEventReader);
+  });
+
+  it('docClient 欠落で例外', () => {
+    delete process.env.USE_IN_MEMORY_DB;
+    expect(() => createErrorEventReader(undefined, 'tbl')).toThrow(
+      'DynamoDB 実装には docClient と tableName が必要です'
+    );
+  });
+
+  it('tableName 欠落で例外', () => {
+    delete process.env.USE_IN_MEMORY_DB;
+    const mockClient = { send: jest.fn() } as unknown as DynamoDBDocumentClient;
+    expect(() => createErrorEventReader(mockClient, undefined)).toThrow(
+      'DynamoDB 実装には docClient と tableName が必要です'
+    );
+  });
+
+  it('シングルトンとして再利用される', () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    expect(createErrorEventReader()).toBe(createErrorEventReader());
+  });
+
+  it('reset 後は新規インスタンス', () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const first = createErrorEventReader();
+    resetErrorEventReader();
+    expect(createErrorEventReader()).not.toBe(first);
+  });
+});

--- a/services/admin/core/tests/unit/errors/in-memory-reader.test.ts
+++ b/services/admin/core/tests/unit/errors/in-memory-reader.test.ts
@@ -1,0 +1,100 @@
+/**
+ * InMemoryErrorEventReader の単体テスト
+ */
+
+import type { ErrorEvent } from '@nagiyu/common';
+import { InMemoryErrorEventReader } from '../../../src/errors/in-memory-reader.js';
+
+const sampleEvent = (overrides: Partial<ErrorEvent> = {}): ErrorEvent => ({
+  eventId: 'evt-1',
+  serviceId: 'stock-tracker',
+  source: 'cloudwatch-alarm',
+  severity: 'error',
+  title: 'sample',
+  message: 'sample message',
+  context: '{}',
+  occurredAt: '2026-05-06T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('InMemoryErrorEventReader', () => {
+  let reader: InMemoryErrorEventReader;
+
+  beforeEach(() => {
+    reader = new InMemoryErrorEventReader();
+  });
+
+  it('list は put した順とは無関係に occurredAt 降順で返す', async () => {
+    reader.put(sampleEvent({ eventId: 'a', occurredAt: '2026-05-06T00:00:00.000Z' }));
+    reader.put(sampleEvent({ eventId: 'b', occurredAt: '2026-05-06T01:00:00.000Z' }));
+    reader.put(sampleEvent({ eventId: 'c', occurredAt: '2026-05-05T23:00:00.000Z' }));
+
+    const result = await reader.list({});
+    expect(result.items.map((e) => e.eventId)).toEqual(['b', 'a', 'c']);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('serviceId で絞り込める', async () => {
+    reader.put(sampleEvent({ eventId: 'a', serviceId: 'stock-tracker' }));
+    reader.put(sampleEvent({ eventId: 'b', serviceId: 'admin' }));
+
+    const result = await reader.list({ serviceId: 'stock-tracker' });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].eventId).toBe('a');
+  });
+
+  it('from / to で期間絞り込みできる', async () => {
+    reader.put(sampleEvent({ eventId: 'a', occurredAt: '2026-05-01T00:00:00.000Z' }));
+    reader.put(sampleEvent({ eventId: 'b', occurredAt: '2026-05-05T00:00:00.000Z' }));
+    reader.put(sampleEvent({ eventId: 'c', occurredAt: '2026-05-10T00:00:00.000Z' }));
+
+    const result = await reader.list({
+      from: '2026-05-04T00:00:00.000Z',
+      to: '2026-05-09T00:00:00.000Z',
+    });
+    expect(result.items.map((e) => e.eventId)).toEqual(['b']);
+  });
+
+  it('limit + cursor でページングできる', async () => {
+    for (let i = 0; i < 5; i++) {
+      reader.put(
+        sampleEvent({
+          eventId: `evt-${i}`,
+          occurredAt: `2026-05-0${i}T00:00:00.000Z`,
+        })
+      );
+    }
+
+    const first = await reader.list({ limit: 2 });
+    expect(first.items).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await reader.list({ limit: 2, cursor: first.nextCursor! });
+    expect(second.items).toHaveLength(2);
+    expect(second.nextCursor).not.toBeNull();
+
+    const third = await reader.list({ limit: 2, cursor: second.nextCursor! });
+    expect(third.items).toHaveLength(1);
+    expect(third.nextCursor).toBeNull();
+  });
+
+  it('findById は eventId / occurredAt / serviceId 全一致で返す', async () => {
+    const event = sampleEvent({ eventId: 'evt-1', serviceId: 's1' });
+    reader.put(event);
+
+    const found = await reader.findById('evt-1', event.occurredAt, 's1');
+    expect(found).toEqual(event);
+  });
+
+  it('findById は不一致のとき null', async () => {
+    reader.put(sampleEvent({ eventId: 'evt-1' }));
+    expect(await reader.findById('missing', '2026-01-01T00:00:00.000Z', 'stock-tracker')).toBeNull();
+  });
+
+  it('reset で状態をクリア', async () => {
+    reader.put(sampleEvent());
+    reader.reset();
+    const result = await reader.list({});
+    expect(result.items).toEqual([]);
+  });
+});

--- a/services/admin/core/tests/unit/errors/reader.test.ts
+++ b/services/admin/core/tests/unit/errors/reader.test.ts
@@ -1,0 +1,49 @@
+/**
+ * ErrorEventReader 共通ヘルパーの単体テスト
+ */
+
+import {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+  decodeCursor,
+  encodeCursor,
+  normalizeLimit,
+} from '../../../src/errors/reader.js';
+
+describe('encodeCursor / decodeCursor', () => {
+  it('オブジェクトを base64url 経由で往復できる', () => {
+    const key = { PK: 'ERROR_EVENT#stock-tracker', SK: 'OCCURRED#2026-05-06T00:00:00Z#evt-1' };
+    const cursor = encodeCursor(key);
+    expect(typeof cursor).toBe('string');
+    expect(decodeCursor(cursor)).toEqual(key);
+  });
+
+  it('decodeCursor は不正な文字列で例外を投げる', () => {
+    expect(() => decodeCursor('not-base64!@#')).toThrow('cursor が不正な形式です');
+  });
+
+  it('decodeCursor は JSON でない base64 で例外を投げる', () => {
+    const invalid = Buffer.from('not json', 'utf-8').toString('base64url');
+    expect(() => decodeCursor(invalid)).toThrow('cursor が不正な形式です');
+  });
+});
+
+describe('normalizeLimit', () => {
+  it('未指定のとき既定値を返す', () => {
+    expect(normalizeLimit(undefined)).toBe(DEFAULT_LIST_LIMIT);
+  });
+
+  it('正常値はそのまま整数にして返す', () => {
+    expect(normalizeLimit(20)).toBe(20);
+    expect(normalizeLimit(20.7)).toBe(20);
+  });
+
+  it('1 未満は 1 に丸める', () => {
+    expect(normalizeLimit(0)).toBe(1);
+    expect(normalizeLimit(-5)).toBe(1);
+  });
+
+  it('上限を超えると上限に丸める', () => {
+    expect(normalizeLimit(MAX_LIST_LIMIT + 50)).toBe(MAX_LIST_LIMIT);
+  });
+});

--- a/services/admin/web/src/app/(protected)/dashboard/page.tsx
+++ b/services/admin/web/src/app/(protected)/dashboard/page.tsx
@@ -2,7 +2,6 @@ import { Box, Card, CardContent, Typography, Button, Chip } from '@mui/material'
 import { hasPermission } from '@nagiyu/common';
 import { getSession } from '@/lib/auth/session';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import NotifyButton from '@/components/notify/NotifyButton';
 
 export default async function DashboardPage() {
@@ -78,7 +77,7 @@ export default async function DashboardPage() {
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               プラットフォーム上で発生したエラー通知の履歴を確認できます
             </Typography>
-            <Button component={Link} href="/errors" variant="contained">
+            <Button href="/errors" variant="contained">
               エラー履歴を表示
             </Button>
           </CardContent>

--- a/services/admin/web/src/app/(protected)/dashboard/page.tsx
+++ b/services/admin/web/src/app/(protected)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { Box, Card, CardContent, Typography, Button, Chip } from '@mui/material'
 import { hasPermission } from '@nagiyu/common';
 import { getSession } from '@/lib/auth/session';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 import NotifyButton from '@/components/notify/NotifyButton';
 
 export default async function DashboardPage() {
@@ -64,6 +65,22 @@ export default async function DashboardPage() {
               通知設定
             </Typography>
             <NotifyButton />
+          </CardContent>
+        </Card>
+      )}
+
+      {hasPermission(user.roles, 'errors:read') && (
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              エラー履歴
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              プラットフォーム上で発生したエラー通知の履歴を確認できます
+            </Typography>
+            <Button component={Link} href="/errors" variant="contained">
+              エラー履歴を表示
+            </Button>
           </CardContent>
         </Card>
       )}

--- a/services/admin/web/src/app/(protected)/errors/[eventId]/page.tsx
+++ b/services/admin/web/src/app/(protected)/errors/[eventId]/page.tsx
@@ -3,7 +3,6 @@ import { hasPermission } from '@nagiyu/common';
 import type { ErrorSeverity } from '@nagiyu/common';
 import { getDynamoDBDocumentClient } from '@nagiyu/aws';
 import { createErrorEventReader } from '@nagiyu/admin-core';
-import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth/session';
 
@@ -103,7 +102,7 @@ export default async function ErrorDetailPage({
   return (
     <Box sx={{ p: 3, maxWidth: 1000, mx: 'auto' }}>
       <Box sx={{ mb: 2 }}>
-        <Button component={Link} href="/errors" variant="text">
+        <Button href="/errors" variant="text">
           ← エラー履歴に戻る
         </Button>
       </Box>

--- a/services/admin/web/src/app/(protected)/errors/[eventId]/page.tsx
+++ b/services/admin/web/src/app/(protected)/errors/[eventId]/page.tsx
@@ -1,0 +1,198 @@
+import { Box, Button, Card, CardContent, Chip, Divider, Typography } from '@mui/material';
+import { hasPermission } from '@nagiyu/common';
+import type { ErrorSeverity } from '@nagiyu/common';
+import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { createErrorEventReader } from '@nagiyu/admin-core';
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { getSession } from '@/lib/auth/session';
+
+const ERROR_MESSAGES = {
+  ERROR_EVENTS_TABLE_NAME_REQUIRED: 'ERROR_EVENTS_TABLE_NAME が設定されていません',
+} as const;
+
+const SEVERITY_COLORS: Record<ErrorSeverity, 'info' | 'warning' | 'error'> = {
+  info: 'info',
+  warning: 'warning',
+  error: 'error',
+  critical: 'error',
+};
+
+function getReader() {
+  const docClient =
+    process.env.USE_IN_MEMORY_DB === 'true' ? undefined : getDynamoDBDocumentClient();
+  const tableName = process.env.ERROR_EVENTS_TABLE_NAME;
+
+  if (!docClient) {
+    return createErrorEventReader(undefined, undefined);
+  }
+
+  if (!tableName) {
+    throw new Error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);
+  }
+
+  return createErrorEventReader(docClient, tableName);
+}
+
+function formatJst(iso: string): string {
+  const date = new Date(iso);
+  return new Intl.DateTimeFormat('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(date);
+}
+
+function tryFormatJson(value: string): string {
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+}
+
+type PageSearchParams = {
+  at?: string;
+  serviceId?: string;
+};
+
+export default async function ErrorDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ eventId: string }>;
+  searchParams: Promise<PageSearchParams>;
+}) {
+  const session = await getSession();
+  if (!session) {
+    const authUrl = process.env.NEXT_PUBLIC_AUTH_URL || process.env.NEXTAUTH_URL || '';
+    redirect(`${authUrl}/signin`);
+  }
+
+  if (!hasPermission(session.user.roles, 'errors:read')) {
+    return (
+      <Box sx={{ p: 3, maxWidth: 800, mx: 'auto' }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          エラー詳細
+        </Typography>
+        <Typography color="error">この画面を表示する権限がありません</Typography>
+      </Box>
+    );
+  }
+
+  const { eventId } = await params;
+  const sp = (await searchParams) ?? {};
+  const occurredAt = sp.at;
+  const serviceId = sp.serviceId;
+
+  if (!occurredAt || !serviceId) {
+    notFound();
+  }
+
+  const reader = getReader();
+  const event = await reader.findById(eventId, occurredAt, serviceId);
+
+  if (!event) {
+    notFound();
+  }
+
+  return (
+    <Box sx={{ p: 3, maxWidth: 1000, mx: 'auto' }}>
+      <Box sx={{ mb: 2 }}>
+        <Button component={Link} href="/errors" variant="text">
+          ← エラー履歴に戻る
+        </Button>
+      </Box>
+
+      <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Chip label={event.severity} size="small" color={SEVERITY_COLORS[event.severity]} />
+        <Typography variant="h5" component="h1">
+          {event.title}
+        </Typography>
+      </Box>
+
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            メタ情報
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
+              <Typography variant="body2" color="text.secondary" sx={{ minWidth: 120 }}>
+                eventId
+              </Typography>
+              <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                {event.eventId}
+              </Typography>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
+              <Typography variant="body2" color="text.secondary" sx={{ minWidth: 120 }}>
+                serviceId
+              </Typography>
+              <Typography variant="body2">{event.serviceId}</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
+              <Typography variant="body2" color="text.secondary" sx={{ minWidth: 120 }}>
+                source
+              </Typography>
+              <Typography variant="body2">{event.source}</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
+              <Typography variant="body2" color="text.secondary" sx={{ minWidth: 120 }}>
+                発生時刻 (JST)
+              </Typography>
+              <Typography variant="body2">{formatJst(event.occurredAt)}</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
+              <Typography variant="body2" color="text.secondary" sx={{ minWidth: 120 }}>
+                発生時刻 (UTC)
+              </Typography>
+              <Typography variant="body2">{event.occurredAt}</Typography>
+            </Box>
+          </Box>
+        </CardContent>
+      </Card>
+
+      <Card sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            本文
+          </Typography>
+          <Typography
+            variant="body2"
+            component="pre"
+            sx={{ whiteSpace: 'pre-wrap', fontFamily: 'inherit', m: 0 }}
+          >
+            {event.message}
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            コンテキスト
+          </Typography>
+          <Divider sx={{ mb: 2 }} />
+          <Box
+            component="pre"
+            sx={{
+              fontSize: 13,
+              backgroundColor: 'grey.100',
+              p: 2,
+              borderRadius: 1,
+              overflow: 'auto',
+              m: 0,
+            }}
+          >
+            {tryFormatJson(event.context)}
+          </Box>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/services/admin/web/src/app/(protected)/errors/page.tsx
+++ b/services/admin/web/src/app/(protected)/errors/page.tsx
@@ -1,0 +1,273 @@
+import {
+  Box,
+  Button,
+  Chip,
+  MenuItem,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { hasPermission } from '@nagiyu/common';
+import type { ErrorEvent, ErrorSeverity } from '@nagiyu/common';
+import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { createErrorEventReader, type ListErrorEventsQuery } from '@nagiyu/admin-core';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getSession } from '@/lib/auth/session';
+
+const ERROR_MESSAGES = {
+  ERROR_EVENTS_TABLE_NAME_REQUIRED: 'ERROR_EVENTS_TABLE_NAME が設定されていません',
+} as const;
+
+const SEVERITY_COLORS: Record<ErrorSeverity, 'info' | 'warning' | 'error'> = {
+  info: 'info',
+  warning: 'warning',
+  error: 'error',
+  critical: 'error',
+};
+
+const PERIOD_PRESETS = [
+  { label: '直近 24 時間', value: '24h', hours: 24 },
+  { label: '直近 7 日', value: '7d', hours: 24 * 7 },
+  { label: '直近 30 日', value: '30d', hours: 24 * 30 },
+  { label: '指定なし', value: 'all', hours: 0 },
+] as const;
+
+type PeriodPresetValue = (typeof PERIOD_PRESETS)[number]['value'];
+
+function isPeriodPreset(value: string): value is PeriodPresetValue {
+  return PERIOD_PRESETS.some((preset) => preset.value === value);
+}
+
+function getReader() {
+  const docClient =
+    process.env.USE_IN_MEMORY_DB === 'true' ? undefined : getDynamoDBDocumentClient();
+  const tableName = process.env.ERROR_EVENTS_TABLE_NAME;
+
+  if (!docClient) {
+    return createErrorEventReader(undefined, undefined);
+  }
+
+  if (!tableName) {
+    throw new Error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);
+  }
+
+  return createErrorEventReader(docClient, tableName);
+}
+
+function buildQueryFromSearchParams(searchParams: {
+  serviceId?: string;
+  period?: string;
+  cursor?: string;
+}): ListErrorEventsQuery {
+  const query: ListErrorEventsQuery = {};
+
+  if (searchParams.serviceId) {
+    query.serviceId = searchParams.serviceId;
+  }
+
+  const periodValue = searchParams.period ?? '24h';
+  const period = isPeriodPreset(periodValue) ? periodValue : '24h';
+  const preset = PERIOD_PRESETS.find((p) => p.value === period);
+  if (preset && preset.hours > 0) {
+    const fromMillis = Date.now() - preset.hours * 60 * 60 * 1000;
+    query.from = new Date(fromMillis).toISOString();
+  }
+
+  if (searchParams.cursor) {
+    query.cursor = searchParams.cursor;
+  }
+
+  return query;
+}
+
+function formatJst(iso: string): string {
+  const date = new Date(iso);
+  return new Intl.DateTimeFormat('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(date);
+}
+
+function truncateMessage(message: string): string {
+  const max = 80;
+  if (message.length <= max) {
+    return message;
+  }
+  return `${message.slice(0, max)}…`;
+}
+
+function buildDetailHref(event: ErrorEvent): string {
+  const params = new URLSearchParams({
+    at: event.occurredAt,
+    serviceId: event.serviceId,
+  });
+  return `/errors/${encodeURIComponent(event.eventId)}?${params.toString()}`;
+}
+
+type PageSearchParams = {
+  serviceId?: string;
+  period?: string;
+  cursor?: string;
+};
+
+export default async function ErrorsListPage({
+  searchParams,
+}: {
+  searchParams: Promise<PageSearchParams>;
+}) {
+  const session = await getSession();
+  if (!session) {
+    const authUrl = process.env.NEXT_PUBLIC_AUTH_URL || process.env.NEXTAUTH_URL || '';
+    redirect(`${authUrl}/signin`);
+  }
+
+  if (!hasPermission(session.user.roles, 'errors:read')) {
+    return (
+      <Box sx={{ p: 3, maxWidth: 800, mx: 'auto' }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          エラー履歴
+        </Typography>
+        <Typography color="error">この画面を表示する権限がありません</Typography>
+      </Box>
+    );
+  }
+
+  const params = (await searchParams) ?? {};
+  const query = buildQueryFromSearchParams(params);
+  const reader = getReader();
+  const { items, nextCursor } = await reader.list(query);
+
+  const periodValue = isPeriodPreset(params.period ?? '24h') ? (params.period ?? '24h') : '24h';
+
+  const nextHrefParams = new URLSearchParams();
+  if (params.serviceId) {
+    nextHrefParams.set('serviceId', params.serviceId);
+  }
+  nextHrefParams.set('period', periodValue);
+  if (nextCursor) {
+    nextHrefParams.set('cursor', nextCursor);
+  }
+  const nextHref = nextCursor ? `/errors?${nextHrefParams.toString()}` : null;
+
+  return (
+    <Box sx={{ p: 3, maxWidth: 1200, mx: 'auto' }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        エラー履歴
+      </Typography>
+
+      <Paper sx={{ p: 2, mb: 2 }}>
+        <form method="get" action="/errors">
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              alignItems: { xs: 'stretch', sm: 'flex-end' },
+              gap: 2,
+            }}
+          >
+            <TextField
+              name="serviceId"
+              label="サービス ID"
+              defaultValue={params.serviceId ?? ''}
+              size="small"
+              sx={{ minWidth: 200 }}
+            />
+            <TextField
+              name="period"
+              label="期間"
+              select
+              defaultValue={periodValue}
+              size="small"
+              sx={{ minWidth: 200 }}
+            >
+              {PERIOD_PRESETS.map((preset) => (
+                <MenuItem key={preset.value} value={preset.value}>
+                  {preset.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <Button type="submit" variant="contained">
+              絞り込み
+            </Button>
+          </Box>
+        </form>
+      </Paper>
+
+      {items.length === 0 ? (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Typography color="text.secondary">エラー履歴がありません</Typography>
+        </Paper>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>発生時刻 (JST)</TableCell>
+                <TableCell>サービス</TableCell>
+                <TableCell>重大度</TableCell>
+                <TableCell>タイトル / 概要</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {items.map((event) => (
+                <TableRow
+                  key={`${event.serviceId}#${event.occurredAt}#${event.eventId}`}
+                  hover
+                  component={Link}
+                  href={buildDetailHref(event)}
+                  sx={{ textDecoration: 'none', cursor: 'pointer' }}
+                >
+                  <TableCell>{formatJst(event.occurredAt)}</TableCell>
+                  <TableCell>
+                    <Chip label={event.serviceId} size="small" />
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={event.severity}
+                      size="small"
+                      color={SEVERITY_COLORS[event.severity]}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" component="div" sx={{ fontWeight: 'bold' }}>
+                      {event.title}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {truncateMessage(event.message)}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {nextHref && (
+        <Box sx={{ mt: 2, textAlign: 'center' }}>
+          <Button component={Link} href={nextHref} variant="outlined">
+            次のページ
+          </Button>
+        </Box>
+      )}
+
+      <Box sx={{ mt: 3 }}>
+        <Button component={Link} href="/dashboard" variant="text">
+          ← ダッシュボードへ戻る
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/services/admin/web/src/app/(protected)/errors/page.tsx
+++ b/services/admin/web/src/app/(protected)/errors/page.tsx
@@ -222,10 +222,7 @@ export default async function ErrorsListPage({
             </TableHead>
             <TableBody>
               {items.map((event) => (
-                <TableRow
-                  key={`${event.serviceId}#${event.occurredAt}#${event.eventId}`}
-                  hover
-                >
+                <TableRow key={`${event.serviceId}#${event.occurredAt}#${event.eventId}`} hover>
                   <TableCell>{formatJst(event.occurredAt)}</TableCell>
                   <TableCell>
                     <Chip label={event.serviceId} size="small" />

--- a/services/admin/web/src/app/(protected)/errors/page.tsx
+++ b/services/admin/web/src/app/(protected)/errors/page.tsx
@@ -17,7 +17,6 @@ import { hasPermission } from '@nagiyu/common';
 import type { ErrorEvent, ErrorSeverity } from '@nagiyu/common';
 import { getDynamoDBDocumentClient } from '@nagiyu/aws';
 import { createErrorEventReader, type ListErrorEventsQuery } from '@nagiyu/admin-core';
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth/session';
 
@@ -218,6 +217,7 @@ export default async function ErrorsListPage({
                 <TableCell>サービス</TableCell>
                 <TableCell>重大度</TableCell>
                 <TableCell>タイトル / 概要</TableCell>
+                <TableCell></TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -225,9 +225,6 @@ export default async function ErrorsListPage({
                 <TableRow
                   key={`${event.serviceId}#${event.occurredAt}#${event.eventId}`}
                   hover
-                  component={Link}
-                  href={buildDetailHref(event)}
-                  sx={{ textDecoration: 'none', cursor: 'pointer' }}
                 >
                   <TableCell>{formatJst(event.occurredAt)}</TableCell>
                   <TableCell>
@@ -248,6 +245,11 @@ export default async function ErrorsListPage({
                       {truncateMessage(event.message)}
                     </Typography>
                   </TableCell>
+                  <TableCell>
+                    <Button href={buildDetailHref(event)} size="small" variant="text">
+                      詳細
+                    </Button>
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -257,14 +259,14 @@ export default async function ErrorsListPage({
 
       {nextHref && (
         <Box sx={{ mt: 2, textAlign: 'center' }}>
-          <Button component={Link} href={nextHref} variant="outlined">
+          <Button href={nextHref} variant="outlined">
             次のページ
           </Button>
         </Box>
       )}
 
       <Box sx={{ mt: 3 }}>
-        <Button component={Link} href="/dashboard" variant="text">
+        <Button href="/dashboard" variant="text">
           ← ダッシュボードへ戻る
         </Button>
       </Box>

--- a/services/admin/web/src/app/api/errors/[eventId]/route.ts
+++ b/services/admin/web/src/app/api/errors/[eventId]/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { hasPermission } from '@nagiyu/common';
+import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { createErrorEventReader } from '@nagiyu/admin-core';
+import { createErrorResponse } from '@nagiyu/nextjs';
+import { getSession } from '@/lib/auth/session';
+
+const ERROR_MESSAGES = {
+  UNAUTHORIZED: 'ログインが必要です',
+  FORBIDDEN: 'この操作を実行する権限がありません',
+  INVALID_REQUEST: 'リクエストパラメータが不正です',
+  NOT_FOUND: '指定されたエラーは見つかりません',
+  INTERNAL_ERROR: 'エラー詳細の取得に失敗しました',
+  ERROR_EVENTS_TABLE_NAME_REQUIRED: 'ERROR_EVENTS_TABLE_NAME が設定されていません',
+} as const;
+
+function getReader() {
+  const docClient =
+    process.env.USE_IN_MEMORY_DB === 'true' ? undefined : getDynamoDBDocumentClient();
+  const tableName = process.env.ERROR_EVENTS_TABLE_NAME;
+
+  if (!docClient) {
+    return createErrorEventReader(undefined, undefined);
+  }
+
+  if (!tableName) {
+    throw new Error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);
+  }
+
+  return createErrorEventReader(docClient, tableName);
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ eventId: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await getSession();
+    if (!session?.user) {
+      return createErrorResponse(401, 'UNAUTHORIZED', ERROR_MESSAGES.UNAUTHORIZED);
+    }
+    if (!hasPermission(session.user.roles, 'errors:read')) {
+      return createErrorResponse(403, 'FORBIDDEN', ERROR_MESSAGES.FORBIDDEN);
+    }
+
+    const { eventId } = await params;
+    const { searchParams } = new URL(request.url);
+    const occurredAt = searchParams.get('at');
+    const serviceId = searchParams.get('serviceId');
+
+    if (!eventId || !occurredAt || !serviceId) {
+      return createErrorResponse(400, 'INVALID_REQUEST', ERROR_MESSAGES.INVALID_REQUEST);
+    }
+
+    const reader = getReader();
+    const event = await reader.findById(eventId, occurredAt, serviceId);
+
+    if (!event) {
+      return createErrorResponse(404, 'NOT_FOUND', ERROR_MESSAGES.NOT_FOUND);
+    }
+
+    return NextResponse.json(event, { status: 200 });
+  } catch (error) {
+    console.error('エラー詳細取得 API の実行に失敗しました', { error });
+    return createErrorResponse(500, 'INTERNAL_ERROR', ERROR_MESSAGES.INTERNAL_ERROR);
+  }
+}

--- a/services/admin/web/src/app/api/errors/route.ts
+++ b/services/admin/web/src/app/api/errors/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+import { hasPermission } from '@nagiyu/common';
+import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { createErrorEventReader, type ListErrorEventsQuery } from '@nagiyu/admin-core';
+import { createErrorResponse } from '@nagiyu/nextjs';
+import { getSession } from '@/lib/auth/session';
+
+const ERROR_MESSAGES = {
+  UNAUTHORIZED: 'ログインが必要です',
+  FORBIDDEN: 'この操作を実行する権限がありません',
+  INVALID_REQUEST: 'リクエストパラメータが不正です',
+  INTERNAL_ERROR: 'エラー履歴の取得に失敗しました',
+  ERROR_EVENTS_TABLE_NAME_REQUIRED: 'ERROR_EVENTS_TABLE_NAME が設定されていません',
+} as const;
+
+function getReader() {
+  const docClient =
+    process.env.USE_IN_MEMORY_DB === 'true' ? undefined : getDynamoDBDocumentClient();
+  const tableName = process.env.ERROR_EVENTS_TABLE_NAME;
+
+  if (!docClient) {
+    return createErrorEventReader(undefined, undefined);
+  }
+
+  if (!tableName) {
+    throw new Error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);
+  }
+
+  return createErrorEventReader(docClient, tableName);
+}
+
+function parseLimit(value: string | null): number | undefined {
+  if (value === null) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isValidIsoString(value: string): boolean {
+  return !Number.isNaN(Date.parse(value));
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  try {
+    const session = await getSession();
+    if (!session?.user) {
+      return createErrorResponse(401, 'UNAUTHORIZED', ERROR_MESSAGES.UNAUTHORIZED);
+    }
+    if (!hasPermission(session.user.roles, 'errors:read')) {
+      return createErrorResponse(403, 'FORBIDDEN', ERROR_MESSAGES.FORBIDDEN);
+    }
+
+    const { searchParams } = new URL(request.url);
+    const query: ListErrorEventsQuery = {};
+
+    const serviceId = searchParams.get('serviceId');
+    if (serviceId) {
+      query.serviceId = serviceId;
+    }
+
+    const from = searchParams.get('from');
+    if (from !== null) {
+      if (!isValidIsoString(from)) {
+        return createErrorResponse(400, 'INVALID_REQUEST', ERROR_MESSAGES.INVALID_REQUEST);
+      }
+      query.from = from;
+    }
+
+    const to = searchParams.get('to');
+    if (to !== null) {
+      if (!isValidIsoString(to)) {
+        return createErrorResponse(400, 'INVALID_REQUEST', ERROR_MESSAGES.INVALID_REQUEST);
+      }
+      query.to = to;
+    }
+
+    const limit = parseLimit(searchParams.get('limit'));
+    if (limit !== undefined) {
+      query.limit = limit;
+    }
+
+    const cursor = searchParams.get('cursor');
+    if (cursor) {
+      query.cursor = cursor;
+    }
+
+    const reader = getReader();
+    const result = await reader.list(query);
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('cursor')) {
+      return createErrorResponse(400, 'INVALID_REQUEST', ERROR_MESSAGES.INVALID_REQUEST);
+    }
+    if (error instanceof Error && error.message.includes('from は to')) {
+      return createErrorResponse(400, 'INVALID_REQUEST', ERROR_MESSAGES.INVALID_REQUEST);
+    }
+
+    console.error('エラー一覧取得 API の実行に失敗しました', { error });
+    return createErrorResponse(500, 'INTERNAL_ERROR', ERROR_MESSAGES.INTERNAL_ERROR);
+  }
+}


### PR DESCRIPTION
## 変更の概要

#2940 の **PR-impl-2（インフラ + Lambda + UI）** を実装する。

エラー通知の永続化と Admin での閲覧を実現する本流経路を一通り構築する。
PR-impl-1 で追加した `libs/aws/error-events` SDK を使い、SNS → Lambda → DynamoDB → Streams → Web Push の流れを実装する。

## 関連 Issue

本 PR ではクローズしない（integration → develop の PR で `Closes #2940` を付ける）。

- #2940

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（admin-batch, admin-core errors, infra-shared に新規テスト 67 件追加。
  新規ファイルはおおむね 100% カバレッジ）
- [x] 関連ドキュメント（`tasks/persist-error-notifications/design.md`）と整合
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（admin Web `next build` / 全 lib `tsc` / CDK `synth` すべて成功）

## 追加内容

### 読み取り経路（commit `b31d38f`）

- `libs/common/auth`: Permission union と admin ロールに `errors:read` を追加
- `services/admin/core/src/errors/`: `ErrorEventReader` を新設
  - DynamoDB / in-memory 両実装、Repository Factory パターン
  - GSI1 (`AllByOccurredAt`) を使った全サービス横断クエリ、`serviceId` 指定時はメインテーブル直引き
  - cursor は `LastEvaluatedKey` を base64url 符号化、`limit` は 1〜100 でクランプ
- `services/admin/web/src/app/api/errors/`:
  - `GET /api/errors`（一覧、フィルタ・ページング対応）
  - `GET /api/errors/{eventId}?at={occurredAt}&serviceId={serviceId}`（詳細）
- `services/admin/web/src/app/(protected)/errors/`:
  - `/errors` 一覧ページ（SSR、サービス・期間フィルタ、cursor ページング）
  - `/errors/{eventId}` 詳細ページ（メタ情報・本文・コンテキスト整形表示）
- ダッシュボードに「エラー履歴」カードと導線を追加

### 書き込み経路 / インフラ（commit `07dbaa0`）

- `infra/shared/lib/error-events-table-stack.ts`: 専用 DynamoDB テーブル
  - `nagiyu-error-events-{env}`、PK/SK + GSI1 `AllByOccurredAt`
  - TTL 180 日、PITR 有効、Streams `NEW_IMAGE`、prod は `RemovalPolicy.RETAIN`
- `services/admin/batch/`（新規ディレクトリ）:
  - `alarm-ingest`: SNS → ErrorEvent → DynamoDB（`libs/aws/error-events` SDK 経由）
    - ALARM 遷移のみ取り込み、OK / SubscriptionConfirmation はスキップ
    - AlarmName から `service-id` を推定（最初の 2 セグメント）
  - `stream-handler`: DynamoDB Streams INSERT → 既存 `WebPushSender.sendAll`
    - `data.url=/errors/{eventId}?at={occurredAt}&serviceId={serviceId}` を生成
- `infra/admin`:
  - `BatchEcrStack`（新規）: alarm-ingest / stream-handler 用 ECR
  - `BatchLambdaStack`（新規）: 2 Lambda + SNS subscription + DynamoEventSource + DLQ
    - 最小権限 IAM（alarm-ingest=PutItem のみ、stream-handler=Streams 読取り + admin 購読テーブル Query/Delete）
  - `LambdaStack`: Web Lambda に `ERROR_EVENTS_TABLE_NAME` と error-events 読取り IAM を追加

## テスト内容

実行結果（合計 486 tests pass）:

| Workspace | Tests | 備考 |
| --- | --- | --- |
| `@nagiyu/common` | 231 | 既存維持 |
| `@nagiyu/aws` | 139 | 既存維持 |
| `@nagiyu/admin-core` | 45 | errors テストを 30 件追加 |
| `@nagiyu/admin` (Web) | 17 | 既存維持 |
| `@nagiyu/admin-batch`（新規） | 28 | alarm-ingest / stream-handler |
| `@nagiyu/infra-shared` | 26 | error-events-table を 9 件追加 |

検証コマンド:
```bash
npm run lint --workspace @nagiyu/common
npm run lint --workspace @nagiyu/aws
npm run lint --workspace @nagiyu/admin-core
npm run lint --workspace @nagiyu/admin
npm run lint --workspace @nagiyu/admin-batch
npm test --workspaces --if-present
npm run build --workspace @nagiyu/admin              # Next.js production build OK
DOMAIN_NAME=test.example.com npx cdk synth          # infra/shared synth OK
DOMAIN_NAME=test.example.com APP_VERSION=0.1.0 npx cdk synth  # infra/admin synth OK
```

## レビューポイント

- **`infra/shared/lib/error-events-table-stack.ts`**: 共有プラットフォーム資産としてのテーブル分離方針。CfnOutput Export を Stream ARN まで提供し、admin の Lambda Stack から `Fn.importValue` で参照する設計
- **`services/admin/batch/src/alarm-ingest.ts`**:
  - `inferServiceIdFromAlarmName` のヒューリスティック（先頭 2 セグメント）が将来サービス追加時に妥当か
  - `inferSeverityFromAlarm` は Phase 1 では一律 `error`。AlarmDescription による拡張ポイントとしてコメント済み
- **`services/admin/batch/src/stream-handler.ts`**: at-least-once の二重 Push 対策は意図的に実装していない（`tasks/persist-error-notifications/design.md` 議論済み）
- **`infra/admin/lib/batch-lambda-stack.ts`**:
  - SNS subscription を新 Lambda に追加するが、**既存 `/api/notify/sns` HTTPS subscription は本 PR では変更しない**。同一 SNS Topic に 2 系統が並走するため、デプロイ後しばらくは Push が二重通知される可能性あり
  - 自己監視向けの SNS Topic 分離は **PR-impl-3** で実施
- **`services/admin/web/src/app/(protected)/errors/[eventId]/page.tsx`** など UI: MUI v9 の Stack コンポーネントが `alignItems` を直接プロパティに取れない型挙動のため、Box + sx の form factor で実装

## スクリーンショット（該当する場合）

UI スクリーンショットは dev デプロイ後に補足予定（実機での Push タップ動作確認も Phase 7 で実施）。

## 補足事項

- **デプロイ順序**: 本 PR を dev 環境にデプロイする際は以下の順で行う必要がある：
  1. `infra-shared`（`NagiyuErrorEventsTableDev` 新設、Output Export を作成）
  2. ECR push（admin batch 用イメージ）
  3. `infra-admin`（`NagiyuAdminBatchECRDev` / `NagiyuAdminBatchLambdaDev` / 既存 `LambdaStack` 更新）
- **本 PR にはランタイム挙動を完成させるための CDK 変更が含まれる**ため、デプロイすると admin の Web Lambda 環境変数が更新される（`ERROR_EVENTS_TABLE_NAME` 追加 + IAM ポリシー拡張）
- **PR-impl-3** で SNS Topic 分離 / 自己監視アラーム / docs/ への永続化を実施する
- Draft で進める。Ready 化は人力で実施


---
_Generated by [Claude Code](https://claude.ai/code/session_016hjRjYUmbWuNfXgqNxA78s)_