### PR TITLE
feat(ui): Chip コンポーネント追加（PR 1-4-A）

### DIFF
--- a/libs/ui/src/components/Chip/Chip.module.css
+++ b/libs/ui/src/components/Chip/Chip.module.css
@@ -1,0 +1,144 @@
+/*
+ * Chip コンポーネントのスタイル定義。
+ *
+ * - すべての色・余白・角丸は tokens.css の Semantic 変数を参照する。
+ * - MUI 等の特定ライブラリへの依存は持たない。
+ * - 状態は `:hover` / `:focus-visible` で表現（onClick あり時のみ反応）。
+ */
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+
+  /* Typography */
+  font-family: var(--font-family-sans);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-tight);
+  white-space: nowrap;
+
+  /* Box */
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  user-select: none;
+
+  /* Reset for <button> */
+  background: none;
+  cursor: default;
+  text-decoration: none;
+  appearance: none;
+
+  transition:
+    background-color var(--duration-fast) var(--easing-out),
+    border-color var(--duration-fast) var(--easing-out),
+    color var(--duration-fast) var(--easing-out);
+}
+
+/* clickable / asChild の場合のみ、hover/active/focus に反応 */
+.interactive {
+  cursor: pointer;
+}
+
+.interactive:focus-visible {
+  outline: 2px solid var(--color-action-primary);
+  outline-offset: 2px;
+}
+
+/* =========================================================================
+ * Size
+ * ========================================================================= */
+
+.size-sm {
+  padding: 2px var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  min-height: 20px;
+}
+
+.size-md {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  min-height: 24px;
+}
+
+.size-lg {
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-md);
+  min-height: 32px;
+}
+
+/* =========================================================================
+ * Variant × Color
+ * Button と同じく `--chip-*` カスタムプロパティで色を解決する。
+ * ========================================================================= */
+
+.color-primary {
+  --chip-bg: var(--color-action-primary);
+  --chip-bg-hover: var(--color-action-primary-hover);
+  --chip-fg: var(--color-action-primary-fg);
+  --chip-border: var(--color-action-primary);
+}
+
+.color-secondary {
+  --chip-bg: var(--color-action-secondary);
+  --chip-bg-hover: var(--color-action-secondary-hover);
+  --chip-fg: var(--color-action-secondary-fg);
+  --chip-border: var(--color-action-secondary);
+}
+
+.color-danger {
+  --chip-bg: var(--color-action-danger);
+  --chip-bg-hover: var(--color-action-danger-hover);
+  --chip-fg: var(--color-action-danger-fg);
+  --chip-border: var(--color-action-danger);
+}
+
+.color-success {
+  --chip-bg: var(--color-action-success);
+  --chip-bg-hover: var(--color-action-success-hover);
+  --chip-fg: var(--color-action-success-fg);
+  --chip-border: var(--color-action-success);
+}
+
+.color-warning {
+  --chip-bg: var(--color-action-warning);
+  --chip-bg-hover: var(--color-action-warning-hover);
+  --chip-fg: var(--color-action-warning-fg);
+  --chip-border: var(--color-action-warning);
+}
+
+.color-neutral {
+  --chip-bg: var(--color-action-neutral);
+  --chip-bg-hover: var(--color-action-neutral-hover);
+  --chip-fg: var(--color-action-neutral-fg);
+  --chip-border: var(--color-border-default);
+}
+
+/* solid: 塗りつぶし（既定） */
+.variant-solid {
+  background-color: var(--chip-bg);
+  color: var(--chip-fg);
+  border-color: var(--chip-border);
+}
+
+.variant-solid.interactive:hover {
+  background-color: var(--chip-bg-hover);
+  border-color: var(--chip-bg-hover);
+}
+
+/* outline: 枠線のみ */
+.variant-outline {
+  background-color: transparent;
+  color: var(--chip-bg);
+  border-color: var(--chip-border);
+}
+
+.variant-outline.interactive:hover {
+  background-color: var(--chip-bg);
+  color: var(--chip-fg);
+}
+
+/* neutral + outline は文字色を fg-default に倒す（バッジとして読みやすく） */
+.variant-outline.color-neutral {
+  color: var(--color-fg-default);
+}

--- a/libs/ui/src/components/Chip/Chip.stories.tsx
+++ b/libs/ui/src/components/Chip/Chip.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import Chip from './Chip';
+
+/**
+ * `Chip` は @nagiyu/ui のタグ・ステータス表示部品。
+ *
+ * - `variant`（solid / outline）× `color`（6 種）× `size`（sm/md/lg）の直交した API
+ * - `onClick` を渡すと `<button>` として描画され、キーボード操作にも対応
+ * - `asChild` で `<Link>` / `<a>` 等への変身に対応（Radix Slot パターン）
+ *
+ * MUI への依存は内部で完全に隠蔽されている。
+ */
+const meta: Meta<typeof Chip> = {
+  title: 'Atoms/Chip',
+  component: Chip,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'inline-radio',
+      options: ['solid', 'outline'],
+    },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'],
+    },
+    size: {
+      control: 'inline-radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    children: { control: 'text' },
+  },
+  args: {
+    variant: 'solid',
+    color: 'neutral',
+    size: 'md',
+    children: 'タグ',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Chip>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  argTypes: { variant: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', gap: 8 }}>
+      <Chip {...args} variant="solid">
+        solid
+      </Chip>
+      <Chip {...args} variant="outline">
+        outline
+      </Chip>
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  argTypes: { color: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+      {(['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'] as const).map(
+        (color) => (
+          <Chip {...args} key={color} color={color}>
+            {color}
+          </Chip>
+        )
+      )}
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  argTypes: { size: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <Chip {...args} size="sm">
+        sm
+      </Chip>
+      <Chip {...args} size="md">
+        md
+      </Chip>
+      <Chip {...args} size="lg">
+        lg
+      </Chip>
+    </div>
+  ),
+};
+
+export const Clickable: Story = {
+  args: { children: 'クリックできる', color: 'primary' },
+  render: (args) => <Chip {...args} onClick={() => alert('clicked')} />,
+};
+
+export const AsChildLink: Story = {
+  args: { variant: 'outline', color: 'primary' },
+  render: (args) => (
+    <Chip {...args} asChild>
+      <a href="https://example.com" target="_blank" rel="noreferrer">
+        リンクとしての Chip
+      </a>
+    </Chip>
+  ),
+};
+
+/**
+ * variant × color のマトリクス（視覚回帰テスト・カタログ用途）。
+ */
+export const Matrix: Story = {
+  argTypes: { variant: { control: false }, color: { control: false } },
+  render: () => (
+    <div style={{ display: 'grid', gap: 8 }}>
+      {(['solid', 'outline'] as const).map((variant) => (
+        <div key={variant} style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {(['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'] as const).map(
+            (color) => (
+              <Chip key={color} variant={variant} color={color}>
+                {variant}/{color}
+              </Chip>
+            )
+          )}
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/libs/ui/src/components/Chip/Chip.tsx
+++ b/libs/ui/src/components/Chip/Chip.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+
+import styles from './Chip.module.css';
+
+/**
+ * Chip のバリアント。
+ *
+ * - `solid`: 塗りつぶし（既定。タグ・ステータス表示）
+ * - `outline`: 枠線のみ（弱めの強調）
+ */
+export type ChipVariant = 'solid' | 'outline';
+
+/**
+ * Chip の色（意味）。Button と同じセマンティック軸。
+ */
+export type ChipColor = 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'neutral';
+
+/**
+ * Chip のサイズ。
+ */
+export type ChipSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Chip のプロパティ。
+ *
+ * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
+ * エスケープハッチは `className` のみ。
+ */
+export interface ChipProps extends Omit<React.HTMLAttributes<HTMLElement>, 'color'> {
+  /**
+   * バリアント。既定: `solid`
+   */
+  variant?: ChipVariant;
+  /**
+   * 色（意味）。既定: `neutral`
+   */
+  color?: ChipColor;
+  /**
+   * サイズ。既定: `md`
+   */
+  size?: ChipSize;
+  /**
+   * `true` の場合、Radix Slot により子要素に Props をマージする。
+   * 子要素は単一の React 要素である必要がある（`<a>` / `<Link>` 等）。
+   *
+   * `onClick` ではなく `<a href>` でナビゲーションしたい場合や、Next.js の
+   * `<Link>` を Chip 風に表示したい場合に使う。
+   */
+  asChild?: boolean;
+  /**
+   * 子要素（ラベル文字列、または `asChild` 時は単一要素）。
+   */
+  children: React.ReactNode;
+}
+
+/**
+ * タグ・ステータス表示用の小型部品。
+ *
+ * - `variant` × `color` × `size` の直交した API
+ * - `onClick` を渡すと `<button>` として描画され、キーボード操作にも対応
+ * - `asChild` で `<Link>` / `<a>` 等への変身に対応（Radix Slot パターン）
+ *
+ * @see docs/development/shared-ui-components.md
+ */
+const Chip = React.forwardRef<HTMLElement, ChipProps>(function Chip(
+  {
+    variant = 'solid',
+    color = 'neutral',
+    size = 'md',
+    asChild = false,
+    onClick,
+    className,
+    children,
+    ...rest
+  },
+  ref
+) {
+  // 描画される要素を決定する:
+  // - asChild: Radix Slot で子要素に props をマージ
+  // - onClick あり: <button type="button">（キーボード操作・a11y 自動対応）
+  // - その他: <span>（静的なタグ表示）
+  const Comp: React.ElementType = asChild ? Slot : onClick ? 'button' : 'span';
+
+  const classes = [
+    styles.chip,
+    styles[`variant-${variant}`],
+    styles[`color-${color}`],
+    styles[`size-${size}`],
+    onClick || asChild ? styles.interactive : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  // <button> で描画する場合は type="button" を付けてフォーム送信を防ぐ。
+  const buttonOnlyProps = !asChild && onClick ? { type: 'button' as const } : {};
+
+  // Comp は span / button / Slot のいずれかになり、ref の型推論が要素ごとに揺れる。
+  // 実態としては HTMLElement のサブタイプを指すため、`as never` でアサーションを通す。
+  return (
+    <Comp ref={ref as never} className={classes} onClick={onClick} {...buttonOnlyProps} {...rest}>
+      {children}
+    </Comp>
+  );
+});
+
+export default Chip;

--- a/libs/ui/src/components/Chip/index.ts
+++ b/libs/ui/src/components/Chip/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Chip';
+export type { ChipProps, ChipVariant, ChipColor, ChipSize } from './Chip';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -8,6 +8,8 @@ export { default as TextField } from './components/TextField';
 export type { TextFieldProps, TextFieldSize, TextFieldType } from './components/TextField';
 export { default as Checkbox } from './components/Checkbox';
 export type { CheckboxProps, CheckboxSize } from './components/Checkbox';
+export { default as Chip } from './components/Chip';
+export type { ChipProps, ChipVariant, ChipColor, ChipSize } from './components/Chip';
 export { default as Header } from './components/layout/Header';
 export type { HeaderProps, NavigationItem } from './components/layout/Header';
 export { default as Footer } from './components/layout/Footer';

--- a/libs/ui/tests/unit/components/Chip/Chip.test.tsx
+++ b/libs/ui/tests/unit/components/Chip/Chip.test.tsx
@@ -1,0 +1,175 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import Chip from '../../../../src/components/Chip/Chip';
+
+describe('Chip', () => {
+  describe('rendering', () => {
+    it('children を表示する', () => {
+      render(<Chip>タグ</Chip>);
+      expect(screen.getByText('タグ')).toBeInTheDocument();
+    });
+
+    it('既定では <span> として描画される（onClick 無し / asChild 無し）', () => {
+      const { container } = render(<Chip>x</Chip>);
+      expect((container.firstChild as HTMLElement).tagName).toBe('SPAN');
+    });
+
+    it('既定値（solid / neutral / md）が適用される', () => {
+      const { container } = render(<Chip>x</Chip>);
+      const node = container.firstChild as HTMLElement;
+      expect(node.className).toContain('variant-solid');
+      expect(node.className).toContain('color-neutral');
+      expect(node.className).toContain('size-md');
+    });
+
+    it('variant / color / size の組み合わせをクラスに反映する', () => {
+      const { container } = render(
+        <Chip variant="outline" color="success" size="sm">
+          x
+        </Chip>
+      );
+      const node = container.firstChild as HTMLElement;
+      expect(node.className).toContain('variant-outline');
+      expect(node.className).toContain('color-success');
+      expect(node.className).toContain('size-sm');
+    });
+
+    it('className を受け付け、内部クラスとマージされる', () => {
+      const { container } = render(<Chip className="custom">x</Chip>);
+      const node = container.firstChild as HTMLElement;
+      expect(node.className).toContain('custom');
+      expect(node.className).toContain('chip');
+    });
+  });
+
+  describe('clickable (button mode)', () => {
+    it('onClick を渡すと <button type="button"> として描画される', () => {
+      render(<Chip onClick={() => {}}>x</Chip>);
+      const btn = screen.getByRole('button');
+      expect(btn.tagName).toBe('BUTTON');
+      expect(btn).toHaveAttribute('type', 'button');
+    });
+
+    it('クリックで onClick が発火する', async () => {
+      const onClick = jest.fn();
+      const user = userEvent.setup();
+      render(<Chip onClick={onClick}>x</Chip>);
+      await user.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('Space / Enter キーでも onClick が発火する', async () => {
+      const onClick = jest.fn();
+      const user = userEvent.setup();
+      render(<Chip onClick={onClick}>x</Chip>);
+      const btn = screen.getByRole('button');
+      btn.focus();
+      await user.keyboard(' ');
+      await user.keyboard('{Enter}');
+      expect(onClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('clickable な場合は interactive クラスが付与される', () => {
+      const { container } = render(<Chip onClick={() => {}}>x</Chip>);
+      expect((container.firstChild as HTMLElement).className).toContain('interactive');
+    });
+  });
+
+  describe('asChild', () => {
+    it('asChild=true で子要素のタグをそのまま使い、props をマージする', () => {
+      render(
+        <Chip asChild color="primary" variant="outline">
+          <a href="/tags/foo">タグ foo</a>
+        </Chip>
+      );
+      const link = screen.getByRole('link', { name: 'タグ foo' });
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', '/tags/foo');
+      expect(link.className).toContain('chip');
+      expect(link.className).toContain('color-primary');
+      expect(link.className).toContain('variant-outline');
+    });
+
+    it('asChild の場合は interactive クラスが付与される', () => {
+      const { container } = render(
+        <Chip asChild>
+          <a href="/x">x</a>
+        </Chip>
+      );
+      expect((container.firstChild as HTMLElement).className).toContain('interactive');
+    });
+
+    it('asChild + button: 子の <button> 要素にスタイルを適用できる', () => {
+      const onClick = jest.fn();
+      render(
+        <Chip asChild>
+          <button onClick={onClick}>クリックタグ</button>
+        </Chip>
+      );
+      const btn = screen.getByRole('button', { name: 'クリックタグ' });
+      expect(btn.tagName).toBe('BUTTON');
+      expect(btn.className).toContain('chip');
+    });
+  });
+
+  describe('html attributes', () => {
+    it('aria-label などの追加属性が反映される', () => {
+      render(<Chip aria-label="ステータス: 成功">成功</Chip>);
+      expect(screen.getByLabelText('ステータス: 成功')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('既定状態で a11y 違反がない', async () => {
+      const { container } = render(<Chip>タグ</Chip>);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('全 variant / color / size の組み合わせで a11y 違反がない', async () => {
+      const variants = ['solid', 'outline'] as const;
+      const colors = ['primary', 'secondary', 'danger', 'success', 'warning', 'neutral'] as const;
+      const sizes = ['sm', 'md', 'lg'] as const;
+
+      const { container } = render(
+        <div>
+          {variants.flatMap((variant) =>
+            colors.flatMap((color) =>
+              sizes.map((size) => (
+                <Chip
+                  key={`${variant}-${color}-${size}`}
+                  variant={variant}
+                  color={color}
+                  size={size}
+                >
+                  {variant}-{color}-{size}
+                </Chip>
+              ))
+            )
+          )}
+        </div>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('clickable 状態で a11y 違反がない', async () => {
+      const { container } = render(<Chip onClick={() => {}}>クリック</Chip>);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('asChild + a タグで a11y 違反がない', async () => {
+      const { container } = render(
+        <Chip asChild>
+          <a href="/x">リンク</a>
+        </Chip>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -79,7 +79,7 @@
 
 ### Chip
 
-- [ ] PR 1-4-A: 実装 + Stories + テスト
+- [x] PR 1-4-A: 実装 + Stories + テスト（variant: solid/outline、color: 6 種、size: sm/md/lg、`onClick` で button 化、`asChild` で `<a>`/`<Link>` への変身。children ベース API。Chip.tsx は statements/lines/functions/branches すべて 100%）
 - [ ] PR 1-4-B: 置換
 - [ ] PR 1-4-C: ESLint 禁止追加
 


### PR DESCRIPTION
## 変更の概要

`@nagiyu/ui` に **`Chip` コンポーネント**を追加する（PR 1-4-A）。

- `variant` × `color` × `size` の直交した API
- `onClick` を渡すと `<button type="button">` として描画され、キーボード操作 (Enter/Space) に自動対応
- **`asChild`** で `<Link>` / `<a>` 等への変身に対応（Radix Slot パターン、Button と同じ）
- **children ベース API**（MUI の `label` Prop は不採用、Button と一貫）

## API

```ts
export type ChipVariant = 'solid' | 'outline';
export type ChipColor = 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'neutral';
export type ChipSize = 'sm' | 'md' | 'lg';

export interface ChipProps extends Omit<React.HTMLAttributes<HTMLElement>, 'color'> {
  variant?: ChipVariant;     // 既定 'solid'
  color?: ChipColor;          // 既定 'neutral'（MUI の default 相当）
  size?: ChipSize;            // 既定 'md'
  asChild?: boolean;          // Radix Slot パターン
  children: React.ReactNode;  // ラベル文字列（または asChild 時は単一要素）
}
```

## 描画モード

| 条件 | 描画される要素 | 用途 |
|---|---|---|
| 既定 | `<span>` | 静的なタグ・ステータス表示 |
| `onClick` あり | `<button type="button">` | クリック反応するタグ（フィルタ等） |
| `asChild` | 子要素のタグそのまま | `<Link>` / `<a>` への変身（タグ → カテゴリ別ページへの遷移など） |

## 採用しなかった機能と理由

| 機能 | 判断 | 理由 |
|---|---|---|
| `clickable` Prop | 不採用、`onClick` の有無で自動判定 | MUI のように両方指定する必要なし |
| `onDelete` (× アイコン) | 不採用 | サービスの実利用 0 件 |
| `icon` / `avatar` | 不採用 | サービスの実利用 0 件 |
| `label` Prop | 不採用、`children` で代替 | Button と一貫、React 的に自然、`asChild` と整合 |

## ファイル構成

```
libs/ui/src/components/Chip/
├── Chip.tsx
├── Chip.module.css
├── Chip.stories.tsx
└── index.ts

libs/ui/tests/unit/components/Chip/
└── Chip.test.tsx
```

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（**17 件 pass / Chip.tsx は statements/lines/functions/branches すべて 100%**）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した（ライブラリ全体: 237 件 pass）
- [x] ビルドエラーがないことを確認した（`tsc` + `copy-assets` + `build-storybook` 成功）

## テスト内容

`Chip.test.tsx` で 17 件のテスト:

- **rendering**: children 表示、`<span>` 既定、既定値（solid/neutral/md）、variant/color/size のクラス反映、className マージ
- **clickable (button mode)**: `onClick` で `<button type="button">`、クリック発火、Space/Enter キー、interactive クラス
- **asChild**: 子の `<a>` への props マージ、interactive クラス、子の `<button>` パターン
- **html attributes**: `aria-label` 追加属性反映
- **a11y（jest-axe）**: 既定 / 全 variant×color×size マトリクス（36 ケース） / clickable / asChild

## レビューポイント

- **`asChild` の採用判断**: portal の Tag → タグ別ページ遷移ユースケース（`<Chip component="a" href={...} />`）への対応として採用。Button と同じ API パターンで覚えやすい。今後 ライブラリ独立性を保ったまま `<Link>` 等にも変身可能。
- **`onClick` で自動 `<button>` 化**: MUI のように `clickable` Prop を別途指定する必要なし。キーボード操作 (Enter/Space) と a11y も自動対応。
- **children ベース API への切り替え**: 既存サービスの 33 箇所は `<Chip label="X" />` → `<Chip>X</Chip>` への機械的な変換が必要（PR 1-4-B で実施）。
- **`as never` のキャスト**: forwardRef の ref 型推論が span/button/Slot の union で揺れるため、実装末尾でアサーション。詳細はコード内コメント参照。

## スクリーンショット

dev 環境の Storybook で視覚確認予定。

## 補足事項

PR 1-4-B（サービス側 20 ファイルの置換）と PR 1-4-C（ESLint 禁止）は本 PR マージ後に別 PR で対応する。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_