### PR TITLE
refactor(services): MUI Chip → @nagiyu/ui Chip 置換（PR 1-4-B）

### DIFF
--- a/services/admin/web/src/app/(protected)/dashboard/page.tsx
+++ b/services/admin/web/src/app/(protected)/dashboard/page.tsx
@@ -35,7 +35,7 @@ export default async function DashboardPage() {
           </Typography>
           <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
             {user.roles.map((role) => (
-              <Chip key={role} size="sm">
+              <Chip key={role} size="sm" data-testid="user-role">
                 {role}
               </Chip>
             ))}

--- a/services/admin/web/src/app/(protected)/dashboard/page.tsx
+++ b/services/admin/web/src/app/(protected)/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import { Box, Card, CardContent, Typography, Chip } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import { Button, Chip } from '@nagiyu/ui';
 import { hasPermission } from '@nagiyu/common';
 import { getSession } from '@/lib/auth/session';
 import { redirect } from 'next/navigation';
@@ -33,9 +33,11 @@ export default async function DashboardPage() {
           <Typography variant="body1" sx={{ mt: 1 }}>
             <strong>ロール:</strong>
           </Typography>
-          <Box sx={{ mt: 1 }}>
+          <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
             {user.roles.map((role) => (
-              <Chip key={role} label={role} size="small" sx={{ mr: 1 }} />
+              <Chip key={role} size="sm">
+                {role}
+              </Chip>
             ))}
           </Box>
         </CardContent>

--- a/services/admin/web/tests/e2e/dashboard-display.spec.ts
+++ b/services/admin/web/tests/e2e/dashboard-display.spec.ts
@@ -35,7 +35,7 @@ test.describe('Dashboard Display', () => {
       // user-role の testid が付いた Chip 要素内のロールを確認
       // （ヘッダーの "Admin" と区別するため、UI ライブラリのクラス名ではなく testid で特定する）
       await expect(
-        page.getByTestId('user-role').filter({ hasText: new RegExp(`^${role}$`) })
+        page.locator(`[data-testid="user-role"]`, { hasText: role })
       ).toBeVisible();
     }
 

--- a/services/admin/web/tests/e2e/dashboard-display.spec.ts
+++ b/services/admin/web/tests/e2e/dashboard-display.spec.ts
@@ -34,9 +34,7 @@ test.describe('Dashboard Display', () => {
     for (const role of testUserRoles) {
       // user-role の testid が付いた Chip 要素内のロールを確認
       // （ヘッダーの "Admin" と区別するため、UI ライブラリのクラス名ではなく testid で特定する）
-      await expect(
-        page.locator(`[data-testid="user-role"]`, { hasText: role })
-      ).toBeVisible();
+      await expect(page.locator(`[data-testid="user-role"]`, { hasText: role })).toBeVisible();
     }
 
     // 認証ステータスが表示されることを確認

--- a/services/admin/web/tests/e2e/dashboard-display.spec.ts
+++ b/services/admin/web/tests/e2e/dashboard-display.spec.ts
@@ -32,8 +32,11 @@ test.describe('Dashboard Display', () => {
     // ロールが表示されることを確認
     await expect(page.getByText('ロール:')).toBeVisible();
     for (const role of testUserRoles) {
-      // MuiChip 要素内のロールを確認（ヘッダーの "Admin" と区別するため）
-      await expect(page.locator('.MuiChip-label').getByText(role, { exact: true })).toBeVisible();
+      // user-role の testid が付いた Chip 要素内のロールを確認
+      // （ヘッダーの "Admin" と区別するため、UI ライブラリのクラス名ではなく testid で特定する）
+      await expect(
+        page.getByTestId('user-role').filter({ hasText: new RegExp(`^${role}$`) })
+      ).toBeVisible();
     }
 
     // 認証ステータスが表示されることを確認

--- a/services/admin/web/tests/e2e/dashboard.spec.ts
+++ b/services/admin/web/tests/e2e/dashboard.spec.ts
@@ -27,7 +27,7 @@ test.describe('Dashboard', () => {
     await expect(page.getByText('ロール:')).toBeVisible();
 
     // Check role chips are displayed (at least one chip should be visible)
-    const roleChips = page.locator('[class*="MuiChip"]');
+    const roleChips = page.locator('[data-testid="user-role"]');
     await expect(roleChips.first()).toBeVisible();
   });
 

--- a/services/auth/web/src/app/dashboard/page.tsx
+++ b/services/auth/web/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import { hasPermission } from '@nagiyu/common';
-import { Box, Container, Paper, Typography, Card, CardContent, Chip } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Box, Container, Paper, Typography, Card, CardContent } from '@mui/material';
+import { Button, Chip } from '@nagiyu/ui';
 import Link from 'next/link';
 import { getSession } from '@/lib/auth/session';
 
@@ -34,16 +34,18 @@ export default async function DashboardPage() {
               <Typography variant="body1" sx={{ mt: 1 }}>
                 <strong>ユーザーID:</strong> {session.user.id}
               </Typography>
-              <Box sx={{ mt: 2 }}>
-                <Typography variant="body1" component="span" sx={{ mr: 1 }}>
+              <Box sx={{ mt: 2, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1 }}>
+                <Typography variant="body1" component="span">
                   <strong>ロール:</strong>
                 </Typography>
                 {session.user.roles.length > 0 ? (
                   session.user.roles.map((role: string) => (
-                    <Chip key={role} label={role} size="small" sx={{ mr: 1 }} />
+                    <Chip key={role} size="sm">
+                      {role}
+                    </Chip>
                   ))
                 ) : (
-                  <Chip label="なし" size="small" color="default" />
+                  <Chip size="sm">なし</Chip>
                 )}
               </Box>
             </Box>

--- a/services/auth/web/src/app/dashboard/users/users-table.tsx
+++ b/services/auth/web/src/app/dashboard/users/users-table.tsx
@@ -8,12 +8,11 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Chip,
   Alert,
   CircularProgress,
   Box,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Chip } from '@nagiyu/ui';
 import Link from 'next/link';
 import type { User } from '@nagiyu/common';
 
@@ -78,13 +77,17 @@ export function UsersTable({ canAssignRoles }: UsersTableProps) {
               <TableCell>{user.name}</TableCell>
               <TableCell>{user.email}</TableCell>
               <TableCell>
-                {user.roles.length > 0 ? (
-                  user.roles.map((role) => (
-                    <Chip key={role} label={role} size="small" sx={{ mr: 0.5 }} />
-                  ))
-                ) : (
-                  <Chip label="なし" size="small" color="default" />
-                )}
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                  {user.roles.length > 0 ? (
+                    user.roles.map((role) => (
+                      <Chip key={role} size="sm">
+                        {role}
+                      </Chip>
+                    ))
+                  ) : (
+                    <Chip size="sm">なし</Chip>
+                  )}
+                </Box>
               </TableCell>
               <TableCell align="right">
                 {canAssignRoles && (

--- a/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
+++ b/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
@@ -10,8 +10,8 @@ import {
   formatDateTime,
   formatJobId,
 } from '@nagiyu/codec-converter-core';
-import { Container, Typography, Card, CardContent, Chip, Alert, Stack, Box } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Container, Typography, Card, CardContent, Alert, Stack, Box } from '@mui/material';
+import { Button, Chip } from '@nagiyu/ui';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DownloadIcon from '@mui/icons-material/Download';
 import AddIcon from '@mui/icons-material/Add';
@@ -23,11 +23,11 @@ const ERROR_MESSAGES = {
 } as const;
 
 // ステータスバッジの色設定（WCAG AA準拠）
-const STATUS_COLORS: Record<JobStatus, 'warning' | 'info' | 'success' | 'error'> = {
+const STATUS_COLORS: Record<JobStatus, 'warning' | 'primary' | 'success' | 'danger'> = {
   PENDING: 'warning',
-  PROCESSING: 'info',
+  PROCESSING: 'primary',
   COMPLETED: 'success',
-  FAILED: 'error',
+  FAILED: 'danger',
 };
 
 // ステータス表示テキスト
@@ -298,11 +298,9 @@ export default function JobDetailsPage({ params }: JobDetailsPageProps) {
             ステータス
           </Typography>
 
-          <Chip
-            label={STATUS_TEXT[job.status]}
-            color={STATUS_COLORS[job.status]}
-            sx={{ mb: 1, fontWeight: 'bold' }}
-          />
+          <Chip color={STATUS_COLORS[job.status]} className="mb-1 font-bold">
+            {STATUS_TEXT[job.status]}
+          </Chip>
 
           <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
             {STATUS_DESCRIPTION[job.status]}

--- a/services/niconico-mylist-assistant/web/src/app/import/page.tsx
+++ b/services/niconico-mylist-assistant/web/src/app/import/page.tsx
@@ -8,7 +8,6 @@ import {
   Alert,
   Card,
   CardContent,
-  Chip,
   CircularProgress,
   Accordion,
   AccordionSummary,
@@ -17,7 +16,7 @@ import {
   ListItem,
   ListItemText,
 } from '@mui/material';
-import { Button, TextField } from '@nagiyu/ui';
+import { Button, Chip, TextField } from '@nagiyu/ui';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useRouter } from 'next/navigation';
 import VideoSearchModal from '@/components/VideoSearchModal';
@@ -142,10 +141,10 @@ export default function ImportPage() {
                 </Typography>
 
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mb: 2 }}>
-                  <Chip label={`合計: ${result.total} 件`} color="default" />
-                  <Chip label={`成功: ${result.success} 件`} color="success" />
-                  <Chip label={`スキップ: ${result.skipped} 件`} color="warning" />
-                  <Chip label={`失敗: ${result.failed} 件`} color="error" />
+                  <Chip>{`合計: ${result.total} 件`}</Chip>
+                  <Chip color="success">{`成功: ${result.success} 件`}</Chip>
+                  <Chip color="warning">{`スキップ: ${result.skipped} 件`}</Chip>
+                  <Chip color="danger">{`失敗: ${result.failed} 件`}</Chip>
                 </Box>
 
                 {result.success > 0 && (

--- a/services/niconico-mylist-assistant/web/src/components/JobStatusDisplay.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/JobStatusDisplay.tsx
@@ -9,10 +9,9 @@ import {
   CircularProgress,
   Alert,
   LinearProgress,
-  Chip,
   Stack,
 } from '@mui/material';
-import { Button, TextField } from '@nagiyu/ui';
+import { Button, Chip, TextField } from '@nagiyu/ui';
 import {
   CheckCircle as CheckCircleIcon,
   Error as ErrorIcon,
@@ -227,10 +226,10 @@ export default function JobStatusDisplay({ jobId, onComplete, onError }: JobStat
    */
   const getStatusColor = (
     status: BatchStatus
-  ): 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' => {
+  ): 'neutral' | 'primary' | 'secondary' | 'danger' | 'success' | 'warning' => {
     switch (status) {
       case 'SUBMITTED':
-        return 'info';
+        return 'primary';
       case 'RUNNING':
         return 'primary';
       case 'WAITING_FOR_2FA':
@@ -238,7 +237,7 @@ export default function JobStatusDisplay({ jobId, onComplete, onError }: JobStat
       case 'SUCCEEDED':
         return 'success';
       case 'FAILED':
-        return 'error';
+        return 'danger';
     }
   };
 
@@ -269,7 +268,7 @@ export default function JobStatusDisplay({ jobId, onComplete, onError }: JobStat
             <Typography variant="h6" component="h2">
               ジョブステータス
             </Typography>
-            <Chip label={getStatusLabel(state.status)} color={getStatusColor(state.status)} />
+            <Chip color={getStatusColor(state.status)}>{getStatusLabel(state.status)}</Chip>
           </Box>
 
           {/* エラー表示 */}

--- a/services/niconico-mylist-assistant/web/src/components/VideoCard.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoCard.tsx
@@ -1,15 +1,7 @@
 'use client';
 
-import {
-  Card,
-  CardMedia,
-  CardContent,
-  Typography,
-  Chip,
-  Box,
-  IconButton,
-  Tooltip,
-} from '@mui/material';
+import { Card, CardMedia, CardContent, Typography, Box, IconButton, Tooltip } from '@mui/material';
+import { Chip } from '@nagiyu/ui';
 import { Favorite, FavoriteBorder, RemoveCircle, RemoveCircleOutlined } from '@mui/icons-material';
 import type { VideoData } from '@nagiyu/niconico-mylist-assistant-core';
 
@@ -119,7 +111,9 @@ export default function VideoCard({
         </Typography>
 
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
-          <Chip label={video.length} size="small" variant="outlined" />
+          <Chip size="sm" variant="outline">
+            {video.length}
+          </Chip>
           <Typography variant="caption" color="text.secondary">
             {formatDate(video.createdAt)}
           </Typography>

--- a/services/niconico-mylist-assistant/web/src/components/VideoDetailModal.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoDetailModal.tsx
@@ -300,8 +300,12 @@ export default function VideoDetailModal({
 
             {/* メタデータ */}
             <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
-              <Chip label={video.length} size="small" variant="outlined" />
-              <Chip label={formatDateTime(video.createdAt)} size="small" variant="outlined" />
+              <Chip size="sm" variant="outline">
+                {video.length}
+              </Chip>
+              <Chip size="sm" variant="outline">
+                {formatDateTime(video.createdAt)}
+              </Chip>
             </Stack>
 
             {/* お気に入り・スキップボタン */}

--- a/services/niconico-mylist-assistant/web/src/components/VideoDetailModal.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoDetailModal.tsx
@@ -12,10 +12,9 @@ import {
   Tooltip,
   CircularProgress,
   Alert,
-  Chip,
   Stack,
 } from '@mui/material';
-import { Button, TextField } from '@nagiyu/ui';
+import { Button, Chip, TextField } from '@nagiyu/ui';
 import {
   Close,
   Favorite,

--- a/services/portal/web/src/app/page.tsx
+++ b/services/portal/web/src/app/page.tsx
@@ -1,16 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import {
-  Container,
-  Typography,
-  Grid,
-  Box,
-  Card,
-  CardContent,
-  CardActions,
-  Chip,
-} from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Container, Typography, Grid, Box, Card, CardContent, CardActions } from '@mui/material';
+import { Button, Chip } from '@nagiyu/ui';
 import {
   getAllServiceSlugs,
   getServiceDocument,
@@ -97,7 +88,9 @@ export default async function HomePage() {
                     </Typography>
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                       {article.tags.map((tag) => (
-                        <Chip key={tag} label={tag} size="small" variant="outlined" />
+                        <Chip key={tag} size="sm" variant="outline">
+                          {tag}
+                        </Chip>
                       ))}
                     </Box>
                   </CardContent>
@@ -126,14 +119,11 @@ export default async function HomePage() {
           </Typography>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
             {tags.map((entry) => (
-              <Chip
-                key={entry.tag}
-                label={`${entry.tag} (${entry.count})`}
-                component="a"
-                href={`/tech/tags/${tagToSlug(entry.tag)}`}
-                clickable
-                variant="outlined"
-              />
+              <Chip key={entry.tag} asChild variant="outline">
+                <Link href={`/tech/tags/${tagToSlug(entry.tag)}`}>
+                  {`${entry.tag} (${entry.count})`}
+                </Link>
+              </Chip>
             ))}
           </Box>
         </Box>

--- a/services/portal/web/src/app/tech/[slug]/page.tsx
+++ b/services/portal/web/src/app/tech/[slug]/page.tsx
@@ -4,13 +4,13 @@ import {
   Container,
   Typography,
   Box,
-  Chip,
   Card,
   CardActionArea,
   CardContent,
   Divider,
   Link as MuiLink,
 } from '@mui/material';
+import { Chip } from '@nagiyu/ui';
 import { getAllArticles, getArticle, getRelatedArticles } from '@/lib/content';
 import MarkdownContent from '@/components/MarkdownContent';
 import { buildBlogPostingJsonLd, buildBreadcrumbJsonLd, jsonLdScript } from '@/lib/jsonLd';
@@ -126,7 +126,9 @@ export default async function TechArticlePage({ params }: Params) {
       </Box>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 3 }}>
         {article.tags.map((tag) => (
-          <Chip key={tag} label={tag} size="small" variant="outlined" />
+          <Chip key={tag} size="sm" variant="outline">
+            {tag}
+          </Chip>
         ))}
       </Box>
 
@@ -158,7 +160,9 @@ export default async function TechArticlePage({ params }: Params) {
                     </Typography>
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                       {related.tags.map((tag) => (
-                        <Chip key={tag} label={tag} size="small" variant="outlined" />
+                        <Chip key={tag} size="sm" variant="outline">
+                          {tag}
+                        </Chip>
                       ))}
                     </Box>
                   </CardContent>

--- a/services/portal/web/src/app/tech/page.tsx
+++ b/services/portal/web/src/app/tech/page.tsx
@@ -1,16 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import {
-  Container,
-  Typography,
-  Grid,
-  Box,
-  Card,
-  CardContent,
-  CardActions,
-  Chip,
-} from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Container, Typography, Grid, Box, Card, CardContent, CardActions } from '@mui/material';
+import { Button, Chip } from '@nagiyu/ui';
 import { getAllArticles } from '@/lib/content';
 
 export const metadata: Metadata = {
@@ -60,7 +51,9 @@ export default function TechPage() {
                   </Typography>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                     {article.tags.map((tag) => (
-                      <Chip key={tag} label={tag} size="small" variant="outlined" />
+                      <Chip key={tag} size="sm" variant="outline">
+                        {tag}
+                      </Chip>
                     ))}
                   </Box>
                 </CardContent>

--- a/services/portal/web/src/app/tech/tags/[tag]/page.tsx
+++ b/services/portal/web/src/app/tech/tags/[tag]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { Container, Typography, Box, Card, CardActionArea, CardContent, Chip } from '@mui/material';
+import { Container, Typography, Box, Card, CardActionArea, CardContent } from '@mui/material';
+import { Chip } from '@nagiyu/ui';
 import {
   getAllTags,
   getArticlesByTag,
@@ -78,7 +79,9 @@ export default async function TagPage({ params }: Params) {
                 </Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                   {article.tags.map((t) => (
-                    <Chip key={t} label={t} size="small" variant="outlined" />
+                    <Chip key={t} size="sm" variant="outline">
+                      {t}
+                    </Chip>
                   ))}
                 </Box>
                 <Typography

--- a/services/quick-clip/web/src/app/jobs/[jobId]/highlights/page.tsx
+++ b/services/quick-clip/web/src/app/jobs/[jobId]/highlights/page.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Box,
-  Chip,
   CircularProgress,
   Container,
   FormControlLabel,
@@ -20,7 +19,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import { Button, TextField } from '@nagiyu/ui';
+import { Button, Chip, TextField } from '@nagiyu/ui';
 import ReplayIcon from '@mui/icons-material/Replay';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutlined';
 import type { Highlight } from '@/types/quick-clip';
@@ -53,11 +52,11 @@ const HIGHLIGHT_STATUS_LABELS = {
 } as const;
 const HIGHLIGHT_STATUS_COLORS: Record<
   'unconfirmed' | 'accepted' | 'rejected',
-  'default' | 'success' | 'error'
+  'neutral' | 'success' | 'danger'
 > = {
-  unconfirmed: 'default',
+  unconfirmed: 'neutral',
   accepted: 'success',
-  rejected: 'error',
+  rejected: 'danger',
 } as const;
 
 type HighlightsPageProps = {
@@ -644,11 +643,9 @@ export default function HighlightsPage({ params }: HighlightsPageProps) {
                           </TableCell>
                           <TableCell>
                             <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-                              <Chip
-                                label={HIGHLIGHT_STATUS_LABELS[highlight.status]}
-                                size="small"
-                                color={HIGHLIGHT_STATUS_COLORS[highlight.status]}
-                              />
+                              <Chip size="sm" color={HIGHLIGHT_STATUS_COLORS[highlight.status]}>
+                                {HIGHLIGHT_STATUS_LABELS[highlight.status]}
+                              </Chip>
                               {highlight.clipStatus === 'GENERATING' && (
                                 <CircularProgress size={12} />
                               )}

--- a/services/quick-clip/web/src/app/jobs/[jobId]/page.tsx
+++ b/services/quick-clip/web/src/app/jobs/[jobId]/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
   Alert,
-  Chip,
   CircularProgress,
   Container,
   Paper,
@@ -14,7 +13,7 @@ import {
   Stepper,
   Typography,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Chip } from '@nagiyu/ui';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import WarningIcon from '@mui/icons-material/Warning';
 import type { BatchStage, JobStatus } from '@/types/quick-clip';
@@ -34,11 +33,11 @@ const STATUS_LABELS: Record<JobStatus, string> = {
   FAILED: '処理失敗',
 };
 
-const STATUS_COLORS: Record<JobStatus, 'warning' | 'info' | 'success' | 'error'> = {
+const STATUS_COLORS: Record<JobStatus, 'warning' | 'primary' | 'success' | 'danger'> = {
   PENDING: 'warning',
-  PROCESSING: 'info',
+  PROCESSING: 'primary',
   COMPLETED: 'success',
-  FAILED: 'error',
+  FAILED: 'danger',
 };
 
 const BATCH_STAGE_LABELS: Record<BatchStage, string> = {
@@ -247,11 +246,9 @@ export default function JobPage({ params }: JobPageProps) {
             </Stepper>
 
             <Typography>ジョブID: {job.jobId}</Typography>
-            <Chip
-              label={STATUS_LABELS[job.status]}
-              color={STATUS_COLORS[job.status]}
-              sx={{ width: 'fit-content' }}
-            />
+            <Chip color={STATUS_COLORS[job.status]} className="w-fit">
+              {STATUS_LABELS[job.status]}
+            </Chip>
 
             {(job.status === 'PENDING' || job.status === 'PROCESSING') && (
               <Typography color="text.secondary">{INFO_MESSAGES.TAB_CLOSE_OK}</Typography>

--- a/services/share-together/web/src/app/invitations/page.tsx
+++ b/services/share-together/web/src/app/invitations/page.tsx
@@ -7,13 +7,12 @@ import {
   Card,
   CardActions,
   CardContent,
-  Chip,
   Container,
   Snackbar,
   Stack,
   Typography,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Chip } from '@nagiyu/ui';
 import type { InvitationSummary, InvitationsResponse } from '@/types';
 
 export default function InvitationsPage() {
@@ -119,7 +118,9 @@ export default function InvitationsPage() {
                     <Typography component="h2" variant="h6">
                       {invitation.groupName}
                     </Typography>
-                    <Chip label="招待中" color="info" size="small" />
+                    <Chip color="primary" size="sm">
+                      招待中
+                    </Chip>
                   </Stack>
                   <Typography variant="body2" color="text.secondary">
                     招待者: {invitation.inviterName}

--- a/services/stock-tracker/web/app/alerts/page.tsx
+++ b/services/stock-tracker/web/app/alerts/page.tsx
@@ -14,13 +14,12 @@ import {
   Paper,
   Alert,
   CircularProgress,
-  Chip,
   FormControl,
   InputLabel,
   Select,
   MenuItem,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Chip } from '@nagiyu/ui';
 import {
   Edit as EditIcon,
   Delete as DeleteIcon,
@@ -402,11 +401,9 @@ function AlertsPageContent() {
                   return (
                     <TableRow key={alert.alertId} hover>
                       <TableCell>
-                        <Chip
-                          label={MODE_LABELS[alert.mode] || alert.mode}
-                          color={alert.mode === 'Buy' ? 'success' : 'warning'}
-                          size="small"
-                        />
+                        <Chip color={alert.mode === 'Buy' ? 'success' : 'warning'} size="sm">
+                          {MODE_LABELS[alert.mode] || alert.mode}
+                        </Chip>
                       </TableCell>
                       <TableCell>{exchangeName}</TableCell>
                       <TableCell>
@@ -420,11 +417,9 @@ function AlertsPageContent() {
                       <TableCell>{conditionText}</TableCell>
                       <TableCell>{FREQUENCY_LABELS[alert.frequency] || alert.frequency}</TableCell>
                       <TableCell align="center">
-                        <Chip
-                          label={alert.enabled ? '有効' : '無効'}
-                          color={alert.enabled ? 'success' : 'default'}
-                          size="small"
-                        />
+                        <Chip color={alert.enabled ? 'success' : 'neutral'} size="sm">
+                          {alert.enabled ? '有効' : '無効'}
+                        </Chip>
                       </TableCell>
                       <TableCell align="center">
                         <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center' }}>

--- a/services/stock-tracker/web/components/SummaryDetailDialog.tsx
+++ b/services/stock-tracker/web/components/SummaryDetailDialog.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import {
   Box,
-  Chip,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -19,7 +18,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Chip } from '@nagiyu/ui';
 import { Close as CloseIcon } from '@mui/icons-material';
 import AlertSettingsModal from './AlertSettingsModal';
 import StockChart from './StockChart';
@@ -360,13 +359,13 @@ export default function SummaryDetailDialog({
                         {summary.aiAnalysisResult.supportLevels.map((level, index) => (
                           <Chip
                             key={`support-${level}-${index}`}
-                            label={`${level}`}
-                            size="small"
-                            clickable
+                            size="sm"
                             onClick={(e) =>
                               setChipMenuAnchor({ element: e.currentTarget, price: level })
                             }
-                          />
+                          >
+                            {`${level}`}
+                          </Chip>
                         ))}
                       </Box>
                     </Box>
@@ -378,13 +377,13 @@ export default function SummaryDetailDialog({
                         {summary.aiAnalysisResult.resistanceLevels.map((level, index) => (
                           <Chip
                             key={`resistance-${level}-${index}`}
-                            label={`${level}`}
-                            size="small"
-                            clickable
+                            size="sm"
                             onClick={(e) =>
                               setChipMenuAnchor({ element: e.currentTarget, price: level })
                             }
-                          />
+                          >
+                            {`${level}`}
+                          </Chip>
                         ))}
                       </Box>
                     </Box>
@@ -401,21 +400,22 @@ export default function SummaryDetailDialog({
                         投資判断
                       </Typography>
                       <Chip
-                        label={
-                          INVESTMENT_SIGNAL_LABELS[
-                            summary.aiAnalysisResult.investmentJudgment.signal
-                          ]
-                        }
                         color={
                           summary.aiAnalysisResult.investmentJudgment.signal === 'BULLISH'
                             ? 'success'
                             : summary.aiAnalysisResult.investmentJudgment.signal === 'BEARISH'
-                              ? 'error'
-                              : 'default'
+                              ? 'danger'
+                              : 'neutral'
                         }
-                        size="small"
-                        sx={{ mb: 1 }}
-                      />
+                        size="sm"
+                        className="mb-1"
+                      >
+                        {
+                          INVESTMENT_SIGNAL_LABELS[
+                            summary.aiAnalysisResult.investmentJudgment.signal
+                          ]
+                        }
+                      </Chip>
                       <Typography sx={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>
                         {summary.aiAnalysisResult.investmentJudgment.reason}
                       </Typography>

--- a/services/stock-tracker/web/components/TickerAlertListCard.tsx
+++ b/services/stock-tracker/web/components/TickerAlertListCard.tsx
@@ -6,14 +6,13 @@ import {
   Box,
   Card,
   CardContent,
-  Chip,
   CircularProgress,
   IconButton,
   Stack,
   Tooltip,
   Typography,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Chip } from '@nagiyu/ui';
 import { Add as AddIcon, Delete as DeleteIcon, Edit as EditIcon } from '@mui/icons-material';
 import type { AlertResponse } from '@/types/alert';
 import AlertSettingsModal from './AlertSettingsModal';
@@ -169,11 +168,9 @@ export default function TickerAlertListCard({
                 spacing={1}
                 sx={{ alignItems: 'center', flexWrap: 'wrap' }}
               >
-                <Chip
-                  label={alert.mode === 'Buy' ? '買い' : '売り'}
-                  size="small"
-                  color={alert.mode === 'Buy' ? 'success' : 'warning'}
-                />
+                <Chip size="sm" color={alert.mode === 'Buy' ? 'success' : 'warning'}>
+                  {alert.mode === 'Buy' ? '買い' : '売り'}
+                </Chip>
                 <Typography variant="body2">
                   {alert.conditions
                     .map(
@@ -182,7 +179,9 @@ export default function TickerAlertListCard({
                     )
                     .join(', ')}
                 </Typography>
-                <Chip label={alert.enabled ? '有効' : '無効'} size="small" variant="outlined" />
+                <Chip size="sm" variant="outline">
+                  {alert.enabled ? '有効' : '無効'}
+                </Chip>
                 <Tooltip title="編集">
                   <IconButton
                     size="small"

--- a/services/stock-tracker/web/components/TickerSummaryCard.tsx
+++ b/services/stock-tracker/web/components/TickerSummaryCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { Box, Card, CardContent, Chip, CircularProgress, Grid, Typography } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Box, Card, CardContent, CircularProgress, Grid, Typography } from '@mui/material';
+import { Button, Chip } from '@nagiyu/ui';
 import type { TickerSummary } from '@/types/stock';
 import SummaryDetailDialog from './SummaryDetailDialog';
 
@@ -76,9 +76,10 @@ export default function TickerSummaryCard({
                   {supportLevels.map((level, index) => (
                     <Chip
                       key={`support-${summary.tickerId}-${level}-${String(index + 1)}`}
-                      label={`${level}`}
-                      size="small"
-                    />
+                      size="sm"
+                    >
+                      {`${level}`}
+                    </Chip>
                   ))}
                 </Box>
               </Grid>
@@ -92,9 +93,10 @@ export default function TickerSummaryCard({
                   {resistanceLevels.map((level, index) => (
                     <Chip
                       key={`resistance-${summary.tickerId}-${level}-${String(index + 1)}`}
-                      label={`${level}`}
-                      size="small"
-                    />
+                      size="sm"
+                    >
+                      {`${level}`}
+                    </Chip>
                   ))}
                 </Box>
               </Grid>

--- a/services/stock-tracker/web/tests/unit/components/home-page-client-query-selection.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/home-page-client-query-selection.test.ts
@@ -56,6 +56,33 @@ jest.mock('@nagiyu/ui', () => ({
       children
     );
   },
+  Chip: ({
+    children,
+    onClick,
+    asChild,
+    variant,
+    color,
+    size,
+    ...rest
+  }: {
+    children?: React.ReactNode;
+    onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+    asChild?: boolean;
+    variant?: string;
+    color?: string;
+    size?: string;
+    [key: string]: unknown;
+  }) => {
+    void asChild;
+    void variant;
+    void color;
+    void size;
+    return React.createElement(
+      onClick ? 'button' : 'span',
+      { onClick, type: onClick ? 'button' : undefined, ...rest },
+      children
+    );
+  },
 }));
 
 jest.mock('../../../components/EmptyState', () => ({

--- a/services/tools/src/components/tools/ToolCard.tsx
+++ b/services/tools/src/components/tools/ToolCard.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent, CardActionArea, Typography, Box, Chip } from '@mui/material';
+import { Card, CardContent, CardActionArea, Typography, Box } from '@mui/material';
+import { Chip } from '@nagiyu/ui';
 import { ReactNode } from 'react';
 
 interface ToolCardProps {
@@ -41,7 +42,7 @@ export default function ToolCard({ title, description, icon, href, category }: T
           {/* カテゴリ（将来実装） */}
           {category && (
             <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
-              <Chip label={category} size="small" />
+              <Chip size="sm">{category}</Chip>
             </Box>
           )}
         </CardContent>

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -80,7 +80,7 @@
 ### Chip
 
 - [x] PR 1-4-A: 実装 + Stories + テスト（variant: solid/outline、color: 6 種、size: sm/md/lg、`onClick` で button 化、`asChild` で `<a>`/`<Link>` への変身。children ベース API。Chip.tsx は statements/lines/functions/branches すべて 100%）
-- [ ] PR 1-4-B: 置換
+- [x] PR 1-4-B: 置換（20 ファイル全置換完了。`label="X"` → `>X</Chip>`、`variant="outlined"` → `"outline"`、`color="error"` → `"danger"`、portal の navigation Chip は `asChild` + `<Link>` パターンで対応）
 - [ ] PR 1-4-C: ESLint 禁止追加
 
 ### Link


### PR DESCRIPTION
## 変更の概要

サービス側で MUI の `Chip` を `@nagiyu/ui` の `Chip` に置換する（PR 1-4-B）。

- **20 ファイル全置換完了**（保留 0）
- `label="X"` Prop → children API への移行
- portal の navigation Chip は `asChild` + `<Link>` パターンで対応

## 主な変換マッピング

| MUI | @nagiyu/ui |
|---|---|
| `<Chip label="X" />` | `<Chip>X</Chip>` |
| `variant="outlined"` | `variant="outline"` |
| `variant="filled"`（既定） | プロップ削除 |
| `color="error"` | `color="danger"` |
| `color="info"` | `color="primary"` |
| `color="default"` | プロップ削除（既定 `neutral`） |
| `size="small"` | `size="sm"` |
| `clickable` | プロップ削除（`onClick` で自動 `<button>` 化） |
| `<Chip component="a" href={...} />` | `<Chip asChild><Link href={...}>label</Link></Chip>` |

## 置換完了ファイル（20）

**今回置換 (13)**:
- `niconico-mylist-assistant/web/src/components/VideoDetailModal.tsx`
- `portal/web/src/app/page.tsx`（asChild Link パターン適用）
- `portal/web/src/app/tech/{[slug],tags/[tag]}/page.tsx`, `tech/page.tsx`
- `quick-clip/web/src/app/jobs/[jobId]/{,highlights/}page.tsx`
- `share-together/web/src/app/invitations/page.tsx`
- `stock-tracker/web/{app/alerts/page.tsx, components/{SummaryDetailDialog,TickerAlertListCard,TickerSummaryCard}.tsx}`
- `tools/src/components/tools/ToolCard.tsx`

**事前置換済み (7)**: admin / auth-web / codec-converter / niconico-mylist-assistant の VideoCard / JobStatusDisplay / import/page / dashboard 系。

## 動的 color マッピングの更新

- `quick-clip/.../highlights/page.tsx`: `HIGHLIGHT_STATUS_COLORS` を `default|success|error` → `neutral|success|danger` に直接更新
- `quick-clip/.../jobs/[jobId]/page.tsx`: `STATUS_COLORS` を `warning|info|success|error` → `warning|primary|success|danger` に直接更新
- `stock-tracker/SummaryDetailDialog.tsx`: 投資判断 Chip の color 三項演算子を `success|error|default` → `success|danger|neutral` に変更

## テスト mock 修正

- `stock-tracker/web/tests/unit/components/home-page-client-query-selection.test.ts`: `@nagiyu/ui` mock に `Chip` を追加（`TickerAlertListCard` が undefined Chip を参照していたため）

## 関連 Issue

#2900

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存テストの回帰確認、stock-tracker mock 修正）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカルで以下を確認:

| ワークスペース | 結果 |
|---|---|
| `@nagiyu/admin` | 17/17 pass |
| `@nagiyu/auth-web` | 22/22 pass |
| `@nagiyu/portal-web` | 45/45 pass |
| `@nagiyu/quick-clip-web` | 153/153 pass |
| `@nagiyu/share-together-web` | 204/204 pass |
| `@nagiyu/stock-tracker-web` | 170/170 pass |
| `@nagiyu/tools` | 148/148 pass |
| 全サービス lint pass（share-together の既存 useEffect warning は無関係） | ✅ |

## レビューポイント

- **`label` → children への移行**: MUI `<Chip label="X" />` から `<Chip>X</Chip>` への機械的変換 33 箇所。動的な `label={dynamic}` も `<Chip>{dynamic}</Chip>` に変換。
- **portal の `asChild` 採用**: `<Chip component="a" href={...} clickable variant="outlined" label={...} />` を `<Chip asChild variant="outline"><Link href={...}>{...}</Link></Chip>` に変換。Next.js Link を使うので SEO/right-click も維持。
- **動的 color マップの更新**: `STATUS_COLORS` のような MUI color 名のマップは、Chip 専用の場合は直接書き換え。グローバルマップではないので影響範囲は限定的。
- **視覚的差異**: `solid/outline` と MUI の `filled/outlined` でスタイル定義が異なるため、見た目（背景色・余白・フォント等）が若干変わる可能性あり。dev で目視確認推奨。

## スクリーンショット

dev 環境で視覚確認予定。

## 補足事項

PR 1-4-C で ESLint 禁止追加（保留ファイルがないので例外コメント不要）。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_