### PR TITLE
feat(eslint): @mui/material の Chip 直接 import を禁止（PR 1-4-C）

### DIFF
--- a/configs/eslint.config.no-restricted-mui.mjs
+++ b/configs/eslint.config.no-restricted-mui.mjs
@@ -16,7 +16,7 @@ export default {
         paths: [
           {
             name: '@mui/material',
-            importNames: ['Button', 'TextField', 'Checkbox'],
+            importNames: ['Button', 'TextField', 'Checkbox', 'Chip'],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },
         ],
@@ -29,6 +29,8 @@ export default {
               '@mui/material/TextField/*',
               '@mui/material/Checkbox',
               '@mui/material/Checkbox/*',
+              '@mui/material/Chip',
+              '@mui/material/Chip/*',
             ],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -81,7 +81,7 @@
 
 - [x] PR 1-4-A: 実装 + Stories + テスト（variant: solid/outline、color: 6 種、size: sm/md/lg、`onClick` で button 化、`asChild` で `<a>`/`<Link>` への変身。children ベース API。Chip.tsx は statements/lines/functions/branches すべて 100%）
 - [x] PR 1-4-B: 置換（20 ファイル全置換完了。`label="X"` → `>X</Chip>`、`variant="outlined"` → `"outline"`、`color="error"` → `"danger"`、portal の navigation Chip は `asChild` + `<Link>` パターンで対応）
-- [ ] PR 1-4-C: ESLint 禁止追加
+- [x] PR 1-4-C: ESLint 禁止追加（共有 config の `importNames` / `patterns.group` に `Chip` を追加。保留ファイルゼロのため例外コメント不要）
 
 ### Link
 


### PR DESCRIPTION
## 変更の概要

サービス側で MUI の `Chip` を直接 import するのを ESLint で禁止する（PR 1-4-C）。Button (1-1-C) / TextField (1-2-C) / Checkbox (1-3-C) と同じ仕組みに `Chip` を追加。

## 実装

`configs/eslint.config.no-restricted-mui.mjs` の `importNames` / `patterns.group` に `Chip` を追加:

```diff
  paths: [
    {
      name: '@mui/material',
-     importNames: ['Button', 'TextField', 'Checkbox'],
+     importNames: ['Button', 'TextField', 'Checkbox', 'Chip'],
      ...
    },
  ],
  patterns: [
    {
      group: [
        ...
+       '@mui/material/Chip',
+       '@mui/material/Chip/*',
      ],
      ...
    },
  ],
```

## 例外運用

**保留ファイルゼロ**のため、例外コメントの付与なし（PR 1-4-B で 20 ファイル全置換完了）。

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能（ESLint ルール拡張）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存テスト回帰確認）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] CI/CD 設定を追加・更新した
- [x] ローカルでテストが全て通ることを確認した（9 サービス lint pass / share-together 既存 warning のみ）
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカルで全 9 サービスの `npm run lint` が pass することを確認。

## 補足事項

これで Phase 1 の Chip セクション完了。次は Link で Phase 1 アトミックコンポーネントが完了する。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_