### PR TITLE
feat(ui): Link コンポーネント追加（PR 1-5-A）

### DIFF
--- a/libs/ui/src/components/Link/Link.module.css
+++ b/libs/ui/src/components/Link/Link.module.css
@@ -1,0 +1,100 @@
+/*
+ * Link コンポーネントのスタイル定義。
+ *
+ * - スタイル付き <a> として動作。色・下線は CSS 変数で切替。
+ * - tokens.css の Semantic 変数のみ参照する（MUI 非依存）。
+ */
+
+.link {
+  /* 文字装飾の既定 */
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--easing-out),
+    text-decoration-color var(--duration-fast) var(--easing-out);
+}
+
+/* focus-visible リング */
+.link:focus-visible {
+  outline: 2px solid var(--color-action-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* =========================================================================
+ * Color
+ * ========================================================================= */
+
+.color-primary {
+  color: var(--color-action-primary);
+}
+
+.color-primary:hover {
+  color: var(--color-action-primary-hover);
+}
+
+.color-secondary {
+  color: var(--color-action-secondary);
+}
+
+.color-secondary:hover {
+  color: var(--color-action-secondary-hover);
+}
+
+.color-danger {
+  color: var(--color-action-danger);
+}
+
+.color-danger:hover {
+  color: var(--color-action-danger-hover);
+}
+
+.color-success {
+  color: var(--color-action-success);
+}
+
+.color-success:hover {
+  color: var(--color-action-success-hover);
+}
+
+.color-warning {
+  color: var(--color-action-warning);
+}
+
+.color-warning:hover {
+  color: var(--color-action-warning-hover);
+}
+
+.color-neutral {
+  color: var(--color-fg-default);
+}
+
+.color-neutral:hover {
+  color: var(--color-fg-muted);
+}
+
+/* inherit は親の color を継承するためルール上書き不要 */
+.color-inherit {
+  color: inherit;
+}
+
+/* =========================================================================
+ * Underline
+ * ========================================================================= */
+
+.underline-none {
+  text-decoration: none;
+}
+
+.underline-hover {
+  text-decoration: none;
+}
+
+.underline-hover:hover {
+  text-decoration: underline;
+}
+
+.underline-always {
+  text-decoration: underline;
+}

--- a/libs/ui/src/components/Link/Link.stories.tsx
+++ b/libs/ui/src/components/Link/Link.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import Link from './Link';
+
+/**
+ * `Link` は @nagiyu/ui のテキスト・リンク部品（スタイル付き `<a>`）。
+ *
+ * - `color`（7 種、`inherit` 含む）× `underline`（none/hover/always）の直交した API
+ * - `asChild` で `next/link` の `<Link>` 等への変身に対応（Radix Slot）
+ *
+ * MUI への依存は内部で完全に隠蔽されている。
+ */
+const meta: Meta<typeof Link> = {
+  title: 'Atoms/Link',
+  component: Link,
+  tags: ['autodocs'],
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'danger', 'success', 'warning', 'neutral', 'inherit'],
+    },
+    underline: {
+      control: 'inline-radio',
+      options: ['none', 'hover', 'always'],
+    },
+    href: { control: 'text' },
+    children: { control: 'text' },
+  },
+  args: {
+    color: 'primary',
+    underline: 'hover',
+    href: 'https://example.com',
+    children: 'リンクテキスト',
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Link>;
+
+export const Default: Story = {};
+
+export const ExternalLink: Story = {
+  args: {
+    href: 'https://github.com/nagiyu/nagiyu-platform',
+    target: '_blank',
+    rel: 'noopener noreferrer',
+    children: 'GitHub - nagiyu/nagiyu-platform',
+  },
+};
+
+export const Colors: Story = {
+  argTypes: { color: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {(
+        ['primary', 'secondary', 'danger', 'success', 'warning', 'neutral', 'inherit'] as const
+      ).map((color) => (
+        <Link {...args} key={color} color={color}>
+          {color}
+        </Link>
+      ))}
+    </div>
+  ),
+};
+
+export const UnderlineVariants: Story = {
+  argTypes: { underline: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <Link {...args} underline="none">
+        underline=none
+      </Link>
+      <Link {...args} underline="hover">
+        underline=hover
+      </Link>
+      <Link {...args} underline="always">
+        underline=always
+      </Link>
+    </div>
+  ),
+};
+
+/**
+ * `inherit` カラー：親要素の文字色をそのまま継承する。
+ * フッター・ヘッダー等のコンテクスト色が決まっている場所で使う。
+ */
+export const InheritColor: Story = {
+  render: (args) => (
+    <p style={{ color: '#7a3a3a' }}>
+      暗赤色のテキスト中に{' '}
+      <Link {...args} color="inherit">
+        継承色のリンク
+      </Link>{' '}
+      を埋め込む例。
+    </p>
+  ),
+};
+
+export const AsChild: Story = {
+  args: { color: 'primary', underline: 'always' },
+  render: (args) => (
+    <Link {...args} asChild>
+      {/* 仮の <a> 要素を渡す。実プロジェクトでは next/link の <Link> を渡す想定。 */}
+      <a href="/some/internal-route">SPA ナビゲーション用リンク（asChild）</a>
+    </Link>
+  ),
+};

--- a/libs/ui/src/components/Link/Link.tsx
+++ b/libs/ui/src/components/Link/Link.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+
+import styles from './Link.module.css';
+
+/**
+ * Link の色（意味）。Button / Chip と同じセマンティック軸に `inherit` を加える。
+ *
+ * - `inherit`: 親の文字色を継承（フッター・ヘッダー等のコンテクストで使う）
+ */
+export type LinkColor =
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'success'
+  | 'warning'
+  | 'neutral'
+  | 'inherit';
+
+/**
+ * Link の下線の表示方法。
+ *
+ * - `none`: 下線なし
+ * - `hover`: hover 時のみ下線（既定）
+ * - `always`: 常に下線
+ */
+export type LinkUnderline = 'none' | 'hover' | 'always';
+
+/**
+ * Link のプロパティ。
+ *
+ * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
+ * エスケープハッチは `className` のみ。
+ */
+export interface LinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
+  /**
+   * 色（意味）。既定: `primary`
+   */
+  color?: LinkColor;
+  /**
+   * 下線の表示方法。既定: `hover`
+   */
+  underline?: LinkUnderline;
+  /**
+   * `true` の場合、Radix Slot により子要素に Props をマージする。
+   * Next.js の `<Link>` を Link 風スタイルで装飾したい場合などに使う。
+   */
+  asChild?: boolean;
+  /**
+   * 子要素（テキスト、または `asChild` 時は単一要素）。
+   */
+  children: React.ReactNode;
+}
+
+/**
+ * テキスト・リンクコンポーネント（スタイル付き `<a>`）。
+ *
+ * - `color` × `underline` で見た目を制御
+ * - `asChild` で `next/link` の `<Link>` 等への変身に対応（Radix Slot パターン）
+ * - `target="_blank"` などの HTML 属性は素通し
+ *
+ * @see docs/development/shared-ui-components.md
+ */
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  { color = 'primary', underline = 'hover', asChild = false, className, children, ...rest },
+  ref
+) {
+  const Comp: React.ElementType = asChild ? Slot : 'a';
+
+  const classes = [
+    styles.link,
+    styles[`color-${color}`],
+    styles[`underline-${underline}`],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <Comp ref={ref as never} className={classes} {...rest}>
+      {children}
+    </Comp>
+  );
+});
+
+export default Link;

--- a/libs/ui/src/components/Link/index.ts
+++ b/libs/ui/src/components/Link/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Link';
+export type { LinkProps, LinkColor, LinkUnderline } from './Link';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -10,6 +10,8 @@ export { default as Checkbox } from './components/Checkbox';
 export type { CheckboxProps, CheckboxSize } from './components/Checkbox';
 export { default as Chip } from './components/Chip';
 export type { ChipProps, ChipVariant, ChipColor, ChipSize } from './components/Chip';
+export { default as Link } from './components/Link';
+export type { LinkProps, LinkColor, LinkUnderline } from './components/Link';
 export { default as Header } from './components/layout/Header';
 export type { HeaderProps, NavigationItem } from './components/layout/Header';
 export { default as Footer } from './components/layout/Footer';

--- a/libs/ui/tests/unit/components/Link/Link.test.tsx
+++ b/libs/ui/tests/unit/components/Link/Link.test.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import Link from '../../../../src/components/Link/Link';
+
+describe('Link', () => {
+  describe('rendering', () => {
+    it('children を表示する', () => {
+      render(<Link href="/x">クリック</Link>);
+      expect(screen.getByText('クリック')).toBeInTheDocument();
+    });
+
+    it('既定では <a> として描画される', () => {
+      const { container } = render(<Link href="/x">x</Link>);
+      expect((container.firstChild as HTMLElement).tagName).toBe('A');
+    });
+
+    it('href が反映される', () => {
+      render(<Link href="/dashboard">x</Link>);
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/dashboard');
+    });
+
+    it('既定値（primary / hover）が適用される', () => {
+      const { container } = render(<Link href="/x">x</Link>);
+      const node = container.firstChild as HTMLElement;
+      expect(node.className).toContain('color-primary');
+      expect(node.className).toContain('underline-hover');
+    });
+
+    it('color / underline の組み合わせをクラスに反映する', () => {
+      const { container } = render(
+        <Link href="/x" color="danger" underline="always">
+          x
+        </Link>
+      );
+      const node = container.firstChild as HTMLElement;
+      expect(node.className).toContain('color-danger');
+      expect(node.className).toContain('underline-always');
+    });
+
+    it('className を受け付け、内部クラスとマージされる', () => {
+      const { container } = render(
+        <Link href="/x" className="custom">
+          x
+        </Link>
+      );
+      const node = container.firstChild as HTMLElement;
+      expect(node.className).toContain('custom');
+      expect(node.className).toContain('link');
+    });
+  });
+
+  describe('html attributes', () => {
+    it('target / rel が反映される', () => {
+      render(
+        <Link href="https://example.com" target="_blank" rel="noopener noreferrer">
+          外部
+        </Link>
+      );
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('aria-label が反映される', () => {
+      render(
+        <Link href="/x" aria-label="ヘルプを開く">
+          ?
+        </Link>
+      );
+      expect(screen.getByLabelText('ヘルプを開く')).toBeInTheDocument();
+    });
+  });
+
+  describe('asChild', () => {
+    it('asChild=true で子要素のタグをそのまま使い、props をマージする', () => {
+      render(
+        <Link asChild color="success" underline="always">
+          <a href="/foo">SPA リンク</a>
+        </Link>
+      );
+      const link = screen.getByRole('link', { name: 'SPA リンク' });
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', '/foo');
+      expect(link.className).toContain('link');
+      expect(link.className).toContain('color-success');
+      expect(link.className).toContain('underline-always');
+    });
+  });
+
+  describe('color', () => {
+    it.each([
+      'primary',
+      'secondary',
+      'danger',
+      'success',
+      'warning',
+      'neutral',
+      'inherit',
+    ] as const)('color=%s で対応するクラスが付与される', (color) => {
+      const { container } = render(
+        <Link href="/x" color={color}>
+          x
+        </Link>
+      );
+      expect((container.firstChild as HTMLElement).className).toContain(`color-${color}`);
+    });
+  });
+
+  describe('underline', () => {
+    it.each(['none', 'hover', 'always'] as const)(
+      'underline=%s で対応するクラスが付与される',
+      (underline) => {
+        const { container } = render(
+          <Link href="/x" underline={underline}>
+            x
+          </Link>
+        );
+        expect((container.firstChild as HTMLElement).className).toContain(`underline-${underline}`);
+      }
+    );
+  });
+
+  describe('refs', () => {
+    it('forwardRef で a 要素にアクセスできる', () => {
+      const ref = React.createRef<HTMLAnchorElement>();
+      render(
+        <Link href="/x" ref={ref}>
+          x
+        </Link>
+      );
+      expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('既定状態で a11y 違反がない', async () => {
+      const { container } = render(<Link href="/x">テスト</Link>);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('全 color の組み合わせで a11y 違反がない', async () => {
+      const colors = [
+        'primary',
+        'secondary',
+        'danger',
+        'success',
+        'warning',
+        'neutral',
+        'inherit',
+      ] as const;
+      const { container } = render(
+        <div>
+          {colors.map((color) => (
+            <Link key={color} href="/x" color={color}>
+              {color}
+            </Link>
+          ))}
+        </div>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('外部リンク（target=_blank + rel）でも a11y 違反がない', async () => {
+      const { container } = render(
+        <Link href="https://example.com" target="_blank" rel="noopener noreferrer">
+          外部
+        </Link>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -85,7 +85,7 @@
 
 ### Link
 
-- [ ] PR 1-5-A: 実装 + Stories + テスト
+- [x] PR 1-5-A: 実装 + Stories + テスト（color: 7 種（inherit 含む）/ underline: none/hover/always / asChild。Link.tsx は statements/lines/functions/branches すべて 100%）
 - [ ] PR 1-5-B: 置換
 - [ ] PR 1-5-C: ESLint 禁止追加
 


### PR DESCRIPTION
## 変更の概要

`@nagiyu/ui` に **`Link` コンポーネント**を追加する（PR 1-5-A）。

- スタイル付き `<a>`（MUI Link と同じ役割）
- `color` × `underline` の直交 API
- `asChild` で Next.js `<Link>` 等への変身に対応

## API

```ts
export type LinkColor = 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'neutral' | 'inherit';
export type LinkUnderline = 'none' | 'hover' | 'always';

export interface LinkProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
  color?: LinkColor;          // 既定 'primary'
  underline?: LinkUnderline;  // 既定 'hover'
  asChild?: boolean;
  children: React.ReactNode;
}
```

`href` / `target` / `rel` などの `<a>` 標準属性は `HTMLAttributes` 継承で透過。

## 設計判断

- **`color: 'inherit'` を採用**: フッター・ヘッダー等のコンテクスト色を継承する用途で必要
- **`asChild` 採用**: SPA ナビゲーション時に `<Link asChild><NextLink href={...}>...</NextLink></Link>` で組み合わせ可能
- **役割は MUI Link と同じ**（スタイル付き `<a>`）。`next/link` の役割（SPA 遷移）は別物として扱う

## 関連 Issue

#2900

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（**23 件 pass / Link.tsx は statements/lines/functions/branches すべて 100%**）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した（ライブラリ全体: 260 件 pass）
- [x] ビルドエラーがないことを確認した（tsc + copy-assets + build-storybook 成功）

## テスト内容

`Link.test.tsx` で 23 件のテスト:

- **rendering**: children / `<a>` 既定 / href 反映 / 既定値（primary, hover）/ color×underline / className マージ
- **html attributes**: `target`/`rel`/`aria-label`
- **asChild**: 子の `<a>` への props マージ
- **color**: 7 種すべて
- **underline**: none/hover/always
- **refs**: forwardRef
- **a11y（jest-axe）**: 既定 / 全 color / 外部リンク（target=_blank + rel）

## レビューポイント

- **`asChild` でも独自 `<a>` でも同じ見た目**: Slot パターンで Next.js Link への変身を許可しつつ、ライブラリ独立性を保つ。
- **`underline` を別軸にした**: MUI と同じ。`underline="always"` は a11y 観点で本文中のリンクに推奨される。
- **`inherit` カラー**: フッター等の暗背景・カラフルなコンテクストでも文字色を継承できる必要があるため必須。

## スクリーンショット

dev 環境の Storybook で視覚確認予定。

## 補足事項

PR 1-5-B（5 ファイルの置換）と PR 1-5-C（ESLint 禁止）は本 PR マージ後に別 PR で対応する。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_