### PR TITLE
style: prettier --write で admin-core / admin-batch のフォーマット整合

### DIFF
--- a/services/admin/batch/tests/unit/alarm-ingest.test.ts
+++ b/services/admin/batch/tests/unit/alarm-ingest.test.ts
@@ -27,9 +27,7 @@ const buildSnsRecord = (
 
 describe('inferServiceIdFromAlarmName', () => {
   it('2 セグメント以上なら最初の 2 セグメントを連結する', () => {
-    expect(inferServiceIdFromAlarmName('stock-tracker-web-error-rate-prod')).toBe(
-      'stock-tracker'
-    );
+    expect(inferServiceIdFromAlarmName('stock-tracker-web-error-rate-prod')).toBe('stock-tracker');
   });
 
   it('1 セグメントならそのまま返す', () => {

--- a/services/admin/batch/tests/unit/stream-handler.test.ts
+++ b/services/admin/batch/tests/unit/stream-handler.test.ts
@@ -135,10 +135,7 @@ describe('handler', () => {
 
   it('MODIFY と REMOVE は skip', async () => {
     const event: StreamHandlerEvent = {
-      Records: [
-        buildStreamRecord(sampleEvent, 'MODIFY'),
-        buildStreamRecord(sampleEvent, 'REMOVE'),
-      ],
+      Records: [buildStreamRecord(sampleEvent, 'MODIFY'), buildStreamRecord(sampleEvent, 'REMOVE')],
     };
     const result = await handler(event);
     expect(result).toEqual({ notified: 0, skipped: 2 });
@@ -154,15 +151,15 @@ describe('handler', () => {
 
   it('VAPID キー未設定で例外', async () => {
     delete process.env.VAPID_PUBLIC_KEY;
-    await expect(
-      handler({ Records: [buildStreamRecord(sampleEvent)] })
-    ).rejects.toThrow('VAPID キーが設定されていません');
+    await expect(handler({ Records: [buildStreamRecord(sampleEvent)] })).rejects.toThrow(
+      'VAPID キーが設定されていません'
+    );
   });
 
   it('APP_URL 未設定で例外', async () => {
     delete process.env.APP_URL;
-    await expect(
-      handler({ Records: [buildStreamRecord(sampleEvent)] })
-    ).rejects.toThrow('APP_URL が設定されていません');
+    await expect(handler({ Records: [buildStreamRecord(sampleEvent)] })).rejects.toThrow(
+      'APP_URL が設定されていません'
+    );
   });
 });

--- a/services/admin/core/src/errors/in-memory-reader.ts
+++ b/services/admin/core/src/errors/in-memory-reader.ts
@@ -65,8 +65,7 @@ export class InMemoryErrorEventReader implements ErrorEventReader {
   ): Promise<ErrorEvent | null> {
     return (
       this.records.find(
-        (e) =>
-          e.eventId === eventId && e.occurredAt === occurredAt && e.serviceId === serviceId
+        (e) => e.eventId === eventId && e.occurredAt === occurredAt && e.serviceId === serviceId
       ) ?? null
     );
   }

--- a/services/admin/core/src/errors/index.ts
+++ b/services/admin/core/src/errors/index.ts
@@ -4,11 +4,7 @@
  * Admin の永続化済みエラーイベント参照のためのドメインロジック。
  */
 
-export type {
-  ErrorEventReader,
-  ListErrorEventsQuery,
-  ListErrorEventsResult,
-} from './reader.js';
+export type { ErrorEventReader, ListErrorEventsQuery, ListErrorEventsResult } from './reader.js';
 export {
   DEFAULT_LIST_LIMIT,
   MAX_LIST_LIMIT,

--- a/services/admin/core/tests/unit/errors/dynamodb-reader.test.ts
+++ b/services/admin/core/tests/unit/errors/dynamodb-reader.test.ts
@@ -4,11 +4,7 @@
 
 import { QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import type { ErrorEvent } from '@nagiyu/common';
-import {
-  buildErrorEventPK,
-  buildErrorEventSK,
-  ERROR_EVENT_GSI1_PK,
-} from '@nagiyu/aws';
+import { buildErrorEventPK, buildErrorEventSK, ERROR_EVENT_GSI1_PK } from '@nagiyu/aws';
 import { DynamoDBErrorEventReader } from '../../../src/errors/dynamodb-reader.js';
 import { encodeCursor } from '../../../src/errors/reader.js';
 

--- a/services/admin/core/tests/unit/errors/factory.test.ts
+++ b/services/admin/core/tests/unit/errors/factory.test.ts
@@ -3,10 +3,7 @@
  */
 
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import {
-  createErrorEventReader,
-  resetErrorEventReader,
-} from '../../../src/errors/factory.js';
+import { createErrorEventReader, resetErrorEventReader } from '../../../src/errors/factory.js';
 import { DynamoDBErrorEventReader } from '../../../src/errors/dynamodb-reader.js';
 import { InMemoryErrorEventReader } from '../../../src/errors/in-memory-reader.js';
 

--- a/services/admin/core/tests/unit/errors/in-memory-reader.test.ts
+++ b/services/admin/core/tests/unit/errors/in-memory-reader.test.ts
@@ -88,7 +88,9 @@ describe('InMemoryErrorEventReader', () => {
 
   it('findById は不一致のとき null', async () => {
     reader.put(sampleEvent({ eventId: 'evt-1' }));
-    expect(await reader.findById('missing', '2026-01-01T00:00:00.000Z', 'stock-tracker')).toBeNull();
+    expect(
+      await reader.findById('missing', '2026-01-01T00:00:00.000Z', 'stock-tracker')
+    ).toBeNull();
   });
 
   it('reset で状態をクリア', async () => {


### PR DESCRIPTION
## 変更の概要

PR #2956 (integration → develop) で `Format Check All Workspaces` ジョブが失敗したため、admin-core / admin-batch のテストファイル等にフォーマット未整合があった点を `prettier --write` で修正する。

## 関連 Issue

- #2940（PR #2956 のフォーマット修正）

## 変更種別

- [ ] 新規機能
- [x] バグ修正（フォーマット）
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 内容

- `services/admin/core/src/errors/{index.ts, in-memory-reader.ts}`
- `services/admin/core/tests/unit/errors/{factory,dynamodb-reader,in-memory-reader}.test.ts`
- `services/admin/batch/tests/unit/{alarm-ingest,stream-handler}.test.ts`

各ワークスペースの `npm run format:check` で All matched files use Prettier code style! を確認済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_016hjRjYUmbWuNfXgqNxA78s)_