### PR TITLE
refactor(services): MUI Link → @nagiyu/ui Link 置換（PR 1-5-B）

### DIFF
--- a/services/portal/web/src/app/about/page.tsx
+++ b/services/portal/web/src/app/about/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
-import { Container, Typography, Box, Link } from '@mui/material';
+import { Container, Typography, Box } from '@mui/material';
+import { Link } from '@nagiyu/ui';
 import { AUTHOR } from '@/lib/author';
 
 export const metadata: Metadata = {

--- a/services/portal/web/src/app/privacy/page.tsx
+++ b/services/portal/web/src/app/privacy/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
-import { Container, Typography, Box, Link } from '@mui/material';
-import { privacyPolicySections } from '@nagiyu/ui';
+import { Container, Typography, Box } from '@mui/material';
+import { Link, privacyPolicySections } from '@nagiyu/ui';
 
 export const metadata: Metadata = {
   title: 'プライバシーポリシー',

--- a/services/tools/src/app/about/page.tsx
+++ b/services/tools/src/app/about/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
-import { Container, Typography, Box, Link } from '@mui/material';
+import { Container, Typography, Box } from '@mui/material';
+import { Link } from '@nagiyu/ui';
 
 export const metadata: Metadata = {
   title: 'Tools について',

--- a/services/tools/src/app/contact/page.tsx
+++ b/services/tools/src/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
-import { Container, Typography, Box, Link } from '@mui/material';
+import { Container, Typography, Box } from '@mui/material';
+import { Link } from '@nagiyu/ui';
 
 export const metadata: Metadata = {
   title: 'お問い合わせ',

--- a/services/tools/src/app/privacy/page.tsx
+++ b/services/tools/src/app/privacy/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
-import { Container, Typography, Box, Link } from '@mui/material';
-import { privacyPolicySections } from '@nagiyu/ui';
+import { Container, Typography, Box } from '@mui/material';
+import { Link, privacyPolicySections } from '@nagiyu/ui';
 
 export const metadata: Metadata = {
   title: 'プライバシーポリシー',

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -86,7 +86,7 @@
 ### Link
 
 - [x] PR 1-5-A: 実装 + Stories + テスト（color: 7 種（inherit 含む）/ underline: none/hover/always / asChild。Link.tsx は statements/lines/functions/branches すべて 100%）
-- [ ] PR 1-5-B: 置換
+- [x] PR 1-5-B: 置換（5 ファイル全置換完了。MUI 既定スタイル+default Props でそのまま代替可能だった）
 - [ ] PR 1-5-C: ESLint 禁止追加
 
 ---


### PR DESCRIPTION
## 変更の概要

サービス側で MUI の `Link` を `@nagiyu/ui` の `Link` に置換する（PR 1-5-B）。

- **5 ファイル全置換完了**（保留 0）
- 既定スタイルそのまま利用、追加プロップ不要

## 置換ファイル

- `portal/web/src/app/about/page.tsx`
- `portal/web/src/app/privacy/page.tsx`
- `tools/src/app/about/page.tsx`
- `tools/src/app/contact/page.tsx`
- `tools/src/app/privacy/page.tsx`

## 変換内容

各ファイルとも以下のシンプルな変換のみ:

```diff
- import { Container, Typography, Box, Link } from '@mui/material';
+ import { Container, Typography, Box } from '@mui/material';
+ import { Link } from '@nagiyu/ui';
```

JSX は `<Link href={...} target="_blank" rel="noopener noreferrer">...</Link>` のまま無変更（@nagiyu/ui Link は HTMLAttributes 継承で `<a>` 標準属性を素通し）。`color`/`underline` は既定値で OK だった。

## 関連 Issue

#2900

## 変更種別

- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存テストの回帰確認）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカルで以下を確認:

| ワークスペース | 結果 |
|---|---|
| `@nagiyu/portal-web` | 45/45 pass |
| `@nagiyu/tools` | 148/148 pass |
| 全サービス lint pass | ✅ |

## レビューポイント

- **シンプル PR**: import 行の変更のみ。JSX 側は無変更で済んだ。
- **`color` / `underline`** の既定値が MUI と互換になるよう設計したため、ファイル側に追加 Prop が要らなかった。

## スクリーンショット

dev 環境で視覚確認予定。

## 補足事項

PR 1-5-C で ESLint 禁止追加（保留ファイルがないので例外コメント不要）。これで Phase 1 アトミックコンポーネントが全 5 部品（Button / TextField / Checkbox / Chip / Link）完了見込み。

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_