### PR TITLE
chore(eslint): MUI Link 直接 import を禁止（PR 1-5-C）

### DIFF
--- a/configs/eslint.config.no-restricted-mui.mjs
+++ b/configs/eslint.config.no-restricted-mui.mjs
@@ -16,7 +16,7 @@ export default {
         paths: [
           {
             name: '@mui/material',
-            importNames: ['Button', 'TextField', 'Checkbox', 'Chip'],
+            importNames: ['Button', 'TextField', 'Checkbox', 'Chip', 'Link'],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },
         ],
@@ -31,6 +31,8 @@ export default {
               '@mui/material/Checkbox/*',
               '@mui/material/Chip',
               '@mui/material/Chip/*',
+              '@mui/material/Link',
+              '@mui/material/Link/*',
             ],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },

--- a/services/portal/web/src/app/tech/[slug]/page.tsx
+++ b/services/portal/web/src/app/tech/[slug]/page.tsx
@@ -106,8 +106,7 @@ export default async function TechArticlePage({ params }: Params) {
       {/* メタ情報 */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1, flexWrap: 'wrap' }}>
         <Typography variant="caption" color="text.secondary">
-          著者:{' '}
-          <Link href="/about">{authorName}</Link>
+          著者: <Link href="/about">{authorName}</Link>
         </Typography>
         <Typography variant="caption" color="text.secondary">
           公開日: {article.publishedAt}

--- a/services/portal/web/src/app/tech/[slug]/page.tsx
+++ b/services/portal/web/src/app/tech/[slug]/page.tsx
@@ -8,9 +8,8 @@ import {
   CardActionArea,
   CardContent,
   Divider,
-  Link as MuiLink,
 } from '@mui/material';
-import { Chip } from '@nagiyu/ui';
+import { Chip, Link } from '@nagiyu/ui';
 import { getAllArticles, getArticle, getRelatedArticles } from '@/lib/content';
 import MarkdownContent from '@/components/MarkdownContent';
 import { buildBlogPostingJsonLd, buildBreadcrumbJsonLd, jsonLdScript } from '@/lib/jsonLd';
@@ -108,9 +107,7 @@ export default async function TechArticlePage({ params }: Params) {
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1, flexWrap: 'wrap' }}>
         <Typography variant="caption" color="text.secondary">
           著者:{' '}
-          <MuiLink href="/about" underline="hover">
-            {authorName}
-          </MuiLink>
+          <Link href="/about">{authorName}</Link>
         </Typography>
         <Typography variant="caption" color="text.secondary">
           公開日: {article.publishedAt}

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -86,8 +86,8 @@
 ### Link
 
 - [x] PR 1-5-A: 実装 + Stories + テスト（color: 7 種（inherit 含む）/ underline: none/hover/always / asChild。Link.tsx は statements/lines/functions/branches すべて 100%）
-- [x] PR 1-5-B: 置換（5 ファイル全置換完了。MUI 既定スタイル+default Props でそのまま代替可能だった）
-- [ ] PR 1-5-C: ESLint 禁止追加
+- [x] PR 1-5-B: 置換（5 ファイル全置換完了。MUI 既定スタイル+default Props でそのまま代替可能だった。※ PR 1-5-C で `tech/[slug]/page.tsx` 1 ファイル取りこぼしを追加置換）
+- [x] PR 1-5-C: ESLint 禁止追加（共有 config の `importNames` / `patterns.group` に `Link` を追加。`tech/[slug]/page.tsx` の `Link as MuiLink` 取りこぼし 1 ファイルを追加置換し、保留ファイルゼロのため例外コメント不要）
 
 ---
 


### PR DESCRIPTION
## 変更の概要

`@mui/material` の `Link` 直接 import を ESLint で禁止する（PR 1-5-C）。

- 共有 config `configs/eslint.config.no-restricted-mui.mjs` の `importNames` / `patterns.group` に `Link` を追加
- PR 1-5-B 取りこぼし `services/portal/web/src/app/tech/[slug]/page.tsx` の `Link as MuiLink` を 1 ファイル追加置換
- 保留ファイルゼロのため `eslint-disable` コメント不要

## 取りこぼし置換ファイル

`services/portal/web/src/app/tech/[slug]/page.tsx`

```diff
- import { ..., Link as MuiLink } from '@mui/material';
- import { Chip } from '@nagiyu/ui';
+ import { ... } from '@mui/material';
+ import { Chip, Link } from '@nagiyu/ui';

- <MuiLink href="/about" underline="hover">{authorName}</MuiLink>
+ <Link href="/about">{authorName}</Link>
```

`underline="hover"` は `@nagiyu/ui` Link の既定値なので省略。

## 関連 Issue

#2900

## 変更種別

- [x] リファクタリング（ESLint ルール強化）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した
- [x] ローカルで lint が全て通ることを確認した

## テスト内容

ローカルで以下を確認:

| 項目 | 結果 |
|---|---|
| `npm run lint --workspaces --if-present`（全 13 workspace） | ✅ exit 0 |
| `npm test --workspace=@nagiyu/portal-web` | 45/45 pass |

## レビューポイント

- **取りこぼしの追加対応**: PR 1-5-B で 5 ファイル置換と記載していたが、ESLint 有効化したところ `tech/[slug]/page.tsx` の `Link as MuiLink` エイリアス import が検出された。本 PR で同時に対応した（実質 6 ファイル目）
- **Link API の互換性**: `underline="hover"` は既定値なので省略可。`href` は HTMLAnchor 属性なので素通し

## スクリーンショット

UI 変更なし（ESLint ルール追加 + 1 ファイルの import / コンポーネント名変更のみ）。

## 補足事項

これにより **Phase 1 アトミックコンポーネント完了**（Button / TextField / Checkbox / Chip / Link の全 5 部品）。次は Phase 2（Select、フォーム系）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_