### PR TITLE
feat(ui): Select コンポーネントを追加（PR 2-1-A）

### DIFF
--- a/libs/ui/src/components/Select/Select.module.css
+++ b/libs/ui/src/components/Select/Select.module.css
@@ -1,0 +1,150 @@
+/*
+ * Select コンポーネントのスタイル定義。
+ *
+ * - すべての色・余白・角丸は tokens.css の Semantic 変数を参照する。
+ * - MUI 等の特定ライブラリへの依存は持たない。
+ * - 状態は `:hover` / `:focus-visible` / `[aria-invalid='true']` / `:disabled` で表現。
+ * - ネイティブ `<select>` をベースにしつつ、`appearance: none` で見た目を統一。
+ */
+
+.wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  font-family: var(--font-family-sans);
+}
+
+.fullWidth {
+  display: flex;
+  width: 100%;
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-fg-default);
+  line-height: var(--line-height-normal);
+}
+
+.requiredMark {
+  color: var(--color-action-danger);
+}
+
+.selectWrapper {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.select {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-surface);
+  color: var(--color-fg-default);
+
+  font-family: inherit;
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+
+  /* chevron 用のスペースを右側に確保 */
+  padding-right: calc(var(--spacing-md) + 1.25rem);
+
+  transition:
+    border-color var(--duration-fast) var(--easing-out),
+    box-shadow var(--duration-fast) var(--easing-out);
+}
+
+.select:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
+}
+
+.select:focus-visible {
+  outline: none;
+  border-color: var(--color-action-primary);
+  box-shadow: 0 0 0 3px var(--color-action-primary-subtle);
+}
+
+.select:disabled {
+  background-color: var(--color-bg-subtle);
+  color: var(--color-fg-disabled);
+  cursor: not-allowed;
+}
+
+.chevron {
+  position: absolute;
+  right: var(--spacing-sm);
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--color-fg-muted);
+  font-size: var(--font-size-sm);
+}
+
+.disabled .chevron {
+  color: var(--color-fg-disabled);
+}
+
+.helperText {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-fg-muted);
+  line-height: var(--line-height-normal);
+}
+
+/* =========================================================================
+ * Size
+ * ========================================================================= */
+
+.size-sm .select {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  padding-right: calc(var(--spacing-sm) + 1.25rem);
+  font-size: var(--font-size-sm);
+  min-height: 32px;
+}
+
+.size-md .select {
+  padding: var(--spacing-sm) var(--spacing-md);
+  padding-right: calc(var(--spacing-md) + 1.25rem);
+  font-size: var(--font-size-md);
+  min-height: 40px;
+}
+
+.size-lg .select {
+  padding: var(--spacing-sm) var(--spacing-md);
+  padding-right: calc(var(--spacing-md) + 1.25rem);
+  font-size: var(--font-size-lg);
+  min-height: 48px;
+}
+
+/* =========================================================================
+ * Error state
+ * ========================================================================= */
+
+.error .select {
+  border-color: var(--color-action-danger);
+}
+
+.error .select:hover:not(:disabled) {
+  border-color: var(--color-action-danger-hover);
+}
+
+.error .select:focus-visible {
+  border-color: var(--color-action-danger);
+  box-shadow: 0 0 0 3px var(--color-action-danger-subtle);
+}
+
+.error .helperText {
+  color: var(--color-action-danger);
+}
+
+/* =========================================================================
+ * Disabled wrapper（label もディム化）
+ * ========================================================================= */
+
+.disabled .label {
+  color: var(--color-fg-disabled);
+}

--- a/libs/ui/src/components/Select/Select.stories.tsx
+++ b/libs/ui/src/components/Select/Select.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
+
+import Select, { type SelectOption } from './Select';
+
+/**
+ * `Select` は @nagiyu/ui の単一選択 dropdown 部品。
+ *
+ * - ネイティブ `<select>` 要素ベースで ARIA / キーボード操作 / モバイル UI を OS 標準に追従
+ * - `options=[{value, label}]` の設定駆動 API（MenuItem ネスト不要）
+ * - `value` + `onChange(value)` の値直渡しシグネチャ
+ * - `placeholder` 指定時は先頭に空 option を挿入（未選択を明示）
+ * - `label` を渡せば `useId` で select と自動関連付け（a11y 必須対応）
+ *
+ * MUI / Radix への依存は内部で完全に隠蔽されている。
+ */
+const meta: Meta<typeof Select> = {
+  title: 'Atoms/Select',
+  component: Select,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'inline-radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    fullWidth: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    required: { control: 'boolean' },
+    error: { control: 'boolean' },
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    helperText: { control: 'text' },
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+const PERIOD_OPTIONS: ReadonlyArray<SelectOption> = [
+  { value: '24h', label: '直近 24 時間' },
+  { value: '7d', label: '直近 7 日' },
+  { value: '30d', label: '直近 30 日' },
+  { value: 'all', label: '指定なし' },
+];
+
+const COUNTRY_OPTIONS: ReadonlyArray<SelectOption> = [
+  { value: 'jp', label: '日本' },
+  { value: 'us', label: 'アメリカ' },
+  { value: 'gb', label: 'イギリス' },
+  { value: 'de', label: 'ドイツ', disabled: true },
+];
+
+const ControlledSelect = (args: React.ComponentProps<typeof Select>) => {
+  const [value, setValue] = React.useState(args.value);
+  return <Select {...args} value={value} onChange={setValue} />;
+};
+
+export const Default: Story = {
+  render: ControlledSelect,
+  args: {
+    label: '期間',
+    value: '24h',
+    options: PERIOD_OPTIONS,
+  },
+};
+
+export const WithPlaceholder: Story = {
+  render: ControlledSelect,
+  args: {
+    label: '国',
+    value: '',
+    placeholder: '選択してください',
+    options: COUNTRY_OPTIONS,
+  },
+};
+
+export const WithHelperText: Story = {
+  render: ControlledSelect,
+  args: {
+    label: '期間',
+    value: '24h',
+    options: PERIOD_OPTIONS,
+    helperText: '集計対象とする期間を選択します',
+  },
+};
+
+export const Required: Story = {
+  render: ControlledSelect,
+  args: {
+    label: '国',
+    value: '',
+    placeholder: '選択してください',
+    required: true,
+    options: COUNTRY_OPTIONS,
+  },
+};
+
+export const Error: Story = {
+  render: ControlledSelect,
+  args: {
+    label: '国',
+    value: '',
+    placeholder: '選択してください',
+    error: true,
+    helperText: '必須項目です',
+    options: COUNTRY_OPTIONS,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: '期間',
+    value: '24h',
+    disabled: true,
+    options: PERIOD_OPTIONS,
+    onChange: () => undefined,
+  },
+};
+
+export const DisabledOption: Story = {
+  render: ControlledSelect,
+  args: {
+    label: '国',
+    value: 'jp',
+    options: COUNTRY_OPTIONS,
+    helperText: 'ドイツは現在受付停止中（option.disabled）',
+  },
+};
+
+export const FullWidth: Story = {
+  render: ControlledSelect,
+  args: {
+    label: '期間',
+    value: '24h',
+    fullWidth: true,
+    options: PERIOD_OPTIONS,
+  },
+};
+
+export const Sizes: Story = {
+  argTypes: { size: { control: false } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16, width: 320 }}>
+      <ControlledSelect {...args} size="sm" label="sm" />
+      <ControlledSelect {...args} size="md" label="md" />
+      <ControlledSelect {...args} size="lg" label="lg" />
+    </div>
+  ),
+  args: {
+    value: '24h',
+    options: PERIOD_OPTIONS,
+  },
+};

--- a/libs/ui/src/components/Select/Select.tsx
+++ b/libs/ui/src/components/Select/Select.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import * as React from 'react';
+
+import styles from './Select.module.css';
+
+export type SelectSize = 'sm' | 'md' | 'lg';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+/**
+ * Select のプロパティ。
+ *
+ * 100% ライブラリ非依存の独自定義。MUI / Radix 等の Props 型は extends しない。
+ * エスケープハッチは `className` のみ。`value` と `onChange` は必須（uncontrolled は非対応）。
+ */
+export interface SelectProps {
+  // ---- 値・イベント ----
+  /**
+   * 選択中の value。未選択を表現したい場合は空文字を渡し、`placeholder` を指定する。
+   */
+  value: string;
+  /**
+   * 値が変化したときのコールバック。MUI 等のイベントオブジェクトではなく、選択された
+   * `value` を直接受け取るシグネチャ。
+   */
+  onChange: (value: string) => void;
+  onBlur?: (event: React.FocusEvent<HTMLSelectElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLSelectElement>) => void;
+
+  // ---- データ ----
+  /**
+   * 選択肢の配列。`MenuItem` のネスト記述ではなく設定駆動 API。
+   */
+  options: ReadonlyArray<SelectOption>;
+
+  // ---- 表示 ----
+  /**
+   * フォームラベル。`<label htmlFor>` で select と関連付ける（内部 `useId` で自動生成）。
+   */
+  label?: React.ReactNode;
+  /**
+   * 未選択（空文字）状態に表示する案内テキスト。指定すると先頭に空 option を挿入する。
+   */
+  placeholder?: string;
+  /**
+   * 入力欄の下に表示される補助テキスト。`error` が true なら危険色で描画される。
+   */
+  helperText?: React.ReactNode;
+
+  // ---- 状態 ----
+  disabled?: boolean;
+  required?: boolean;
+  /**
+   * エラー状態。境界線・helperText が危険色になり、`aria-invalid` が付与される。
+   */
+  error?: boolean;
+
+  // ---- レイアウト ----
+  fullWidth?: boolean;
+  /**
+   * サイズ。既定: `md`
+   */
+  size?: SelectSize;
+
+  // ---- その他 HTML ----
+  id?: string;
+  name?: string;
+  autoFocus?: boolean;
+
+  // ---- a11y ----
+  'aria-label'?: string;
+
+  // ---- エスケープハッチ ----
+  className?: string;
+}
+
+/**
+ * 単一選択 dropdown コンポーネント。
+ *
+ * - ネイティブ `<select>` をラップしているため、ARIA / キーボード操作 / モバイル UI は OS 標準に追従
+ * - `label` と select は `useId` 経由で自動関連付け（a11y 必須対応）
+ * - `placeholder` 指定時は先頭に空 option を挿入（未選択を明示）
+ * - `error` で危険色の境界線・helperText、`aria-invalid` 自動付与
+ *
+ * @see docs/development/shared-ui-components.md
+ */
+const Select = React.forwardRef<HTMLDivElement, SelectProps>(function Select(
+  {
+    value,
+    onChange,
+    onBlur,
+    onFocus,
+    options,
+    label,
+    placeholder,
+    helperText,
+    disabled = false,
+    required = false,
+    error = false,
+    fullWidth = false,
+    size = 'md',
+    id,
+    name,
+    autoFocus,
+    'aria-label': ariaLabel,
+    className,
+  },
+  ref
+) {
+  const generatedId = React.useId();
+  const selectId = id ?? generatedId;
+  const helperTextId = `${selectId}-helper-text`;
+
+  const wrapperClasses = [
+    styles.wrapper,
+    fullWidth ? styles.fullWidth : null,
+    disabled ? styles.disabled : null,
+    error ? styles.error : null,
+    styles[`size-${size}`],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div ref={ref} className={wrapperClasses}>
+      {label ? (
+        <label htmlFor={selectId} className={styles.label}>
+          {label}
+          {required ? (
+            <span aria-hidden="true" className={styles.requiredMark}>
+              {' '}
+              *
+            </span>
+          ) : null}
+        </label>
+      ) : null}
+      <div className={styles.selectWrapper}>
+        <select
+          id={selectId}
+          name={name}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          disabled={disabled}
+          required={required}
+          autoFocus={autoFocus}
+          aria-label={ariaLabel}
+          aria-invalid={error || undefined}
+          aria-describedby={helperText ? helperTextId : undefined}
+          className={styles.select}
+        >
+          {placeholder !== undefined ? (
+            <option value="" disabled={required}>
+              {placeholder}
+            </option>
+          ) : null}
+          {options.map((option) => (
+            <option key={option.value} value={option.value} disabled={option.disabled}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <span aria-hidden="true" className={styles.chevron}>
+          ▾
+        </span>
+      </div>
+      {helperText ? (
+        <p id={helperTextId} className={styles.helperText}>
+          {helperText}
+        </p>
+      ) : null}
+    </div>
+  );
+});
+
+export default Select;

--- a/libs/ui/src/components/Select/index.ts
+++ b/libs/ui/src/components/Select/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Select';
+export type { SelectProps, SelectSize, SelectOption } from './Select';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -12,6 +12,8 @@ export { default as Chip } from './components/Chip';
 export type { ChipProps, ChipVariant, ChipColor, ChipSize } from './components/Chip';
 export { default as Link } from './components/Link';
 export type { LinkProps, LinkColor, LinkUnderline } from './components/Link';
+export { default as Select } from './components/Select';
+export type { SelectProps, SelectSize, SelectOption } from './components/Select';
 export { default as Header } from './components/layout/Header';
 export type { HeaderProps, NavigationItem } from './components/layout/Header';
 export { default as Footer } from './components/layout/Footer';

--- a/libs/ui/tests/unit/components/Select/Select.test.tsx
+++ b/libs/ui/tests/unit/components/Select/Select.test.tsx
@@ -1,0 +1,340 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import Select, { type SelectOption } from '../../../../src/components/Select/Select';
+
+const PERIOD_OPTIONS: ReadonlyArray<SelectOption> = [
+  { value: '24h', label: '直近 24 時間' },
+  { value: '7d', label: '直近 7 日' },
+  { value: '30d', label: '直近 30 日' },
+];
+
+function ControlledSelect(props: Omit<React.ComponentProps<typeof Select>, 'onChange'>) {
+  const [value, setValue] = React.useState(props.value);
+  return <Select {...props} value={value} onChange={setValue} />;
+}
+
+describe('Select', () => {
+  describe('rendering', () => {
+    it('options を <option> として描画する', () => {
+      render(
+        <Select label="期間" value="24h" onChange={() => undefined} options={PERIOD_OPTIONS} />
+      );
+      const select = screen.getByLabelText('期間');
+      expect(select).toBeInTheDocument();
+      expect(select.tagName).toBe('SELECT');
+      expect(screen.getByRole('option', { name: '直近 24 時間' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: '直近 7 日' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: '直近 30 日' })).toBeInTheDocument();
+    });
+
+    it('label を渡すと <label> が描画され、select と htmlFor で関連付けられる', () => {
+      render(
+        <Select label="期間" value="24h" onChange={() => undefined} options={PERIOD_OPTIONS} />
+      );
+      expect(screen.getByLabelText('期間')).toBeInTheDocument();
+    });
+
+    it('id を明示すれば尊重される', () => {
+      render(
+        <Select
+          id="my-select"
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+        />
+      );
+      expect(screen.getByLabelText('期間')).toHaveAttribute('id', 'my-select');
+    });
+
+    it('helperText が描画され、aria-describedby で関連付けられる', () => {
+      render(
+        <Select
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          helperText="集計対象とする期間"
+        />
+      );
+      const select = screen.getByLabelText('期間');
+      const helperId = select.getAttribute('aria-describedby');
+      expect(helperId).toBeTruthy();
+      expect(document.getElementById(helperId!)).toHaveTextContent('集計対象とする期間');
+    });
+
+    it('placeholder が指定されると先頭に空 option が描画される', () => {
+      render(
+        <Select
+          label="期間"
+          value=""
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          placeholder="選択してください"
+        />
+      );
+      const placeholderOption = screen.getByRole('option', {
+        name: '選択してください',
+      }) as HTMLOptionElement;
+      expect(placeholderOption.value).toBe('');
+    });
+
+    it('placeholder が指定されないと空 option は描画されない', () => {
+      render(
+        <Select label="期間" value="24h" onChange={() => undefined} options={PERIOD_OPTIONS} />
+      );
+      expect(screen.queryByRole('option', { name: '' })).not.toBeInTheDocument();
+    });
+
+    it('required かつ placeholder の場合、placeholder option は disabled になる', () => {
+      render(
+        <Select
+          label="期間"
+          value=""
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          placeholder="選択してください"
+          required
+        />
+      );
+      const placeholderOption = screen.getByRole('option', {
+        name: '選択してください',
+      }) as HTMLOptionElement;
+      expect(placeholderOption.disabled).toBe(true);
+    });
+
+    it('option.disabled が true の項目は disabled として描画される', () => {
+      render(
+        <Select
+          label="国"
+          value="jp"
+          onChange={() => undefined}
+          options={[
+            { value: 'jp', label: '日本' },
+            { value: 'us', label: 'アメリカ', disabled: true },
+          ]}
+        />
+      );
+      const us = screen.getByRole('option', { name: 'アメリカ' }) as HTMLOptionElement;
+      expect(us.disabled).toBe(true);
+    });
+
+    it('既定値（md / no fullWidth）が適用される', () => {
+      const { container } = render(
+        <Select label="期間" value="24h" onChange={() => undefined} options={PERIOD_OPTIONS} />
+      );
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.className).toContain('size-md');
+      expect(wrapper.className).not.toContain('fullWidth');
+    });
+
+    it('size を指定するとそのサイズクラスが適用される', () => {
+      const { container } = render(
+        <Select
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          size="lg"
+        />
+      );
+      expect((container.firstChild as HTMLElement).className).toContain('size-lg');
+    });
+
+    it('fullWidth を指定すると fullWidth クラスが適用される', () => {
+      const { container } = render(
+        <Select
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          fullWidth
+        />
+      );
+      expect((container.firstChild as HTMLElement).className).toContain('fullWidth');
+    });
+
+    it('required の場合、ラベルに視覚的な * が付与される', () => {
+      const { container } = render(
+        <Select
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          required
+        />
+      );
+      expect(container.textContent).toContain('*');
+    });
+
+    it('aria-label が select 要素に伝わる', () => {
+      render(
+        <Select
+          aria-label="期間選択"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+        />
+      );
+      expect(screen.getByLabelText('期間選択')).toBeInTheDocument();
+    });
+
+    it('className が wrapper に追加される', () => {
+      const { container } = render(
+        <Select
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          className="custom-class"
+        />
+      );
+      expect((container.firstChild as HTMLElement).className).toContain('custom-class');
+    });
+  });
+
+  describe('events', () => {
+    it('onChange が選択された value で発火する', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(<Select label="期間" value="24h" onChange={onChange} options={PERIOD_OPTIONS} />);
+      await user.selectOptions(screen.getByLabelText('期間'), '7d');
+      expect(onChange).toHaveBeenCalledWith('7d');
+    });
+
+    it('controlled で value が更新される', async () => {
+      const user = userEvent.setup();
+      render(<ControlledSelect label="期間" value="24h" options={PERIOD_OPTIONS} />);
+      const select = screen.getByLabelText('期間') as HTMLSelectElement;
+      await user.selectOptions(select, '30d');
+      expect(select.value).toBe('30d');
+    });
+
+    it('disabled の時は変更できない', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+      render(
+        <Select label="期間" value="24h" onChange={onChange} options={PERIOD_OPTIONS} disabled />
+      );
+      await user.selectOptions(screen.getByLabelText('期間'), '7d').catch(() => undefined);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('onBlur / onFocus が発火する', async () => {
+      const onBlur = jest.fn();
+      const onFocus = jest.fn();
+      const user = userEvent.setup();
+      render(
+        <>
+          <Select
+            label="期間"
+            value="24h"
+            onChange={() => undefined}
+            options={PERIOD_OPTIONS}
+            onBlur={onBlur}
+            onFocus={onFocus}
+          />
+          <button type="button">外</button>
+        </>
+      );
+      await user.click(screen.getByLabelText('期間'));
+      expect(onFocus).toHaveBeenCalled();
+      await user.click(screen.getByRole('button', { name: '外' }));
+      expect(onBlur).toHaveBeenCalled();
+    });
+  });
+
+  describe('error state', () => {
+    it('error の場合、aria-invalid が true になる', () => {
+      render(
+        <Select
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          error
+        />
+      );
+      expect(screen.getByLabelText('期間')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('error が false の場合、aria-invalid は付与されない', () => {
+      render(
+        <Select label="期間" value="24h" onChange={() => undefined} options={PERIOD_OPTIONS} />
+      );
+      expect(screen.getByLabelText('期間')).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('error の場合、wrapper に error クラスが付与される', () => {
+      const { container } = render(
+        <Select
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          error
+        />
+      );
+      expect((container.firstChild as HTMLElement).className).toContain('error');
+    });
+  });
+
+  describe('a11y', () => {
+    it('label 付きで axe 違反が無い', async () => {
+      const { container } = render(
+        <Select label="期間" value="24h" onChange={() => undefined} options={PERIOD_OPTIONS} />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('placeholder + required の組み合わせでも axe 違反が無い', async () => {
+      const { container } = render(
+        <Select
+          label="国"
+          value=""
+          onChange={() => undefined}
+          options={[{ value: 'jp', label: '日本' }]}
+          placeholder="選択してください"
+          required
+        />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('error + helperText で axe 違反が無い', async () => {
+      const { container } = render(
+        <Select
+          label="期間"
+          value=""
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+          error
+          helperText="必須項目です"
+        />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('forwardRef', () => {
+    it('ref が wrapper の div に渡る', () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(
+        <Select
+          ref={ref}
+          label="期間"
+          value="24h"
+          onChange={() => undefined}
+          options={PERIOD_OPTIONS}
+        />
+      );
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+  });
+});

--- a/tasks/shared-ui-components/tasks.md
+++ b/tasks/shared-ui-components/tasks.md
@@ -95,8 +95,8 @@
 
 ### Select
 
-- [ ] PR 2-1-A: `libs/ui` に `Select` 実装（MUI の `FormControl` / `MenuItem` / `InputLabel` を統合）
-- [ ] PR 2-1-A: Stories + テスト
+- [x] PR 2-1-A: `libs/ui` に `Select` 実装（ネイティブ `<select>` ベース、`options` 配列 + 値直渡し `onChange` API。size sm/md/lg / placeholder / error / required / fullWidth / disabled / option.disabled。Select.tsx は statements/lines/functions/branches すべて 100%、ライブラリ全体 lines 95.19% / branches 92.82%）
+- [x] PR 2-1-A: Stories（Default / WithPlaceholder / WithHelperText / Required / Error / Disabled / DisabledOption / FullWidth / Sizes）+ ユニット + a11y テスト 25/25 pass
 - [ ] PR 2-1-B: 全サービスで置換
 - [ ] PR 2-1-C: ESLint 禁止追加（`Select` / `MenuItem` / `FormControl` / `InputLabel`）
 


### PR DESCRIPTION
## 変更の概要

`@nagiyu/ui` に **`Select` コンポーネント** を追加する（PR 2-1-A）。Phase 2 フォーム系の最初の部品。

ネイティブ `<select>` 要素をベースとした単一選択 dropdown で、MUI の `FormControl` / `MenuItem` / `InputLabel` の 3 部品を 1 部品に統合。MUI / Radix への依存はゼロで、ARIA / キーボード操作 / モバイル UI は OS 標準に追従する。

## API 設計

```tsx
<Select
  label="期間"
  value={period}
  onChange={setPeriod}
  size="sm"
  options={[
    { value: '24h', label: '直近 24 時間' },
    { value: '7d',  label: '直近 7 日' },
  ]}
/>
```

主な特徴:

- **設定駆動**: `options=[{ value, label, disabled? }]` で記述（MenuItem ネスト不要）
- **値直渡し**: `onChange: (value: string) => void`（MUI の `SelectChangeEvent` ではない）
- **a11y 自動**: `label` を渡せば `useId` で select と自動関連付け
- **`placeholder`**: 指定時は先頭に空 option を挿入。`required` 併用で送信前選択を強制
- size: `sm | md | lg`、`fullWidth` / `disabled` / `error` / `helperText` 対応
- エスケープハッチは `className` のみ

multiple / グルーピング / autocomplete は YAGNI で除外（現状の使用箇所 7 件すべてが単一選択）。将来必要になれば API 拡張で対応。

## 関連 Issue

#2900

## 変更種別

- [x] 新機能（共通 UI コンポーネント追加）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加した（`libs/ui/tests/unit/components/Select/Select.test.tsx`）
- [x] Storybook Stories を追加した（`Select.stories.tsx`）
- [x] 関連ドキュメントを更新した（`tasks/shared-ui-components/tasks.md`）
- [x] ローカルでテストが全て通ることを確認した
- [x] ローカルで lint / prettier が全て通ることを確認した

## テスト内容

ローカルで以下を確認:

| 項目 | 結果 |
|---|---|
| Select ユニット + a11y テスト | 25/25 pass |
| `@nagiyu/ui` 全体テスト | 285/285 pass |
| Select.tsx カバレッジ | statements/lines/functions/branches すべて 100% |
| `@nagiyu/ui` 全体カバレッジ | lines 95.19% / branches 92.82%（閾値 90% / 80% 維持） |
| `npm run lint --workspaces --if-present` | ✅ exit 0 |
| `npx prettier --check` | ✅ pass |

a11y テストは `jest-axe` で 3 シナリオ:
- `label` 付き基本形
- `placeholder` + `required` の組み合わせ
- `error` + `helperText`

## レビューポイント

- **API 形状**: 事前合意の通り「`options` 配列 + 値直渡し `onChange`」を採用。MUI 互換性より将来差し替えの楽さを優先。
- **ネイティブ `<select>` 採用**: モバイルでは OS ネイティブ UI が出るため UX が高く、ARIA / キーボード操作も標準動作。カスタム dropdown は YAGNI で見送り。
- **`required` + `placeholder` の連携**: placeholder option を `disabled` として描画し、HTML5 form validation の必須選択を機能させる。

## スクリーンショット

dev 環境の Storybook で視覚確認予定（PR マージ後の dev デプロイで反映）。

## 補足事項

PR 2-1-B（全サービス置換）と PR 2-1-C（ESLint 禁止追加）は本 PR マージ後に順次着手予定。置換対象は admin/errors の `<TextField select>` 1 件、tools の `<TextField select>` 2 件、share-together / niconico の Select+FormControl 各 1〜2 件、計 7 箇所程度を想定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_