### PR TITLE
fix(admin): dashboard の shared Button 置換漏れを修正

### DIFF
--- a/services/admin/web/src/app/(protected)/dashboard/page.tsx
+++ b/services/admin/web/src/app/(protected)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { Box, Card, CardContent, Typography } from '@mui/material';
 import { Button, Chip } from '@nagiyu/ui';
 import { hasPermission } from '@nagiyu/common';
 import { getSession } from '@/lib/auth/session';
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import NotifyButton from '@/components/notify/NotifyButton';
 
@@ -80,8 +81,8 @@ export default async function DashboardPage() {
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               プラットフォーム上で発生したエラー通知の履歴を確認できます
             </Typography>
-            <Button href="/errors" variant="contained">
-              エラー履歴を表示
+            <Button asChild variant="solid">
+              <Link href="/errors">エラー履歴を表示</Link>
             </Button>
           </CardContent>
         </Card>


### PR DESCRIPTION
## 変更の概要

admin の dev デプロイ（integration ブランチ向け Build & Push Docker Image ワークフロー）で Next.js build の TypeScript チェックが失敗していた問題の hotfix。

```
./src/app/(protected)/dashboard/page.tsx:83:36
Type error: Type '"contained"' is not assignable to type 'ButtonVariant | undefined'.
```

PR 1-1-B 系で `services/admin/.../dashboard/page.tsx` の Button を `@nagiyu/ui` へ置換した際、line 83 だけ MUI 互換のプロパティ（`variant="contained"` + `href` 直渡し）が取り残されていた。同ファイル line 91 の `asChild` + 子要素パターンに揃える。

## なぜ今になって表面化したか

- 修正漏れ自体は develop に既に存在
- admin の dev デプロイは Full の `next build --webpack` で TypeScript 厳格チェックを実行
- integration ブランチへの develop 取り込み（merge `dca18ff`）後に当該ワークフローが走り、初めて検出された
- Fast CI のビルドジョブでも本来検出されるべきだが、admin の Fast Verification ワークフローでは型チェックがスキップされていた可能性（要別途確認、本 PR では扱わない）

## 修正内容

```diff
- <Button href="/errors" variant="contained">
-   エラー履歴を表示
- </Button>
+ <Button asChild variant="solid">
+   <Link href="/errors">エラー履歴を表示</Link>
+ </Button>
```

加えて `import Link from 'next/link';` を追加。

| Before | After | 理由 |
|---|---|---|
| `variant="contained"` | `variant="solid"` | shared `Button` の variant は `'solid' \| 'outline' \| 'ghost'`。MUI の "contained" は意味的に "solid"（強調アクション）に対応 |
| `href="/errors"` | `asChild` + `<Link href>` | shared `Button` は `href` 非対応。同ファイル line 91 の既存パターンに統一 |
| `<a>` ではなく `<Link>` | - | `@next/next/no-html-link-for-pages` ルール対応（内部リンクは next/link 必須） |

## 関連 Issue

#2900

## 変更種別

- [x] バグ修正（dev デプロイブロック）

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 関連箇所の型・ビルドが通ることを確認した
- [x] ローカルでテストが全て通ることを確認した
- [x] ローカルで lint / prettier が全て通ることを確認した

## テスト内容

ローカルで以下を確認:

| 項目 | 結果 |
|---|---|
| `npm run build --workspace=@nagiyu/admin`（CI と同じ next build） | TypeScript チェック含めて成功 |
| `npm run lint --workspace=@nagiyu/admin` | exit 0 |
| `npm test --workspace=@nagiyu/admin` | 17/17 pass |
| `prettier --check` | pass |

## 範囲調査（横展開漏れの確認）

リポジトリ全体で `variant="contained"` / `variant="outlined"` / `variant="text"` を shared `Button` に渡している残りの箇所は無いことを確認:

- `libs/ui/.../ErrorBoundary.tsx`、`libs/ui/.../*Dialog.tsx` の Button は MUI Button（eslint-disable で意図的に MUI のまま、Phase 2 以降で置換予定）
- `services/admin/.../errors/page.tsx` の Button も MUI Button（同上、eslint-disable）
- `services/stock-tracker` 等の `variant="outlined"` はすべて Card / Paper / TableContainer（Button ではない）

したがって、shared Button + MUI variant の組み合わせは dashboard の 1 箇所のみ。

## レビューポイント

- `variant="contained"` → `variant="solid"` のマッピングは MUI Button の "塗りつぶし強調" → shared `Button` の "塗りつぶし強調" として意味的に一致するため妥当と判断。
- `<a>` ではなく `<Link>` を採用したのは Next.js の `@next/next/no-html-link-for-pages` ルール対応のため。line 91 の `<a>` は外部 URL（`process.env.NEXT_PUBLIC_AUTH_URL`）なので同ルールの対象外で残置 OK。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_