### PR TITLE
feat(admin): errors の period filter を @nagiyu/ui Select に置換（PR 2-1-B-1）

### DIFF
--- a/services/admin/web/src/app/(protected)/errors/page.tsx
+++ b/services/admin/web/src/app/(protected)/errors/page.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   // eslint-disable-next-line no-restricted-imports -- color="info" / label プロップが @nagiyu/ui Chip 未対応のため保留 (Issue #2900 Phase 2 以降で置換予定)
   Chip,
-  MenuItem,
   Paper,
   Table,
   TableBody,
@@ -12,7 +11,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  // eslint-disable-next-line no-restricted-imports -- select 機能が @nagiyu/ui TextField 未対応のため保留 (PR 2-1 Select で対応予定)
+  // eslint-disable-next-line no-restricted-imports -- sx={{ minWidth }} と size="small" の組み合わせが必要なため MUI TextField を利用する
   TextField,
   Typography,
 } from '@mui/material';
@@ -22,6 +21,7 @@ import { getDynamoDBDocumentClient } from '@nagiyu/aws';
 import { createErrorEventReader, type ListErrorEventsQuery } from '@nagiyu/admin-core';
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/auth/session';
+import PeriodFilterSelect from '@/components/errors/PeriodFilterSelect';
 
 const ERROR_MESSAGES = {
   ERROR_EVENTS_TABLE_NAME_REQUIRED: 'ERROR_EVENTS_TABLE_NAME が設定されていません',
@@ -186,20 +186,15 @@ export default async function ErrorsListPage({
               size="small"
               sx={{ minWidth: 200 }}
             />
-            <TextField
-              name="period"
-              label="期間"
-              select
-              defaultValue={periodValue}
-              size="small"
-              sx={{ minWidth: 200 }}
-            >
-              {PERIOD_PRESETS.map((preset) => (
-                <MenuItem key={preset.value} value={preset.value}>
-                  {preset.label}
-                </MenuItem>
-              ))}
-            </TextField>
+            <Box sx={{ minWidth: 200 }}>
+              <PeriodFilterSelect
+                defaultValue={periodValue}
+                options={PERIOD_PRESETS.map((preset) => ({
+                  value: preset.value,
+                  label: preset.label,
+                }))}
+              />
+            </Box>
             <Button type="submit" variant="contained">
               絞り込み
             </Button>

--- a/services/admin/web/src/components/errors/PeriodFilterSelect.tsx
+++ b/services/admin/web/src/components/errors/PeriodFilterSelect.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+
+import { Select, type SelectOption } from '@nagiyu/ui';
+
+interface PeriodFilterSelectProps {
+  defaultValue: string;
+  options: ReadonlyArray<SelectOption>;
+}
+
+export default function PeriodFilterSelect({ defaultValue, options }: PeriodFilterSelectProps) {
+  const [value, setValue] = React.useState(defaultValue);
+
+  return (
+    <Select
+      name="period"
+      label="期間"
+      size="sm"
+      value={value}
+      onChange={setValue}
+      options={options}
+      fullWidth
+    />
+  );
+}


### PR DESCRIPTION
## 変更の概要

admin の errors/page.tsx で `<TextField select>` + `<MenuItem>` で実装していた期間フィルターを `@nagiyu/ui` の `Select` に置換する。

PR 2-1-B（全サービス置換）を **3 PR に分割した最初の PR**:
- **PR 2-1-B-1（本 PR）: admin（1 ファイル）**
- PR 2-1-B-2: niconico + share-together + tools（4 ファイル）
- PR 2-1-B-3: stock-tracker（8 ファイル）

## Server / Client 境界の処理

errors/page.tsx は React Server Component で、`<form method="get" action="/errors">` のクラシック HTML form 送信に依存している。一方 shared `Select` は `'use client'` + controlled（`value`+`onChange` 必須）。そのため

1. `PeriodFilterSelect` を独立した Client Component として切り出し
2. Server から `defaultValue` と `options` を props（serializable）で渡す
3. Client 側で `useState` 管理しつつ `name="period"` で form submit に乗せる

という構成にした。`PERIOD_PRESETS` は Server 側のクエリ計算（`hours: 24` 等）にも必要なため Server に残し、Client へは `value` / `label` のみ渡して重複を回避。

## 変更内容

```diff
+ import PeriodFilterSelect from '@/components/errors/PeriodFilterSelect';
- MenuItem,
- // eslint-disable-next-line ... select 機能が @nagiyu/ui TextField 未対応のため保留
+ // eslint-disable-next-line ... sx={{ minWidth }} と size="small" の組み合わせが必要なため MUI TextField を利用する
  TextField,

- <TextField name="period" label="期間" select defaultValue={...} ...>
-   {PERIOD_PRESETS.map((preset) => (
-     <MenuItem key={preset.value} value={preset.value}>{preset.label}</MenuItem>
-   ))}
- </TextField>
+ <Box sx={{ minWidth: 200 }}>
+   <PeriodFilterSelect
+     defaultValue={periodValue}
+     options={PERIOD_PRESETS.map((p) => ({ value: p.value, label: p.label }))}
+   />
+ </Box>
```

新規ファイル `PeriodFilterSelect.tsx`:

```tsx
'use client';
import * as React from 'react';
import { Select, type SelectOption } from '@nagiyu/ui';

interface PeriodFilterSelectProps {
  defaultValue: string;
  options: ReadonlyArray<SelectOption>;
}

export default function PeriodFilterSelect({ defaultValue, options }: PeriodFilterSelectProps) {
  const [value, setValue] = React.useState(defaultValue);
  return (
    <Select name="period" label="期間" size="sm"
      value={value} onChange={setValue} options={options} fullWidth />
  );
}
```

## 関連 Issue

#2900

## 変更種別

- [x] 既存機能の改善（共通 UI コンポーネント置換）

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] ローカルでビルドが通ることを確認した
- [x] ローカルでテストが全て通ることを確認した
- [x] ローカルで lint / prettier が全て通ることを確認した

## テスト内容

| 項目 | 結果 |
|---|---|
| `npm run build --workspace=@nagiyu/admin`（型チェック含む） | ✅ |
| `npm run lint --workspace=@nagiyu/admin` | ✅ exit 0 |
| `npm test --workspace=@nagiyu/admin` | ✅ 17/17 pass |
| `prettier --check` | ✅ pass |

UI 動作（フィルターの実選択 + form submit）は CI の E2E（chromium-mobile）と dev デプロイ後の手動確認に委ねる。

## レビューポイント

- **Server Component 内の Client Component 切り出し**: ローカルで使い捨ての wrapper component を作るのは admin/web ではこれまで前例がないため、今後パターン化されるなら別途共通化を検討。本 PR ではスコープ最小化のため `services/admin/web/src/components/errors/` に閉じる。
- **`PERIOD_PRESETS` の重複回避**: Server 側で `hours` メタを保持しつつ Client へは `value`/`label` のみ渡すことで、定義は 1 箇所に保つ。
- **`sx={{ minWidth: 200 }}`** は親 `<Box>` で囲んで shared Select に `fullWidth` を渡す方式（shared Select に `sx`/`style` 直接渡しを許す API は意図的に持たせていない）。

## スクリーンショット

UI の見た目はネイティブ `<select>` ベースに変わるが、機能（4 つの期間プリセット選択 → submit）は等価。dev デプロイ後に確認予定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_