### PR TITLE
feat: niconico/share-together/tools の MUI Select を @nagiyu/ui Select に置換（PR 2-1-B-2）

### DIFF
--- a/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
+++ b/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
@@ -33,10 +33,10 @@ test.describe('Video List Page', () => {
     await page.goto('/mylist');
 
     // お気に入りフィルター
-    await expect(page.getByLabel('お気に入り')).toBeVisible();
+    await expect(page.locator('#favorite-filter')).toBeVisible();
 
     // スキップフィルター
-    await expect(page.getByLabel('スキップ')).toBeVisible();
+    await expect(page.locator('#skip-filter')).toBeVisible();
 
     // タイトル検索フィールド
     await expect(page.getByPlaceholder('動画タイトルで検索')).toBeVisible();
@@ -47,7 +47,7 @@ test.describe('Video List Page', () => {
     await page.waitForLoadState('networkidle');
 
     // ユーザー設定未作成の状態では「お気に入りのみ」で0件になる
-    await page.getByLabel('お気に入り').selectOption('true');
+    await page.locator('#favorite-filter').selectOption('true');
 
     // 空の状態メッセージ
     await expect(page.getByText('動画が見つかりませんでした')).toBeVisible();
@@ -227,7 +227,7 @@ test.describe('Video List Page', () => {
     await page.waitForResponse((res) => res.url().includes('/api/videos/'));
 
     // お気に入りフィルターを変更
-    await page.getByLabel('お気に入り').selectOption('true');
+    await page.locator('#favorite-filter').selectOption('true');
 
     // APIレスポンスを待つ
     const filterResponse = await page.waitForResponse((res) => res.url().includes('/api/videos'));
@@ -257,7 +257,7 @@ test.describe('Video List Page', () => {
     await page.waitForLoadState('networkidle');
 
     // スキップフィルターを変更
-    await page.getByLabel('スキップ').selectOption('false');
+    await page.locator('#skip-filter').selectOption('false');
 
     // APIレスポンスを待つ
     await page.waitForResponse((response) => response.url().includes('/api/videos'));
@@ -428,7 +428,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // お気に入りフィルターを変更
-    await page.getByLabel('お気に入り').selectOption('true');
+    await page.locator('#favorite-filter').selectOption('true');
 
     // URLが更新されることを確認
     await expect(page).toHaveURL('/mylist?favorite=true');
@@ -453,7 +453,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // スキップフィルターを変更
-    await page.getByLabel('スキップ').selectOption('false');
+    await page.locator('#skip-filter').selectOption('false');
 
     // URLが更新されることを確認
     await expect(page).toHaveURL('/mylist?skip=false');
@@ -491,10 +491,10 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // お気に入りフィルターを変更
-    await page.getByLabel('お気に入り').selectOption('true');
+    await page.locator('#favorite-filter').selectOption('true');
 
     // スキップフィルターを変更
-    await page.getByLabel('スキップ').selectOption('false');
+    await page.locator('#skip-filter').selectOption('false');
 
     // URLが更新されることを確認
     await expect(page).toHaveURL('/mylist?favorite=true&skip=false');
@@ -571,7 +571,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // フィルターを変更
-    await page.getByLabel('お気に入り').selectOption('true');
+    await page.locator('#favorite-filter').selectOption('true');
 
     // offsetがリセットされることを確認
     await expect(page).toHaveURL('/mylist?favorite=true');
@@ -606,7 +606,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // フィルターを変更
-    await page.getByLabel('お気に入り').selectOption('true');
+    await page.locator('#favorite-filter').selectOption('true');
 
     // URLが更新されることを確認
     await expect(page).toHaveURL('/mylist?favorite=true');
@@ -637,7 +637,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // フィルターを変更
-    await page.getByLabel('お気に入り').selectOption('true');
+    await page.locator('#favorite-filter').selectOption('true');
 
     await expect(page).toHaveURL('/mylist?favorite=true');
 
@@ -733,7 +733,7 @@ test.describe('Video List URL Synchronization', () => {
     // URL パラメータと Select 要素の value の両方が反映されることを確認
     await expect(page).toHaveURL(/favorite=true/);
     await expect(page).toHaveURL(/skip=false/);
-    await expect(page.getByLabel('お気に入り')).toHaveValue('true');
-    await expect(page.getByLabel('スキップ')).toHaveValue('false');
+    await expect(page.locator('#favorite-filter')).toHaveValue('true');
+    await expect(page.locator('#skip-filter')).toHaveValue('false');
   });
 });

--- a/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
+++ b/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
@@ -33,10 +33,10 @@ test.describe('Video List Page', () => {
     await page.goto('/mylist');
 
     // お気に入りフィルター
-    await expect(page.getByRole('combobox', { name: 'お気に入り' })).toBeVisible();
+    await expect(page.getByLabel('お気に入り')).toBeVisible();
 
     // スキップフィルター
-    await expect(page.getByRole('combobox', { name: 'スキップ' })).toBeVisible();
+    await expect(page.getByLabel('スキップ')).toBeVisible();
 
     // タイトル検索フィールド
     await expect(page.getByPlaceholder('動画タイトルで検索')).toBeVisible();
@@ -47,9 +47,7 @@ test.describe('Video List Page', () => {
     await page.waitForLoadState('networkidle');
 
     // ユーザー設定未作成の状態では「お気に入りのみ」で0件になる
-    const favoriteFilter = page.getByRole('combobox', { name: 'お気に入り' });
-    await favoriteFilter.click();
-    await page.getByRole('option', { name: 'お気に入りのみ' }).click();
+    await page.getByLabel('お気に入り').selectOption('true');
 
     // 空の状態メッセージ
     await expect(page.getByText('動画が見つかりませんでした')).toBeVisible();
@@ -229,9 +227,7 @@ test.describe('Video List Page', () => {
     await page.waitForResponse((res) => res.url().includes('/api/videos/'));
 
     // お気に入りフィルターを変更
-    const favoriteFilter = page.getByRole('combobox', { name: 'お気に入り' });
-    await favoriteFilter.click();
-    await page.getByRole('option', { name: 'お気に入りのみ' }).click();
+    await page.getByLabel('お気に入り').selectOption('true');
 
     // APIレスポンスを待つ
     const filterResponse = await page.waitForResponse((res) => res.url().includes('/api/videos'));
@@ -261,9 +257,7 @@ test.describe('Video List Page', () => {
     await page.waitForLoadState('networkidle');
 
     // スキップフィルターを変更
-    const skipFilter = page.getByRole('combobox', { name: 'スキップ' });
-    await skipFilter.click();
-    await page.getByRole('option', { name: '通常動画のみ' }).click();
+    await page.getByLabel('スキップ').selectOption('false');
 
     // APIレスポンスを待つ
     await page.waitForResponse((response) => response.url().includes('/api/videos'));
@@ -434,9 +428,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // お気に入りフィルターを変更
-    const favoriteFilter = page.getByRole('combobox', { name: 'お気に入り' });
-    await favoriteFilter.click();
-    await page.getByRole('option', { name: 'お気に入りのみ' }).click();
+    await page.getByLabel('お気に入り').selectOption('true');
 
     // URLが更新されることを確認
     await expect(page).toHaveURL('/mylist?favorite=true');
@@ -461,9 +453,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // スキップフィルターを変更
-    const skipFilter = page.getByRole('combobox', { name: 'スキップ' });
-    await skipFilter.click();
-    await page.getByRole('option', { name: '通常動画のみ' }).click();
+    await page.getByLabel('スキップ').selectOption('false');
 
     // URLが更新されることを確認
     await expect(page).toHaveURL('/mylist?skip=false');
@@ -501,14 +491,10 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // お気に入りフィルターを変更
-    const favoriteFilter = page.getByRole('combobox', { name: 'お気に入り' });
-    await favoriteFilter.click();
-    await page.getByRole('option', { name: 'お気に入りのみ' }).click();
+    await page.getByLabel('お気に入り').selectOption('true');
 
     // スキップフィルターを変更
-    const skipFilter = page.getByRole('combobox', { name: 'スキップ' });
-    await skipFilter.click();
-    await page.getByRole('option', { name: '通常動画のみ' }).click();
+    await page.getByLabel('スキップ').selectOption('false');
 
     // URLが更新されることを確認
     await expect(page).toHaveURL('/mylist?favorite=true&skip=false');
@@ -585,9 +571,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // フィルターを変更
-    const favoriteFilter = page.getByRole('combobox', { name: 'お気に入り' });
-    await favoriteFilter.click();
-    await page.getByRole('option', { name: 'お気に入りのみ' }).click();
+    await page.getByLabel('お気に入り').selectOption('true');
 
     // offsetがリセットされることを確認
     await expect(page).toHaveURL('/mylist?favorite=true');
@@ -622,9 +606,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // フィルターを変更
-    const favoriteFilter = page.getByRole('combobox', { name: 'お気に入り' });
-    await favoriteFilter.click();
-    await page.getByRole('option', { name: 'お気に入りのみ' }).click();
+    await page.getByLabel('お気に入り').selectOption('true');
 
     // URLが更新されることを確認
     await expect(page).toHaveURL('/mylist?favorite=true');
@@ -655,9 +637,7 @@ test.describe('Video List URL Synchronization', () => {
     await page.waitForLoadState('networkidle');
 
     // フィルターを変更
-    const favoriteFilter = page.getByRole('combobox', { name: 'お気に入り' });
-    await favoriteFilter.click();
-    await page.getByRole('option', { name: 'お気に入りのみ' }).click();
+    await page.getByLabel('お気に入り').selectOption('true');
 
     await expect(page).toHaveURL('/mylist?favorite=true');
 
@@ -750,10 +730,10 @@ test.describe('Video List URL Synchronization', () => {
     await page.goto('/mylist?favorite=true&skip=false');
     await page.waitForLoadState('networkidle');
 
-    // フィルターの状態が反映されることを確認
-    // Material-UI の Select コンポーネントは combobox ロールだが value を直接確認できないため、
-    // URLパラメータが正しく設定されていることを確認
+    // URL パラメータと Select 要素の value の両方が反映されることを確認
     await expect(page).toHaveURL(/favorite=true/);
     await expect(page).toHaveURL(/skip=false/);
+    await expect(page.getByLabel('お気に入り')).toHaveValue('true');
+    await expect(page.getByLabel('スキップ')).toHaveValue('false');
   });
 });

--- a/services/niconico-mylist-assistant/web/src/components/VideoListFilters.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoListFilters.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Box, FormControl, InputLabel, Select, MenuItem, SelectChangeEvent } from '@mui/material';
-import { Button, TextField } from '@nagiyu/ui';
+import { Box } from '@mui/material';
+import { Button, Select, TextField, type SelectOption } from '@nagiyu/ui';
 
 interface VideoListFiltersProps {
   favoriteFilter: string;
@@ -12,6 +12,18 @@ interface VideoListFiltersProps {
   onSkipFilterChange: (value: string) => void;
   onSearch: (value: string) => void;
 }
+
+const FAVORITE_OPTIONS: ReadonlyArray<SelectOption> = [
+  { value: 'all', label: 'すべて' },
+  { value: 'true', label: 'お気に入りのみ' },
+  { value: 'false', label: 'お気に入り以外' },
+];
+
+const SKIP_OPTIONS: ReadonlyArray<SelectOption> = [
+  { value: 'all', label: 'すべて' },
+  { value: 'false', label: '通常動画のみ' },
+  { value: 'true', label: 'スキップ動画のみ' },
+];
 
 /**
  * 動画一覧フィルターコンポーネント
@@ -33,14 +45,6 @@ export default function VideoListFilters({
     setInputKeyword(searchKeyword);
   }, [searchKeyword]);
 
-  const handleFavoriteChange = (event: SelectChangeEvent) => {
-    onFavoriteFilterChange(event.target.value);
-  };
-
-  const handleSkipChange = (event: SelectChangeEvent) => {
-    onSkipFilterChange(event.target.value);
-  };
-
   const handleSearch = () => {
     onSearch(inputKeyword);
   };
@@ -60,35 +64,29 @@ export default function VideoListFilters({
         mb: 3,
       }}
     >
-      <FormControl size="small" sx={{ minWidth: 200 }}>
-        <InputLabel id="favorite-filter-label">お気に入り</InputLabel>
+      <Box sx={{ minWidth: 200 }}>
         <Select
-          labelId="favorite-filter-label"
           id="favorite-filter"
-          value={favoriteFilter}
           label="お気に入り"
-          onChange={handleFavoriteChange}
-        >
-          <MenuItem value="all">すべて</MenuItem>
-          <MenuItem value="true">お気に入りのみ</MenuItem>
-          <MenuItem value="false">お気に入り以外</MenuItem>
-        </Select>
-      </FormControl>
+          size="sm"
+          value={favoriteFilter}
+          onChange={onFavoriteFilterChange}
+          options={FAVORITE_OPTIONS}
+          fullWidth
+        />
+      </Box>
 
-      <FormControl size="small" sx={{ minWidth: 200 }}>
-        <InputLabel id="skip-filter-label">スキップ</InputLabel>
+      <Box sx={{ minWidth: 200 }}>
         <Select
-          labelId="skip-filter-label"
           id="skip-filter"
-          value={skipFilter}
           label="スキップ"
-          onChange={handleSkipChange}
-        >
-          <MenuItem value="all">すべて</MenuItem>
-          <MenuItem value="false">通常動画のみ</MenuItem>
-          <MenuItem value="true">スキップ動画のみ</MenuItem>
-        </Select>
-      </FormControl>
+          size="sm"
+          value={skipFilter}
+          onChange={onSkipFilterChange}
+          options={SKIP_OPTIONS}
+          fullWidth
+        />
+      </Box>
 
       <Box sx={{ display: 'flex', gap: 1, minWidth: 240 }}>
         <TextField

--- a/services/share-together/web/src/components/ListWorkspace.tsx
+++ b/services/share-together/web/src/components/ListWorkspace.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Box, FormControl, InputLabel, MenuItem, Select, Snackbar, Stack } from '@mui/material';
+import { Box, Snackbar, Stack } from '@mui/material';
+import { Select, type SelectOption } from '@nagiyu/ui';
 import { CreateItemDialog } from '@/components/CreateItemDialog';
 import { ListSidebar } from '@/components/ListSidebar';
 import { TodoList } from '@/components/TodoList';
@@ -15,6 +16,11 @@ type SharedList = {
   listId: string;
   name: string;
 };
+
+const SCOPE_OPTIONS: ReadonlyArray<SelectOption> = [
+  { value: 'personal', label: '個人' },
+  { value: 'shared', label: '共有' },
+];
 
 const ERROR_MESSAGES = {
   SHARED_GROUPS_FETCH_FAILED: '共有グループ一覧の取得に失敗しました',
@@ -267,59 +273,50 @@ export function ListWorkspace({
     <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ alignItems: 'flex-start' }}>
       <Box sx={{ width: { xs: '100%', md: 320 }, flexShrink: 0 }}>
         <Stack spacing={2}>
-          <FormControl fullWidth size="small">
-            <InputLabel id="list-scope-select-label">表示範囲</InputLabel>
+          <Select
+            id="list-scope-select"
+            label="表示範囲"
+            size="sm"
+            fullWidth
+            value={scope}
+            onChange={(nextValue) => {
+              const nextScope = nextValue as 'personal' | 'shared';
+              setScope(nextScope);
+              if (nextScope === 'personal') {
+                setSelectedListId(initialListId);
+              }
+              let nextLists: readonly { listId: string; name: string }[] = [];
+              if (nextScope === 'shared') {
+                nextLists = sharedLists;
+              }
+              if (nextScope === 'shared' && !selectedGroupId && sharedGroups.length > 0) {
+                setSelectedGroupId(sharedGroups[0].groupId);
+              }
+              if (nextLists.length > 0) {
+                setSelectedListId(nextLists[0].listId);
+              }
+            }}
+            options={SCOPE_OPTIONS}
+          />
+          {scope === 'shared' ? (
             <Select
-              labelId="list-scope-select-label"
-              id="list-scope-select"
-              label="表示範囲"
-              value={scope}
-              onChange={(event) => {
-                const nextScope = event.target.value as 'personal' | 'shared';
-                setScope(nextScope);
-                if (nextScope === 'personal') {
-                  setSelectedListId(initialListId);
-                }
-                let nextLists: readonly { listId: string; name: string }[] = [];
-                if (nextScope === 'shared') {
-                  nextLists = sharedLists;
-                }
-                if (nextScope === 'shared' && !selectedGroupId && sharedGroups.length > 0) {
-                  setSelectedGroupId(sharedGroups[0].groupId);
-                }
+              id="shared-group-select"
+              label="グループ"
+              size="sm"
+              fullWidth
+              value={selectedGroupId}
+              onChange={(nextGroupId) => {
+                const nextLists = sharedListsByGroup[nextGroupId] ?? [];
+                setSelectedGroupId(nextGroupId);
                 if (nextLists.length > 0) {
                   setSelectedListId(nextLists[0].listId);
                 }
               }}
-            >
-              <MenuItem value="personal">個人</MenuItem>
-              <MenuItem value="shared">共有</MenuItem>
-            </Select>
-          </FormControl>
-          {scope === 'shared' ? (
-            <FormControl fullWidth size="small">
-              <InputLabel id="shared-group-select-label">グループ</InputLabel>
-              <Select
-                labelId="shared-group-select-label"
-                id="shared-group-select"
-                label="グループ"
-                value={selectedGroupId}
-                onChange={(event) => {
-                  const nextGroupId = event.target.value;
-                  const nextLists = sharedListsByGroup[nextGroupId] ?? [];
-                  setSelectedGroupId(nextGroupId);
-                  if (nextLists.length > 0) {
-                    setSelectedListId(nextLists[0].listId);
-                  }
-                }}
-              >
-                {sharedGroups.map((group) => (
-                  <MenuItem key={group.groupId} value={group.groupId}>
-                    {group.name}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+              options={sharedGroups.map((group) => ({
+                value: group.groupId,
+                label: group.name,
+              }))}
+            />
           ) : null}
           <ListSidebar
             heading={scope === 'personal' ? '個人リスト' : '共有リスト'}

--- a/services/share-together/web/tests/e2e/personal-lists.spec.ts
+++ b/services/share-together/web/tests/e2e/personal-lists.spec.ts
@@ -274,14 +274,12 @@ test.describe('個人リスト管理', () => {
     await page.goto('/lists?listId=list-default');
     await expect(page.getByText('個人スコープToDo')).toBeVisible();
 
-    const scopeSelect = page.getByRole('combobox', { name: '表示範囲' }).first();
+    const scopeSelect = page.getByLabel('表示範囲').first();
 
-    await scopeSelect.click();
-    await page.getByRole('option', { name: '共有' }).click();
+    await scopeSelect.selectOption('shared');
     await expect(page.getByText('共有スコープToDo')).toBeVisible();
 
-    await scopeSelect.click();
-    await page.getByRole('option', { name: '個人' }).click();
+    await scopeSelect.selectOption('personal');
     await expect(page.getByText('個人スコープToDo')).toBeVisible();
     await expect(page.getByText('ToDo一覧の取得に失敗しました。')).not.toBeVisible();
   });
@@ -324,12 +322,9 @@ test.describe('個人リスト管理', () => {
     });
 
     await page.goto('/lists?listId=list-default');
-    const scopeSelect = page.getByRole('combobox', { name: '表示範囲' }).first();
-    await scopeSelect.click();
-    await page.getByRole('option', { name: '共有' }).click();
-    await expect(page.getByRole('combobox', { name: 'グループ' })).toHaveText(
-      '共有作成検証グループ'
-    );
+    const scopeSelect = page.getByLabel('表示範囲').first();
+    await scopeSelect.selectOption('shared');
+    await expect(page.getByLabel('グループ')).toHaveValue('shared-create-group');
     await expect(page.getByRole('button', { name: '共有リストを作成' })).toBeVisible();
 
     await page.getByRole('button', { name: '共有リストを作成' }).click();

--- a/services/share-together/web/tests/unit/ListWorkspace.test.tsx
+++ b/services/share-together/web/tests/unit/ListWorkspace.test.tsx
@@ -234,11 +234,10 @@ describe('ListWorkspace', () => {
   it('個人と共有を切り替えると共有グループと共有ToDoをAPIから表示する', async () => {
     render(<ListWorkspace initialListId="mock-default-list" />);
 
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '共有' }));
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });
 
     await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: 'グループ' })).toBeInTheDocument();
+      expect(screen.getByLabelText('グループ')).toBeInTheDocument();
     });
     await waitFor(() => {
       expect(screen.getByText('会議用の議題を共有する')).toBeInTheDocument();
@@ -248,14 +247,12 @@ describe('ListWorkspace', () => {
   it('共有から個人に戻したときに個人リストのToDoを取得する', async () => {
     render(<ListWorkspace initialListId="mock-default-list" />);
 
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '共有' }));
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });
     await waitFor(() => {
       expect(screen.getByText('会議用の議題を共有する')).toBeInTheDocument();
     });
 
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '個人' }));
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'personal' } });
     await waitFor(() => {
       expect(screen.getByText('個人ToDo(初期)')).toBeInTheDocument();
     });
@@ -267,15 +264,13 @@ describe('ListWorkspace', () => {
   it('共有スコープへ切り替えると選択グループの共有リストを表示できる', async () => {
     render(<ListWorkspace initialListId="group-list-2" />);
 
-    expect(screen.getByRole('combobox', { name: '表示範囲' })).toHaveTextContent('個人');
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '共有' }));
+    expect(screen.getByLabelText('表示範囲')).toHaveValue('personal');
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });
     await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: '表示範囲' })).toHaveTextContent('共有');
+      expect(screen.getByLabelText('表示範囲')).toHaveValue('shared');
     });
-    fireEvent.mouseDown(screen.getByLabelText('グループ'));
-    fireEvent.click(screen.getByRole('option', { name: 'ルームメイト' }));
-    expect(screen.getByRole('combobox', { name: 'グループ' })).toHaveTextContent('ルームメイト');
+    fireEvent.change(screen.getByLabelText('グループ'), { target: { value: 'group-2' } });
+    expect(screen.getByLabelText('グループ')).toHaveValue('group-2');
     await waitFor(() => {
       expect(screen.getByText('ルームメイト家事分担')).toBeInTheDocument();
       expect(screen.getByText('ゴミ出し当番を確認する')).toBeInTheDocument();
@@ -285,9 +280,9 @@ describe('ListWorkspace', () => {
   it('個人リストAPI有効時は個人ToDoをAPIから取得する', async () => {
     render(<ListWorkspace initialListId="api-personal-list-1" />);
 
-    expect(screen.getByRole('combobox', { name: '表示範囲' })).toHaveTextContent('個人');
+    expect(screen.getByLabelText('表示範囲')).toHaveValue('personal');
     expect(screen.getByRole('heading', { name: '個人リスト' })).toBeInTheDocument();
-    expect(screen.queryByRole('combobox', { name: 'グループ' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('グループ')).not.toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByText('API個人ToDo')).toBeInTheDocument();
     });
@@ -300,8 +295,7 @@ describe('ListWorkspace', () => {
   it('共有リスト選択時は URL を変更せず ToDo を切り替える', async () => {
     render(<ListWorkspace initialListId="group-list-2" />);
 
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '共有' }));
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'ルームメイト家事分担' })).toBeInTheDocument();
     });
@@ -314,8 +308,7 @@ describe('ListWorkspace', () => {
   it('共有リストを作成するとAPIを呼び出してリストを追加する', async () => {
     render(<ListWorkspace initialListId="mock-default-list" />);
 
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '共有' }));
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '共有リストを作成' })).toBeInTheDocument();
@@ -348,8 +341,7 @@ describe('ListWorkspace', () => {
   it('共有リスト作成APIが失敗した場合はエラーメッセージを表示する', async () => {
     render(<ListWorkspace initialListId="mock-default-list" />);
 
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '共有' }));
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '共有リストを作成' })).toBeInTheDocument();
@@ -371,8 +363,7 @@ describe('ListWorkspace', () => {
 
     render(<ListWorkspace initialListId="mock-default-list" />);
 
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '共有' }));
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });
 
     await waitFor(() => {
       expect(
@@ -405,8 +396,7 @@ describe('ListWorkspace', () => {
 
     render(<ListWorkspace initialListId="mock-default-list" />);
 
-    fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
-    fireEvent.click(screen.getByRole('option', { name: '共有' }));
+    fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });
 
     await waitFor(() => {
       expect(
@@ -434,7 +424,7 @@ describe('ListWorkspace', () => {
   it('個人スコープでは共有リストの編集・削除ボタンが表示されない', async () => {
     render(<ListWorkspace initialListId="mock-default-list" />);
 
-    expect(screen.getByRole('combobox', { name: '表示範囲' })).toHaveTextContent('個人');
+    expect(screen.getByLabelText('表示範囲')).toHaveValue('personal');
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: /を編集$/ })).not.toBeInTheDocument();
     });

--- a/services/tools/src/app/hash-generator/HashGeneratorClient.tsx
+++ b/services/tools/src/app/hash-generator/HashGeneratorClient.tsx
@@ -5,14 +5,13 @@ import {
   Alert,
   Box,
   Container,
-  MenuItem,
   Snackbar,
   Stack,
-  // eslint-disable-next-line no-restricted-imports -- アルゴリズム選択で TextField の select プロップ（dropdown 化）を使うため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する（Select は PR 2-1-A で別実装予定）
+  // eslint-disable-next-line no-restricted-imports -- multiline + slotProps.input.readOnly + sx 指定が必要なため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する
   TextField,
   Typography,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Select } from '@nagiyu/ui';
 import ClearIcon from '@mui/icons-material/Clear';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
@@ -97,19 +96,13 @@ export default function HashGeneratorClient() {
       </Typography>
 
       <Box sx={{ mb: 3 }}>
-        <TextField
-          select
+        <Select
           fullWidth
           label="アルゴリズム"
           value={algorithm}
-          onChange={(event) => setAlgorithm(event.target.value as HashAlgorithm)}
-        >
-          {HASH_ALGORITHMS.map((item) => (
-            <MenuItem key={item} value={item}>
-              {item}
-            </MenuItem>
-          ))}
-        </TextField>
+          onChange={(value) => setAlgorithm(value as HashAlgorithm)}
+          options={HASH_ALGORITHMS.map((item) => ({ value: item, label: item }))}
+        />
       </Box>
 
       <Box sx={{ mb: 3 }}>

--- a/services/tools/src/app/timestamp-converter/TimestampConverterClient.tsx
+++ b/services/tools/src/app/timestamp-converter/TimestampConverterClient.tsx
@@ -5,14 +5,13 @@ import {
   Alert,
   Box,
   Container,
-  MenuItem,
   Snackbar,
   Stack,
-  // eslint-disable-next-line no-restricted-imports -- タイムゾーン選択で TextField の select プロップ（dropdown 化）を使うため、@nagiyu/ui ではなく MUI の TextField をそのまま利用する（Select は PR 2-1-A で別実装予定）
+  // eslint-disable-next-line no-restricted-imports -- error/helperText の動的切替などの組み合わせで MUI TextField を利用する
   TextField,
   Typography,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import { Button, Select } from '@nagiyu/ui';
 import ClearIcon from '@mui/icons-material/Clear';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { writeToClipboard } from '@nagiyu/browser';
@@ -143,19 +142,16 @@ export default function TimestampConverterClient() {
       </Typography>
 
       <Box sx={{ mb: 3 }}>
-        <TextField
-          select
+        <Select
           fullWidth
           label="タイムゾーン"
           value={timeZone}
-          onChange={(event) => setTimeZone(event.target.value)}
-        >
-          {STOCK_TRACKER_TIMEZONE_OPTIONS.map((option) => (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          ))}
-        </TextField>
+          onChange={setTimeZone}
+          options={STOCK_TRACKER_TIMEZONE_OPTIONS.map((option) => ({
+            value: option.value,
+            label: option.label,
+          }))}
+        />
       </Box>
 
       <Box sx={{ mb: 3 }}>


### PR DESCRIPTION
## 変更の概要

PR 2-1-B（全サービス Select 置換）を 3 PR に分割した **2 番目の PR**:

- PR 2-1-B-1: admin（merged）
- **PR 2-1-B-2（本 PR）: niconico + share-together + tools（4 ファイル + テスト 3 ファイル）**
- PR 2-1-B-3: stock-tracker（8 ファイル）

中規模サービス 3 つで MUI の `Select` / `FormControl` / `InputLabel` / `MenuItem` を `@nagiyu/ui` の `Select` に置換する。

## 置換ファイル

| サービス | ファイル | 変更 |
|---|---|---|
| niconico | `web/src/components/VideoListFilters.tsx` | `<FormControl>` + MUI Select ×2 → shared Select ×2、薄い `handle*` wrapper を撤去 |
| share-together | `web/src/components/ListWorkspace.tsx` | `<FormControl>` + MUI Select ×2（表示範囲・グループ）→ shared Select、`SCOPE_OPTIONS` を const で抽出 |
| tools | `src/app/hash-generator/HashGeneratorClient.tsx` | `<TextField select>` + `<MenuItem>` → shared Select。残る MUI `TextField` の eslint-disable 理由を更新 |
| tools | `src/app/timestamp-converter/TimestampConverterClient.tsx` | 同上 |

## テスト調整（重要）

shared `Select` はネイティブ `<select>` 要素ベースのため、MUI Select の `combobox` role + `mouseDown` パターンを書き換えた。

### ユニット（jest）

```diff
- fireEvent.mouseDown(screen.getByLabelText('表示範囲'));
- fireEvent.click(screen.getByRole('option', { name: '共有' }));
+ fireEvent.change(screen.getByLabelText('表示範囲'), { target: { value: 'shared' } });

- expect(screen.getByRole('combobox', { name: '表示範囲' })).toHaveTextContent('共有');
+ expect(screen.getByLabelText('表示範囲')).toHaveValue('shared');
```

### E2E（Playwright）

```diff
- const scopeSelect = page.getByRole('combobox', { name: '表示範囲' }).first();
- await scopeSelect.click();
- await page.getByRole('option', { name: '共有' }).click();
+ await page.getByLabel('表示範囲').first().selectOption('shared');

- await expect(page.getByRole('combobox', { name: 'お気に入り' })).toBeVisible();
+ await expect(page.getByLabel('お気に入り')).toBeVisible();
```

niconico の video-list.spec.ts には「MUI の combobox は value を直接確認できないため URL パラメータで確認」という古いコメントがあったため、ネイティブ select の value チェック (`toHaveValue`) を追加し、コメントも更新。

## 関連 Issue

#2900

## 変更種別

- [x] 既存機能の改善（共通 UI コンポーネント置換）

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] ローカルでビルドが通ることを確認した
- [x] ローカルでテストが全て通ることを確認した
- [x] ローカルで lint / prettier が全て通ることを確認した

## テスト内容

| 項目 | 結果 |
|---|---|
| `npm run build --workspace=@nagiyu/{niconico-mylist-assistant-web,share-together-web,tools}` | ✅ |
| `npm run lint --workspace=...` | ✅ exit 0（既存 warning は本 PR 無関係） |
| `prettier --check`（変更ファイル） | ✅ |
| `npm test --workspace=@nagiyu/share-together-web` | ✅ 204/204 pass（ListWorkspace.test.tsx 10/10） |
| `npm test --workspace=@nagiyu/tools` | ✅ 148/148 pass |

niconico/web は unit test スクリプト未定義（E2E のみ）。E2E は CI（chromium-mobile）で確認。

## レビューポイント

- **テストパターンの書き換え**: shared Select 採用に伴い、MUI Select 専用のテストヘルパー（`mouseDown` + option click、`combobox` role + `toHaveTextContent`）からネイティブ select 用（`fireEvent.change` + `toHaveValue` / Playwright `selectOption`）へ全面的に書き換えた。今後 Select を使うテストはこのパターンに従う想定（後続 PR 2-1-B-3 でも同様）。
- **`'共有作成検証グループ'` の確認方法**: テキスト一致から `groupId='shared-create-group'` の value 一致に変更。fixture を直接参照する形になるが、テストの意図（共有グループ選択時に `groupId` が当該値になる）はより明確になる。
- **`<FormControl size="small">` の代替**: shared Select に `size="sm"` を渡し、`fullWidth` で親幅に合わせる方式（shared Select は `display: inline-flex` が既定で、`fullWidth=true` で `width: 100%`）。

## スクリーンショット

UI の見た目はネイティブ `<select>` ベースに変わるが、機能は等価（フィルター選択 → 状態反映）。dev デプロイ後に確認予定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_