### PR TITLE
feat: Phase 2 の MUI Select 系を ESLint 禁止対象に追加（PR 2-1-C）

### DIFF
--- a/configs/eslint.config.no-restricted-mui.mjs
+++ b/configs/eslint.config.no-restricted-mui.mjs
@@ -7,6 +7,12 @@
  * 対象を増やす場合（PR 1-2-C 以降）は `paths.importNames` と `patterns.group` の両方に
  * コンポーネント名を追加すること。例外的に MUI を直接使いたい場合は、当該行に
  * `// eslint-disable-next-line no-restricted-imports -- 理由` を付与すること。
+ *
+ * `FormControl` は Select の構成要素として共通 Select に統合済みだが、Radio グループ
+ * 用途（`<FormControl component="fieldset">` で fieldset/legend セマンティクスを得る）
+ * では共通化対象外。該当箇所では disable コメント + 理由で例外運用する。
+ * `MenuItem` も同様に MUI Menu（dropdown）の子要素用途では共通化対象外で、Menu 配下
+ * での利用は disable コメント + 理由で例外運用する。
  */
 export default {
   rules: {
@@ -16,7 +22,17 @@ export default {
         paths: [
           {
             name: '@mui/material',
-            importNames: ['Button', 'TextField', 'Checkbox', 'Chip', 'Link'],
+            importNames: [
+              'Button',
+              'TextField',
+              'Checkbox',
+              'Chip',
+              'Link',
+              'Select',
+              'MenuItem',
+              'FormControl',
+              'InputLabel',
+            ],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },
         ],
@@ -33,6 +49,14 @@ export default {
               '@mui/material/Chip/*',
               '@mui/material/Link',
               '@mui/material/Link/*',
+              '@mui/material/Select',
+              '@mui/material/Select/*',
+              '@mui/material/MenuItem',
+              '@mui/material/MenuItem/*',
+              '@mui/material/FormControl',
+              '@mui/material/FormControl/*',
+              '@mui/material/InputLabel',
+              '@mui/material/InputLabel/*',
             ],
             message: '共通コンポーネントは @nagiyu/ui から import してください',
           },

--- a/services/codec-converter/web/src/app/page.tsx
+++ b/services/codec-converter/web/src/app/page.tsx
@@ -8,13 +8,14 @@ import {
   Typography,
   Paper,
   Alert,
-  FormControl,
   FormLabel,
   RadioGroup,
   FormControlLabel,
   Radio,
   Box,
 } from '@mui/material';
+// eslint-disable-next-line no-restricted-imports -- Radio グループの fieldset/legend セマンティクス用途。共通 Select の構成要素ではないため統合対象外。
+import { FormControl } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 

--- a/services/stock-tracker/web/components/SummaryDetailDialog.tsx
+++ b/services/stock-tracker/web/components/SummaryDetailDialog.tsx
@@ -9,7 +9,6 @@ import {
   Divider,
   IconButton,
   Menu,
-  MenuItem,
   Table,
   TableBody,
   TableCell,
@@ -18,6 +17,8 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+// eslint-disable-next-line no-restricted-imports -- MUI Menu の子要素として利用。共通 Select の選択肢用途とは別物のため統合対象外。
+import { MenuItem } from '@mui/material';
 import { Button, Chip } from '@nagiyu/ui';
 import { Close as CloseIcon } from '@mui/icons-material';
 import AlertSettingsModal from './AlertSettingsModal';


### PR DESCRIPTION
## 変更の概要

Issue #2900 の Phase 2 完結として、共通 Select に統合した MUI コンポーネント（Select / MenuItem / FormControl / InputLabel）を ESLint `no-restricted-imports` で直接 import 禁止対象に追加する（PR 2-1-C）。

### 追加禁止対象

`configs/eslint.config.no-restricted-mui.mjs` の `paths.importNames` と `patterns.group` に以下を追加:

- `Select`
- `MenuItem`
- `FormControl`
- `InputLabel`

### disable + 理由コメントによる例外運用

`FormControl` と `MenuItem` は Select 用途以外でも使われるため、該当 2 箇所で `eslint-disable-next-line no-restricted-imports -- 理由` を付与して例外扱いとする。

| ファイル | 例外用途 |
|---|---|
| `services/codec-converter/web/src/app/page.tsx` | Radio グループの fieldset/legend セマンティクス用途で `<FormControl component="fieldset">` を直接利用 |
| `services/stock-tracker/web/components/SummaryDetailDialog.tsx` | MUI Menu（dropdown）の子要素として `MenuItem` を直接利用 |

これらは共通 Select の構成要素ではないため統合対象外。grep で例外箇所を後追いできるよう、disable には必ず理由コメントを付与する運用とする（`docs/development/shared-ui-components.md` の ADR-11 改修フロー参照）。

## 関連 Issue

Refs #2900

## 変更種別

- [x] CI/CD 更新（ESLint 設定変更）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テスト不要、ESLint 設定変更のみ）
- [x] 関連ドキュメントを更新した（ESLint 設定ファイルの doc コメントを追記）
- [x] CI/CD 設定を追加・更新した
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `npm run lint --workspaces --if-present` ✅ 64 ワークスペース全て pass、エラー 0、warning 1（既存）
- `npm test --workspace=@nagiyu/stock-tracker-web` ✅ 170/170 pass
- `npm run build --workspace=@nagiyu/codec-converter-web` ✅ ビルド成功
- `npm run build --workspace=@nagiyu/stock-tracker-web` ✅ ビルド成功
- `grep -rn "@mui/material.*Select\|MenuItem\|FormControl\|InputLabel"` で残存箇所を全件確認、上記 2 箇所のみが残ることを確認

## レビューポイント

### FormControl / MenuItem の二重用途への対応

両方とも Select 用途以外（Radio グループ・Menu dropdown）で利用されるため、ESLint 一律禁止 + disable 例外運用の形にした。代替案として「FormControl と MenuItem は禁止対象から除外する」も検討したが、以下の理由で disable 運用を採用:

- ドキュメント（適用範囲表）との整合性が取れる
- 例外箇所を grep で機械的に追跡可能
- 将来 Radio / Menu を共通化する際、disable コメント箇所が置換対象として明確

### `eslint.config.no-restricted-mui.mjs` の説明コメント追記

二重用途への対応方針を doc コメントに明文化。Phase 3 / 4 で同様の二重用途コンポーネント（例: `Paper` は単独利用と `Card` 等の構成要素両方）が出てきた場合の参考とする。

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

本 PR マージで Issue #2900 の Phase 2 が完結する。残作業:

1. **integration → develop の PR**: Phase 0〜2 完了後、人の確認を取って起票
2. **Phase 3 / 4 の新規 Issue 起票**: 本 Issue とスコープを分けて別途管理（次に下書き提示予定）

https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy2bJVyRorYXK38Kkq1QYC)_