### PR TITLE
feat(infra): E2E HTML レポートホスティング基盤を追加し portal で PoC

### DIFF
--- a/.github/workflows/portal-verify.yml
+++ b/.github/workflows/portal-verify.yml
@@ -206,6 +206,7 @@ jobs:
 
       - name: Upload Playwright HTML report to reports.nagiyu.com
         if: always()
+        continue-on-error: true
         run: |
           aws s3 sync services/portal/web/playwright-report/ \
             "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
@@ -272,6 +273,7 @@ jobs:
 
       - name: Upload Playwright HTML report to reports.nagiyu.com
         if: always()
+        continue-on-error: true
         run: |
           aws s3 sync services/portal/web/playwright-report/ \
             "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
@@ -338,6 +340,7 @@ jobs:
 
       - name: Upload Playwright HTML report to reports.nagiyu.com
         if: always()
+        continue-on-error: true
         run: |
           aws s3 sync services/portal/web/playwright-report/ \
             "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \

--- a/.github/workflows/portal-verify.yml
+++ b/.github/workflows/portal-verify.yml
@@ -196,6 +196,21 @@ jobs:
           path: services/portal/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/portal/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   e2e-test-chromium-desktop:
     name: Run E2E Tests (chromium-desktop)
     runs-on: ubuntu-latest
@@ -246,6 +261,21 @@ jobs:
           name: test-results-chromium-desktop
           path: services/portal/web/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/portal/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
 
   e2e-test-webkit-mobile:
     name: Run E2E Tests (webkit-mobile)
@@ -298,6 +328,21 @@ jobs:
           path: services/portal/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/portal/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
+
   report:
     name: Report Results to PR
     runs-on: ubuntu-latest
@@ -344,6 +389,13 @@ jobs:
               'skipped': '⏭️'
             };
 
+            const reportBaseUrl = `https://reports.nagiyu.com/portal/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'E2E Tests (chromium-mobile)': 'chromium-mobile',
+              'E2E Tests (chromium-desktop)': 'chromium-desktop',
+              'E2E Tests (webkit-mobile)': 'webkit-mobile',
+            };
+
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = '${{ github.base_ref }}' === 'develop';
             const header = allSuccess
@@ -354,14 +406,19 @@ jobs:
             body += isFull
               ? '**Portal - Full Verification**\n\n'
               : '**Portal - Fast Verification**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({

--- a/docs/development/e2e-reports.md
+++ b/docs/development/e2e-reports.md
@@ -1,0 +1,90 @@
+# E2E HTML レポートのホスティング
+
+各サービスの Playwright E2E テストの HTML レポートは `reports.nagiyu.com` で公開しており、PR コメントから直接開ける。
+
+## URL 体系
+
+```
+https://reports.nagiyu.com/{service}/pr-{pr-number}/{run-id}/{project}/index.html
+```
+
+| 階層 | 値 | 例 |
+|---|---|---|
+| `service` | サービス名 | `portal`, `admin`, `auth-app`, `codec-converter`, `niconico-mylist-assistant`, `quick-clip`, `share-together`, `stock-tracker`, `tools` |
+| `pr-{pr-number}` | GitHub の PR 番号（人間がたどる用） | `pr-123` |
+| `run-id` | GitHub Actions の `${{ github.run_id }}`（globally unique） | `9876543210` |
+| `project` | Playwright project 名 | `chromium-mobile`, `chromium-desktop`, `webkit-mobile` |
+
+例:
+```
+https://reports.nagiyu.com/portal/pr-123/9876543210/chromium-mobile/
+```
+
+`run-id` で URL がユニーク化されているため、CI 再実行時も衝突しない。
+
+## ライフサイクル
+
+- S3 バケット側の **3 日**自動削除ルールでオブジェクトが消える
+- レポートが必要になったら CI を再実行する運用とする
+- 「過去のレポートをずっと残しておく」用途は想定していない（必要なら GitHub Actions の Artifact からダウンロード可能、こちらは 30 日保持）
+
+## アクセス制限
+
+- **public（認証なし）**
+- E2E テストは `USE_IN_MEMORY_DB=true` / `SKIP_AUTH_CHECK=true` でダミーデータのみ扱うため、レポートに機微情報は含まれない前提
+- リポジトリも public のため、テストコード・パス・アサーションはもともと公開情報
+
+## PR コメントとの連携
+
+各サービスの `*-verify.yml` の `report` ジョブが、PR コメントテーブルに **Report 列** を追加する形でリンクを貼る。
+
+```
+| Job | Status | Report |
+|-----|--------|--------|
+| E2E Tests (chromium-mobile) | ✅ success | [📊 View](https://reports.nagiyu.com/...) |
+| E2E Tests (chromium-desktop) | ⏭️ skipped | - |
+```
+
+- `success` または `failure` のときだけリンクを表示
+- `skipped` / `cancelled` では `-`
+
+## 失敗時の見方
+
+1. PR コメントの「📊 View」リンクをクリック
+2. Playwright HTML レポートが開く（テスト一覧・失敗時のスクショ・トレース）
+3. 失敗トレース（`.zip`）はリンク先からダウンロードして [trace.playwright.dev](https://trace.playwright.dev/) に投入すると詳細が見える
+
+レポートが 3 日経過して消えていた場合:
+- CI を再実行して新しい `run-id` でレポートを再生成
+- もしくは GitHub Actions の Artifact（保持期間 30 日）から `playwright-report-*` をダウンロード
+
+## インフラ構成
+
+- S3 バケット `nagiyu-e2e-reports`（環境非依存）
+- CloudFront Distribution（OAC 経由で S3 を参照）
+- Route53 ALIAS レコード `reports.nagiyu.com → CloudFront`
+- 既存の wildcard ACM 証明書（`*.nagiyu.com`）を流用
+- CDK 定義: [`infra/shared/lib/reports-hosting-stack.ts`](../../infra/shared/lib/reports-hosting-stack.ts)
+
+## アップロードフロー
+
+各サービスの `*-verify.yml` の E2E ジョブ末尾で以下を実行:
+
+```yaml
+- name: Configure AWS credentials for report upload
+  if: always()
+  uses: aws-actions/configure-aws-credentials@v4
+  with:
+    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    aws-region: us-east-1
+
+- name: Upload Playwright HTML report to reports.nagiyu.com
+  if: always()
+  run: |
+    aws s3 sync services/{service}/web/playwright-report/ \
+      "s3://nagiyu-e2e-reports/{service}/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/{project}/" \
+      --delete --no-progress
+```
+
+`if: always()` で E2E が失敗してもアップロードを行う（失敗時こそレポートを見たい）。

--- a/infra/shared/bin/shared.ts
+++ b/infra/shared/bin/shared.ts
@@ -12,6 +12,7 @@ import { IamIntegrationPolicyStack } from '../lib/iam/iam-integration-policy-sta
 import { IamUsersStack } from '../lib/iam/iam-users-stack';
 import { DockerBuildLockStack } from '../lib/docker-build-lock-stack';
 import { ErrorEventsTableStack } from '../lib/error-events-table-stack';
+import { ReportsHostingStack } from '../lib/reports-hosting-stack';
 
 const app = new cdk.App();
 
@@ -116,5 +117,13 @@ new ErrorEventsTableStack(
     description: `Platform Error Events DynamoDB Table - ${env} environment`,
   }
 );
+
+// E2E HTML レポートのホスティング基盤（環境非依存）
+// 各サービスの Playwright HTML レポートを reports.nagiyu.com で公開する
+new ReportsHostingStack(app, 'NagiyuE2eReportsHosting', {
+  domainName,
+  env: stackEnv,
+  description: 'E2E HTML reports hosting (S3 + CloudFront)',
+});
 
 app.synth();

--- a/infra/shared/lib/reports-hosting-stack.ts
+++ b/infra/shared/lib/reports-hosting-stack.ts
@@ -1,0 +1,111 @@
+import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as targets from 'aws-cdk-lib/aws-route53-targets';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { SSM_PARAMETERS } from '../libs/utils/ssm';
+
+export interface ReportsHostingStackProps extends cdk.StackProps {
+  domainName: string;
+}
+
+const REPORTS_SUBDOMAIN = 'reports';
+const REPORTS_BUCKET_NAME = 'nagiyu-e2e-reports';
+const REPORTS_LIFECYCLE_DAYS = 3;
+
+/**
+ * E2E HTML レポートを reports.nagiyu.com で公開するためのホスティング基盤
+ *
+ * - S3 バケットに各サービスの Playwright HTML レポートを GitHub Actions から sync
+ * - CloudFront + OAC 経由で公開（バケット自体は非公開）
+ * - 既存の wildcard ACM 証明書（*.nagiyu.com）を流用
+ * - 3 日経過したオブジェクトは自動削除（CI 再実行で再生成する運用）
+ *
+ * URL 体系:
+ *   https://reports.nagiyu.com/{service}/pr-{pr-number}/{run-id}/{project}/index.html
+ */
+export class ReportsHostingStack extends cdk.Stack {
+  public readonly bucket: s3.IBucket;
+  public readonly distribution: cloudfront.IDistribution;
+
+  constructor(scope: Construct, id: string, props: ReportsHostingStackProps) {
+    super(scope, id, props);
+
+    this.bucket = new s3.Bucket(this, 'ReportsBucket', {
+      bucketName: REPORTS_BUCKET_NAME,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      versioned: false,
+      lifecycleRules: [
+        {
+          id: 'DeleteAfter3Days',
+          enabled: true,
+          expiration: cdk.Duration.days(REPORTS_LIFECYCLE_DAYS),
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
+        },
+      ],
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    const certificateArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.ACM_CERTIFICATE_ARN
+    );
+    const certificate = acm.Certificate.fromCertificateArn(this, 'Certificate', certificateArn);
+
+    const reportsDomain = `${REPORTS_SUBDOMAIN}.${props.domainName}`;
+
+    this.distribution = new cloudfront.Distribution(this, 'ReportsDistribution', {
+      comment: 'E2E Playwright HTML reports hosting',
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(this.bucket),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+        cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        compress: true,
+      },
+      defaultRootObject: 'index.html',
+      domainNames: [reportsDomain],
+      certificate,
+      minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
+      httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+    });
+
+    const hostedZoneId = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.ROUTE53_HOSTED_ZONE_ID
+    );
+    const hostedZone = route53.HostedZone.fromHostedZoneAttributes(this, 'HostedZone', {
+      hostedZoneId,
+      zoneName: props.domainName,
+    });
+
+    new route53.ARecord(this, 'ReportsAliasRecord', {
+      zone: hostedZone,
+      recordName: REPORTS_SUBDOMAIN,
+      target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(this.distribution)),
+      comment: 'E2E reports hosting (alias to CloudFront)',
+    });
+
+    new cdk.CfnOutput(this, 'BucketName', {
+      value: this.bucket.bucketName,
+      description: 'S3 bucket for E2E HTML reports',
+    });
+
+    new cdk.CfnOutput(this, 'DistributionDomainName', {
+      value: this.distribution.distributionDomainName,
+      description: 'CloudFront distribution domain for E2E reports',
+    });
+
+    new cdk.CfnOutput(this, 'ReportsDomain', {
+      value: reportsDomain,
+      description: 'Public domain for E2E reports',
+    });
+  }
+}

--- a/infra/shared/tests/unit/reports-hosting-stack.test.js
+++ b/infra/shared/tests/unit/reports-hosting-stack.test.js
@@ -1,0 +1,79 @@
+const cdk = require('aws-cdk-lib');
+const { Template, Match } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { ReportsHostingStack } = require('../../lib/reports-hosting-stack');
+
+const STACK_PROPS = {
+  domainName: 'nagiyu.com',
+  env: { account: '123456789012', region: 'us-east-1' },
+};
+
+describe('ReportsHostingStack', () => {
+  it('固定バケット名で E2E レポート用 S3 バケットを作成する', () => {
+    const app = new cdk.App();
+    const stack = new ReportsHostingStack(app, 'TestReportsHostingStack', STACK_PROPS);
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: 'nagiyu-e2e-reports',
+    });
+  });
+
+  it('パブリックアクセスブロックを有効化する', () => {
+    const app = new cdk.App();
+    const stack = new ReportsHostingStack(app, 'TestReportsHostingStack', STACK_PROPS);
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+    });
+  });
+
+  it('3 日でレポートオブジェクトを削除するライフサイクルルールを設定する', () => {
+    const app = new cdk.App();
+    const stack = new ReportsHostingStack(app, 'TestReportsHostingStack', STACK_PROPS);
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      LifecycleConfiguration: {
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Id: 'DeleteAfter3Days',
+            Status: 'Enabled',
+            ExpirationInDays: 3,
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('reports.nagiyu.com を CloudFront のエイリアスドメインに設定する', () => {
+    const app = new cdk.App();
+    const stack = new ReportsHostingStack(app, 'TestReportsHostingStack', STACK_PROPS);
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        Aliases: ['reports.nagiyu.com'],
+        DefaultRootObject: 'index.html',
+      }),
+    });
+  });
+
+  it('Route53 に reports サブドメインの ALIAS レコードを作成する', () => {
+    const app = new cdk.App();
+    const stack = new ReportsHostingStack(app, 'TestReportsHostingStack', STACK_PROPS);
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::Route53::RecordSet', {
+      Name: 'reports.nagiyu.com.',
+      Type: 'A',
+    });
+  });
+});

--- a/tasks/issue-2976-e2e-report-hosting/design.md
+++ b/tasks/issue-2976-e2e-report-hosting/design.md
@@ -1,0 +1,186 @@
+# E2E HTML レポートホスティング - 技術設計
+
+<!--
+    このドキュメントは開発時のみ使用します。
+    開発完了後に重要な設計決定を docs/ に ADR として抽出し、
+    tasks/issue-2976-e2e-report-hosting/ ディレクトリごと削除します。
+-->
+
+## ゴール
+
+`reports.nagiyu.com` で各サービスの Playwright HTML レポートを公開し、PR コメントから直接開けるようにする。
+
+## アーキテクチャ概要
+
+```
+GitHub Actions (E2E job)
+  └─ aws s3 sync playwright-report/ → S3 bucket
+                                              │
+Browser (PR reviewer)                          │
+  └─ https://reports.nagiyu.com/...            │
+        ↓                                       │
+Route53 (reports.nagiyu.com → ALIAS)            │
+        ↓                                       │
+CloudFront (新規 distribution)                  │
+        ↓ OAC                                   │
+S3 bucket ←──────────────────────────────────────┘
+  └─ Lifecycle: 3 日で自動削除
+```
+
+## CDK 実装場所
+
+**結論: `infra/shared/` 配下に新規スタックとして追加**
+
+### 検討した選択肢
+
+| 案 | メリット | デメリット |
+|---|---|---|
+| A. `infra/reports/` を新規作成 | サービスと同じ独立構造で対称性が高い | 新規パッケージのオーバーヘッド（package.json / tsconfig 等） |
+| B. `infra/shared/lib/reports-hosting-stack.ts` 追加 | プラットフォーム横断リソースとして既存 `DockerBuildLockStack` `ErrorEventsTableStack` と並列、軽量 | shared にデプロイ系リソースが混ざる |
+
+**B を採用**: 全サービスで共有される CI 基盤リソースであり、`DockerBuildLockStack`（同じく CI 用 S3 バケット）の前例がある。
+
+### 追加するスタック
+
+`infra/shared/lib/reports-hosting-stack.ts`:
+- S3 バケット（`nagiyu-e2e-reports`）
+    - encryption: S3_MANAGED
+    - blockPublicAccess: BLOCK_ALL（CloudFront OAC 経由のみ）
+    - lifecycle: 3 日で削除
+- CloudFront Distribution
+    - origin: S3 (Origin Access Control)
+    - 既存の wildcard ACM 証明書（`*.nagiyu.com`）を SSM 経由で参照
+    - エイリアスドメイン: `reports.nagiyu.com`
+    - default behavior: CACHING_OPTIMIZED（URL に `run_id` が含まれるため同じ URL で内容が変わらず、キャッシュの安全性が担保される）
+    - default root object: `index.html`
+- Route53 ARecord
+    - `reports.nagiyu.com` → CloudFront ALIAS
+
+`infra/shared/bin/shared.ts` に `ReportsHostingStack` の追加を反映。
+
+## ACM 証明書
+
+**結論: 既存の wildcard `*.nagiyu.com` を流用**
+
+`infra/shared/lib/acm-stack.ts` で既に `*.nagiyu.com` の wildcard 証明書を発行しており、SSM Parameter `SSM_PARAMETERS.ACM_CERTIFICATE_ARN` で参照可能。`reports.nagiyu.com` はそのカバー範囲内なので、新規証明書は発行しない。
+
+## 環境分離
+
+**結論: 環境分離なし（dev/prod の区別をしない）**
+
+E2E は PR の verify ジョブで実行されるものであり、master PR では発火しない（既存ワークフローの `on.pull_request.branches: [integration/**, develop]` で確認済み）。よってレポートは「dev 寄りの開発成果物」しか存在せず、本番系と分離する動機がない。
+
+S3 バケット名・CloudFront・Route53 レコードはすべて 1 セットのみ。
+
+## URL 体系
+
+```
+https://reports.nagiyu.com/{service}/pr-{pr-number}/{run-id}/{project}/index.html
+```
+
+| 階層 | 値 | 例 |
+|---|---|---|
+| service | サービス名 | `portal` / `admin` / `auth-app` / ... |
+| pr-{pr-number} | PR 番号（人間がたどる用） | `pr-123` |
+| run-id | GitHub Actions の `run_id` | `9876543210` |
+| project | Playwright project 名 | `chromium-mobile` |
+
+`run-id` は globally unique なので、再実行時も衝突しない。
+
+## CI ワークフロー変更
+
+### E2E ジョブに追加するステップ
+
+```yaml
+- name: Configure AWS credentials
+  uses: aws-actions/configure-aws-credentials@v4
+  with:
+    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    aws-region: us-east-1
+
+- name: Upload Playwright report to S3
+  if: always()
+  run: |
+    aws s3 sync services/portal/web/playwright-report/ \
+      "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+      --delete
+
+- name: Output report URL
+  if: always()
+  id: report-url
+  run: |
+    echo "url=https://reports.nagiyu.com/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" >> "$GITHUB_OUTPUT"
+```
+
+### IAM 権限
+
+既存の `secrets.AWS_ACCESS_KEY_ID` で使われる IAM ユーザー（`infra/shared/lib/iam/iam-application-policy-stack.ts` の application policy）には既に `s3:PutObject` / `s3:GetObject` / `s3:DeleteObject` が `resources: ['*']` で付与されているため、**追加の IAM 変更は不要**。
+
+### Report ジョブの変更
+
+各 `*-verify.yml` の `report` ジョブで生成している PR コメントテーブルに、HTML レポートのリンク列を追加する。
+
+```javascript
+// 既存
+const results = {
+  'E2E Tests (chromium-mobile)': '${{ needs.e2e-test-chromium-mobile.result }}',
+  // ...
+};
+
+// 追加
+const reportUrls = {
+  'E2E Tests (chromium-mobile)': 'https://reports.nagiyu.com/portal/pr-{pr}/{run-id}/chromium-mobile/',
+  // ...
+};
+
+// テーブルに Report 列を追加
+body += '| Job | Status | Report |\n';
+body += '|-----|--------|--------|\n';
+for (const [job, result] of Object.entries(results)) {
+  const url = reportUrls[job];
+  const link = url ? `[📊 View](${url})` : '-';
+  body += `| ${job} | ${emoji} ${result} | ${link} |\n`;
+}
+```
+
+## 実装ステップ（PoC PR）
+
+1. `infra/shared/lib/reports-hosting-stack.ts` 新規作成
+2. `infra/shared/bin/shared.ts` にスタック追加
+3. `.github/workflows/portal-verify.yml` の E2E ジョブに S3 アップロード追加
+4. `.github/workflows/portal-verify.yml` の Report ジョブに HTML レポートリンク追加
+5. `docs/development/e2e-reports.md`（仮）に運用ドキュメント追加
+6. CI を実行し、実物のレポート HTML が想定通り公開されることを確認
+7. レポート HTML に機微情報が含まれていないことを目視確認
+
+## 横展開 PR（別 PR）
+
+PoC が動いたら、残り 8 サービスの `*-verify.yml` に同じパターンを適用する:
+
+- `admin-verify.yml`
+- `auth-verify-app.yml`
+- `codec-converter-verify.yml`
+- `niconico-mylist-assistant-verify.yml`
+- `quick-clip-verify.yml`
+- `share-together-verify.yml`
+- `stock-tracker-verify.yml`
+- `tools-verify.yml`
+
+## 確定済み方針（user 確認済み）
+
+1. **CDK 実装場所**: `infra/shared/lib/reports-hosting-stack.ts`
+2. **S3 バケット名**: `nagiyu-e2e-reports`
+3. **CloudFront キャッシュポリシー**: `CACHING_OPTIMIZED`（URL に `run_id` を含むため安全）
+4. **OAC**: 新規構築のため Origin Access Control を採用
+5. **CDK スタック名**: `NagiyuE2eReportsHosting`
+6. **PR コメント表示形式**: 既存テーブルに Report 列を追加（各 E2E 行に `[📊 View](url)`）
+
+## docs/ への移行メモ
+
+- [ ] `docs/development/e2e-reports.md`（新規）に運用ドキュメントを作成
+    - URL 体系
+    - ライフサイクル（3 日で削除、CI 再実行で再生成）
+    - PR コメントからのアクセス方法
+    - トラブル時の見方（S3 直接 / Artifact フォールバック）
+- [ ] `docs/branching.md` に「E2E レポートが reports.nagiyu.com で公開されている」旨を追記（任意）


### PR DESCRIPTION
## 変更の概要

`reports.nagiyu.com` で各サービスの Playwright HTML レポートを公開するホスティング基盤を整備し、`portal` サービスで PoC を実装する。

これまで GitHub Actions Artifact からダウンロードして手元で展開する必要があった HTML レポートを、PR コメントのリンクから直接ブラウザで開けるようにする。

### この PR に含まれる変更

- **インフラ（CDK）**
    - `infra/shared/lib/reports-hosting-stack.ts`: 新規スタック
        - S3 バケット `nagiyu-e2e-reports`（3 日ライフサイクル、BlockPublicAccess）
        - CloudFront Distribution（OAC 経由で S3 を origin、`CACHING_OPTIMIZED`）
        - 既存 wildcard ACM 証明書（`*.nagiyu.com`）を SSM 経由で流用
        - Route53 ALIAS レコード `reports.nagiyu.com → CloudFront`
    - `infra/shared/bin/shared.ts`: スタック配線追加
    - `infra/shared/tests/unit/reports-hosting-stack.test.js`: 5 件のユニットテスト追加
- **CI ワークフロー（PoC: portal のみ）**
    - `.github/workflows/portal-verify.yml` の E2E 3 ジョブ末尾に S3 sync ステップを追加
    - `report` ジョブの PR コメントテーブルに **Report 列**を追加し、各 E2E 行に `[📊 View](url)` のリンクを掲載
- **ドキュメント**
    - `docs/development/e2e-reports.md`: 運用ドキュメント新規作成（URL 体系・ライフサイクル・PR 連携・トラブル時の見方等）
    - `tasks/issue-2976-e2e-report-hosting/design.md`: 開発時の設計メモ（マージ前に削除予定）

## 関連 Issue

refs #2976（integration → develop の PR で `Closes #2976` を付ける）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新
- [x] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（CDK スタックに 5 件のユニットテスト）
- [x] 関連ドキュメントを更新した（`docs/development/e2e-reports.md`）
- [x] CI/CD 設定を追加・更新した（portal の verify ワークフロー）
- [x] ローカルでテストが全て通ることを確認した（`infra-shared` の lint / test グリーン）
- [x] ビルドエラーがないことを確認した（CDK synth 成功）

## テスト内容

### CDK ユニットテスト（`infra/shared/tests/unit/reports-hosting-stack.test.js`）

- 固定バケット名 `nagiyu-e2e-reports` で S3 バケットが作成される
- パブリックアクセスブロックが全項目で有効化される
- 3 日でレポートを削除するライフサイクルルールが設定される
- CloudFront に `reports.nagiyu.com` がエイリアスドメインとして設定される
- Route53 に `reports.nagiyu.com` の A レコード（ALIAS）が作成される

### CDK synth 確認

```bash
cd infra/shared
DOMAIN_NAME=nagiyu.com CDK_DEFAULT_ACCOUNT=... CDK_DEFAULT_REGION=us-east-1 \
  npx cdk synth NagiyuE2eReportsHosting
```

- `BucketName` / `DistributionDomainName` / `ReportsDomain=reports.nagiyu.com` が Outputs に出力されることを確認

### CI 動作確認（マージ後 dev で確認）

- portal の verify ジョブで E2E 実行時にレポートが S3 にアップロードされる
- PR コメントの Report 列に正しい URL が表示される
- `https://reports.nagiyu.com/portal/pr-{pr}/{run-id}/{project}/` で HTML レポートが開ける
- レポート内容に想定外の機微情報が含まれていないことを目視確認

## レビューポイント

1. **CDK スタックの実装場所**: `infra/shared/lib/` に追加する選択をした（プラットフォーム横断リソースで `DockerBuildLockStack` の前例あり）。代替案として `infra/reports/` 独立パッケージ化もあったが、軽量さを優先。
2. **CloudFront キャッシュ**: `CACHING_OPTIMIZED` を採用。URL に `run_id` が含まれるため同じ URL で内容が変わることはなく、キャッシュの安全性が担保される。
3. **アクセス制限**: いったん public（認証なし）で構築。`USE_IN_MEMORY_DB=true` / `SKIP_AUTH_CHECK=true` でダミーデータのみ扱う前提で、レポートに機微情報は含まれない判断。実物を見て要否を再判断する。
4. **PR コメントの Report 列**: テーブルに列を追加するスタイルで、`success`/`failure` のときのみリンク表示、`skipped`/`cancelled` では `-`。
5. **既存の Artifact 機能は残す**: `actions/upload-artifact` 30 日保持はそのまま維持し、3 日経過してレポートが消えた場合のフォールバックにする。

## スクリーンショット

なし（CI/インフラ変更のみ）。デプロイ後の PR コメントは別途確認予定。

## 補足事項

- 横展開（残り 8 サービス: admin / auth-app / codec-converter / niconico-mylist-assistant / quick-clip / share-together / stock-tracker / tools）は本 PR マージ後に別 PR で対応する
- stock-tracker E2E ジョブの不要な AWS 認証情報整理は別 Issue（#2977）にて
- `tasks/issue-2976-e2e-report-hosting/` は integration → develop マージ前に削除する


---
_Generated by [Claude Code](https://claude.ai/code/session_01QRcHL3Ad9ao64z63qE1WfF)_