### PR TITLE
fix(services): @nagiyu/ui の tokens.css を全サービスで import + stock-tracker のレイアウト堅牢化

### DIFF
--- a/services/admin/web/src/app/layout.tsx
+++ b/services/admin/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { ServiceLayout } from '@nagiyu/ui';
+import '@nagiyu/ui/tokens.css';
 import './globals.css';
 
 export const metadata: Metadata = {

--- a/services/auth/web/src/app/layout.tsx
+++ b/services/auth/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { ServiceLayout } from '@nagiyu/ui';
+import '@nagiyu/ui/tokens.css';
 import './globals.css';
 
 export const metadata: Metadata = {

--- a/services/codec-converter/web/src/app/layout.tsx
+++ b/services/codec-converter/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { ServiceLayout } from '@nagiyu/ui';
+import '@nagiyu/ui/tokens.css';
 
 export const metadata: Metadata = {
   title: 'Codec Converter',

--- a/services/niconico-mylist-assistant/web/src/app/layout.tsx
+++ b/services/niconico-mylist-assistant/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { ServiceLayout, ServiceWorkerRegistration } from '@nagiyu/ui';
 import { Navigation } from '@/components/Navigation';
+import '@nagiyu/ui/tokens.css';
 import './globals.css';
 
 export const metadata: Metadata = {

--- a/services/quick-clip/web/src/app/layout.tsx
+++ b/services/quick-clip/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { ServiceLayout } from '@nagiyu/ui';
+import '@nagiyu/ui/tokens.css';
 
 export const metadata: Metadata = {
   title: 'さくっとクリップ',

--- a/services/share-together/web/jest.config.ts
+++ b/services/share-together/web/jest.config.ts
@@ -8,6 +8,8 @@ const config: Config = {
   moduleNameMapper: {
     // @nagiyu/ui の CSS Modules import をスタブ化（クラス名そのものを返す）
     '\\.module\\.css$': 'identity-obj-proxy',
+    // @nagiyu/ui/tokens.css は CSS Modules ではないため別途スタブ化（layout 系テストで参照される）
+    '^@nagiyu/ui/tokens\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/share-together-core$': '<rootDir>/../core/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',

--- a/services/share-together/web/src/app/layout.tsx
+++ b/services/share-together/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { ServiceLayout, ServiceWorkerRegistration } from '@nagiyu/ui';
 import LastVisitedPathTracker from '@/components/LastVisitedPathTracker';
 import { Navigation } from '@/components/Navigation';
 import UserRegistrationInitializer from '@/components/UserRegistrationInitializer';
+import '@nagiyu/ui/tokens.css';
 
 export const metadata: Metadata = {
   title: 'Share Together',

--- a/services/stock-tracker/web/app/globals.css
+++ b/services/stock-tracker/web/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-family-sans);
+  font-family: Arial, Helvetica, sans-serif;
 }

--- a/services/stock-tracker/web/app/globals.css
+++ b/services/stock-tracker/web/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-family-sans);
 }

--- a/services/stock-tracker/web/app/layout.tsx
+++ b/services/stock-tracker/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { ServiceWorkerRegistration } from '@nagiyu/ui';
 import ThemeRegistry from '@/components/ThemeRegistry';
+import '@nagiyu/ui/tokens.css';
 import './globals.css';
 
 export const metadata: Metadata = {

--- a/services/stock-tracker/web/app/summaries/page.tsx
+++ b/services/stock-tracker/web/app/summaries/page.tsx
@@ -143,7 +143,7 @@ export default function SummariesPage() {
       <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
         日次サマリー
       </Typography>
-      <Box sx={{ display: 'flex', gap: 2, mb: 2, alignItems: 'center' }}>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2, alignItems: 'center', flexWrap: 'wrap' }}>
         <Box sx={{ minWidth: 220 }}>
           <Select
             id="exchange-filter"

--- a/services/stock-tracker/web/app/summaries/page.tsx
+++ b/services/stock-tracker/web/app/summaries/page.tsx
@@ -182,7 +182,7 @@ export default function SummariesPage() {
         </Alert>
       )}
 
-      <Box sx={{ display: 'grid', gap: 2 }}>
+      <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: 'minmax(0, 1fr)' }}>
         {isLoading ? (
           <Typography color="text.secondary">読み込み中...</Typography>
         ) : (

--- a/services/tools/src/app/layout.tsx
+++ b/services/tools/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Header, Footer, type NavigationItem } from '@nagiyu/ui';
 import HomeIcon from '@mui/icons-material/Home';
 import InfoIcon from '@mui/icons-material/Info';
 import ThemeRegistry from '@/components/ThemeRegistry';
+import '@nagiyu/ui/tokens.css';
 import './globals.css';
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## 変更の概要

`portal` 以外の 8 サービス（admin / auth / codec-converter / niconico-mylist-assistant / quick-clip / share-together / stock-tracker / tools）のルートレイアウト (`app/layout.tsx`) で `@nagiyu/ui/tokens.css` が未 import になっていたため、`@nagiyu/ui` の共有コンポーネント（Button / Chip / Link / TextField / Select / Checkbox 等）が参照する CSS 変数（`--font-family-sans` / `--color-action-*` / `--color-border-*` / `--spacing-*` 等）が全て未定義となり、宣言が invalid at computed value time で無効化されて見た目が崩れていた問題を修正する。

### 解消される症状（Tools / Niconico Mylist Assistant 等で確認済み）

- フォントがブラウザ既定（セリフ系）に化ける
- ボタンが背景・枠線とも透明の "白抜き" 状態になる
- TextField の枠線が消えて入力欄の境界が分からなくなる
- 余白・角丸・フォーカスリング等も併せて崩れる

`portal/web` のみ既に対応済み（`services/portal/web/src/app/layout.tsx:10`）だったため、それに揃える形で残り 8 サービスを修正する。

### 主な変更

1. **8 サービスの `app/layout.tsx`** に `import '@nagiyu/ui/tokens.css';` を追加
   - `globals.css` を import している 5 サービスではその直前に挿入（`portal/web` と同じ並び）
   - `globals.css` を import していない 3 サービス（`share-together` / `quick-clip` / `codec-converter`）では、最後の `@nagiyu/ui` import 直後に挿入

2. **`services/share-together/web/jest.config.ts`** の `moduleNameMapper` に `^@nagiyu/ui/tokens\\.css$` を追加（`tests/unit/app/layout.test.tsx` が tokens.css の import を解決できず Web Unit Tests が落ちていた件の対処）

3. **`services/stock-tracker/web/app/summaries/page.tsx`** のレイアウトを font-metric 変動に対して堅牢化:
   - アクションバーの flex Box に `flexWrap: 'wrap'` を追加
   - サマリーカード一覧の grid Box に `gridTemplateColumns: 'minmax(0, 1fr)'` を明示

   tokens.css 適用後に MUI の `typography.fontFamily` が sans stack に解決され、CI 上の実フォントが Roboto 系に変わって cell やボタン幅が増えた結果、grid item の既定 `min-width: auto` のために `<Table sx={{ minWidth: 760 }}>` が grid track を膨張させ、root が viewport を横にはみ出して E2E `summary-display.spec.ts:525 詳細ダイアログがモバイル幅で画面内に収まる` が失敗していた。grid・flex の縮小可能性を明示することで解消。

## 関連 Issue

Closes #2972

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保） — 既存テストの jest 設定を 1 行追加（share-together）。新規テストは追加していない。本件は CSS 変数 import の有無による見た目の問題で、ユニットテストでの検出は困難。dev 環境での目視確認で担保。
- [ ] 関連ドキュメントを更新した — `docs/development/shared-ui-components.md` 等にサービス側で tokens.css を import する旨の補足は本 PR スコープ外（必要なら別 PR）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合） — 該当なし
- [x] ローカルでテストが全て通ることを確認した — share-together は ローカル `npm test` で 44 suites / 204 tests 全 pass を確認
- [x] ビルドエラーがないことを確認した — Fast CI (8 サービス) 全て pass

## テスト内容

- 既存の単体テスト・E2E テストへの影響を CI で確認:
    - Web Unit Tests: 全 8 サービス pass
    - E2E (chromium-mobile): 全 8 サービス pass（含 stock-tracker `tests/e2e/summary-display.spec.ts:525`）
    - Lint / Format / Build / Docker Build: 全 pass

- dev 環境で各サービスを目視確認:
    - フォントがサンセリフ系に正しく解決されている
    - 共有 Button の `solid` バリアントに背景色（青／グレー等）が正しく付く
    - 共有 TextField / Select の枠線が表示されている
    - Stock Tracker `/summaries` のモバイル表示で「サマリー更新」ボタンが viewport 内に収まる

## レビューポイント

- **import の挿入位置**: `globals.css` よりも**前**に置く（globals.css がトークンを上書きできる順序にする / `portal/web` の慣習に揃える）。`globals.css` 未 import のサービスは最後の `@nagiyu/ui` import 直後に置いた。
- **stock-tracker のレイアウト堅牢化**: `flexWrap: 'wrap'` と `minmax(0, 1fr)` は font-metric 変動にも耐える既知のテクニック。表示は通常時変わらず、狭い viewport で正しく折り返し / 横スクロールするようになるだけ。
- **`@nagiyu/ui` パッケージ側で tokens.css を自動 import する根本対策**（バンドラーの CSS order に影響）は本 PR ではやらず、サービス側で明示 import する現方針を維持している。今後 9 個目以降のサービスを追加する際は、サービス側で tokens.css の import を忘れないよう運用ルールに含める方が良いかも。

## スクリーンショット（該当する場合）

dev 環境での目視確認済み（人力レビュー時に必要なら添付）。

## 補足事項

- 本 PR は integration ブランチ `integration/2972-shared-ui-tokens-import` から develop へのマージ用 PR（Draft 作成）。Ready 化・マージは人力で実施する。
- 作業ブランチ → integration への PR (#2973) は既に Ready 化・マージ済み。
- 含まれる commit:
    - 8 サービスの layout.tsx に tokens.css import 追加
    - share-together の jest.config に tokens.css moduleNameMapper 追加
    - stock-tracker `/summaries` の grid / flex 堅牢化（2 箇所）
    - body フォント変更の試行＋revert（履歴に意思決定の経緯を残すため敢えて squash していない；squash merge を希望なら mergeコマンド側で対応可）


---
_Generated by [Claude Code](https://claude.ai/code/session_016VYTu368MQQy4MwarB67sf)_