### PR TITLE
revert(ci): portal の S3 アップロード step から continue-on-error を削除

### DIFF
--- a/.github/workflows/portal-verify.yml
+++ b/.github/workflows/portal-verify.yml
@@ -206,7 +206,6 @@ jobs:
 
       - name: Upload Playwright HTML report to reports.nagiyu.com
         if: always()
-        continue-on-error: true
         run: |
           aws s3 sync services/portal/web/playwright-report/ \
             "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
@@ -273,7 +272,6 @@ jobs:
 
       - name: Upload Playwright HTML report to reports.nagiyu.com
         if: always()
-        continue-on-error: true
         run: |
           aws s3 sync services/portal/web/playwright-report/ \
             "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
@@ -340,7 +338,6 @@ jobs:
 
       - name: Upload Playwright HTML report to reports.nagiyu.com
         if: always()
-        continue-on-error: true
         run: |
           aws s3 sync services/portal/web/playwright-report/ \
             "s3://nagiyu-e2e-reports/portal/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \


### PR DESCRIPTION
## 変更の概要

PR #2978 で鶏と卵対策として一時的に追加していた `continue-on-error: true` を、portal-verify.yml の E2E アップロードステップ 3 つから削除する。

CDK スタックは dev にデプロイ済みで `nagiyu-e2e-reports` バケットが存在するため、本来の挙動（S3 アップロード失敗時に E2E ジョブを fail させる）に戻すことで、レポート公開機能を **end-to-end で初めて検証** する段階に入る。

## 関連 Issue

refs #2976

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（CI 自体が検証）
- [x] 関連ドキュメントを更新した（変更なし、運用ドキュメントは前 PR で追加済み）
- [x] CI/CD 設定を追加・更新した
- [x] ローカルでテストが全て通ることを確認した（YAML 構文 OK）
- [x] ビルドエラーがないことを確認した

## テスト内容

本 PR の「テスト」は **CI 自体**。`continue-on-error` のセーフティネットを外した状態で、以下を初めて end-to-end 検証する:

1. `aws s3 sync` が CI から成功するか（IAM ポリシーの過不足、バケット名の妥当性）
2. PR コメントに表示される `https://reports.nagiyu.com/portal/pr-{pr}/{run-id}/{project}/` が実際にブラウザで開けるか（OAC のバケットポリシー、CloudFront、Route53、ACM）
3. レポート HTML 内のアセット（CSS / JS / トレース等）が正しく配信されるか

## レビューポイント

### この PR がグリーンになる条件

- portal の E2E（chromium-mobile）が成功
    - テスト本体の成否は前 PR と同じ
    - 加えて `Upload Playwright HTML report to reports.nagiyu.com` ステップが成功すること

### この PR が赤くなった場合の想定原因

| 症状 | 想定原因 | 対処 |
|---|---|---|
| `aws s3 sync` で AccessDenied | IAM ポリシー不足、バケットポリシー未設定 | `infra/shared/lib/iam/iam-application-policy-stack.ts` の `s3:*` 範囲、CDK の OAC 設定確認 |
| sync 成功するも `reports.nagiyu.com` で 403/404 | CloudFront OAC のバケットポリシー反映漏れ、defaultRootObject 不備 | CDK の `S3BucketOrigin.withOriginAccessControl()` 自動設定確認 |
| DNS が引けない | Route53 ALIAS レコード反映待ち、hosted zone 関連 | dig で確認 |

### マージ前確認

- [ ] PR コメントの Report 列のリンクをクリックしてレポート HTML が開けることを実物で確認
- [ ] ブラウザで開いたレポートに想定外の機微情報が含まれていないことを目視確認

## スクリーンショット

該当なし（CI 変更のみ）。

## 補足事項

- 本 PR がグリーン化を確認できたら、後続 PR で残り 8 サービス（admin / auth-app / codec-converter / niconico-mylist-assistant / quick-clip / share-together / stock-tracker / tools）に同じパターンを横展開する
- 仮に本 PR が赤くなった場合は、本 PR 内で原因を特定して修正してから横展開に進む（横展開先の 8 ファイルに同じ問題が伝播するのを避けるため）


---
_Generated by [Claude Code](https://claude.ai/code/session_01QRcHL3Ad9ao64z63qE1WfF)_