### PR TITLE
fix(infra): CloudFront のサブディレクトリ末尾 / で AccessDenied になる問題を修正

### DIFF
--- a/infra/shared/lib/reports-hosting-stack.ts
+++ b/infra/shared/lib/reports-hosting-stack.ts
@@ -57,6 +57,26 @@ export class ReportsHostingStack extends cdk.Stack {
     );
     const certificate = acm.Certificate.fromCertificateArn(this, 'Certificate', certificateArn);
 
+    // CloudFront の defaultRootObject はディストリビューションの root (`/`) にしか
+    // 効かないため、`/foo/bar/` のようにサブディレクトリで終わるリクエストでは
+    // S3 にそのままキーが渡されて AccessDenied になる。
+    // Playwright HTML レポートは各ディレクトリに index.html がある構造なので、
+    // 末尾が `/` のとき index.html を補完する CloudFront Function を挟む。
+    const rewriteToIndexHtml = new cloudfront.Function(this, 'RewriteToIndexHtml', {
+      comment: 'Append index.html to URIs ending with /',
+      code: cloudfront.FunctionCode.fromInline(
+        [
+          'function handler(event) {',
+          '  var request = event.request;',
+          '  if (request.uri.endsWith("/")) {',
+          '    request.uri += "index.html";',
+          '  }',
+          '  return request;',
+          '}',
+        ].join('\n')
+      ),
+    });
+
     const reportsDomain = `${REPORTS_SUBDOMAIN}.${props.domainName}`;
 
     this.distribution = new cloudfront.Distribution(this, 'ReportsDistribution', {
@@ -68,6 +88,12 @@ export class ReportsHostingStack extends cdk.Stack {
         cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
         cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
         compress: true,
+        functionAssociations: [
+          {
+            function: rewriteToIndexHtml,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          },
+        ],
       },
       defaultRootObject: 'index.html',
       domainNames: [reportsDomain],

--- a/infra/shared/tests/unit/reports-hosting-stack.test.js
+++ b/infra/shared/tests/unit/reports-hosting-stack.test.js
@@ -76,4 +76,32 @@ describe('ReportsHostingStack', () => {
       Type: 'A',
     });
   });
+
+  it('末尾 / を index.html に書き換える CloudFront Function を作成する', () => {
+    const app = new cdk.App();
+    const stack = new ReportsHostingStack(app, 'TestReportsHostingStack', STACK_PROPS);
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudFront::Function', {
+      FunctionCode: Match.stringLikeRegexp('endsWith\\("/"\\)'),
+    });
+  });
+
+  it('CloudFront Function を viewer-request に紐付ける', () => {
+    const app = new cdk.App();
+    const stack = new ReportsHostingStack(app, 'TestReportsHostingStack', STACK_PROPS);
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          FunctionAssociations: Match.arrayWith([
+            Match.objectLike({
+              EventType: 'viewer-request',
+            }),
+          ]),
+        }),
+      }),
+    });
+  });
 });


### PR DESCRIPTION
## 変更の概要

PR #2980 で end-to-end 検証中、`https://reports.nagiyu.com/portal/pr-2980/{run-id}/chromium-mobile/` が `AccessDenied` を返すことが判明した。原因は CloudFront の `defaultRootObject` 仕様で、これは distribution の root (`/`) にしか効かず、サブディレクトリで終わる URI には適用されない。

末尾が `/` のとき `index.html` を補完する CloudFront Function を viewer-request に紐付けることで、Playwright HTML レポートのディレクトリベース URL が正しく配信されるようにする。

## 関連 Issue

refs #2976

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（CDK ユニットテスト 2 件追加で計 7 件）
- [x] 関連ドキュメントを更新した（既存ドキュメントへの追記不要、CDK コード内コメントで説明）
- [x] CI/CD 設定を追加・更新した（変更なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（CDK synth で Function が生成されることを確認）

## テスト内容

### CDK ユニットテスト

- 末尾 `/` を `index.html` に書き換える CloudFront Function が作成される
- CloudFront Function が viewer-request に紐付けられる

### CDK synth 確認

```bash
cd infra/shared
DOMAIN_NAME=nagiyu.com CDK_DEFAULT_ACCOUNT=... CDK_DEFAULT_REGION=us-east-1 \
  npx cdk synth NagiyuE2eReportsHosting
```

`AWS::CloudFront::Function` リソースが生成され、`FunctionAssociations` が `EventType: viewer-request` で設定されていることを確認。

### マージ後 dev 確認（人力）

- [ ] `https://reports.nagiyu.com/portal/pr-2980/25586407346/chromium-mobile/`（末尾 `/`）でレポート HTML が開ける
- [ ] アセット（CSS / JS / 画像 / トレース等）も正しく配信される

## レビューポイント

### 関数の最小化

意図的にトレイリングスラッシュのみを処理する最小実装にしている。`/foo` のようにスラッシュもドットも無いケースの自動補完（`/foo` → `/foo/index.html`）は意図せぬパス書き換えのリスクがあるため対応しない。Playwright HTML レポートの URL は必ず末尾スラッシュ付き or 拡張子付きアセットなので問題ない。

### 関連 PR との関係

- PR #2980（continue-on-error 削除）と本 PR は独立。本 PR がマージ・デプロイされてから PR #2980 を実物で再検証するのが順序。
- ただし PR #2980 自体は「アップロード step が成功することの検証」を目的としており、CI レベルでは既にグリーンになっているので、本 PR の前にマージしても理論上は問題ない（end-to-end 検証は本 PR のデプロイ後に行う）。

## スクリーンショット

該当なし（CDK 変更のみ）。

## 補足事項

- 本 PR がマージ・デプロイされた後、PR #2980 のレポート URL を再度クリックして動作確認することで、レポート公開機能が end-to-end で機能することの最終確認になる
- その後、残り 8 サービスへの横展開 PR に進む


---
_Generated by [Claude Code](https://claude.ai/code/session_01QRcHL3Ad9ao64z63qE1WfF)_