### PR TITLE
feat(ci): 残り 8 サービスの E2E ジョブにレポートホスティングを横展開

### DIFF
--- a/.github/workflows/admin-verify.yml
+++ b/.github/workflows/admin-verify.yml
@@ -180,6 +180,21 @@ jobs:
           path: services/admin/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/admin/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/admin/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   e2e-test-chromium-desktop:
     name: Run E2E Tests (chromium-desktop)
     runs-on: ubuntu-latest
@@ -238,6 +253,21 @@ jobs:
           path: services/admin/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/admin/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/admin/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
+
   e2e-test-webkit-mobile:
     name: Run E2E Tests (webkit-mobile)
     runs-on: ubuntu-latest
@@ -295,6 +325,21 @@ jobs:
           name: test-results-full-webkit-mobile
           path: services/admin/web/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/admin/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/admin/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
 
   build:
     name: Next.js Build Verification
@@ -387,6 +432,13 @@ jobs:
               'skipped': '⏭️'
             };
 
+            const reportBaseUrl = `https://reports.nagiyu.com/admin/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'E2E Tests (chromium-mobile)': 'chromium-mobile',
+              'E2E Tests (chromium-desktop)': 'chromium-desktop',
+              'E2E Tests (webkit-mobile)': 'webkit-mobile',
+            };
+
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
@@ -397,14 +449,19 @@ jobs:
             body += isFull
               ? '**Full Verification (All devices + Coverage)**\n\n'
               : '**Fast Verification (E2E: chromium-mobile only)**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({

--- a/.github/workflows/auth-verify-app.yml
+++ b/.github/workflows/auth-verify-app.yml
@@ -177,6 +177,21 @@ jobs:
           path: services/auth/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/auth/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/auth-app/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   e2e-test-chromium-desktop:
     name: Run E2E Tests (chromium-desktop)
     runs-on: ubuntu-latest
@@ -234,6 +249,21 @@ jobs:
           path: services/auth/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/auth/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/auth-app/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
+
   e2e-test-webkit-mobile:
     name: Run E2E Tests (webkit-mobile)
     runs-on: ubuntu-latest
@@ -290,6 +320,21 @@ jobs:
           name: test-results-full-webkit-mobile
           path: services/auth/web/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/auth/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/auth-app/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
 
   build:
     name: Next.js Build Verification
@@ -384,6 +429,13 @@ jobs:
               'skipped': '⏭️'
             };
 
+            const reportBaseUrl = `https://reports.nagiyu.com/auth-app/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'E2E Tests (chromium-mobile)': 'chromium-mobile',
+              'E2E Tests (chromium-desktop)': 'chromium-desktop',
+              'E2E Tests (webkit-mobile)': 'webkit-mobile',
+            };
+
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
@@ -394,14 +446,19 @@ jobs:
             body += isFull
               ? '**Full Verification (All devices)**\n\n'
               : '**Fast Verification (E2E: chromium-mobile only)**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({

--- a/.github/workflows/codec-converter-verify.yml
+++ b/.github/workflows/codec-converter-verify.yml
@@ -171,6 +171,21 @@ jobs:
           path: services/codec-converter/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/codec-converter/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/codec-converter/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   integration-test-chromium-desktop:
     name: Run Integration Tests (chromium-desktop)
     runs-on: ubuntu-latest
@@ -226,6 +241,21 @@ jobs:
           path: services/codec-converter/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/codec-converter/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/codec-converter/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
+
   integration-test-webkit-mobile:
     name: Run Integration Tests (webkit-mobile)
     runs-on: ubuntu-latest
@@ -280,6 +310,21 @@ jobs:
           name: test-results-full-webkit-mobile
           path: services/codec-converter/web/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/codec-converter/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/codec-converter/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
 
   lint:
     name: Lint Check
@@ -449,6 +494,13 @@ jobs:
               'skipped': '⏭️'
             };
 
+            const reportBaseUrl = `https://reports.nagiyu.com/codec-converter/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'Integration Tests (chromium-mobile)': 'chromium-mobile',
+              'Integration Tests (chromium-desktop)': 'chromium-desktop',
+              'Integration Tests (webkit-mobile)': 'webkit-mobile',
+            };
+
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop' || github.base_ref === 'master';
             const header = allSuccess
@@ -459,14 +511,19 @@ jobs:
             body += isFull
               ? '**Codec Converter - Full Verification**\n\n'
               : '**Codec Converter - Fast Verification**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({

--- a/.github/workflows/niconico-mylist-assistant-verify.yml
+++ b/.github/workflows/niconico-mylist-assistant-verify.yml
@@ -394,6 +394,21 @@ jobs:
           path: services/niconico-mylist-assistant/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/niconico-mylist-assistant/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/niconico-mylist-assistant/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   e2e-test-web-chromium-desktop:
     name: E2E Tests (chromium-desktop)
     runs-on: ubuntu-latest
@@ -458,6 +473,21 @@ jobs:
           path: services/niconico-mylist-assistant/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/niconico-mylist-assistant/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/niconico-mylist-assistant/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
+
   e2e-test-web-webkit-mobile:
     name: E2E Tests (webkit-mobile)
     runs-on: ubuntu-latest
@@ -521,6 +551,21 @@ jobs:
           name: test-results-full-webkit-mobile
           path: services/niconico-mylist-assistant/web/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/niconico-mylist-assistant/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/niconico-mylist-assistant/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
 
   test-batch-integration:
     name: Batch Integration Tests
@@ -615,6 +660,13 @@ jobs:
               'skipped': '⏭️'
             };
 
+            const reportBaseUrl = `https://reports.nagiyu.com/niconico-mylist-assistant/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'E2E Tests (chromium-mobile)': 'chromium-mobile',
+              'E2E Tests (chromium-desktop)': 'chromium-desktop',
+              'E2E Tests (webkit-mobile)': 'webkit-mobile',
+            };
+
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
@@ -625,14 +677,19 @@ jobs:
             body += isFull
               ? '**Niconico Mylist Assistant - Full Verification**\n\n'
               : '**Niconico Mylist Assistant - Fast Verification**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({

--- a/.github/workflows/quick-clip-verify.yml
+++ b/.github/workflows/quick-clip-verify.yml
@@ -576,6 +576,21 @@ jobs:
           path: services/quick-clip/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/quick-clip/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/quick-clip/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   e2e-test-web-chromium-desktop:
     name: E2E Tests (chromium-desktop)
     runs-on: ubuntu-latest
@@ -629,6 +644,21 @@ jobs:
           path: services/quick-clip/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/quick-clip/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/quick-clip/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
+
   e2e-test-web-webkit-mobile:
     name: E2E Tests (webkit-mobile)
     runs-on: ubuntu-latest
@@ -681,6 +711,21 @@ jobs:
           name: test-results-full-webkit-mobile
           path: services/quick-clip/web/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/quick-clip/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/quick-clip/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
 
   report:
     name: Report Results to PR
@@ -754,6 +799,13 @@ jobs:
               skipped: '⏭️'
             };
 
+            const reportBaseUrl = `https://reports.nagiyu.com/quick-clip/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'E2E Tests (chromium-mobile)': 'chromium-mobile',
+              'E2E Tests (chromium-desktop)': 'chromium-desktop',
+              'E2E Tests (webkit-mobile)': 'webkit-mobile',
+            };
+
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = context.payload.pull_request?.base?.ref === 'develop';
             const header = allSuccess
@@ -762,14 +814,19 @@ jobs:
 
             let body = `${header}\n\n`;
             body += isFull ? '**QuickClip - Full Verification**\n\n' : '**QuickClip - Fast Verification**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({

--- a/.github/workflows/share-together-verify.yml
+++ b/.github/workflows/share-together-verify.yml
@@ -261,6 +261,21 @@ jobs:
           path: services/share-together/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/share-together/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/share-together/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   e2e-test-web-chromium-desktop:
     name: E2E Tests (chromium-desktop)
     runs-on: ubuntu-latest
@@ -319,6 +334,21 @@ jobs:
           path: services/share-together/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/share-together/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/share-together/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
+
   e2e-test-web-webkit-mobile:
     name: E2E Tests (webkit-mobile)
     runs-on: ubuntu-latest
@@ -376,6 +406,21 @@ jobs:
           name: test-results-webkit-mobile
           path: services/share-together/web/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/share-together/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/share-together/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
 
   synth-infra:
     name: Synthesize Infrastructure
@@ -466,18 +511,30 @@ jobs:
                 ? '## ❌ Some Full Checks Failed'
                 : '## ❌ Some Fast Checks Failed';
 
+            const reportBaseUrl = `https://reports.nagiyu.com/share-together/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'E2E Tests (chromium-mobile)': 'chromium-mobile',
+              'E2E Tests (chromium-desktop)': 'chromium-desktop',
+              'E2E Tests (webkit-mobile)': 'webkit-mobile',
+            };
+
             let body = `${header}\n\n`;
             body += isFullVerification
               ? '**Share Together - Full Verification**\n\n'
               : '**Share Together - Fast Verification**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({

--- a/.github/workflows/stock-tracker-verify.yml
+++ b/.github/workflows/stock-tracker-verify.yml
@@ -344,6 +344,21 @@ jobs:
           path: services/stock-tracker/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/stock-tracker/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/stock-tracker/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   e2e-test-web-chromium-desktop:
     name: Run E2E Tests Web (chromium-desktop)
     runs-on: ubuntu-latest
@@ -424,6 +439,21 @@ jobs:
           path: services/stock-tracker/web/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/stock-tracker/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/stock-tracker/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
+
   e2e-test-web-webkit-mobile:
     name: Run E2E Tests Web (webkit-mobile)
     runs-on: ubuntu-latest
@@ -503,6 +533,21 @@ jobs:
           name: test-results-full-webkit-mobile
           path: services/stock-tracker/web/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/stock-tracker/web/playwright-report/ \
+            "s3://nagiyu-e2e-reports/stock-tracker/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
 
   lint:
     name: Lint Code
@@ -640,18 +685,30 @@ jobs:
               ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
               : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
 
+            const reportBaseUrl = `https://reports.nagiyu.com/stock-tracker/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'E2E Tests Web (chromium-mobile)': 'chromium-mobile',
+              'E2E Tests Web (chromium-desktop)': 'chromium-desktop',
+              'E2E Tests Web (webkit-mobile)': 'webkit-mobile',
+            };
+
             let body = `${header}\n\n`;
             body += isFull
               ? '**Full Verification (All devices + Coverage)**\n\n'
               : '**Fast Verification (chromium-mobile only)**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({

--- a/.github/workflows/tools-verify.yml
+++ b/.github/workflows/tools-verify.yml
@@ -154,6 +154,21 @@ jobs:
           path: services/tools/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/tools/playwright-report/ \
+            "s3://nagiyu-e2e-reports/tools/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-mobile/" \
+            --delete --no-progress
+
   e2e-test-chromium-desktop:
     name: Run E2E Tests (chromium-desktop)
     runs-on: ubuntu-latest
@@ -210,6 +225,21 @@ jobs:
           path: services/tools/test-results/
           retention-days: 30
 
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/tools/playwright-report/ \
+            "s3://nagiyu-e2e-reports/tools/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/chromium-desktop/" \
+            --delete --no-progress
+
   e2e-test-webkit-mobile:
     name: Run E2E Tests (webkit-mobile)
     runs-on: ubuntu-latest
@@ -265,6 +295,21 @@ jobs:
           name: test-results-full-webkit-mobile
           path: services/tools/test-results/
           retention-days: 30
+
+      - name: Configure AWS credentials for report upload
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload Playwright HTML report to reports.nagiyu.com
+        if: always()
+        run: |
+          aws s3 sync services/tools/playwright-report/ \
+            "s3://nagiyu-e2e-reports/tools/pr-${{ github.event.pull_request.number }}/${{ github.run_id }}/webkit-mobile/" \
+            --delete --no-progress
 
   lint:
     name: Lint Code
@@ -346,6 +391,13 @@ jobs:
               'skipped': '⏭️'
             };
 
+            const reportBaseUrl = `https://reports.nagiyu.com/tools/pr-${context.issue.number}/${context.runId}`;
+            const reportProjects = {
+              'E2E Tests (chromium-mobile)': 'chromium-mobile',
+              'E2E Tests (chromium-desktop)': 'chromium-desktop',
+              'E2E Tests (webkit-mobile)': 'webkit-mobile',
+            };
+
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
@@ -356,14 +408,19 @@ jobs:
             body += isFull
               ? '**Full Verification (All devices + Coverage)**\n\n'
               : '**Fast Verification (chromium-mobile only)**\n\n';
-            body += '| Job | Status |\n';
-            body += '|-----|--------|\n';
+            body += '| Job | Status | Report |\n';
+            body += '|-----|--------|--------|\n';
 
             for (const [job, result] of Object.entries(results)) {
               const emoji = statusEmoji[result] || '❓';
-              body += `| ${job} | ${emoji} ${result} |\n`;
+              const project = reportProjects[job];
+              const reportLink = (project && (result === 'success' || result === 'failure'))
+                ? `[📊 View](${reportBaseUrl}/${project}/)`
+                : '-';
+              body += `| ${job} | ${emoji} ${result} | ${reportLink} |\n`;
             }
 
+            body += `\n_E2E HTML reports are retained for 3 days. Re-run CI to regenerate._\n`;
             body += `\n[View workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId})`;
 
             github.rest.issues.createComment({


### PR DESCRIPTION
## 変更の概要

PR #2978 / #2980 / #2983 で portal を PoC として確立した E2E HTML レポートホスティング機構を、残り 8 サービスの `*-verify.yml` に横展開する。

各サービスの 3 つの E2E ジョブ末尾に S3 アップロードステップを追加し、`report` ジョブの PR コメントテーブルに **Report 列** を追加して `[📊 View](url)` リンクを掲載する。

## 対応サービス

| Workflow | URL slug | レポート source path |
|---|---|---|
| admin-verify.yml | admin | services/admin/web/playwright-report/ |
| auth-verify-app.yml | auth-app | services/auth/web/playwright-report/ |
| codec-converter-verify.yml | codec-converter | services/codec-converter/web/playwright-report/ |
| niconico-mylist-assistant-verify.yml | niconico-mylist-assistant | services/niconico-mylist-assistant/web/playwright-report/ |
| quick-clip-verify.yml | quick-clip | services/quick-clip/web/playwright-report/ |
| share-together-verify.yml | share-together | services/share-together/web/playwright-report/ |
| stock-tracker-verify.yml | stock-tracker | services/stock-tracker/web/playwright-report/ |
| tools-verify.yml | tools | **services/tools/playwright-report/**（`/web/` 無し） |

## 関連 Issue

refs #2976

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（CI 自体が検証、portal で同パターンが既にグリーン化済み）
- [x] 関連ドキュメントを更新した（運用ドキュメントは PR #2978 で追加済み、追記不要）
- [x] CI/CD 設定を追加・更新した
- [x] ローカルでテストが全て通ることを確認した（YAML 構文 OK）
- [x] ビルドエラーがないことを確認した

## テスト内容

`portal-verify.yml` で確立されたパターンを 8 サービスに横展開しただけなので、portal で動いた前提で同様に動くはず。各 PR の Verify ジョブで以下を初めて検証する:

1. 各サービスの S3 sync が成功する（IAM ポリシーの過不足、source path の正しさ）
2. 各サービスの PR コメントに表示される URL（`https://reports.nagiyu.com/{service}/pr-{pr}/{run-id}/{project}/`）が実際にブラウザで開ける

## レビューポイント

### サービス間の差異への対応

各 workflow には微妙な差があり、それぞれに合わせて編集している:

1. **codec-converter**: ジョブ ID が `integration-test-*`、PR コメントの行ラベルが `Integration Tests (...)`。それに合わせて `reportProjects` のキーを `Integration Tests (...)` にした。
2. **stock-tracker**: 既存の Configure AWS credentials が E2E ジョブの上部にあり、Run Playwright tests step が DEV_CREDENTIALS_* で env 上書きしているが、step-level env はその step のみで、後続の Upload step は元の `secrets.AWS_*` を継承する。それでも他サービスとの一貫性のために重複する Configure AWS step を Upload 直前に追加している（冗長だが副作用なし、将来の構成変更にも耐性がある）。
3. **stock-tracker** の PR コメント: 行ラベルが `E2E Tests Web (...)` (extra "Web") なので、`reportProjects` のキーをそれに合わせた。
4. **share-together**: 他と異なり artifact name が `test-results-{project}`（`-full-` 無し）。anchor として正確に使い分けている。
5. **tools**: source path が `services/tools/playwright-report/`（`/web/` 無し）。

### `if: always()` を全ステップに付与

E2E テストが失敗してもレポートをアップロードする（失敗時こそレポートを見たい）。

## マージ前確認（人力）

- [ ] 8 サービスすべての CI を再実行（または何らかの軽微な変更を加えて PR を上げる等）して、各サービスの Report 列に表示される URL が実物で開けることを確認
- [ ] 失敗時にもレポートが S3 にアップロードされることを確認

ただし全サービスを一度に検証するのは現実的でないので、本 PR のマージ後に各サービスの次回 PR で順次確認する運用でも良い（前 PR で確立したパターンと同一なので、リスクは低い）。

## スクリーンショット

該当なし（CI 変更のみ）。

## 補足事項

- 本 PR がマージされると、Issue #2976 の対応はほぼ完了。残るは `integration/2976-host-e2e-test-reports → develop` の PR を作成して develop（および dev 環境）に反映するだけ
- その integration → develop PR は本 PR マージ後、人の確認を取った上で別途作成予定
- `tasks/issue-2976-e2e-report-hosting/` は integration → develop の PR 内で削除する


---
_Generated by [Claude Code](https://claude.ai/code/session_01QRcHL3Ad9ao64z63qE1WfF)_