### PR TITLE
refactor(libs/common): formatFileSize と formatPrice を集約（#2994）

### DIFF
--- a/libs/common/src/format/file-size.ts
+++ b/libs/common/src/format/file-size.ts
@@ -1,0 +1,10 @@
+/**
+ * ファイルサイズを人間が読める形式にフォーマットする。
+ * 1 MB 未満は KB、それ以上は MB として小数点第 1 位まで表示する。
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/libs/common/src/format/index.ts
+++ b/libs/common/src/format/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Format Module
+ *
+ * 数値・ファイルサイズなど、サービス横断で再利用される表示用フォーマッタを提供する。
+ */
+
+export { formatFileSize } from './file-size.js';
+export { formatPrice } from './price.js';

--- a/libs/common/src/format/price.ts
+++ b/libs/common/src/format/price.ts
@@ -1,0 +1,10 @@
+/**
+ * 価格表示用の数値フォーマッタ。小数点第 2 位まで表示する。
+ *
+ * @example
+ * formatPrice(120.5)  // "120.50"
+ * formatPrice(120)    // "120.00"
+ */
+export function formatPrice(value: number): string {
+  return value.toFixed(2);
+}

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -9,6 +9,9 @@
 // Auth module - Authentication and Authorization utilities
 export * from './auth/index.js';
 
+// Format module - 表示用フォーマッタ（数値・ファイルサイズ等）
+export * from './format/index.js';
+
 // Validation module - Common validation utilities
 export * from './validation/index.js';
 // Logger module - Structured logging functionality

--- a/libs/common/tests/unit/format/file-size.test.ts
+++ b/libs/common/tests/unit/format/file-size.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatFileSize } from '../../../src/format/file-size.js';
+
+describe('formatFileSize', () => {
+  describe('1 MB 未満は KB 単位で表示する', () => {
+    it('512 KB', () => {
+      expect(formatFileSize(512 * 1024)).toBe('512.0 KB');
+    });
+
+    it('1023 KB（境界値直前）', () => {
+      expect(formatFileSize(1023 * 1024)).toBe('1023.0 KB');
+    });
+
+    it('小数を含むサイズも切り捨てず小数点第 1 位まで表示', () => {
+      expect(formatFileSize(1.5 * 1024)).toBe('1.5 KB');
+    });
+
+    it('0 バイトは "0.0 KB"', () => {
+      expect(formatFileSize(0)).toBe('0.0 KB');
+    });
+  });
+
+  describe('1 MB 以上は MB 単位で表示する', () => {
+    it('1 MB（境界値）', () => {
+      expect(formatFileSize(1024 * 1024)).toBe('1.0 MB');
+    });
+
+    it('50 MB', () => {
+      expect(formatFileSize(50 * 1024 * 1024)).toBe('50.0 MB');
+    });
+
+    it('小数を含むサイズは小数点第 1 位に四捨五入', () => {
+      expect(formatFileSize(2.75 * 1024 * 1024)).toBe('2.8 MB');
+    });
+  });
+});

--- a/libs/common/tests/unit/format/price.test.ts
+++ b/libs/common/tests/unit/format/price.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatPrice } from '../../../src/format/price.js';
+
+describe('formatPrice', () => {
+  it('整数は小数点第 2 位までゼロ埋めする', () => {
+    expect(formatPrice(100)).toBe('100.00');
+    expect(formatPrice(120)).toBe('120.00');
+  });
+
+  it('小数を持つ値はそのまま小数点第 2 位まで表示', () => {
+    expect(formatPrice(120.5)).toBe('120.50');
+    expect(formatPrice(120.99)).toBe('120.99');
+  });
+
+  it('小数点第 3 位以降は四捨五入', () => {
+    expect(formatPrice(120.555)).toBe('120.56');
+    expect(formatPrice(120.554)).toBe('120.55');
+  });
+
+  it('0 は "0.00"', () => {
+    expect(formatPrice(0)).toBe('0.00');
+  });
+
+  it('大きな値も正しく表示する', () => {
+    expect(formatPrice(1000000)).toBe('1000000.00');
+  });
+
+  it('小さな値も小数点第 2 位まで表示', () => {
+    expect(formatPrice(0.01)).toBe('0.01');
+  });
+
+  it('負の値も正しく表示する', () => {
+    expect(formatPrice(-1.5)).toBe('-1.50');
+  });
+});

--- a/services/codec-converter/core/src/format.ts
+++ b/services/codec-converter/core/src/format.ts
@@ -1,16 +1,4 @@
 /**
- * ファイルサイズを人間が読める形式にフォーマット
- * @param bytes ファイルサイズ（バイト）
- * @returns フォーマットされた文字列（KB または MB）
- */
-export function formatFileSize(bytes: number): string {
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-/**
  * Unix timestampを日時文字列にフォーマット
  * @param timestamp Unix timestamp（秒）
  * @returns 日本語ロケールでフォーマットされた日時文字列

--- a/services/codec-converter/core/src/index.ts
+++ b/services/codec-converter/core/src/index.ts
@@ -21,7 +21,7 @@ export {
 } from './validation';
 
 // Format utilities
-export { formatFileSize, formatDateTime, formatJobId } from './format';
+export { formatDateTime, formatJobId } from './format';
 
 // Resource selector
 export type { JobDefinitionSize } from './resource-selector';

--- a/services/codec-converter/core/tests/unit/format.test.ts
+++ b/services/codec-converter/core/tests/unit/format.test.ts
@@ -1,26 +1,4 @@
-import { formatFileSize, formatDateTime, formatJobId } from '../../src/format';
-
-describe('formatFileSize', () => {
-  it('KB単位でフォーマット（1MB未満）', () => {
-    expect(formatFileSize(512 * 1024)).toBe('512.0 KB');
-    expect(formatFileSize(1023 * 1024)).toBe('1023.0 KB');
-  });
-
-  it('MB単位でフォーマット（1MB以上）', () => {
-    expect(formatFileSize(1024 * 1024)).toBe('1.0 MB');
-    expect(formatFileSize(50 * 1024 * 1024)).toBe('50.0 MB');
-    expect(formatFileSize(100 * 1024 * 1024)).toBe('100.0 MB');
-  });
-
-  it('小数点以下1桁まで表示', () => {
-    expect(formatFileSize(1.5 * 1024)).toBe('1.5 KB');
-    expect(formatFileSize(2.75 * 1024 * 1024)).toBe('2.8 MB');
-  });
-
-  it('0バイト', () => {
-    expect(formatFileSize(0)).toBe('0.0 KB');
-  });
-});
+import { formatDateTime, formatJobId } from '../../src/format';
 
 describe('formatDateTime', () => {
   it('Unix timestamp（秒）を日本語ロケールの日時文字列にフォーマット', () => {

--- a/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
+++ b/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
@@ -6,10 +6,10 @@ import {
   type Job,
   type JobStatus,
   type CodecType,
-  formatFileSize,
   formatDateTime,
   formatJobId,
 } from '@nagiyu/codec-converter-core';
+import { formatFileSize } from '@nagiyu/common';
 import { Container, Typography, Card, CardContent, Alert, Stack, Box } from '@mui/material';
 import { Button, Chip } from '@nagiyu/ui';
 import RefreshIcon from '@mui/icons-material/Refresh';

--- a/services/codec-converter/web/src/app/page.tsx
+++ b/services/codec-converter/web/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, FormEvent, DragEvent, ChangeEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { validateFile, type CodecType } from '@nagiyu/codec-converter-core';
+import { formatFileSize } from '@nagiyu/common';
 import {
   Container,
   Typography,
@@ -138,13 +139,6 @@ export default function Home() {
       setError(errorMessage);
       setIsUploading(false);
     }
-  };
-
-  const formatFileSize = (bytes: number): string => {
-    if (bytes < 1024 * 1024) {
-      return `${(bytes / 1024).toFixed(2)} KB`;
-    }
-    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
   };
 
   return (

--- a/services/stock-tracker/web/components/AlertSettingsModal.tsx
+++ b/services/stock-tracker/web/components/AlertSettingsModal.tsx
@@ -16,7 +16,8 @@ import {
 } from '@mui/material';
 import { Button, Select } from '@nagiyu/ui';
 import { urlBase64ToUint8Array } from '@nagiyu/browser';
-import { calculateTargetPriceFromPercentage, formatPrice } from '../lib/percentage-helper';
+import { formatPrice } from '@nagiyu/common';
+import { calculateTargetPriceFromPercentage } from '../lib/percentage-helper';
 import type { Timeframe } from '../types/stock';
 import { TIMEFRAME_LABELS } from '../types/stock';
 import type { AlertResponse, AlertFrequency, AlertMode } from '../types/alert';

--- a/services/stock-tracker/web/lib/percentage-helper.ts
+++ b/services/stock-tracker/web/lib/percentage-helper.ts
@@ -40,4 +40,3 @@ export function calculateTargetPriceFromPercentage(basePrice: number, percentage
   // 小数点第2位まで四捨五入して返す
   return Math.round(targetPrice * 100) / 100;
 }
-

--- a/services/stock-tracker/web/lib/percentage-helper.ts
+++ b/services/stock-tracker/web/lib/percentage-helper.ts
@@ -41,16 +41,3 @@ export function calculateTargetPriceFromPercentage(basePrice: number, percentage
   return Math.round(targetPrice * 100) / 100;
 }
 
-/**
- * 計算結果をフォーマットして文字列に変換
- *
- * @param value - 数値
- * @returns 小数点第2位までフォーマットした文字列
- *
- * @example
- * formatPrice(120.5) // "120.50"
- * formatPrice(120) // "120.00"
- */
-export function formatPrice(value: number): string {
-  return value.toFixed(2);
-}

--- a/services/stock-tracker/web/tests/unit/lib/percentage-helper.test.ts
+++ b/services/stock-tracker/web/tests/unit/lib/percentage-helper.test.ts
@@ -6,7 +6,6 @@
 
 import {
   calculateTargetPriceFromPercentage,
-  formatPrice,
   PERCENTAGE_ERROR_MESSAGES,
 } from '../../../lib/percentage-helper';
 
@@ -157,34 +156,4 @@ describe('Percentage Helper', () => {
     });
   });
 
-  describe('formatPrice', () => {
-    it('整数値を小数点第2位までフォーマットする', () => {
-      expect(formatPrice(100)).toBe('100.00');
-    });
-
-    it('小数点第1位までの値を第2位までフォーマットする', () => {
-      expect(formatPrice(120.5)).toBe('120.50');
-    });
-
-    it('小数点第2位までの値をそのままフォーマットする', () => {
-      expect(formatPrice(120.99)).toBe('120.99');
-    });
-
-    it('小数点第3位以降は四捨五入される', () => {
-      expect(formatPrice(120.555)).toBe('120.56');
-      expect(formatPrice(120.554)).toBe('120.55');
-    });
-
-    it('0をフォーマットする', () => {
-      expect(formatPrice(0)).toBe('0.00');
-    });
-
-    it('非常に大きな値をフォーマットする', () => {
-      expect(formatPrice(1000000)).toBe('1000000.00');
-    });
-
-    it('非常に小さな値をフォーマットする', () => {
-      expect(formatPrice(0.01)).toBe('0.01');
-    });
-  });
 });

--- a/services/stock-tracker/web/tests/unit/lib/percentage-helper.test.ts
+++ b/services/stock-tracker/web/tests/unit/lib/percentage-helper.test.ts
@@ -155,5 +155,4 @@ describe('Percentage Helper', () => {
       });
     });
   });
-
 });

--- a/tasks/2782-code-consolidation/candidates.md
+++ b/tasks/2782-code-consolidation/candidates.md
@@ -267,7 +267,7 @@ libs 間: ui → browser → common（一方向、循環禁止）
 | D | ErrorDisplay | 小 | S | なし | 中 | 軽 |
 | E | 数値・日付フォーマッタ | 小 | S | 小 | 中 | 軽 |
 | F | base64 / URL utility | 小 | S | 小 | 小 | 軽 |
-| G | localStorage マネージャ | 小 | S | なし | 小 | 軽 |
+| G | localStorage マネージャ | — | — | — | — | — | ※ Phase A 後の実装前確認で **libs/browser に既に共通化済み**と判明したため **スキップ**（[#2782 コメント](https://github.com/nagiyu/nagiyu-platform/issues/2782) 参照） |
 | H | Repository Factory レジストリ | 中 | M | 小 | 中 | 中 |
 | I | Web Push ペイロード Builder | 中 | M | 中 | 中 | 中 |
 | J | ThemeRegistry / ServiceLayout | 中 | M | 中 | 中 | 中 |
@@ -286,35 +286,39 @@ libs 間: ui → browser → common（一方向、循環禁止）
 
 ---
 
-## 4. Top 5 推奨（軽い順 → 重い順）
+## 4. 推奨（4 件構成、軽い順 → 重い順）
 
 軽い候補から integration ブランチに順次取り込む方針。dev 環境への影響を抑え、レビュー粒度も保ちやすい。
 
-### Top 5（最軽）: G. localStorage 名前空間マネージャを libs/browser へ
+> **更新（Phase A 後）**: 実装前確認の結果、G は **libs/browser に既に共通化済み**であることが判明したため **スキップ**。本計画は **4 件構成**（E → D+C → H → A）で進める。
 
-- **狙い**: `libs/browser` に SSR 安全な `createNamespacedStorage(prefix)` を追加し、share-together の lastVisitedPath を置き換える。今後の SPA UX（戻り先復帰、設定永続化）の基盤。
-- **想定差分**: 新規 1 ファイル（libs/browser）、既存置換 1〜2 ファイル
-- **完了条件**: 新ユーティリティの単体テスト追加、既存サービス（share-together）が新 API に移行、テスト全グリーン
+### ~~Top 5（最軽）: G. localStorage 名前空間マネージャを libs/browser へ~~（スキップ）
 
-### Top 4: E. 数値・日付フォーマッタを libs/common へ
+- **状態**: 実装前確認で **既に共通化済み**と判明、スキップ
+- **発見事実**: `libs/browser/src/localStorage.ts` に SSR 安全・JSON 自動 parse/stringify・容量超過ハンドリング付きの `getItem`/`setItem`/`removeItem` が既に存在。services 全体で `window.localStorage` 直接利用は 0 件、share-together / tools の利用箇所はいずれも `@nagiyu/browser` 経由（独自再実装ではない）
+- **判断**: Phase A 候補洗い出しが浅かった（Explore は libs の実装内容まで深く確認していなかった）。`createNamespacedStorage(prefix)` の追加は、現状の重複が無いため効果が限定的と判断しスキップ
 
-- **狙い**: `libs/common/src/format/` に formatNumber / formatCurrency / formatPercent / formatTimestamp を集約。tools / stock-tracker から抽出。
-- **想定差分**: 新規 1〜2 ファイル、置換 3〜5 ファイル
-- **完了条件**: ロケールオプションのテスト、stock-tracker の formatPrice / tools の timestamp が libs/common 経由に移行
+### 着手順 1: E. 数値・ファイルサイズフォーマッタを libs/common へ（**縮小スコープ**）
 
-### Top 3: D + C. ErrorDisplay と Snackbar Provider の libs/ui 昇格
+- **狙い**: `libs/common/src/format/` に `formatFileSize` と `formatPrice` を切り出し、サービス間でフォーマット書式を統一する基盤を作る
+- **対象**: codec-converter/core/src/format.ts の `formatFileSize`、stock-tracker/web/lib/percentage-helper.ts の `formatPrice` の 2 関数のみ
+- **対象外（ドメイン固有・据え置き）**: tools/timestamp（タイムゾーン処理）、admin の Intl.DateTimeFormat、codec-converter の formatDateTime / formatJobId、stock-tracker 内に散在する `toFixed(2)` 直書き（サービス内 DRY 問題）
+- **想定差分**: libs/common 新規 5 ファイル + 既存置換 5〜6 ファイル
+- **完了条件**: libs/common のカバレッジ 80% 維持、codec-converter / stock-tracker のテスト全グリーン
+
+### 着手順 2: D + C. ErrorDisplay と Snackbar Provider の libs/ui 昇格
 
 - **狙い**: stock-tracker の `<ErrorDisplay>` と `<SnackbarProvider>` を `libs/ui` に昇格。`useSnackbar()` フックも export し、複数サービスで利用可能にする。
 - **想定差分**: 新規 2〜3 ファイル、置換 2〜4 サービス
 - **完了条件**: storybook（あれば）追加、stock-tracker が libs/ui 版に切替、その他サービス（quick-clip / share-together）でも opt-in 可能
 
-### Top 2: H. Repository Factory レジストリ拡張（libs/aws）
+### 着手順 3: H. Repository Factory レジストリ拡張（libs/aws）
 
 - **狙い**: `libs/aws` の Factory 機構に複数 repository 一括 register API を追加。auth サービスにも適用し、4 サービスで統一。
 - **想定差分**: libs/aws 1〜2 ファイル拡張、サービス 4 つの factory リファクタ
 - **完了条件**: 各サービスの repository factory boilerplate 削減、テスト全グリーン、既存 InMemory 切替動作維持
 
-### Top 1（最重）: A. COMMON_ERROR_MESSAGES 拡張と全サービスのエラーメッセージ集約
+### 着手順 4（最重）: A. COMMON_ERROR_MESSAGES 拡張と全サービスのエラーメッセージ集約
 
 - **狙い**: `libs/common/src/constants/error-messages.ts` を拡張し、サービス固有メッセージのレジストリ機構を導入。`extractErrorMessage()` も `libs/common` に昇格。全サービスの ERROR_MESSAGES を整理。
 - **想定差分**: libs/common 拡張、10+ サービスファイルのリファクタ
@@ -322,12 +326,13 @@ libs 間: ui → browser → common（一方向、循環禁止）
 
 ---
 
-## 5. Top 5 に含めなかった候補について
+## 5. 上記に含めなかった候補について
 
 以下の候補は重要だが、本 Issue（#2782）のスコープ外として **別 Issue で別途対応**する想定。
 
 - **K, L, M, R, S**（重い候補）: いずれも工数 L または波及範囲が API 全面に及ぶ。1 つの integration ブランチに含めると dev 安定性が損なわれるリスク。完了後に別途 Issue 起票して取り組む。
-- **B, F, I, J, N, O, P, Q, T, U, V**（中規模／個別最適）: 効果はあるが、今期の最優先 5 件には入れない。Top 5 完了後の継続候補として candidates ドキュメントに残し、整理は parent Issue #2782 で更新する。
+- **B, F, I, J, N, O, P, Q, T, U, V**（中規模／個別最適）: 効果はあるが、今期の最優先には入れない。本 Issue（4 件構成）完了後の継続候補として candidates ドキュメントに残し、整理は parent Issue #2782 で更新する。
+- **G**: 上記の通り **既に共通化済み**（再掲）。
 
 ---
 
@@ -336,11 +341,13 @@ libs 間: ui → browser → common（一方向、循環禁止）
 - **依存ルール**: すべての候補で `ui → browser → common` / `core → common` を厳守する。共通化先の libs を間違えるとリファクタが大規模化するため、PR ごとに依存方向を確認する。
 - **テスト**: `coverageThreshold` 80% を維持する。共通化対象が utility 系なら新規テスト追加が容易。UI 系（C, D）はビジュアルリグレッションに注意。
 - **エラー文言**: CLAUDE.md「エラーメッセージは日本語 + 定数化」に従う。Top 1（A）はこれを徹底する位置づけ。
-- **integration ブランチ運用**: Top 5 → Top 1 を順次マージ。各サブ Issue は **integration マージ + dev 反映確認** をもってクローズ（今回の特例運用）。
+- **integration ブランチ運用**: 着手順 1 → 4 を順次マージ。各サブ Issue は **integration マージ + dev 反映確認** をもってクローズ（今回の特例運用）。
 - **クリーンアップ**: 全 Top 完了後、本ディレクトリ（`tasks/2782-code-consolidation/`）を削除し、永続化必要な内容は `docs/development/shared-libraries.md` 等に反映する（Phase C）。
 
 ---
 
 ## 7. 次アクション
 
-本ドキュメントのレビュー後、Phase B として **Top 5（G: localStorage マネージャ）** のサブ Issue を #2782 配下に起票し、`integration/2782-code-consolidation` 向けの作業ブランチを切る。
+Phase B として **着手順 1（E: 数値・ファイルサイズフォーマッタ、サブ Issue #2994）** から実装を進める。本 PR (#2994) は本ドキュメントの 4 件構成への更新も含む。
+
+着手順 1 の integration マージ + dev 反映確認後、着手順 2（D+C）→ 3（H）→ 4（A）を同様の流れで進める。


### PR DESCRIPTION
## 変更の概要

サブ Issue #2994（数値・ファイルサイズフォーマッタを libs/common へ集約）の実装 PR。

- `libs/common` に `format/` モジュールを新設し、`formatFileSize` と `formatPrice` を提供
- 既存の重複実装を `@nagiyu/common` 経由に移行（codec-converter / stock-tracker）
- `tasks/2782-code-consolidation/candidates.md` を 4 件構成に更新（G スキップ、E 縮小スコープへ反映）

## 関連 Issue

- 親 Issue: #2782（コード共通化調査）
- サブ Issue: #2994（本 PR が対応）
- 本 PR は integration への取り込み用のため `Closes` は使用しない（CLAUDE.md 運用ルール）
- サブ Issue #2994 は **integration マージ + dev 反映確認**の合図でクローズ予定（特例運用）

## 変更種別

- [x] リファクタリング
- [x] ドキュメント更新（candidates.md）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ 80% 以上を維持）
  - libs/common: **245 tests pass**（新規 format テスト 14 ケース追加）
  - codec-converter-core: **73 tests pass**（formatFileSize テストは libs 側に移行）
  - stock-tracker-web: **170 tests pass**（formatPrice テストは libs 側に移行）
- [x] 関連ドキュメントを更新した（`tasks/2782-code-consolidation/candidates.md`）
- [ ] CI/CD 設定を追加・更新した — N/A
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（lint: libs/common / codec-converter-web / stock-tracker-web 全て clean）

## テスト内容

- 新規 `libs/common/tests/unit/format/file-size.test.ts`: 7 ケース（KB/MB 境界、小数、0 バイト等）
- 新規 `libs/common/tests/unit/format/price.test.ts`: 7 ケース（整数、小数、四捨五入、負値等）
- 既存テストの調整: codec-converter-core / stock-tracker-web の該当 describe ブロックを libs/common 側に移動

## レビューポイント

- **書式の統一（破壊的だが軽微）**: `codec-converter/web/src/app/page.tsx` のローカル `formatFileSize` は `toFixed(2)`（小数 2 桁）で実装されていましたが、libs/common 版（`toFixed(1)`）に統一しました。アップロード画面のファイルサイズ表示が「1.50 KB」→「1.5 KB」に変わります（意図的な書式というより不揃いと判断）
- **互換シムなし**: CLAUDE.md「シムを残さない」原則に従い、`codec-converter/core/src/format.ts` の `formatFileSize` を削除し、呼出側を `@nagiyu/common` 直接 import に切り替えています（互換維持より重複本質の排除を優先）
- **対象外**: `tools/timestamp`（タイムゾーン処理）、`admin` の `Intl.DateTimeFormat`、`stock-tracker` 内 `toFixed(2)` 直書きはスコープ外として据え置き（candidates.md 記載）
- **依存方向ルール**: `services/*/core → libs/common` / `services/*/web → libs/common` ともに既存ルールに準拠（新規違反なし）

## スクリーンショット（該当する場合）

UI 変更は codec-converter のアップロード画面のファイルサイズ表示書式のみ（軽微）。スクリーンショットは省略。

## 補足事項

- candidates.md には **G を「既に共通化済み」とマーク**、**E を縮小スコープ実施として記録** しました
- マージ → dev 環境反映確認 → 合図をいただき次第、Claude がサブ Issue #2994 をクローズします
- 次の着手は **着手順 2: D + C（ErrorDisplay と SnackbarProvider の libs/ui 昇格）** の予定


---
_Generated by [Claude Code](https://claude.ai/code/session_011uzfoBx7UTkJ4KdKKNCkzK)_