### PR TITLE
feat(infra/shared): Claude 用閲覧専用 IAM ユーザーとポリシーを追加 (#3000)

### DIFF
--- a/docs/infra/shared/iam.md
+++ b/docs/infra/shared/iam.md
@@ -26,8 +26,13 @@ IAM ポリシーと IAM ユーザーは AWS CDK で管理されています。
 ```
 infra/shared/
 ├── lib/iam/
-│   ├── iam-policies-stack.ts    # IAM マネージドポリシー（4つ）
-│   └── iam-users-stack.ts       # IAM ユーザー（2つ）
+│   ├── iam-core-policy-stack.ts             # デプロイポリシー: Core
+│   ├── iam-application-policy-stack.ts      # デプロイポリシー: Application
+│   ├── iam-container-policy-stack.ts        # デプロイポリシー: Container
+│   ├── iam-integration-policy-stack.ts      # デプロイポリシー: Integration
+│   ├── iam-claude-readonly-policy-stack.ts  # Claude 用閲覧専用ポリシー
+│   ├── iam-policies-stack.ts                # 旧（4 ポリシーまとめ。互換用）
+│   └── iam-users-stack.ts                   # IAM ユーザー（3 ユーザー）
 ├── iam/                         # 旧 CloudFormation テンプレート（バックアップ）
 │   ├── policies/
 │   │   ├── backup/              # YAML ファイルのバックアップ
@@ -130,6 +135,37 @@ aws cloudformation deploy \
   --region us-east-1
 ```
 
+#### 1.5. Claude Read-Only Policy
+
+**CDK スタック名:** `NagiyuSharedIamClaudeReadonly`
+
+**概要:**
+Claude Code on the web のリモート環境から AWS リソースを「閲覧のみ」で調査するためのポリシー。
+デプロイポリシー（1.1〜1.4）とは独立した専用ポリシーで、List / Get / Describe / Scan / Query / Filter
+系のみを許可する。
+
+**主な許可（Allow）権限:**
+- **CloudFormation / CloudWatch / Logs**: スタック状態、メトリクス、ログ本文の取得
+- **Lambda / ECS / Batch / ECR**: 関数・コンテナ構成の閲覧、ECR イメージのメタデータ取得
+- **CloudFront / API Gateway / ACM / Route53**: 配信・API・証明書・DNS の構成把握
+- **DynamoDB / S3**: テーブル / バケットの構成と内容（後述の Deny 対象を除く）
+- **EC2 / VPC**: ネットワーク構成の Describe
+- **SNS / SQS / EventBridge**: メッセージング / イベント基盤の構成把握
+- **SSM / KMS**: パラメータ / キーのメタデータ閲覧（Decrypt は禁止）
+- **IAM**: 権限構成の Read（Get / List / SimulatePolicy）
+- **STS**: `GetCallerIdentity` で自身の identity 確認
+
+**明示 Deny:**
+- `secretsmanager:GetSecretValue` / `secretsmanager:GetRandomPassword`
+- `kms:Decrypt` / `kms:Encrypt` / `kms:ReEncrypt*` / `kms:GenerateDataKey*` / `kms:GenerateRandom`
+    - **副次効果**: SSM SecureString パラメータの値取得もこの Deny で実質的に防がれる
+- `dynamodb:GetItem` / `BatchGetItem` / `Scan` / `Query` を
+  `arn:aws:dynamodb:*:*:table/nagiyu-auth-users-*`（GSI 含む）に対して Deny
+    - PII（email / googleId / name 等）の閲覧経路を遮断
+
+**参照方法:**
+- `arn:aws:iam::{account}:policy/nagiyu-claude-readonly-policy`（`managedPolicyName` で固定）
+
 ### 2. GitHub Actions ユーザー
 
 **CDK スタック名:** `SharedIamUsers`（NagiyuGitHubActionsUser リソース）
@@ -203,6 +239,64 @@ aws configure --profile nagiyu-local-dev
 export AWS_PROFILE=nagiyu-local-dev
 ```
 
+### 4. Claude 閲覧専用ユーザー
+
+**CDK スタック名:** `SharedIamUsers`（NagiyuClaudeReadonlyUser リソース）
+
+**概要:**
+Claude Code on the web のリモート環境に投入し、Claude が AWS リソースを閲覧調査するための IAM ユーザー。
+
+**ユーザー名:** `nagiyu-claude-readonly`
+
+**アタッチされるポリシー:**
+- `nagiyu-claude-readonly-policy`（Claude Read-Only Policy 単独）
+
+**出力値（CfnOutput）:**
+- ユーザー ARN
+- ユーザー名
+
+**アクセスキー発行手順:**
+1. AWS マネジメントコンソールにログイン
+2. IAM → ユーザー → `nagiyu-claude-readonly` を選択
+3. 「セキュリティ認証情報」タブ → 「アクセスキーを作成」
+4. 用途は「サードパーティーサービス」を選択し、アクセスキー ID と
+   シークレットアクセスキーを安全に保存
+5. 発行後はユーザーごとに最大 2 本までしか保持できないため、不要になった旧キーは削除
+
+**Claude Code on the web への登録:**
+
+CDK / 設定ファイルではなく、**Claude Code on the web のリモート環境設定 UI** から
+セッション環境変数として投入する。
+
+| 環境変数名 | 値 |
+| --- | --- |
+| `AWS_ACCESS_KEY_ID` | 発行したアクセスキー ID |
+| `AWS_SECRET_ACCESS_KEY` | 発行したシークレットアクセスキー |
+| `AWS_REGION` | `us-east-1` |
+
+**動作確認:**
+
+Claude セッション内で以下が成功すること:
+
+```bash
+aws sts get-caller-identity
+aws logs describe-log-groups --region us-east-1
+aws cloudformation list-stacks --region us-east-1
+```
+
+同セッション内で以下が `AccessDenied` で失敗すること（保護が効いている証拠）:
+
+```bash
+aws secretsmanager get-secret-value --secret-id <任意のシークレット>
+aws dynamodb scan --table-name nagiyu-auth-users-dev
+aws ssm get-parameter --name <SecureString パラメータ> --with-decryption
+```
+
+**注意:**
+- このユーザーには **デプロイ権限を一切付与しない**（既存 4 ポリシーは添付しない）
+- ローカル開発・CI / CD では使わない（`nagiyu-local-dev` / `nagiyu-github-actions` を利用）
+- アクセスキーは Claude Code on the web 以外の環境にコピーしない
+
 ---
 
 ## デプロイ手順（CDK）
@@ -241,6 +335,21 @@ npx cdk deploy SharedIamPolicies --require-approval never
 - nagiyu-deploy-policy-container
 - nagiyu-deploy-policy-integration
 
+### ステップ2.5: Claude 閲覧専用ポリシーのデプロイ
+
+```bash
+cd infra/shared
+
+# 差分確認
+npx cdk diff NagiyuSharedIamClaudeReadonly
+
+# デプロイ
+npx cdk deploy NagiyuSharedIamClaudeReadonly --require-approval never
+```
+
+このコマンドで Claude 用の独立した閲覧専用ポリシー (`nagiyu-claude-readonly-policy`)
+がデプロイされる。デプロイポリシー（ステップ2）には影響を与えない。
+
 ### ステップ3: IAM ユーザーのデプロイ
 
 ポリシーのデプロイ完了後、IAM ユーザーをデプロイします。
@@ -255,9 +364,10 @@ npx cdk diff SharedIamUsers
 npx cdk deploy SharedIamUsers --require-approval never
 ```
 
-このコマンドで2つのユーザーが一度にデプロイされます:
+このコマンドで3つのユーザーが一度にデプロイされます:
 - nagiyu-github-actions
 - nagiyu-local-dev
+- nagiyu-claude-readonly
 
 ### ステップ4: 動作確認
 

--- a/infra/shared/bin/shared.ts
+++ b/infra/shared/bin/shared.ts
@@ -9,6 +9,7 @@ import { IamCorePolicyStack } from '../lib/iam/iam-core-policy-stack';
 import { IamApplicationPolicyStack } from '../lib/iam/iam-application-policy-stack';
 import { IamContainerPolicyStack } from '../lib/iam/iam-container-policy-stack';
 import { IamIntegrationPolicyStack } from '../lib/iam/iam-integration-policy-stack';
+import { IamClaudeReadonlyPolicyStack } from '../lib/iam/iam-claude-readonly-policy-stack';
 import { IamUsersStack } from '../lib/iam/iam-users-stack';
 import { DockerBuildLockStack } from '../lib/docker-build-lock-stack';
 import { ErrorEventsTableStack } from '../lib/error-events-table-stack';
@@ -89,6 +90,12 @@ const integrationPolicyStack = new IamIntegrationPolicyStack(app, 'NagiyuSharedI
   description: 'Shared IAM Integration and Security Deploy Policy (KMS, Secrets, SSM, SNS, SQS, EventBridge, Auto Scaling)',
 });
 
+// Claude Code on the web 用の閲覧専用ポリシー（環境非依存・既存 4 ポリシーから独立）
+const claudeReadonlyPolicyStack = new IamClaudeReadonlyPolicyStack(app, 'NagiyuSharedIamClaudeReadonly', {
+  env: stackEnv,
+  description: 'Shared IAM Claude Read-Only Policy (List/Get/Describe with explicit Deny on secrets/PII)',
+});
+
 // IAM Users スタックを作成（ポリシーに依存）
 new IamUsersStack(app, 'NagiyuSharedIamUsers', {
   policies: {
@@ -96,9 +103,10 @@ new IamUsersStack(app, 'NagiyuSharedIamUsers', {
     application: applicationPolicyStack.policy,
     container: containerPolicyStack.policy,
     integration: integrationPolicyStack.policy,
+    claudeReadonly: claudeReadonlyPolicyStack.policy,
   },
   env: stackEnv,
-  description: 'Shared IAM Users for GitHub Actions and Local Development',
+  description: 'Shared IAM Users for GitHub Actions, Local Development and Claude Code on the web',
 });
 
 new DockerBuildLockStack(app, 'NagiyuDockerBuildLock', {

--- a/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
+++ b/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
@@ -1,0 +1,167 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+/**
+ * IAM Claude Read-Only Policy Stack
+ *
+ * Claude Code on the web から AWS リソースを閲覧調査するための
+ * 読み取り専用ポリシーを定義します。
+ *
+ * 設計方針:
+ * - List / Get / Describe / Scan / Query / Filter / Search 系のみ許可
+ * - 既存の 4 デプロイポリシーには影響を与えない独立リソース
+ * - PII / 機密情報の閲覧経路は明示 Deny で遮断
+ *     - Secrets Manager: GetSecretValue を Deny
+ *     - KMS: Decrypt / Encrypt / GenerateDataKey 系を Deny
+ *       （副作用として SSM SecureString も復号不可になる）
+ *     - DynamoDB: nagiyu-auth-users-* テーブルへの読み取りを Deny
+ */
+export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
+  public readonly policy: iam.IManagedPolicy;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    this.policy = new iam.ManagedPolicy(this, 'Policy', {
+      managedPolicyName: 'nagiyu-claude-readonly-policy',
+      description:
+        'Claude Code on the web 用の閲覧専用権限。機密リソースは明示 Deny で遮断。',
+      statements: [
+        new iam.PolicyStatement({
+          sid: 'AllowReadOnlyOperations',
+          effect: iam.Effect.ALLOW,
+          actions: [
+            // CloudFormation
+            'cloudformation:Describe*',
+            'cloudformation:Get*',
+            'cloudformation:List*',
+            // CloudWatch / Logs
+            'cloudwatch:Describe*',
+            'cloudwatch:Get*',
+            'cloudwatch:List*',
+            'logs:Describe*',
+            'logs:Get*',
+            'logs:List*',
+            'logs:FilterLogEvents',
+            'logs:StartQuery',
+            'logs:StopQuery',
+            'logs:TestMetricFilter',
+            // Lambda
+            'lambda:Get*',
+            'lambda:List*',
+            // ECS / Batch
+            'ecs:Describe*',
+            'ecs:List*',
+            'batch:Describe*',
+            'batch:List*',
+            // ECR
+            'ecr:Describe*',
+            'ecr:List*',
+            'ecr:Get*',
+            'ecr:BatchCheckLayerAvailability',
+            'ecr:BatchGetImage',
+            // CloudFront
+            'cloudfront:Get*',
+            'cloudfront:List*',
+            // API Gateway (read-only は GET メソッド)
+            'apigateway:GET',
+            // DynamoDB (auth-users への読み取りは別途 Deny)
+            'dynamodb:Describe*',
+            'dynamodb:List*',
+            'dynamodb:GetItem',
+            'dynamodb:BatchGetItem',
+            'dynamodb:Scan',
+            'dynamodb:Query',
+            // S3
+            's3:Get*',
+            's3:List*',
+            's3:Describe*',
+            // EC2 / VPC
+            'ec2:Describe*',
+            'ec2:Get*',
+            // Route53
+            'route53:Get*',
+            'route53:List*',
+            'route53:TestDNSAnswer',
+            // ACM
+            'acm:Describe*',
+            'acm:List*',
+            'acm:GetCertificate',
+            // SNS / SQS / EventBridge
+            'sns:Get*',
+            'sns:List*',
+            'sqs:Get*',
+            'sqs:List*',
+            'events:Describe*',
+            'events:List*',
+            'events:TestEventPattern',
+            // SSM (SecureString の復号は KMS Deny で遮断される)
+            'ssm:Describe*',
+            'ssm:List*',
+            'ssm:Get*',
+            // KMS (メタデータのみ。Decrypt は別途 Deny)
+            'kms:Describe*',
+            'kms:List*',
+            'kms:Get*',
+            // IAM (構成把握用の Read のみ)
+            'iam:Get*',
+            'iam:List*',
+            'iam:GenerateServiceLastAccessedDetails',
+            'iam:SimulatePrincipalPolicy',
+            'iam:SimulateCustomPolicy',
+            // Application Auto Scaling
+            'application-autoscaling:Describe*',
+            // STS (自分の identity 確認用)
+            'sts:GetCallerIdentity',
+          ],
+          resources: ['*'],
+        }),
+        // 機密値の取得を遮断
+        new iam.PolicyStatement({
+          sid: 'DenySecretRetrieval',
+          effect: iam.Effect.DENY,
+          actions: [
+            'secretsmanager:GetSecretValue',
+            'secretsmanager:GetRandomPassword',
+          ],
+          resources: ['*'],
+        }),
+        // 復号経路を遮断（SecureString パラメータの値取得もこれで防げる）
+        new iam.PolicyStatement({
+          sid: 'DenyKmsDataOperations',
+          effect: iam.Effect.DENY,
+          actions: [
+            'kms:Decrypt',
+            'kms:Encrypt',
+            'kms:ReEncrypt*',
+            'kms:GenerateDataKey',
+            'kms:GenerateDataKey*',
+            'kms:GenerateRandom',
+          ],
+          resources: ['*'],
+        }),
+        // PII を含む auth-users テーブルへの読み取りを遮断
+        new iam.PolicyStatement({
+          sid: 'DenyAuthUsersTableAccess',
+          effect: iam.Effect.DENY,
+          actions: [
+            'dynamodb:GetItem',
+            'dynamodb:BatchGetItem',
+            'dynamodb:Scan',
+            'dynamodb:Query',
+          ],
+          resources: [
+            'arn:aws:dynamodb:*:*:table/nagiyu-auth-users-*',
+            'arn:aws:dynamodb:*:*:table/nagiyu-auth-users-*/index/*',
+          ],
+        }),
+      ],
+    });
+
+    new cdk.CfnOutput(this, 'ClaudeReadonlyPolicyArnExport', {
+      value: this.policy.managedPolicyArn,
+      description: 'Claude readonly policy ARN for nagiyu',
+    });
+  }
+}

--- a/infra/shared/lib/iam/iam-users-stack.ts
+++ b/infra/shared/lib/iam/iam-users-stack.ts
@@ -8,18 +8,20 @@ export interface IamUsersStackProps extends cdk.StackProps {
     application: iam.IManagedPolicy;
     container: iam.IManagedPolicy;
     integration: iam.IManagedPolicy;
+    claudeReadonly: iam.IManagedPolicy;
   };
 }
 
 /**
  * IAM Users Stack
  *
- * GitHub Actions と ローカル開発用の IAM ユーザーを管理します。
+ * GitHub Actions / ローカル開発 / Claude Code on the web 用の IAM ユーザーを管理します。
  * アクセスキーは手動発行するため、このスタックでは作成しません。
  */
 export class IamUsersStack extends cdk.Stack {
   public readonly githubActionsUser: iam.IUser;
   public readonly localDevUser: iam.IUser;
+  public readonly claudeReadonlyUser: iam.IUser;
 
   constructor(scope: Construct, id: string, props: IamUsersStackProps) {
     super(scope, id, props);
@@ -53,6 +55,15 @@ export class IamUsersStack extends cdk.Stack {
 
 
     // ==========================================
+    // Claude Read-Only User
+    // ==========================================
+    this.claudeReadonlyUser = new iam.User(this, 'NagiyuClaudeReadonlyUser', {
+      userName: 'nagiyu-claude-readonly',
+      managedPolicies: [props.policies.claudeReadonly],
+    });
+
+
+    // ==========================================
     // Exports
     // ==========================================
     // GitHub Actions User
@@ -75,6 +86,17 @@ export class IamUsersStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'LocalDevUserNameExport', {
       value: this.localDevUser.userName,
       description: 'Local developer user name',
+    });
+
+    // Claude Read-Only User
+    new cdk.CfnOutput(this, 'ClaudeReadonlyUserArnExport', {
+      value: this.claudeReadonlyUser.userArn,
+      description: 'Claude readonly user ARN',
+    });
+
+    new cdk.CfnOutput(this, 'ClaudeReadonlyUserNameExport', {
+      value: this.claudeReadonlyUser.userName,
+      description: 'Claude readonly user name',
     });
   }
 }


### PR DESCRIPTION
## 変更の概要

Claude Code on the web のリモート環境から AWS リソースを「閲覧のみ」で調査できるよう、
専用の IAM ユーザーとポリシーを CDK で新設する変更を develop に取り込む。

- 新規 ManagedPolicy: `nagiyu-claude-readonly-policy`
    - List / Get / Describe / Scan / Query / Filter 系のみ Allow
    - Secrets Manager 値・KMS Decrypt 系・`nagiyu-auth-users-*` テーブルは明示 Deny
- 新規 IAM User: `nagiyu-claude-readonly`（上記ポリシーのみアタッチ）
- 既存 4 デプロイポリシー（core / application / container / integration）には影響なし
- アクセスキーは既存ユーザーと同様、CDK では発行せず手動発行
- ドキュメント (`docs/infra/shared/iam.md`) に運用手順とアクセスキーの
  Claude Code on the web への投入方法を追記

## 関連 Issue

Closes #3000

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
    - 既存 IAM 関連スタックには専用テストが存在しないため新規追加なし。
      既存 Jest スイート 33 件全パス。
- [x] 関連ドキュメントを更新した（`docs/infra/shared/iam.md`）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
    - 該当なし
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- ローカル: `tsc` ビルド成功 / `jest` 33 件成功 / `eslint` クリア /
  `cdk synth` 全スタック成功
- integration ブランチ上で Fast CI（Lint / Unit Tests / Build / CDK Synth）が
  すべて success（PR #3001）
- dev 環境で以下を別セッションにて確認済み:
    - `nagiyu-claude-readonly-policy` ポリシー作成
    - `nagiyu-claude-readonly` ユーザー作成 & ポリシーアタッチ

## レビューポイント

1. **SSM SecureString の保護方針**
    - Issue 本文では `Condition: ssm:ParameterType = SecureString` と書いていたが、
      実際には AWS で実在しない Condition キーのため、`kms:Decrypt` の Deny で
      代替（SecureString は KMS で復号されるため、Decrypt を塞げば値の取得は
      実質不可能）。
2. **ポリシーサイズ**
    - 1 ポリシー構成（既存は 4 分割）。synth 後の no-whitespace JSON は
      1,834 文字（上限 6,144 の 30%）で、ワイルドカード活用により余裕あり。
3. **Allow 範囲**
    - 含まれる主要サービス: CloudFormation / CloudWatch Logs（本文取得含む）/
      Lambda / ECS / Batch / ECR / CloudFront / API Gateway / DynamoDB / S3 /
      EC2 / Route53 / ACM / SNS / SQS / EventBridge / SSM / KMS（メタデータのみ）/
      IAM（Read のみ）/ Application Auto Scaling / STS

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

- マージ後、AWS マネジメントコンソールで `nagiyu-claude-readonly` のアクセスキーを
  手動発行し、Claude Code on the web のリモート環境設定 UI から
  `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION=us-east-1` として
  投入する（手順詳細は `docs/infra/shared/iam.md` の「4. Claude 閲覧専用ユーザー」）。
- 本 PR がマージされると Issue #3000 は自動クローズされる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWdHEfPcWC4SCb25gxMffK)_