### PR TITLE
test(auth-web): session.ts のテストを追加して Coverage Threshold を達成（#2782）

### DIFF
--- a/services/auth/web/tests/unit/lib/auth/session.test.ts
+++ b/services/auth/web/tests/unit/lib/auth/session.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from '@jest/globals';
+
+jest.mock('@nagiyu/auth-core', () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock('@nagiyu/nextjs/session', () => ({
+  createSessionGetter: jest.fn(
+    (config: {
+      auth: () => Promise<unknown>;
+      createTestSession: () => unknown;
+      mapSession: (session: unknown) => unknown;
+    }) => {
+      return async () => {
+        if (process.env.SKIP_AUTH_CHECK === 'true') {
+          return config.mapSession(config.createTestSession());
+        }
+        const session = await config.auth();
+        return session ? config.mapSession(session) : null;
+      };
+    }
+  ),
+}));
+
+import { auth as mockedAuth } from '@nagiyu/auth-core';
+
+describe('getSession', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('SKIP_AUTH_CHECK=true のときはテスト用セッションを返す', async () => {
+    process.env.SKIP_AUTH_CHECK = 'true';
+    process.env.TEST_USER_EMAIL = 'mock@example.com';
+    process.env.TEST_USER_ROLES = 'admin,viewer';
+
+    const { getSession } = await import('../../../../src/lib/auth/session');
+    const session = await getSession();
+
+    expect(session).toBeDefined();
+    expect(session?.user?.email).toBe('mock@example.com');
+    expect(session?.user?.roles).toEqual(['admin', 'viewer']);
+  });
+
+  it('TEST_USER_EMAIL が未設定なら test@example.com を使う', async () => {
+    process.env.SKIP_AUTH_CHECK = 'true';
+    delete process.env.TEST_USER_EMAIL;
+    delete process.env.TEST_USER_ROLES;
+
+    const { getSession } = await import('../../../../src/lib/auth/session');
+    const session = await getSession();
+
+    expect(session?.user?.email).toBe('test@example.com');
+    expect(session?.user?.roles).toEqual(['admin']);
+  });
+
+  it('SKIP_AUTH_CHECK 未設定で auth が null を返すと null', async () => {
+    delete process.env.SKIP_AUTH_CHECK;
+    (mockedAuth as jest.Mock).mockResolvedValueOnce(null);
+
+    const { getSession } = await import('../../../../src/lib/auth/session');
+    const session = await getSession();
+
+    expect(session).toBeNull();
+  });
+
+  it('SKIP_AUTH_CHECK 未設定で auth が session を返すと mapSession 経由で返す', async () => {
+    delete process.env.SKIP_AUTH_CHECK;
+    (mockedAuth as jest.Mock).mockResolvedValueOnce({
+      user: { id: 'u1', email: 'u1@example.com', name: 'U1', roles: ['admin'] },
+      expires: '2099-01-01T00:00:00.000Z',
+    });
+
+    const { getSession } = await import('../../../../src/lib/auth/session');
+    const session = await getSession();
+
+    expect(session?.user?.id).toBe('u1');
+    expect(session?.expires).toBe('2099-01-01T00:00:00.000Z');
+  });
+
+  it('expires 未指定なら mapSession でデフォルト値が補完される', async () => {
+    delete process.env.SKIP_AUTH_CHECK;
+    (mockedAuth as jest.Mock).mockResolvedValueOnce({
+      user: { id: 'u2', email: 'u2@example.com', name: 'U2', roles: [] },
+    });
+
+    const { getSession } = await import('../../../../src/lib/auth/session');
+    const session = await getSession();
+
+    expect(session?.expires).toBeDefined();
+    expect(new Date(session!.expires!).getTime()).toBeGreaterThan(Date.now());
+  });
+});


### PR DESCRIPTION
## 変更の概要

PR #3014 (`integration/2782-code-consolidation → develop`) で Coverage Check（80% threshold）が auth-web で fail していたため、`src/lib/auth/session.ts` に対する単体テストを追加して閾値を達成する。

## 経緯

- PR #3014 で develop 向け CI が走り、auth-verify-app の Coverage Check が 76.96% で 80% 未達
- 原因は既存の `middleware.ts` (0%) / `session.ts` (0%) の未テスト
- ユーザー判断（[#3014 コメント](https://github.com/nagiyu/nagiyu-platform/pull/3014)）により本 PR で対処
- `middleware.ts` は Edge Runtime + 動的 import のため jest 単体テストが現実的でないと判断、`session.ts` のみを対象とした

## 追加内容

`services/auth/web/tests/unit/lib/auth/session.test.ts` 5 ケース：
- `SKIP_AUTH_CHECK=true` でテスト用セッション生成（TEST_USER_EMAIL/ROLES の環境変数バリエーション 2 ケース）
- `SKIP_AUTH_CHECK` 未設定で `auth()` が null を返すケース
- `auth()` がセッションを返すケース（mapSession 経由で expires がそのまま透過）
- `expires` 未指定で mapSession のデフォルト補完が効くケース

## カバレッジ改善

| 指標 | Before | After |
|---|---|---|
| All files (Stmts) | 76.96% | 89.09% |
| All files (Lines) | 76.96% | 89.09% |
| All files (Branch) | 87.93% | 90.47% |
| `session.ts` 単体 | 0% | 100% |

## 関連 PR

- PR #3014（本 PR がマージされると自動的に最新 commit が反映される）
- 親 Issue #2782

## 変更種別

- [x] テスト追加

## 補足事項

- 本 PR マージ後、PR #3014 の Coverage Check が再実行され pass する想定
- `middleware.ts` の coverage は別途対応が必要だが、`All files` 平均が 89% で 80% threshold は満たすため本 PR では対象外

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011uzfoBx7UTkJ4KdKKNCkzK)_