### PR TITLE
fix(ci): UI Storybook デプロイで @nagiyu/common を先にビルド

### DIFF
--- a/.github/workflows/ui-storybook-deploy.yml
+++ b/.github/workflows/ui-storybook-deploy.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'libs/ui/**'
       - 'libs/browser/**'
+      - 'libs/common/**'
       - 'infra/ui-storybook/**'
       - 'package.json'
       - 'package-lock.json'
@@ -48,8 +49,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Build dependencies (browser, ui)
+      - name: Build dependencies (common, browser, ui)
         run: |
+          npm run build --workspace=@nagiyu/common
           npm run build --workspace=@nagiyu/browser
           npm run build --workspace=@nagiyu/ui
 


### PR DESCRIPTION
## 変更の概要

`Deploy UI Storybook` ワークフロー (`.github/workflows/ui-storybook-deploy.yml`) を修正し、`@nagiyu/ui` のビルド前に `@nagiyu/common` をビルドするようにした。あわせて `paths` トリガーに `libs/common/**` を追加した。

これにより、`libs/ui/src/components/error/ErrorAlert.tsx` などで `import { APIError } from '@nagiyu/common'` を解決できず TS2307 で失敗していたデプロイが通るようになる。

## 関連 Issue

<!-- integration → develop の PR で Closes を付与する -->
Refs #3016

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）<!-- ワークフローの修正のみのため対象外 -->
- [ ] 関連ドキュメントを更新した <!-- 既存運用順 (common → browser → ui → nextjs) と整合するのみ -->
- [x] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- ローカルで `npm run build --workspace=@nagiyu/common && npm run build --workspace=@nagiyu/browser && npm run build --workspace=@nagiyu/ui` を実行し、3 つすべて成功することを確認。
- 修正後の `ui-storybook-deploy.yml` のビルドステップが `ui-verify.yml` (build job) と同じ依存ビルド順序になっていることを確認。

## レビューポイント

- ビルドステップ名のラベルを `(browser, ui)` から `(common, browser, ui)` に更新している。
- `paths` トリガーに `libs/common/**` を追加したことで、common の変更だけで Storybook デプロイが走るようになる点。意図的（依存関係に追従するため）だが、もし不要なデプロイ起動を避けたい場合は外す判断もある。

## スクリーンショット（該当する場合）

なし（CI ワークフローの修正）。

## 補足事項

- 失敗ログ抜粋:

  ```
  src/components/error/ErrorAlert.tsx(5,26): error TS2307: Cannot find module '@nagiyu/common' or its corresponding type declarations.
  tests/unit/components/error/ErrorAlert.test.tsx(3,26): error TS2307: Cannot find module '@nagiyu/common' or its corresponding type declarations.
  ```

- CLAUDE.md の運用フローに従い、Issue #3016 を起票し integration ブランチ `integration/3016-fix-storybook-deploy` 経由で本 Draft PR を作成している。


---
_Generated by [Claude Code](https://claude.ai/code/session_013aygxYHbf465t6yX8QRUVb)_