### PR TITLE
fix(stock-tracker): アラート一覧で無効化アラートを表示する

### DIFF
--- a/services/stock-tracker/web/app/api/alerts/route.ts
+++ b/services/stock-tracker/web/app/api/alerts/route.ts
@@ -134,11 +134,8 @@ export const GET = withAuth(
       // ユーザーIDを取得
       const userId = session.user.userId;
 
-      // アラート一覧取得（無効化済みアラートは UI 上で「削除済み」と同等に扱うため除外）
-      const result = await alertRepo.getByUserId(userId, {
-        ...parsePagination(request),
-        enabledOnly: true,
-      });
+      // アラート一覧取得（無効化済みアラートも UI に表示するため除外しない）
+      const result = await alertRepo.getByUserId(userId, parsePagination(request));
 
       // TickerリポジトリでSymbolとNameを取得
       // TODO: Phase 1では簡易実装（N+1問題あり）。Phase 2でバッチ取得に最適化

--- a/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
@@ -33,13 +33,49 @@ describe('GET /api/alerts', () => {
     mockGetByUserId.mockResolvedValue({ items: [] });
   });
 
-  it('Web 一覧取得時に enabledOnly: true でリポジトリを呼ぶ', async () => {
+  it('Web 一覧取得時に enabledOnly フィルタを付けずにリポジトリを呼ぶ', async () => {
     await GET(new NextRequest('http://localhost/api/alerts'));
 
     expect(mockGetByUserId).toHaveBeenCalledTimes(1);
-    expect(mockGetByUserId).toHaveBeenCalledWith(
-      'test-user',
-      expect.objectContaining({ enabledOnly: true })
-    );
+    const [, options] = mockGetByUserId.mock.calls[0];
+    expect(options).not.toHaveProperty('enabledOnly');
+  });
+
+  it('無効化済みアラートもレスポンスに含めて返す', async () => {
+    mockGetByUserId.mockResolvedValue({
+      items: [
+        {
+          AlertID: 'enabled-1',
+          TickerID: 'NASDAQ:NVDA',
+          Mode: 'Buy',
+          Frequency: 'MINUTE_LEVEL',
+          ConditionList: [{ field: 'price', operator: 'gte', value: 120 }],
+          Enabled: true,
+          CreatedAt: 1,
+          UpdatedAt: 1,
+        },
+        {
+          AlertID: 'disabled-1',
+          TickerID: 'NASDAQ:AAPL',
+          Mode: 'Sell',
+          Frequency: 'MINUTE_LEVEL',
+          ConditionList: [{ field: 'price', operator: 'lte', value: 100 }],
+          Enabled: false,
+          CreatedAt: 1,
+          UpdatedAt: 1,
+        },
+      ],
+    });
+    mockTickerGetById.mockResolvedValue({ Symbol: 'X', Name: 'X' });
+
+    const response = await GET(new NextRequest('http://localhost/api/alerts'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.alerts).toHaveLength(2);
+    expect(body.alerts.map((a: { alertId: string; enabled: boolean }) => a.enabled)).toEqual([
+      true,
+      false,
+    ]);
   });
 });


### PR DESCRIPTION
## 変更の概要

StockTracker の `/alerts`（アラート管理画面）で、無効化されたアラートが一覧に表示されない問題を修正する。`GET /api/alerts` がリポジトリに `enabledOnly: true` を渡していたため、編集モーダルから無効化したアラートが一覧から消え、再度有効化する手段を失う UX バグになっていた。

UI 側（`app/alerts/page.tsx`）は元々「状態」列で 有効/無効 を出し分け、`AlertSettingsModal` も有効化トグルを持っており、無効化アラートを表示する前提の設計となっている。API 側でフィルタを外して UI 仕様に揃える方針とした。

## 関連 Issue

Refs #3031

（Issue のクローズは integration → develop マージ時に行う想定のため、この PR では `Closes` を付けない）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（UI 仕様と一致させる修正のためドキュメント変更なし）
- [ ] CI/CD 設定を追加・更新した（変更なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

`services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts` を更新:

- `enabledOnly` オプションを付けずにリポジトリを呼ぶことを検証
- リポジトリが `Enabled: false` を含むアラートを返した場合、レスポンスにも `enabled: false` を含めて返すことを検証

`alerts-get-route.test.ts` / `alerts-route-filter.test.ts` / `alerts-create-route.test.ts` / `alerts-update-route.test.ts` / `lib/alert-filter.test.ts` で計 12 件すべて pass を確認。

## レビューポイント

- API レスポンスに無効化アラートを含めるよう変更したが、`/alerts` 以外の API 呼び出し元（バッチ・通知系など）がこの API を使っていないか確認したい。バッチ側は core の `AlertRepository.getByUserId` を直接利用しているため Web API には依存しないと判断。
- ティッカー単位の `GET /api/alerts/tickers/[tickerId]` は元から `enabledOnly` を付けておらず影響なし。

## スクリーンショット（該当する場合）

なし（UI 構造の変更はなく、API のフィルタ条件のみ変更）

## 補足事項

ホームページのティッカーカード等で表示する「Active alerts」のような有効件数集計が必要な箇所があれば、UI 側で `enabled` フラグを見て絞り込む方針となる。今回は調査時点で `/api/alerts` の応答を直接件数集計に使う箇所は見つからなかったが、レビュー時に確認いただきたい。

---
_Generated by [Claude Code](https://claude.ai/code/session_016DjXsYGxXUstoFiPgU5Kc7)_