### PR TITLE
fix(stock-tracker): アラート一覧で無効化アラートを表示する (#3031)

### DIFF
--- a/services/stock-tracker/web/app/api/alerts/route.ts
+++ b/services/stock-tracker/web/app/api/alerts/route.ts
@@ -134,11 +134,8 @@ export const GET = withAuth(
       // ユーザーIDを取得
       const userId = session.user.userId;
 
-      // アラート一覧取得（無効化済みアラートは UI 上で「削除済み」と同等に扱うため除外）
-      const result = await alertRepo.getByUserId(userId, {
-        ...parsePagination(request),
-        enabledOnly: true,
-      });
+      // アラート一覧取得（無効化済みアラートも UI に表示するため除外しない）
+      const result = await alertRepo.getByUserId(userId, parsePagination(request));
 
       // TickerリポジトリでSymbolとNameを取得
       // TODO: Phase 1では簡易実装（N+1問題あり）。Phase 2でバッチ取得に最適化

--- a/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
@@ -33,13 +33,49 @@ describe('GET /api/alerts', () => {
     mockGetByUserId.mockResolvedValue({ items: [] });
   });
 
-  it('Web 一覧取得時に enabledOnly: true でリポジトリを呼ぶ', async () => {
+  it('Web 一覧取得時に enabledOnly フィルタを付けずにリポジトリを呼ぶ', async () => {
     await GET(new NextRequest('http://localhost/api/alerts'));
 
     expect(mockGetByUserId).toHaveBeenCalledTimes(1);
-    expect(mockGetByUserId).toHaveBeenCalledWith(
-      'test-user',
-      expect.objectContaining({ enabledOnly: true })
-    );
+    const [, options] = mockGetByUserId.mock.calls[0];
+    expect(options).not.toHaveProperty('enabledOnly');
+  });
+
+  it('無効化済みアラートもレスポンスに含めて返す', async () => {
+    mockGetByUserId.mockResolvedValue({
+      items: [
+        {
+          AlertID: 'enabled-1',
+          TickerID: 'NASDAQ:NVDA',
+          Mode: 'Buy',
+          Frequency: 'MINUTE_LEVEL',
+          ConditionList: [{ field: 'price', operator: 'gte', value: 120 }],
+          Enabled: true,
+          CreatedAt: 1,
+          UpdatedAt: 1,
+        },
+        {
+          AlertID: 'disabled-1',
+          TickerID: 'NASDAQ:AAPL',
+          Mode: 'Sell',
+          Frequency: 'MINUTE_LEVEL',
+          ConditionList: [{ field: 'price', operator: 'lte', value: 100 }],
+          Enabled: false,
+          CreatedAt: 1,
+          UpdatedAt: 1,
+        },
+      ],
+    });
+    mockTickerGetById.mockResolvedValue({ Symbol: 'X', Name: 'X' });
+
+    const response = await GET(new NextRequest('http://localhost/api/alerts'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.alerts).toHaveLength(2);
+    expect(body.alerts.map((a: { alertId: string; enabled: boolean }) => a.enabled)).toEqual([
+      true,
+      false,
+    ]);
   });
 });


### PR DESCRIPTION
## 変更の概要

StockTracker の `/alerts`（アラート管理画面）で、無効化されたアラートが一覧に表示されない問題を修正する。

`GET /api/alerts` がリポジトリに `enabledOnly: true` を渡していたため、編集モーダルから無効化したアラートが一覧から消え、再度有効化する手段を失う UX バグになっていた。UI 側（`app/alerts/page.tsx`）は元々「状態」列で 有効/無効 を出し分け、`AlertSettingsModal` も有効化トグルを持っており、無効化アラートを表示する前提の設計となっている。API 側でフィルタを外して UI 仕様に揃えた。

## 関連 Issue

Closes #3031

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（UI 仕様と一致させる修正のためドキュメント変更なし）
- [ ] CI/CD 設定を追加・更新した（変更なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した
- [x] dev 環境での動作確認を完了した

## テスト内容

`services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts` を更新:

- `enabledOnly` オプションを付けずにリポジトリを呼ぶことを検証
- リポジトリが `Enabled: false` を含むアラートを返した場合、レスポンスにも `enabled: false` を含めて返すことを検証

Fast CI（PR #3032）にて Web Build / Core Build / Batch Build / Infrastructure Build / Docker Build / Web/Core/Batch Unit Tests / E2E (chromium-mobile) / Lint / Format Check / Infra Synth がすべて pass。

## レビューポイント

- API レスポンスに無効化アラートを含めるよう変更したが、Web API を直接利用する他箇所が無いことを確認済み（バッチ側は core の `AlertRepository.getByUserId` を直接利用）。
- ティッカー単位の `GET /api/alerts/tickers/[tickerId]` は元から `enabledOnly` を付けておらず影響なし。

## スクリーンショット（該当する場合）

なし（UI 構造の変更はなく、API のフィルタ条件のみ変更）

## 補足事項

PR #3032（claude/fix-disabled-alerts-display-UhkJS → integration/3031-fix-disabled-alerts-display）が dev 環境で動作確認済みのため、integration → develop の PR を作成する。

---
_Generated by [Claude Code](https://claude.ai/code/session_016DjXsYGxXUstoFiPgU5Kc7)_