### PR TITLE
feat(stock-tracker): 予測精度ダッシュボード UI PoC（モックデータ）（#3023）

### DIFF
--- a/services/stock-tracker/web/app/prediction-evaluation/page.tsx
+++ b/services/stock-tracker/web/app/prediction-evaluation/page.tsx
@@ -21,7 +21,8 @@ const DEFAULT_PERIOD: EvaluationPeriod = '7d';
 const DEFAULT_MIN_COUNT = 5;
 
 const UNAUTHORIZED_MESSAGE = '予測精度ダッシュボードを表示する権限がありません。';
-const POC_NOTICE = 'PoC 段階：本ダッシュボードはモックデータを表示しています（作業 7 で本物の API に差し替え予定）。';
+const POC_NOTICE =
+  'PoC 段階：本ダッシュボードはモックデータを表示しています（作業 7 で本物の API に差し替え予定）。';
 
 function PredictionEvaluationContent() {
   const { data: session, status } = useSession();

--- a/services/stock-tracker/web/app/prediction-evaluation/page.tsx
+++ b/services/stock-tracker/web/app/prediction-evaluation/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+import { Alert, Box, CircularProgress, Container, Typography } from '@mui/material';
+import { ErrorAlert, LoadingState } from '@nagiyu/ui';
+import { useSession } from 'next-auth/react';
+import { hasPermission } from '@nagiyu/common';
+import PeriodSelector from '@/components/prediction-evaluation/PeriodSelector';
+import KpiCards from '@/components/prediction-evaluation/KpiCards';
+import DailyTrendChart from '@/components/prediction-evaluation/DailyTrendChart';
+import SignalAccuracyChart from '@/components/prediction-evaluation/SignalAccuracyChart';
+import TickerAccuracyTable from '@/components/prediction-evaluation/TickerAccuracyTable';
+import ExchangeAccuracyTable from '@/components/prediction-evaluation/ExchangeAccuracyTable';
+import {
+  usePredictionEvaluationSummary,
+  usePredictionEvaluationTickers,
+} from '@/lib/prediction-evaluation/use-prediction-evaluation';
+import type { EvaluationPeriod } from '@/lib/prediction-evaluation/types';
+
+const DEFAULT_PERIOD: EvaluationPeriod = '7d';
+const DEFAULT_MIN_COUNT = 5;
+
+const UNAUTHORIZED_MESSAGE = '予測精度ダッシュボードを表示する権限がありません。';
+const POC_NOTICE = 'PoC 段階：本ダッシュボードはモックデータを表示しています（作業 7 で本物の API に差し替え予定）。';
+
+function PredictionEvaluationContent() {
+  const { data: session, status } = useSession();
+  const [period, setPeriod] = useState<EvaluationPeriod>(DEFAULT_PERIOD);
+
+  const summary = usePredictionEvaluationSummary(period);
+  const tickers = usePredictionEvaluationTickers(period, DEFAULT_MIN_COUNT);
+
+  if (status === 'loading') {
+    return <LoadingState message="セッション情報を確認中..." />;
+  }
+
+  const hasReadPermission =
+    !!session?.user &&
+    'roles' in session.user &&
+    Array.isArray(session.user.roles) &&
+    hasPermission(session.user.roles, 'stocks:read');
+
+  if (!hasReadPermission) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4 }} role="main">
+        <ErrorAlert message={UNAUTHORIZED_MESSAGE} title="権限エラー" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 3 }} role="main">
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
+          予測精度ダッシュボード
+        </Typography>
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {POC_NOTICE}
+        </Alert>
+      </Box>
+
+      <Box sx={{ mb: 3 }}>
+        <PeriodSelector value={period} onChange={setPeriod} />
+      </Box>
+
+      {summary.error && <ErrorAlert message={summary.error} />}
+      {tickers.error && <ErrorAlert message={tickers.error} />}
+
+      {summary.loading || !summary.data ? (
+        <LoadingState message="集計サマリーを読み込み中..." />
+      ) : summary.data.kpi.judgedCount === 0 ? (
+        <Alert severity="info" sx={{ mb: 3 }}>
+          指定された期間に採点済みの予測がありません。
+        </Alert>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <KpiCards kpi={summary.data.kpi} />
+          <DailyTrendChart data={summary.data.dailyTrend} />
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+              gap: 3,
+            }}
+          >
+            <SignalAccuracyChart data={summary.data.bySignal} />
+            <ExchangeAccuracyTable data={summary.data.byExchange} />
+          </Box>
+        </Box>
+      )}
+
+      <Box sx={{ mt: 3 }}>
+        {tickers.loading || !tickers.data ? (
+          <LoadingState message="銘柄別精度を読み込み中..." />
+        ) : (
+          <TickerAccuracyTable data={tickers.data.tickers} minCount={tickers.data.minCount} />
+        )}
+      </Box>
+    </Container>
+  );
+}
+
+export default function PredictionEvaluationPage() {
+  return (
+    <Suspense
+      fallback={
+        <Container maxWidth="xl" sx={{ py: 3 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
+        </Container>
+      }
+    >
+      <PredictionEvaluationContent />
+    </Suspense>
+  );
+}

--- a/services/stock-tracker/web/components/ThemeRegistry.tsx
+++ b/services/stock-tracker/web/components/ThemeRegistry.tsx
@@ -21,7 +21,10 @@ function ThemeRegistryContent({ children, version = '1.0.0' }: ThemeRegistryProp
     'roles' in session.user &&
     Array.isArray(session.user.roles) &&
     hasPermission(session.user.roles, 'stocks:read')
-      ? [{ label: 'サマリー', href: '/summaries' }]
+      ? [
+          { label: 'サマリー', href: '/summaries' },
+          { label: '予測精度', href: '/prediction-evaluation' },
+        ]
       : []),
     { label: '保有株式', href: '/holdings' },
     { label: 'アラート', href: '/alerts' },

--- a/services/stock-tracker/web/components/prediction-evaluation/DailyTrendChart.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/DailyTrendChart.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
 import type { EChartsOption } from 'echarts';
 import type { DailyTrendPoint } from '@/lib/prediction-evaluation/types';
 

--- a/services/stock-tracker/web/components/prediction-evaluation/DailyTrendChart.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/DailyTrendChart.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
+import type { EChartsOption } from 'echarts';
+import type { DailyTrendPoint } from '@/lib/prediction-evaluation/types';
+
+const ReactECharts = dynamic(() => import('echarts-for-react'), { ssr: false });
+
+export interface DailyTrendChartProps {
+  data: DailyTrendPoint[];
+}
+
+const NA = '—';
+
+export const buildDailyTrendOption = (data: DailyTrendPoint[]): EChartsOption => ({
+  tooltip: {
+    trigger: 'axis',
+  },
+  legend: {
+    data: ['方向精度 (%)', '判定済み件数'],
+    bottom: 0,
+  },
+  grid: {
+    left: '8%',
+    right: '8%',
+    top: '12%',
+    bottom: '20%',
+  },
+  xAxis: {
+    type: 'category',
+    data: data.map((point) => point.date),
+    axisLabel: {
+      rotate: 45,
+      fontSize: 10,
+    },
+  },
+  yAxis: [
+    {
+      type: 'value',
+      name: '精度 (%)',
+      min: 0,
+      max: 100,
+      position: 'left',
+    },
+    {
+      type: 'value',
+      name: '件数',
+      min: 0,
+      position: 'right',
+    },
+  ],
+  series: [
+    {
+      name: '方向精度 (%)',
+      type: 'line',
+      yAxisIndex: 0,
+      data: data.map((point) =>
+        point.directionalAccuracy === null ? '-' : point.directionalAccuracy
+      ),
+      connectNulls: false,
+      smooth: false,
+      itemStyle: { color: '#1976d2' },
+    },
+    {
+      name: '判定済み件数',
+      type: 'bar',
+      yAxisIndex: 1,
+      data: data.map((point) => point.judgedCount),
+      itemStyle: { color: 'rgba(38, 166, 154, 0.5)' },
+    },
+  ],
+});
+
+export default function DailyTrendChart({ data }: DailyTrendChartProps) {
+  if (data.length === 0) {
+    return (
+      <Paper variant="outlined" sx={{ p: 3 }}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          日次の方向精度推移
+        </Typography>
+        <Typography color="text.secondary">表示できるデータがありません</Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Typography variant="h6" component="h2" gutterBottom>
+        日次の方向精度推移
+      </Typography>
+      <Box
+        sx={{ width: '100%', minHeight: { xs: 280, md: 360 } }}
+        role="img"
+        aria-label="日次方向精度推移チャート"
+      >
+        <ReactECharts
+          option={buildDailyTrendOption(data)}
+          style={{ height: '100%', minHeight: 280 }}
+          opts={{ renderer: 'canvas', locale: 'JP' }}
+          notMerge
+          lazyUpdate
+        />
+      </Box>
+      <TableContainer sx={{ mt: 2, maxHeight: 240 }}>
+        <Table size="small" aria-label="日次方向精度の数値テーブル">
+          <TableHead>
+            <TableRow>
+              <TableCell>日付</TableCell>
+              <TableCell align="right">方向精度</TableCell>
+              <TableCell align="right">判定済み件数</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.map((point) => (
+              <TableRow key={point.date}>
+                <TableCell>{point.date}</TableCell>
+                <TableCell align="right">
+                  {point.directionalAccuracy === null
+                    ? NA
+                    : `${point.directionalAccuracy.toFixed(1)}%`}
+                </TableCell>
+                <TableCell align="right">{point.judgedCount.toLocaleString('ja-JP')}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Paper>
+  );
+}

--- a/services/stock-tracker/web/components/prediction-evaluation/ExchangeAccuracyTable.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/ExchangeAccuracyTable.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import type { ExchangeAccuracyEntry } from '@/lib/prediction-evaluation/types';
+
+export interface ExchangeAccuracyTableProps {
+  data: ExchangeAccuracyEntry[];
+}
+
+const NA = '—';
+
+export default function ExchangeAccuracyTable({ data }: ExchangeAccuracyTableProps) {
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Typography variant="h6" component="h2" gutterBottom>
+        取引所別精度
+      </Typography>
+      {data.length === 0 ? (
+        <Typography color="text.secondary">表示できるデータがありません</Typography>
+      ) : (
+        <TableContainer>
+          <Table size="small" aria-label="取引所別精度テーブル">
+            <TableHead>
+              <TableRow>
+                <TableCell>取引所</TableCell>
+                <TableCell align="right">精度</TableCell>
+                <TableCell align="right">判定件数</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.map((entry) => (
+                <TableRow key={entry.exchangeId} data-testid={`exchange-row-${entry.exchangeId}`}>
+                  <TableCell>
+                    <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
+                      {entry.exchangeName}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {entry.exchangeId}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    {entry.accuracy === null ? NA : `${entry.accuracy.toFixed(1)}%`}
+                  </TableCell>
+                  <TableCell align="right">{entry.count.toLocaleString('ja-JP')}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Paper>
+  );
+}

--- a/services/stock-tracker/web/components/prediction-evaluation/KpiCards.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/KpiCards.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import type { KpiSummary } from '@/lib/prediction-evaluation/types';
+
+export interface KpiCardsProps {
+  kpi: KpiSummary;
+}
+
+const NA = '—';
+
+export const formatPercent = (value: number | null): string => {
+  if (value === null || Number.isNaN(value)) {
+    return NA;
+  }
+  return `${value.toFixed(1)}%`;
+};
+
+export const formatCount = (value: number): string => value.toLocaleString('ja-JP');
+
+interface KpiCardItem {
+  key: string;
+  label: string;
+  value: string;
+  description: string;
+}
+
+export const buildKpiItems = (kpi: KpiSummary): KpiCardItem[] => [
+  {
+    key: 'total-accuracy',
+    label: '総合精度',
+    value: formatPercent(kpi.totalAccuracy),
+    description: '全シグナルの的中率',
+  },
+  {
+    key: 'directional-accuracy',
+    label: '方向精度',
+    value: formatPercent(kpi.directionalAccuracy),
+    description: 'BULLISH / BEARISH のみ',
+  },
+  {
+    key: 'neutral-ratio',
+    label: 'NEUTRAL 比率',
+    value: formatPercent(kpi.neutralRatio),
+    description: 'NEUTRAL 予測の割合',
+  },
+  {
+    key: 'judged-count',
+    label: '判定済み件数',
+    value: formatCount(kpi.judgedCount),
+    description: '採点済みの予測数',
+  },
+  {
+    key: 'ai-failure-count',
+    label: 'AI 失敗件数',
+    value: formatCount(kpi.aiFailureCount),
+    description: '採点対象外（解析失敗）',
+  },
+];
+
+export default function KpiCards({ kpi }: KpiCardsProps) {
+  const items = buildKpiItems(kpi);
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: 'repeat(2, 1fr)',
+          sm: 'repeat(3, 1fr)',
+          md: 'repeat(5, 1fr)',
+        },
+        gap: 2,
+      }}
+      role="region"
+      aria-label="KPI 一覧"
+    >
+      {items.map((item) => (
+        <Card key={item.key} variant="outlined" data-testid={`kpi-card-${item.key}`}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              {item.label}
+            </Typography>
+            <Typography
+              variant="h5"
+              component="div"
+              sx={{ fontWeight: 'bold', mt: 1 }}
+              data-testid={`kpi-value-${item.key}`}
+            >
+              {item.value}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {item.description}
+            </Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/services/stock-tracker/web/components/prediction-evaluation/PeriodSelector.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/PeriodSelector.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { Select } from '@nagiyu/ui';
+import {
+  EVALUATION_PERIODS,
+  PERIOD_LABELS,
+  type EvaluationPeriod,
+} from '@/lib/prediction-evaluation/types';
+
+export interface PeriodSelectorProps {
+  value: EvaluationPeriod;
+  onChange: (period: EvaluationPeriod) => void;
+}
+
+const isEvaluationPeriod = (value: string): value is EvaluationPeriod =>
+  (EVALUATION_PERIODS as readonly string[]).includes(value);
+
+export default function PeriodSelector({ value, onChange }: PeriodSelectorProps) {
+  const handleChange = (next: string) => {
+    if (isEvaluationPeriod(next)) {
+      onChange(next);
+    }
+  };
+
+  return (
+    <Box sx={{ minWidth: 200, maxWidth: 320 }}>
+      <Select
+        id="prediction-evaluation-period"
+        label="集計期間"
+        size="sm"
+        fullWidth
+        value={value}
+        onChange={handleChange}
+        options={EVALUATION_PERIODS.map((period) => ({
+          value: period,
+          label: PERIOD_LABELS[period],
+        }))}
+      />
+    </Box>
+  );
+}

--- a/services/stock-tracker/web/components/prediction-evaluation/SignalAccuracyChart.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/SignalAccuracyChart.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
 import type { EChartsOption } from 'echarts';
 import { SIGNAL_LABELS, type SignalAccuracyEntry } from '@/lib/prediction-evaluation/types';
 

--- a/services/stock-tracker/web/components/prediction-evaluation/SignalAccuracyChart.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/SignalAccuracyChart.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
+import type { EChartsOption } from 'echarts';
+import { SIGNAL_LABELS, type SignalAccuracyEntry } from '@/lib/prediction-evaluation/types';
+
+const ReactECharts = dynamic(() => import('echarts-for-react'), { ssr: false });
+
+export interface SignalAccuracyChartProps {
+  data: SignalAccuracyEntry[];
+}
+
+const NA = '—';
+
+const SIGNAL_COLORS: Record<SignalAccuracyEntry['signal'], string> = {
+  BULLISH: '#26a69a',
+  NEUTRAL: '#9e9e9e',
+  BEARISH: '#ef5350',
+};
+
+export const buildSignalChartOption = (data: SignalAccuracyEntry[]): EChartsOption => ({
+  tooltip: {
+    trigger: 'axis',
+    axisPointer: { type: 'shadow' },
+  },
+  grid: {
+    left: '12%',
+    right: '8%',
+    top: '8%',
+    bottom: '20%',
+  },
+  xAxis: {
+    type: 'category',
+    data: data.map((entry) => SIGNAL_LABELS[entry.signal]),
+  },
+  yAxis: {
+    type: 'value',
+    name: '精度 (%)',
+    min: 0,
+    max: 100,
+  },
+  series: [
+    {
+      name: '精度 (%)',
+      type: 'bar',
+      data: data.map((entry) => ({
+        value: entry.accuracy === null ? 0 : entry.accuracy,
+        itemStyle: { color: SIGNAL_COLORS[entry.signal] },
+      })),
+      label: {
+        show: true,
+        position: 'top',
+        formatter: (params: { dataIndex: number }) => {
+          const entry = data[params.dataIndex];
+          if (!entry) return '';
+          return entry.accuracy === null ? '—' : `${entry.accuracy.toFixed(1)}%`;
+        },
+      },
+    },
+  ],
+});
+
+export default function SignalAccuracyChart({ data }: SignalAccuracyChartProps) {
+  const isEmpty = data.every((entry) => entry.count === 0);
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Typography variant="h6" component="h2" gutterBottom>
+        シグナル別の精度
+      </Typography>
+      {isEmpty ? (
+        <Typography color="text.secondary">表示できるデータがありません</Typography>
+      ) : (
+        <>
+          <Box
+            sx={{ width: '100%', minHeight: { xs: 240, md: 320 } }}
+            role="img"
+            aria-label="シグナル別精度のグラフ"
+          >
+            <ReactECharts
+              option={buildSignalChartOption(data)}
+              style={{ height: '100%', minHeight: 240 }}
+              opts={{ renderer: 'canvas', locale: 'JP' }}
+              notMerge
+              lazyUpdate
+            />
+          </Box>
+          <TableContainer sx={{ mt: 2 }}>
+            <Table size="small" aria-label="シグナル別精度の数値テーブル">
+              <TableHead>
+                <TableRow>
+                  <TableCell>シグナル</TableCell>
+                  <TableCell align="right">精度</TableCell>
+                  <TableCell align="right">件数</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.map((entry) => (
+                  <TableRow key={entry.signal}>
+                    <TableCell>{SIGNAL_LABELS[entry.signal]}</TableCell>
+                    <TableCell align="right">
+                      {entry.accuracy === null ? NA : `${entry.accuracy.toFixed(1)}%`}
+                    </TableCell>
+                    <TableCell align="right">{entry.count.toLocaleString('ja-JP')}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/services/stock-tracker/web/components/prediction-evaluation/TickerAccuracyTable.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/TickerAccuracyTable.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import type { TickerAccuracyEntry } from '@/lib/prediction-evaluation/types';
+
+export interface TickerAccuracyTableProps {
+  data: TickerAccuracyEntry[];
+  minCount: number;
+}
+
+export const formatHitRatio = (hit: number, total: number): string => {
+  if (total === 0) {
+    return '—';
+  }
+  const ratio = (hit / total) * 100;
+  return `${ratio.toFixed(1)}% (${hit}/${total})`;
+};
+
+export default function TickerAccuracyTable({ data, minCount }: TickerAccuracyTableProps) {
+  const sorted = [...data].sort((a, b) => b.accuracy - a.accuracy);
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', mb: 1 }}>
+        <Typography variant="h6" component="h2">
+          銘柄別精度
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {`判定件数 ≥ ${minCount} の銘柄のみ`}
+        </Typography>
+      </Box>
+      {sorted.length === 0 ? (
+        <Typography color="text.secondary">表示できるデータがありません</Typography>
+      ) : (
+        <TableContainer sx={{ maxHeight: 480 }}>
+          <Table size="small" stickyHeader aria-label="銘柄別精度テーブル">
+            <TableHead>
+              <TableRow>
+                <TableCell>銘柄</TableCell>
+                <TableCell>取引所</TableCell>
+                <TableCell align="right">方向精度</TableCell>
+                <TableCell align="right">判定件数</TableCell>
+                <TableCell align="right">BULLISH 的中</TableCell>
+                <TableCell align="right">BEARISH 的中</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {sorted.map((entry) => (
+                <TableRow
+                  key={entry.tickerId}
+                  hover
+                  data-testid={`ticker-row-${entry.tickerId}`}
+                >
+                  <TableCell>
+                    <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
+                      {entry.tickerId}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {entry.tickerName}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>{entry.exchangeId}</TableCell>
+                  <TableCell align="right">{entry.accuracy.toFixed(1)}%</TableCell>
+                  <TableCell align="right">{entry.count.toLocaleString('ja-JP')}</TableCell>
+                  <TableCell align="right">
+                    {formatHitRatio(entry.bullishHit, entry.bullishTotal)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatHitRatio(entry.bearishHit, entry.bearishTotal)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Paper>
+  );
+}

--- a/services/stock-tracker/web/components/prediction-evaluation/TickerAccuracyTable.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/TickerAccuracyTable.tsx
@@ -56,11 +56,7 @@ export default function TickerAccuracyTable({ data, minCount }: TickerAccuracyTa
             </TableHead>
             <TableBody>
               {sorted.map((entry) => (
-                <TableRow
-                  key={entry.tickerId}
-                  hover
-                  data-testid={`ticker-row-${entry.tickerId}`}
-                >
+                <TableRow key={entry.tickerId} hover data-testid={`ticker-row-${entry.tickerId}`}>
                   <TableCell>
                     <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
                       {entry.tickerId}

--- a/services/stock-tracker/web/jest.config.ts
+++ b/services/stock-tracker/web/jest.config.ts
@@ -22,13 +22,30 @@ const config: Config = {
   },
   modulePathIgnorePatterns: ['<rootDir>/../../../package.json'],
   coverageDirectory: 'coverage',
-  collectCoverageFrom: ['lib/repository-factory.ts', 'lib/percentage-helper.ts'],
+  collectCoverageFrom: [
+    'lib/repository-factory.ts',
+    'lib/percentage-helper.ts',
+    'lib/prediction-evaluation/**/*.ts',
+    'components/prediction-evaluation/**/*.tsx',
+  ],
   coverageThreshold: {
     global: {
       branches: 100,
       functions: 100,
       lines: 100,
       statements: 100,
+    },
+    './lib/prediction-evaluation/': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+    './components/prediction-evaluation/': {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
 };

--- a/services/stock-tracker/web/lib/prediction-evaluation/mock-data.ts
+++ b/services/stock-tracker/web/lib/prediction-evaluation/mock-data.ts
@@ -1,0 +1,433 @@
+/**
+ * 予測精度ダッシュボード PoC 用モックデータ
+ *
+ * `tasks/stock-tracer-prediction-evaluation/tasks.md` § 作業 1 のスコープに従い、
+ * `SummaryResponse` / `TickersResponse` 型に準拠したハードコード JSON を提供する。
+ *
+ * バリエーション：
+ * - 複数日 / 複数銘柄 / 複数取引所
+ * - 高精度ケース・低精度ケース
+ * - 空状態（judgedCount = 0）
+ * - 部分欠損（accuracy = null）
+ *
+ * 作業 7 で `use-prediction-evaluation.ts` から fetch 呼び出しに差し替えた時点で、
+ * 本ファイルはテストフィクスチャに移動するか削除される予定。
+ */
+
+import type {
+  EvaluationPeriod,
+  SummaryResponse,
+  TickersResponse,
+} from './types';
+
+const NOW_MS = Date.UTC(2026, 4, 11, 12, 0, 0); // 2026-05-11 12:00 UTC（PoC 用の固定値）
+
+const EXCHANGE_NASDAQ = { id: 'NASDAQ', name: 'NASDAQ' };
+const EXCHANGE_TSE = { id: 'TSE', name: '東京証券取引所' };
+const EXCHANGE_NYSE = { id: 'NYSE', name: 'NYSE' };
+
+/** 期間ごとの日次推移サンプル */
+const DAILY_TREND_7D = [
+  { date: '2026-05-04', directionalAccuracy: 66.7, judgedCount: 9 },
+  { date: '2026-05-05', directionalAccuracy: 55.6, judgedCount: 9 },
+  { date: '2026-05-06', directionalAccuracy: null, judgedCount: 0 }, // 部分欠損
+  { date: '2026-05-07', directionalAccuracy: 75.0, judgedCount: 8 },
+  { date: '2026-05-08', directionalAccuracy: 50.0, judgedCount: 10 },
+  { date: '2026-05-09', directionalAccuracy: 62.5, judgedCount: 8 },
+  { date: '2026-05-10', directionalAccuracy: 70.0, judgedCount: 10 },
+];
+
+const DAILY_TREND_30D = [
+  ...Array.from({ length: 23 }, (_, i) => {
+    const day = 11 + i;
+    const directionalAccuracy = i % 7 === 4 ? null : 50 + ((i * 13) % 35);
+    const judgedCount = i % 7 === 4 ? 0 : 6 + (i % 5);
+    return {
+      date: `2026-04-${String(day).padStart(2, '0')}`,
+      directionalAccuracy,
+      judgedCount,
+    };
+  }),
+  ...DAILY_TREND_7D,
+];
+
+const DAILY_TREND_90D = Array.from({ length: 83 }, (_, i) => {
+  const base = new Date(Date.UTC(2026, 1, 12)).getTime();
+  const date = new Date(base + i * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const directionalAccuracy = i % 11 === 7 ? null : 48 + ((i * 7) % 40);
+  const judgedCount = i % 11 === 7 ? 0 : 5 + (i % 7);
+  return { date, directionalAccuracy, judgedCount };
+}).concat(DAILY_TREND_7D);
+
+const MOCK_SUMMARY_7D: SummaryResponse = {
+  period: '7d',
+  evaluatedAt: NOW_MS,
+  kpi: {
+    totalAccuracy: 64.8,
+    directionalAccuracy: 63.5,
+    neutralRatio: 22.2,
+    judgedCount: 54,
+    aiFailureCount: 3,
+  },
+  dailyTrend: DAILY_TREND_7D,
+  bySignal: [
+    { signal: 'BULLISH', accuracy: 70.0, count: 20 },
+    { signal: 'NEUTRAL', accuracy: 66.7, count: 12 },
+    { signal: 'BEARISH', accuracy: 54.5, count: 22 },
+  ],
+  byExchange: [
+    {
+      exchangeId: EXCHANGE_NASDAQ.id,
+      exchangeName: EXCHANGE_NASDAQ.name,
+      accuracy: 71.4,
+      count: 21,
+    },
+    {
+      exchangeId: EXCHANGE_TSE.id,
+      exchangeName: EXCHANGE_TSE.name,
+      accuracy: 58.3,
+      count: 24,
+    },
+    {
+      exchangeId: EXCHANGE_NYSE.id,
+      exchangeName: EXCHANGE_NYSE.name,
+      accuracy: null, // 部分欠損
+      count: 9,
+    },
+  ],
+};
+
+const MOCK_SUMMARY_30D: SummaryResponse = {
+  period: '30d',
+  evaluatedAt: NOW_MS,
+  kpi: {
+    totalAccuracy: 58.2,
+    directionalAccuracy: 56.4,
+    neutralRatio: 26.1,
+    judgedCount: 218,
+    aiFailureCount: 11,
+  },
+  dailyTrend: DAILY_TREND_30D,
+  bySignal: [
+    { signal: 'BULLISH', accuracy: 61.0, count: 82 },
+    { signal: 'NEUTRAL', accuracy: 60.5, count: 57 },
+    { signal: 'BEARISH', accuracy: 53.8, count: 79 },
+  ],
+  byExchange: [
+    {
+      exchangeId: EXCHANGE_NASDAQ.id,
+      exchangeName: EXCHANGE_NASDAQ.name,
+      accuracy: 62.1,
+      count: 87,
+    },
+    {
+      exchangeId: EXCHANGE_TSE.id,
+      exchangeName: EXCHANGE_TSE.name,
+      accuracy: 55.4,
+      count: 92,
+    },
+    {
+      exchangeId: EXCHANGE_NYSE.id,
+      exchangeName: EXCHANGE_NYSE.name,
+      accuracy: 48.7,
+      count: 39,
+    },
+  ],
+};
+
+const MOCK_SUMMARY_90D: SummaryResponse = {
+  period: '90d',
+  evaluatedAt: NOW_MS,
+  kpi: {
+    totalAccuracy: 55.9,
+    directionalAccuracy: 53.7,
+    neutralRatio: 28.0,
+    judgedCount: 642,
+    aiFailureCount: 34,
+  },
+  dailyTrend: DAILY_TREND_90D,
+  bySignal: [
+    { signal: 'BULLISH', accuracy: 57.2, count: 240 },
+    { signal: 'NEUTRAL', accuracy: 58.3, count: 180 },
+    { signal: 'BEARISH', accuracy: 51.0, count: 222 },
+  ],
+  byExchange: [
+    {
+      exchangeId: EXCHANGE_NASDAQ.id,
+      exchangeName: EXCHANGE_NASDAQ.name,
+      accuracy: 59.4,
+      count: 261,
+    },
+    {
+      exchangeId: EXCHANGE_TSE.id,
+      exchangeName: EXCHANGE_TSE.name,
+      accuracy: 54.8,
+      count: 270,
+    },
+    {
+      exchangeId: EXCHANGE_NYSE.id,
+      exchangeName: EXCHANGE_NYSE.name,
+      accuracy: 49.2,
+      count: 111,
+    },
+  ],
+};
+
+/** 全期間：判定済みが 0 件で「空状態」UI を確認できるよう意図的に空にする */
+const MOCK_SUMMARY_ALL_EMPTY: SummaryResponse = {
+  period: 'all',
+  evaluatedAt: NOW_MS,
+  kpi: {
+    totalAccuracy: null,
+    directionalAccuracy: null,
+    neutralRatio: null,
+    judgedCount: 0,
+    aiFailureCount: 0,
+  },
+  dailyTrend: [],
+  bySignal: [
+    { signal: 'BULLISH', accuracy: null, count: 0 },
+    { signal: 'NEUTRAL', accuracy: null, count: 0 },
+    { signal: 'BEARISH', accuracy: null, count: 0 },
+  ],
+  byExchange: [],
+};
+
+export const MOCK_SUMMARY_BY_PERIOD: Record<EvaluationPeriod, SummaryResponse> = {
+  '7d': MOCK_SUMMARY_7D,
+  '30d': MOCK_SUMMARY_30D,
+  '90d': MOCK_SUMMARY_90D,
+  all: MOCK_SUMMARY_ALL_EMPTY,
+};
+
+const MOCK_TICKERS_7D: TickersResponse = {
+  period: '7d',
+  minCount: 5,
+  tickers: [
+    {
+      tickerId: 'NASDAQ:NVDA',
+      tickerName: 'NVIDIA Corporation',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 83.3,
+      count: 6,
+      bullishHit: 4,
+      bullishTotal: 4,
+      bearishHit: 1,
+      bearishTotal: 2,
+    },
+    {
+      tickerId: 'NASDAQ:AAPL',
+      tickerName: 'Apple Inc.',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 71.4,
+      count: 7,
+      bullishHit: 3,
+      bullishTotal: 4,
+      bearishHit: 2,
+      bearishTotal: 3,
+    },
+    {
+      tickerId: 'TSE:7203',
+      tickerName: 'トヨタ自動車',
+      exchangeId: EXCHANGE_TSE.id,
+      accuracy: 62.5,
+      count: 8,
+      bullishHit: 3,
+      bullishTotal: 5,
+      bearishHit: 2,
+      bearishTotal: 3,
+    },
+    {
+      tickerId: 'TSE:6758',
+      tickerName: 'ソニーグループ',
+      exchangeId: EXCHANGE_TSE.id,
+      accuracy: 50.0,
+      count: 6,
+      bullishHit: 2,
+      bullishTotal: 4,
+      bearishHit: 1,
+      bearishTotal: 2,
+    },
+    {
+      tickerId: 'NYSE:KO',
+      tickerName: 'The Coca-Cola Company',
+      exchangeId: EXCHANGE_NYSE.id,
+      accuracy: 40.0,
+      count: 5,
+      bullishHit: 1,
+      bullishTotal: 3,
+      bearishHit: 1,
+      bearishTotal: 2,
+    },
+    {
+      tickerId: 'NASDAQ:GOOG',
+      tickerName: 'Alphabet Inc.',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 33.3,
+      count: 6,
+      bullishHit: 1,
+      bullishTotal: 3,
+      bearishHit: 1,
+      bearishTotal: 3,
+    },
+  ],
+};
+
+const MOCK_TICKERS_30D: TickersResponse = {
+  period: '30d',
+  minCount: 5,
+  tickers: [
+    {
+      tickerId: 'NASDAQ:NVDA',
+      tickerName: 'NVIDIA Corporation',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 75.0,
+      count: 24,
+      bullishHit: 12,
+      bullishTotal: 15,
+      bearishHit: 6,
+      bearishTotal: 9,
+    },
+    {
+      tickerId: 'NASDAQ:AAPL',
+      tickerName: 'Apple Inc.',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 66.7,
+      count: 27,
+      bullishHit: 11,
+      bullishTotal: 16,
+      bearishHit: 7,
+      bearishTotal: 11,
+    },
+    {
+      tickerId: 'TSE:7203',
+      tickerName: 'トヨタ自動車',
+      exchangeId: EXCHANGE_TSE.id,
+      accuracy: 60.7,
+      count: 28,
+      bullishHit: 9,
+      bullishTotal: 14,
+      bearishHit: 8,
+      bearishTotal: 14,
+    },
+    {
+      tickerId: 'TSE:6758',
+      tickerName: 'ソニーグループ',
+      exchangeId: EXCHANGE_TSE.id,
+      accuracy: 56.0,
+      count: 25,
+      bullishHit: 8,
+      bullishTotal: 14,
+      bearishHit: 6,
+      bearishTotal: 11,
+    },
+    {
+      tickerId: 'NYSE:KO',
+      tickerName: 'The Coca-Cola Company',
+      exchangeId: EXCHANGE_NYSE.id,
+      accuracy: 47.6,
+      count: 21,
+      bullishHit: 5,
+      bullishTotal: 11,
+      bearishHit: 5,
+      bearishTotal: 10,
+    },
+    {
+      tickerId: 'NASDAQ:GOOG',
+      tickerName: 'Alphabet Inc.',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 42.3,
+      count: 26,
+      bullishHit: 5,
+      bullishTotal: 13,
+      bearishHit: 6,
+      bearishTotal: 13,
+    },
+  ],
+};
+
+const MOCK_TICKERS_90D: TickersResponse = {
+  period: '90d',
+  minCount: 5,
+  tickers: [
+    {
+      tickerId: 'NASDAQ:NVDA',
+      tickerName: 'NVIDIA Corporation',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 68.4,
+      count: 76,
+      bullishHit: 32,
+      bullishTotal: 46,
+      bearishHit: 20,
+      bearishTotal: 30,
+    },
+    {
+      tickerId: 'NASDAQ:AAPL',
+      tickerName: 'Apple Inc.',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 61.5,
+      count: 78,
+      bullishHit: 28,
+      bullishTotal: 44,
+      bearishHit: 20,
+      bearishTotal: 34,
+    },
+    {
+      tickerId: 'TSE:7203',
+      tickerName: 'トヨタ自動車',
+      exchangeId: EXCHANGE_TSE.id,
+      accuracy: 56.8,
+      count: 81,
+      bullishHit: 24,
+      bullishTotal: 40,
+      bearishHit: 22,
+      bearishTotal: 41,
+    },
+    {
+      tickerId: 'TSE:6758',
+      tickerName: 'ソニーグループ',
+      exchangeId: EXCHANGE_TSE.id,
+      accuracy: 52.6,
+      count: 76,
+      bullishHit: 21,
+      bullishTotal: 38,
+      bearishHit: 19,
+      bearishTotal: 38,
+    },
+    {
+      tickerId: 'NYSE:KO',
+      tickerName: 'The Coca-Cola Company',
+      exchangeId: EXCHANGE_NYSE.id,
+      accuracy: 45.2,
+      count: 62,
+      bullishHit: 14,
+      bullishTotal: 32,
+      bearishHit: 14,
+      bearishTotal: 30,
+    },
+    {
+      tickerId: 'NASDAQ:GOOG',
+      tickerName: 'Alphabet Inc.',
+      exchangeId: EXCHANGE_NASDAQ.id,
+      accuracy: 41.3,
+      count: 75,
+      bullishHit: 16,
+      bullishTotal: 39,
+      bearishHit: 15,
+      bearishTotal: 36,
+    },
+  ],
+};
+
+const MOCK_TICKERS_ALL_EMPTY: TickersResponse = {
+  period: 'all',
+  minCount: 5,
+  tickers: [],
+};
+
+export const MOCK_TICKERS_BY_PERIOD: Record<EvaluationPeriod, TickersResponse> = {
+  '7d': MOCK_TICKERS_7D,
+  '30d': MOCK_TICKERS_30D,
+  '90d': MOCK_TICKERS_90D,
+  all: MOCK_TICKERS_ALL_EMPTY,
+};

--- a/services/stock-tracker/web/lib/prediction-evaluation/mock-data.ts
+++ b/services/stock-tracker/web/lib/prediction-evaluation/mock-data.ts
@@ -14,11 +14,7 @@
  * 本ファイルはテストフィクスチャに移動するか削除される予定。
  */
 
-import type {
-  EvaluationPeriod,
-  SummaryResponse,
-  TickersResponse,
-} from './types';
+import type { EvaluationPeriod, SummaryResponse, TickersResponse } from './types';
 
 const NOW_MS = Date.UTC(2026, 4, 11, 12, 0, 0); // 2026-05-11 12:00 UTC（PoC 用の固定値）
 

--- a/services/stock-tracker/web/lib/prediction-evaluation/types.ts
+++ b/services/stock-tracker/web/lib/prediction-evaluation/types.ts
@@ -1,0 +1,89 @@
+/**
+ * 予測精度ダッシュボード API レスポンス型定義
+ *
+ * `tasks/stock-tracer-prediction-evaluation/design.md` §1.3 に準拠する。
+ * 本 PoC 段階では作業 6（精度集計 API）未実装のため、`mock-data.ts` で
+ * これらの型を満たすハードコード JSON を返す。作業 2 の PoC FB 反映で
+ * 内容（フィールド構成）が変わる可能性あり。
+ */
+
+export type EvaluationPeriod = '7d' | '30d' | '90d' | 'all';
+
+export const EVALUATION_PERIODS: readonly EvaluationPeriod[] = ['7d', '30d', '90d', 'all'];
+
+export const PERIOD_LABELS: Record<EvaluationPeriod, string> = {
+  '7d': '直近 7 日',
+  '30d': '直近 30 日',
+  '90d': '直近 90 日',
+  all: '全期間',
+};
+
+export type PredictedSignal = 'BULLISH' | 'NEUTRAL' | 'BEARISH';
+
+export const SIGNAL_LABELS: Record<PredictedSignal, string> = {
+  BULLISH: '強気（BULLISH）',
+  NEUTRAL: '中立（NEUTRAL）',
+  BEARISH: '弱気（BEARISH）',
+};
+
+export interface KpiSummary {
+  /** 総合精度（%）。判定済み 0 件なら null */
+  totalAccuracy: number | null;
+  /** 方向精度（%、BULLISH + BEARISH のみ） */
+  directionalAccuracy: number | null;
+  /** NEUTRAL 比率（%） */
+  neutralRatio: number | null;
+  /** 判定済み件数 */
+  judgedCount: number;
+  /** 採点対象外（AiAnalysisError あり）件数 */
+  aiFailureCount: number;
+}
+
+export interface DailyTrendPoint {
+  /** YYYY-MM-DD */
+  date: string;
+  directionalAccuracy: number | null;
+  judgedCount: number;
+}
+
+export interface SignalAccuracyEntry {
+  signal: PredictedSignal;
+  accuracy: number | null;
+  count: number;
+}
+
+export interface ExchangeAccuracyEntry {
+  exchangeId: string;
+  exchangeName: string;
+  accuracy: number | null;
+  count: number;
+}
+
+export interface SummaryResponse {
+  period: EvaluationPeriod;
+  /** 集計時刻（unix timestamp ms） */
+  evaluatedAt: number;
+  kpi: KpiSummary;
+  dailyTrend: DailyTrendPoint[];
+  bySignal: SignalAccuracyEntry[];
+  byExchange: ExchangeAccuracyEntry[];
+}
+
+export interface TickerAccuracyEntry {
+  tickerId: string;
+  tickerName: string;
+  exchangeId: string;
+  /** 方向精度ベース（NEUTRAL 除外） */
+  accuracy: number;
+  count: number;
+  bullishHit: number;
+  bullishTotal: number;
+  bearishHit: number;
+  bearishTotal: number;
+}
+
+export interface TickersResponse {
+  period: EvaluationPeriod;
+  minCount: number;
+  tickers: TickerAccuracyEntry[];
+}

--- a/services/stock-tracker/web/lib/prediction-evaluation/use-prediction-evaluation.ts
+++ b/services/stock-tracker/web/lib/prediction-evaluation/use-prediction-evaluation.ts
@@ -1,0 +1,149 @@
+'use client';
+
+/**
+ * 予測精度ダッシュボード PoC 用データ取得 hook
+ *
+ * 作業 1（UI PoC）の段階ではモック JSON を Promise でラップして返す。
+ * 作業 7 でここの実装を `fetch('/api/prediction-evaluation/...')` に
+ * 差し替えることで、UI 側のコード変更を最小に保つ「唯一の差し替え点」。
+ *
+ * URL クエリ `?scenario=error` でエラー応答、`?scenario=loading` でローディング
+ * 永続を再現できる（PoC レビュー時に状態を試したいケース向け）。
+ */
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { MOCK_SUMMARY_BY_PERIOD, MOCK_TICKERS_BY_PERIOD } from './mock-data';
+import type { EvaluationPeriod, SummaryResponse, TickersResponse } from './types';
+
+export interface FetchState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const MOCK_DELAY_MS = 300;
+
+const ERROR_MESSAGES = {
+  FETCH_SUMMARY: '予測精度サマリーの取得に失敗しました',
+  FETCH_TICKERS: '銘柄別精度の取得に失敗しました',
+} as const;
+
+type Scenario = 'normal' | 'loading' | 'error';
+
+const resolveScenario = (raw: string | null): Scenario => {
+  if (raw === 'loading' || raw === 'error') {
+    return raw;
+  }
+  return 'normal';
+};
+
+const simulateFetch = <T>(
+  payload: T,
+  scenario: Scenario,
+  errorMessage: string
+): Promise<T> => {
+  if (scenario === 'loading') {
+    return new Promise<T>(() => {
+      /* never resolve */
+    });
+  }
+  if (scenario === 'error') {
+    return new Promise<T>((_resolve, reject) => {
+      setTimeout(() => reject(new Error(errorMessage)), MOCK_DELAY_MS);
+    });
+  }
+  return new Promise<T>((resolve) => {
+    setTimeout(() => resolve(payload), MOCK_DELAY_MS);
+  });
+};
+
+/**
+ * 銘柄テーブルの `minCount` フィルタはモック段階ではクライアントで適用する。
+ * 作業 6（API 実装）後はサーバー側で適用されるため、本関数はそのまま削除される予定。
+ */
+export const applyMinCountFilter = (
+  response: TickersResponse,
+  minCount: number
+): TickersResponse => {
+  return {
+    ...response,
+    minCount,
+    tickers: response.tickers.filter((ticker) => ticker.count >= minCount),
+  };
+};
+
+export function usePredictionEvaluationSummary(period: EvaluationPeriod): FetchState<SummaryResponse> {
+  const searchParams = useSearchParams();
+  const scenario = resolveScenario(searchParams?.get('scenario') ?? null);
+
+  const [state, setState] = useState<FetchState<SummaryResponse>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ data: null, loading: true, error: null });
+
+    simulateFetch(MOCK_SUMMARY_BY_PERIOD[period], scenario, ERROR_MESSAGES.FETCH_SUMMARY)
+      .then((data) => {
+        if (cancelled) return;
+        setState({ data, loading: false, error: null });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          data: null,
+          loading: false,
+          error: err instanceof Error ? err.message : ERROR_MESSAGES.FETCH_SUMMARY,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [period, scenario]);
+
+  return state;
+}
+
+export function usePredictionEvaluationTickers(
+  period: EvaluationPeriod,
+  minCount: number
+): FetchState<TickersResponse> {
+  const searchParams = useSearchParams();
+  const scenario = resolveScenario(searchParams?.get('scenario') ?? null);
+
+  const [state, setState] = useState<FetchState<TickersResponse>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ data: null, loading: true, error: null });
+
+    simulateFetch(MOCK_TICKERS_BY_PERIOD[period], scenario, ERROR_MESSAGES.FETCH_TICKERS)
+      .then((data) => {
+        if (cancelled) return;
+        setState({ data: applyMinCountFilter(data, minCount), loading: false, error: null });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          data: null,
+          loading: false,
+          error: err instanceof Error ? err.message : ERROR_MESSAGES.FETCH_TICKERS,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [period, minCount, scenario]);
+
+  return state;
+}

--- a/services/stock-tracker/web/lib/prediction-evaluation/use-prediction-evaluation.ts
+++ b/services/stock-tracker/web/lib/prediction-evaluation/use-prediction-evaluation.ts
@@ -38,11 +38,7 @@ const resolveScenario = (raw: string | null): Scenario => {
   return 'normal';
 };
 
-const simulateFetch = <T>(
-  payload: T,
-  scenario: Scenario,
-  errorMessage: string
-): Promise<T> => {
+const simulateFetch = <T>(payload: T, scenario: Scenario, errorMessage: string): Promise<T> => {
   if (scenario === 'loading') {
     return new Promise<T>(() => {
       /* never resolve */
@@ -73,7 +69,9 @@ export const applyMinCountFilter = (
   };
 };
 
-export function usePredictionEvaluationSummary(period: EvaluationPeriod): FetchState<SummaryResponse> {
+export function usePredictionEvaluationSummary(
+  period: EvaluationPeriod
+): FetchState<SummaryResponse> {
   const searchParams = useSearchParams();
   const scenario = resolveScenario(searchParams?.get('scenario') ?? null);
 

--- a/services/stock-tracker/web/tests/e2e/prediction-evaluation.spec.ts
+++ b/services/stock-tracker/web/tests/e2e/prediction-evaluation.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * 予測精度ダッシュボード PoC のスモーク E2E。
+ *
+ * PoC 段階ではモックデータ（`lib/prediction-evaluation/mock-data.ts`）が
+ * クライアント側で組み立てられるため、API モックは不要。`SKIP_AUTH_CHECK=true`
+ * の E2E 環境でテストユーザー（stock-admin）として表示できる前提。
+ */
+
+test.describe('予測精度ダッシュボード PoC', () => {
+  test('ダッシュボードの主要セクションが表示される', async ({ page }) => {
+    await page.goto('/prediction-evaluation');
+
+    await expect(page.getByRole('heading', { name: '予測精度ダッシュボード' })).toBeVisible();
+    await expect(page.getByText(/PoC 段階/)).toBeVisible();
+
+    // 期間セレクター
+    await expect(page.getByLabel('集計期間')).toBeVisible();
+
+    // KPI カード（5 種類）
+    await expect(page.getByTestId('kpi-card-total-accuracy')).toBeVisible();
+    await expect(page.getByTestId('kpi-card-directional-accuracy')).toBeVisible();
+    await expect(page.getByTestId('kpi-card-neutral-ratio')).toBeVisible();
+    await expect(page.getByTestId('kpi-card-judged-count')).toBeVisible();
+    await expect(page.getByTestId('kpi-card-ai-failure-count')).toBeVisible();
+
+    // セクション見出し
+    await expect(page.getByRole('heading', { name: '日次の方向精度推移' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'シグナル別の精度' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '取引所別精度' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '銘柄別精度' })).toBeVisible();
+  });
+
+  test('期間を切り替えると別の集計が表示される', async ({ page }) => {
+    await page.goto('/prediction-evaluation');
+
+    const judgedCountValue = page.getByTestId('kpi-value-judged-count');
+    await expect(judgedCountValue).toBeVisible();
+    const initialCount = await judgedCountValue.textContent();
+
+    await page.getByLabel('集計期間').selectOption('30d');
+
+    await expect
+      .poll(async () => await judgedCountValue.textContent(), { timeout: 5000 })
+      .not.toBe(initialCount);
+  });
+
+  test('全期間（all）で空状態のメッセージが表示される', async ({ page }) => {
+    await page.goto('/prediction-evaluation');
+
+    await page.getByLabel('集計期間').selectOption('all');
+
+    await expect(page.getByText('指定された期間に採点済みの予測がありません。')).toBeVisible();
+  });
+
+  test('scenario=error クエリでエラーアラートが表示される', async ({ page }) => {
+    await page.goto('/prediction-evaluation?scenario=error');
+
+    await expect(page.getByText('予測精度サマリーの取得に失敗しました')).toBeVisible();
+  });
+});

--- a/services/stock-tracker/web/tests/unit/components/prediction-evaluation/daily-trend-chart.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/prediction-evaluation/daily-trend-chart.test.ts
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DailyTrendChart, {
+  buildDailyTrendOption,
+} from '../../../../components/prediction-evaluation/DailyTrendChart';
+import type { DailyTrendPoint } from '../../../../lib/prediction-evaluation/types';
+
+jest.mock('echarts-for-react', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', { 'data-testid': 'mock-echarts' }),
+}));
+
+const POINTS: DailyTrendPoint[] = [
+  { date: '2026-05-01', directionalAccuracy: 70, judgedCount: 10 },
+  { date: '2026-05-02', directionalAccuracy: null, judgedCount: 0 },
+  { date: '2026-05-03', directionalAccuracy: 55.5, judgedCount: 9 },
+];
+
+describe('buildDailyTrendOption', () => {
+  it('x 軸に日付、series に方向精度と件数を含む', () => {
+    const option = buildDailyTrendOption(POINTS) as Record<string, unknown>;
+    expect(option.xAxis).toMatchObject({ data: ['2026-05-01', '2026-05-02', '2026-05-03'] });
+
+    const series = option.series as Array<{ name: string; data: unknown[] }>;
+    expect(series).toHaveLength(2);
+    expect(series[0].name).toBe('方向精度 (%)');
+    expect(series[0].data).toEqual([70, '-', 55.5]);
+    expect(series[1].name).toBe('判定済み件数');
+    expect(series[1].data).toEqual([10, 0, 9]);
+  });
+});
+
+describe('DailyTrendChart rendering', () => {
+  it('データありの場合はチャートとテーブルを表示する', () => {
+    render(React.createElement(DailyTrendChart, { data: POINTS }));
+
+    expect(screen.getByText('日次の方向精度推移')).toBeTruthy();
+    expect(screen.getByRole('img', { name: '日次方向精度推移チャート' })).toBeTruthy();
+
+    // テーブル行（ヘッダ + 3 データ行）
+    expect(screen.getByText('2026-05-01')).toBeTruthy();
+    expect(screen.getByText('70.0%')).toBeTruthy();
+    expect(screen.getByText('55.5%')).toBeTruthy();
+    // 部分欠損は — として表示
+    const naCells = screen.getAllByText('—');
+    expect(naCells.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('データ 0 件の場合は空状態テキストを表示する', () => {
+    render(React.createElement(DailyTrendChart, { data: [] }));
+    expect(screen.getByText('表示できるデータがありません')).toBeTruthy();
+  });
+});

--- a/services/stock-tracker/web/tests/unit/components/prediction-evaluation/exchange-accuracy-table.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/prediction-evaluation/exchange-accuracy-table.test.ts
@@ -1,0 +1,23 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ExchangeAccuracyTable from '../../../../components/prediction-evaluation/ExchangeAccuracyTable';
+import type { ExchangeAccuracyEntry } from '../../../../lib/prediction-evaluation/types';
+
+const ENTRIES: ExchangeAccuracyEntry[] = [
+  { exchangeId: 'NASDAQ', exchangeName: 'NASDAQ', accuracy: 70, count: 21 },
+  { exchangeId: 'NYSE', exchangeName: 'NYSE', accuracy: null, count: 9 },
+];
+
+describe('ExchangeAccuracyTable', () => {
+  it('各取引所の精度と件数を表示する', () => {
+    render(React.createElement(ExchangeAccuracyTable, { data: ENTRIES }));
+    expect(screen.getByTestId('exchange-row-NASDAQ').textContent).toContain('70.0%');
+    expect(screen.getByTestId('exchange-row-NYSE').textContent).toContain('—');
+  });
+
+  it('空配列の場合は空状態テキストを表示する', () => {
+    render(React.createElement(ExchangeAccuracyTable, { data: [] }));
+    expect(screen.getByText('表示できるデータがありません')).toBeTruthy();
+  });
+});

--- a/services/stock-tracker/web/tests/unit/components/prediction-evaluation/kpi-cards.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/prediction-evaluation/kpi-cards.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import KpiCards, {
+  buildKpiItems,
+  formatPercent,
+  formatCount,
+} from '../../../../components/prediction-evaluation/KpiCards';
+import type { KpiSummary } from '../../../../lib/prediction-evaluation/types';
+
+const buildKpi = (overrides: Partial<KpiSummary> = {}): KpiSummary => ({
+  totalAccuracy: 65.5,
+  directionalAccuracy: 60.1,
+  neutralRatio: 22.4,
+  judgedCount: 142,
+  aiFailureCount: 5,
+  ...overrides,
+});
+
+describe('KpiCards helpers', () => {
+  it('formatPercent は数値を 1 桁の % 文字列にする', () => {
+    expect(formatPercent(65.5)).toBe('65.5%');
+    expect(formatPercent(0)).toBe('0.0%');
+  });
+
+  it('formatPercent は null / NaN を — にする', () => {
+    expect(formatPercent(null)).toBe('—');
+    expect(formatPercent(Number.NaN)).toBe('—');
+  });
+
+  it('formatCount は ja-JP のロケール表記', () => {
+    expect(formatCount(1234)).toBe('1,234');
+  });
+
+  it('buildKpiItems は 5 つの KPI を返す', () => {
+    const items = buildKpiItems(buildKpi());
+    expect(items.map((item) => item.key)).toEqual([
+      'total-accuracy',
+      'directional-accuracy',
+      'neutral-ratio',
+      'judged-count',
+      'ai-failure-count',
+    ]);
+  });
+});
+
+describe('KpiCards rendering', () => {
+  it('5 つのカードと数値を表示する', () => {
+    render(React.createElement(KpiCards, { kpi: buildKpi() }));
+
+    expect(screen.getByTestId('kpi-value-total-accuracy').textContent).toBe('65.5%');
+    expect(screen.getByTestId('kpi-value-directional-accuracy').textContent).toBe('60.1%');
+    expect(screen.getByTestId('kpi-value-neutral-ratio').textContent).toBe('22.4%');
+    expect(screen.getByTestId('kpi-value-judged-count').textContent).toBe('142');
+    expect(screen.getByTestId('kpi-value-ai-failure-count').textContent).toBe('5');
+  });
+
+  it('null 値は — として表示される', () => {
+    render(
+      React.createElement(KpiCards, {
+        kpi: buildKpi({
+          totalAccuracy: null,
+          directionalAccuracy: null,
+          neutralRatio: null,
+          judgedCount: 0,
+        }),
+      })
+    );
+
+    expect(screen.getByTestId('kpi-value-total-accuracy').textContent).toBe('—');
+    expect(screen.getByTestId('kpi-value-directional-accuracy').textContent).toBe('—');
+    expect(screen.getByTestId('kpi-value-neutral-ratio').textContent).toBe('—');
+    expect(screen.getByTestId('kpi-value-judged-count').textContent).toBe('0');
+  });
+});

--- a/services/stock-tracker/web/tests/unit/components/prediction-evaluation/period-selector.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/prediction-evaluation/period-selector.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PeriodSelector from '../../../../components/prediction-evaluation/PeriodSelector';
+
+describe('PeriodSelector', () => {
+  it('ラベルを表示し現在の値を反映する', () => {
+    render(React.createElement(PeriodSelector, { value: '30d', onChange: jest.fn() }));
+    expect(screen.getByText('集計期間')).toBeTruthy();
+    const select = screen.getByLabelText('集計期間') as HTMLSelectElement;
+    expect(select.value).toBe('30d');
+  });
+
+  it('値変更時に onChange が呼ばれる', () => {
+    const onChange = jest.fn();
+    render(React.createElement(PeriodSelector, { value: '7d', onChange }));
+
+    const select = screen.getByLabelText('集計期間') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '30d' } });
+
+    expect(onChange).toHaveBeenCalledWith('30d');
+  });
+
+  it('未定義の値（不正な期間）が来ても onChange を呼ばない', () => {
+    const onChange = jest.fn();
+    render(React.createElement(PeriodSelector, { value: '7d', onChange }));
+
+    const select = screen.getByLabelText('集計期間') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'invalid' } });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/services/stock-tracker/web/tests/unit/components/prediction-evaluation/signal-accuracy-chart.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/prediction-evaluation/signal-accuracy-chart.test.ts
@@ -26,7 +26,9 @@ describe('buildSignalChartOption', () => {
   });
 
   it('null accuracy は値 0 として series に渡す', () => {
-    const option = buildSignalChartOption(ENTRIES) as { series: Array<{ data: Array<{ value: number }> }> };
+    const option = buildSignalChartOption(ENTRIES) as {
+      series: Array<{ data: Array<{ value: number }> }>;
+    };
     const values = option.series[0].data.map((d) => d.value);
     expect(values).toEqual([70, 0, 55]);
   });

--- a/services/stock-tracker/web/tests/unit/components/prediction-evaluation/signal-accuracy-chart.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/prediction-evaluation/signal-accuracy-chart.test.ts
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SignalAccuracyChart, {
+  buildSignalChartOption,
+} from '../../../../components/prediction-evaluation/SignalAccuracyChart';
+import type { SignalAccuracyEntry } from '../../../../lib/prediction-evaluation/types';
+
+jest.mock('echarts-for-react', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', { 'data-testid': 'mock-echarts' }),
+}));
+
+const ENTRIES: SignalAccuracyEntry[] = [
+  { signal: 'BULLISH', accuracy: 70, count: 20 },
+  { signal: 'NEUTRAL', accuracy: null, count: 0 },
+  { signal: 'BEARISH', accuracy: 55, count: 18 },
+];
+
+describe('buildSignalChartOption', () => {
+  it('x 軸にシグナルのラベルを並べる', () => {
+    const option = buildSignalChartOption(ENTRIES) as Record<string, unknown>;
+    expect(option.xAxis).toMatchObject({
+      data: ['強気（BULLISH）', '中立（NEUTRAL）', '弱気（BEARISH）'],
+    });
+  });
+
+  it('null accuracy は値 0 として series に渡す', () => {
+    const option = buildSignalChartOption(ENTRIES) as { series: Array<{ data: Array<{ value: number }> }> };
+    const values = option.series[0].data.map((d) => d.value);
+    expect(values).toEqual([70, 0, 55]);
+  });
+});
+
+describe('SignalAccuracyChart rendering', () => {
+  it('データありの場合はチャートとテーブルを表示する', () => {
+    render(React.createElement(SignalAccuracyChart, { data: ENTRIES }));
+    expect(screen.getByText('シグナル別の精度')).toBeTruthy();
+    expect(screen.getByRole('img', { name: 'シグナル別精度のグラフ' })).toBeTruthy();
+    expect(screen.getByText('70.0%')).toBeTruthy();
+    expect(screen.getByText('55.0%')).toBeTruthy();
+  });
+
+  it('全件 count=0 のときは空状態を表示する', () => {
+    const emptyEntries: SignalAccuracyEntry[] = [
+      { signal: 'BULLISH', accuracy: null, count: 0 },
+      { signal: 'NEUTRAL', accuracy: null, count: 0 },
+      { signal: 'BEARISH', accuracy: null, count: 0 },
+    ];
+    render(React.createElement(SignalAccuracyChart, { data: emptyEntries }));
+    expect(screen.getByText('表示できるデータがありません')).toBeTruthy();
+  });
+});

--- a/services/stock-tracker/web/tests/unit/components/prediction-evaluation/ticker-accuracy-table.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/prediction-evaluation/ticker-accuracy-table.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TickerAccuracyTable, {
+  formatHitRatio,
+} from '../../../../components/prediction-evaluation/TickerAccuracyTable';
+import type { TickerAccuracyEntry } from '../../../../lib/prediction-evaluation/types';
+
+const ENTRIES: TickerAccuracyEntry[] = [
+  {
+    tickerId: 'NASDAQ:NVDA',
+    tickerName: 'NVIDIA',
+    exchangeId: 'NASDAQ',
+    accuracy: 80,
+    count: 10,
+    bullishHit: 4,
+    bullishTotal: 5,
+    bearishHit: 4,
+    bearishTotal: 5,
+  },
+  {
+    tickerId: 'TSE:7203',
+    tickerName: 'トヨタ自動車',
+    exchangeId: 'TSE',
+    accuracy: 60,
+    count: 8,
+    bullishHit: 3,
+    bullishTotal: 5,
+    bearishHit: 2,
+    bearishTotal: 3,
+  },
+];
+
+describe('formatHitRatio', () => {
+  it('total=0 のとき — を返す', () => {
+    expect(formatHitRatio(0, 0)).toBe('—');
+  });
+
+  it('割合と件数を併記する', () => {
+    expect(formatHitRatio(3, 5)).toBe('60.0% (3/5)');
+  });
+});
+
+describe('TickerAccuracyTable', () => {
+  it('行を精度の降順で表示する', () => {
+    render(React.createElement(TickerAccuracyTable, { data: ENTRIES, minCount: 5 }));
+    const rows = screen.getAllByRole('row');
+    // ヘッダ + 2 データ行
+    expect(rows.length).toBe(3);
+    // 1 番目のデータ行が最も精度が高い
+    expect(rows[1].textContent).toContain('NASDAQ:NVDA');
+  });
+
+  it('minCount をヘッダに表示する', () => {
+    render(React.createElement(TickerAccuracyTable, { data: ENTRIES, minCount: 5 }));
+    expect(screen.getByText(/判定件数 ≥ 5 の銘柄のみ/)).toBeTruthy();
+  });
+
+  it('空配列の場合は空状態テキストを表示する', () => {
+    render(React.createElement(TickerAccuracyTable, { data: [], minCount: 5 }));
+    expect(screen.getByText('表示できるデータがありません')).toBeTruthy();
+  });
+});

--- a/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/mock-data.test.ts
+++ b/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/mock-data.test.ts
@@ -1,0 +1,83 @@
+import {
+  MOCK_SUMMARY_BY_PERIOD,
+  MOCK_TICKERS_BY_PERIOD,
+} from '../../../../lib/prediction-evaluation/mock-data';
+import { EVALUATION_PERIODS } from '../../../../lib/prediction-evaluation/types';
+
+describe('予測精度 PoC モックデータ', () => {
+  describe('MOCK_SUMMARY_BY_PERIOD', () => {
+    it('期間ごとに SummaryResponse が定義されている', () => {
+      EVALUATION_PERIODS.forEach((period) => {
+        const response = MOCK_SUMMARY_BY_PERIOD[period];
+        expect(response).toBeDefined();
+        expect(response.period).toBe(period);
+        expect(typeof response.evaluatedAt).toBe('number');
+      });
+    });
+
+    it('all 期間は空状態（judgedCount=0、dailyTrend=[]、byExchange=[]）', () => {
+      const all = MOCK_SUMMARY_BY_PERIOD['all'];
+      expect(all.kpi.judgedCount).toBe(0);
+      expect(all.kpi.totalAccuracy).toBeNull();
+      expect(all.kpi.directionalAccuracy).toBeNull();
+      expect(all.kpi.neutralRatio).toBeNull();
+      expect(all.dailyTrend).toEqual([]);
+      expect(all.byExchange).toEqual([]);
+    });
+
+    it('7d は部分欠損（accuracy=null）を含む', () => {
+      const summary = MOCK_SUMMARY_BY_PERIOD['7d'];
+      expect(summary.dailyTrend.some((p) => p.directionalAccuracy === null)).toBe(true);
+      expect(summary.byExchange.some((e) => e.accuracy === null)).toBe(true);
+    });
+
+    it('bySignal は 3 シグナルすべてを含む', () => {
+      const summary = MOCK_SUMMARY_BY_PERIOD['7d'];
+      const signals = summary.bySignal.map((entry) => entry.signal).sort();
+      expect(signals).toEqual(['BEARISH', 'BULLISH', 'NEUTRAL']);
+    });
+
+    it('日次推移の各エントリは YYYY-MM-DD 形式の date を持つ', () => {
+      EVALUATION_PERIODS.forEach((period) => {
+        const summary = MOCK_SUMMARY_BY_PERIOD[period];
+        summary.dailyTrend.forEach((point) => {
+          expect(point.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        });
+      });
+    });
+
+    it('30d / 90d は十分な日数の dailyTrend を持つ', () => {
+      expect(MOCK_SUMMARY_BY_PERIOD['30d'].dailyTrend.length).toBeGreaterThanOrEqual(20);
+      expect(MOCK_SUMMARY_BY_PERIOD['90d'].dailyTrend.length).toBeGreaterThanOrEqual(60);
+    });
+  });
+
+  describe('MOCK_TICKERS_BY_PERIOD', () => {
+    it('期間ごとに TickersResponse が定義されている', () => {
+      EVALUATION_PERIODS.forEach((period) => {
+        const response = MOCK_TICKERS_BY_PERIOD[period];
+        expect(response).toBeDefined();
+        expect(response.period).toBe(period);
+        expect(typeof response.minCount).toBe('number');
+      });
+    });
+
+    it('all 期間は空状態（tickers=[]）', () => {
+      expect(MOCK_TICKERS_BY_PERIOD['all'].tickers).toEqual([]);
+    });
+
+    it('複数取引所のティッカーを含む', () => {
+      const tickers = MOCK_TICKERS_BY_PERIOD['7d'].tickers;
+      const exchanges = new Set(tickers.map((t) => t.exchangeId));
+      expect(exchanges.size).toBeGreaterThanOrEqual(2);
+    });
+
+    it('各ティッカーで bullishHit ≤ bullishTotal、bearishHit ≤ bearishTotal が成り立つ', () => {
+      MOCK_TICKERS_BY_PERIOD['90d'].tickers.forEach((ticker) => {
+        expect(ticker.bullishHit).toBeLessThanOrEqual(ticker.bullishTotal);
+        expect(ticker.bearishHit).toBeLessThanOrEqual(ticker.bearishTotal);
+        expect(ticker.count).toBeGreaterThanOrEqual(ticker.bullishTotal + ticker.bearishTotal);
+      });
+    });
+  });
+});

--- a/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/use-prediction-evaluation-hook.test.ts
+++ b/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/use-prediction-evaluation-hook.test.ts
@@ -1,5 +1,4 @@
 /** @jest-environment jsdom */
-import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 const searchParamsRef: { current: URLSearchParams } = { current: new URLSearchParams() };
@@ -57,9 +56,12 @@ describe('usePredictionEvaluationSummary', () => {
   });
 
   it('period 切替時に新しいデータを取得する', async () => {
-    const { result, rerender } = renderHook(({ period }) => usePredictionEvaluationSummary(period), {
-      initialProps: { period: '7d' as const },
-    });
+    const { result, rerender } = renderHook(
+      ({ period }) => usePredictionEvaluationSummary(period),
+      {
+        initialProps: { period: '7d' as const },
+      }
+    );
 
     await act(async () => {
       jest.advanceTimersByTime(500);

--- a/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/use-prediction-evaluation-hook.test.ts
+++ b/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/use-prediction-evaluation-hook.test.ts
@@ -1,0 +1,123 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+const searchParamsRef: { current: URLSearchParams } = { current: new URLSearchParams() };
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useSearchParams: () => searchParamsRef.current,
+}));
+
+import {
+  usePredictionEvaluationSummary,
+  usePredictionEvaluationTickers,
+} from '../../../../lib/prediction-evaluation/use-prediction-evaluation';
+
+describe('usePredictionEvaluationSummary', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    searchParamsRef.current = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('初期状態は loading=true', () => {
+    const { result } = renderHook(() => usePredictionEvaluationSummary('7d'));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('遅延後に data が返り loading=false になる', async () => {
+    const { result } = renderHook(() => usePredictionEvaluationSummary('7d'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.period).toBe('7d');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('scenario=error の URL クエリでエラーになる', async () => {
+    searchParamsRef.current = new URLSearchParams('scenario=error');
+    const { result } = renderHook(() => usePredictionEvaluationSummary('30d'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toContain('失敗しました');
+  });
+
+  it('period 切替時に新しいデータを取得する', async () => {
+    const { result, rerender } = renderHook(({ period }) => usePredictionEvaluationSummary(period), {
+      initialProps: { period: '7d' as const },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await waitFor(() => expect(result.current.data?.period).toBe('7d'));
+
+    rerender({ period: '30d' as const });
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await waitFor(() => expect(result.current.data?.period).toBe('30d'));
+  });
+});
+
+describe('usePredictionEvaluationTickers', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    searchParamsRef.current = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('minCount に応じて結果がフィルタされる', async () => {
+    const { result } = renderHook(() => usePredictionEvaluationTickers('7d', 7));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data?.minCount).toBe(7);
+    result.current.data?.tickers.forEach((ticker) => {
+      expect(ticker.count).toBeGreaterThanOrEqual(7);
+    });
+  });
+
+  it('scenario=error でエラーを返す', async () => {
+    searchParamsRef.current = new URLSearchParams('scenario=error');
+    const { result } = renderHook(() => usePredictionEvaluationTickers('7d', 5));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toContain('銘柄別精度');
+  });
+
+  it('scenario=loading では loading=true のまま', () => {
+    searchParamsRef.current = new URLSearchParams('scenario=loading');
+    const { result } = renderHook(() => usePredictionEvaluationTickers('7d', 5));
+
+    // resolve/reject されないため永続 loading
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/use-prediction-evaluation.test.ts
+++ b/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/use-prediction-evaluation.test.ts
@@ -1,0 +1,71 @@
+import { applyMinCountFilter } from '../../../../lib/prediction-evaluation/use-prediction-evaluation';
+import type { TickersResponse } from '../../../../lib/prediction-evaluation/types';
+
+const buildResponse = (): TickersResponse => ({
+  period: '7d',
+  minCount: 0,
+  tickers: [
+    {
+      tickerId: 'A',
+      tickerName: 'A',
+      exchangeId: 'X',
+      accuracy: 60,
+      count: 10,
+      bullishHit: 4,
+      bullishTotal: 5,
+      bearishHit: 2,
+      bearishTotal: 5,
+    },
+    {
+      tickerId: 'B',
+      tickerName: 'B',
+      exchangeId: 'X',
+      accuracy: 40,
+      count: 4,
+      bullishHit: 1,
+      bullishTotal: 2,
+      bearishHit: 1,
+      bearishTotal: 2,
+    },
+    {
+      tickerId: 'C',
+      tickerName: 'C',
+      exchangeId: 'Y',
+      accuracy: 50,
+      count: 6,
+      bullishHit: 2,
+      bullishTotal: 3,
+      bearishHit: 1,
+      bearishTotal: 3,
+    },
+  ],
+});
+
+describe('applyMinCountFilter', () => {
+  it('count が minCount 以上のティッカーのみ残す', () => {
+    const filtered = applyMinCountFilter(buildResponse(), 6);
+    expect(filtered.tickers.map((t) => t.tickerId)).toEqual(['A', 'C']);
+  });
+
+  it('返却される minCount は引数の値を反映する', () => {
+    const filtered = applyMinCountFilter(buildResponse(), 6);
+    expect(filtered.minCount).toBe(6);
+  });
+
+  it('minCount=0 のときはすべて残す', () => {
+    const filtered = applyMinCountFilter(buildResponse(), 0);
+    expect(filtered.tickers.length).toBe(3);
+  });
+
+  it('minCount が大きすぎると 0 件になる', () => {
+    const filtered = applyMinCountFilter(buildResponse(), 9999);
+    expect(filtered.tickers).toEqual([]);
+  });
+
+  it('元のレスポンスを変更しない（イミュータブル）', () => {
+    const original = buildResponse();
+    const snapshot = JSON.stringify(original);
+    applyMinCountFilter(original, 6);
+    expect(JSON.stringify(original)).toBe(snapshot);
+  });
+});

--- a/tasks/stock-tracer-prediction-evaluation/tasks.md
+++ b/tasks/stock-tracer-prediction-evaluation/tasks.md
@@ -315,8 +315,8 @@ A 案を採用し、独立エンティティではなく既存 `DailySummaryEnti
 
 | 作業 | ブランチ | PR | ステータス | 担当セッション |
 |------|---------|----|-----------|---------------|
-| 0. 設計ドキュメント | `claude/3018-design-docs` | （本 PR） | 進行中 | — |
-| 1. UI PoC（モックデータ） | `claude/3018-ui-poc` | — | 未着手 | — |
+| 0. 設計ドキュメント | `claude/3018-design-docs` | #3020 | マージ済 | — |
+| 1. UI PoC（モックデータ） | `claude/3018-ui-poc` | — | 進行中 | Issue #3023 |
 | 2. PoC FB 反映で要件再確定 | `claude/3018-refine-docs` | — | 未着手 | — |
 | 3. Entity / Repository 拡張 | `claude/3018-entity` | — | 未着手 | — |
 | 4. 判定 / 集計ロジック | `claude/3018-judge-logic` | — | 未着手 | — |

--- a/tasks/stock-tracer-prediction-evaluation/tasks.md
+++ b/tasks/stock-tracer-prediction-evaluation/tasks.md
@@ -53,31 +53,31 @@
 
 UI を先行実装し、dev 環境で実物を確認できる状態にする。API はまだ存在しないため、`design.md` §1.3 の `SummaryResponse` / `TickersResponse` に準拠したハードコード JSON をモックとして使う。**この段階では backend / DB / 集計ロジックに一切触れない**。
 
-- [ ] `web/lib/prediction-evaluation/mock-data.ts` 作成
+- [x] `web/lib/prediction-evaluation/mock-data.ts` 作成
     - `MOCK_SUMMARY_RESPONSE: SummaryResponse`
     - `MOCK_TICKERS_RESPONSE: TickersResponse`
     - 内容バリエーション：複数日（日次推移を見られる程度の長さ）/ 複数銘柄 / 複数取引所 / 高精度・低精度ケース / 空状態（`judgedCount = 0`）/ 部分欠損（`accuracy = null`）を含め、UI の主要な状態を網羅
-- [ ] `web/lib/prediction-evaluation/use-prediction-evaluation.ts` 作成
+- [x] `web/lib/prediction-evaluation/use-prediction-evaluation.ts` 作成
     - `usePredictionEvaluationSummary(period)` / `usePredictionEvaluationTickers(period, minCount)` の 2 つの custom hook
     - PoC 段階ではモック JSON を Promise でラップして返す（loading / error 状態の UI も試せるよう setTimeout で小さな遅延を入れる、または error scenario 用のクエリパラメータで切替）
     - 作業 7 でここを fetch に差し替える「唯一の差し替え点」とする
-- [ ] `web/app/prediction-evaluation/page.tsx` 作成
+- [x] `web/app/prediction-evaluation/page.tsx` 作成
     - 既存認証フローでガード
     - 期間ステートを保持し、上記 hook を呼ぶ
     - ローディング / 空状態 / エラー UI
-- [ ] `web/components/prediction-evaluation/` 配下に各コンポーネント作成
+- [x] `web/components/prediction-evaluation/` 配下に各コンポーネント作成
     - `PeriodSelector.tsx`
     - `KpiCards.tsx`
     - `DailyTrendChart.tsx`
     - `SignalAccuracyChart.tsx`
     - `TickerAccuracyTable.tsx`
     - `ExchangeAccuracyTable.tsx`
-- [ ] 既存ナビゲーションに「予測精度」リンクを追加（既存ヘッダー / サイドバーに合わせる）
-- [ ] レスポンシブ対応（Material-UI ブレークポイント）
-- [ ] アクセシビリティ：グラフ値はテーブルで補助参照可能に
-- [ ] コンポーネントユニットテスト（モックデータを fixture として利用）
-- [ ] E2E：基本表示と期間切替の Fast CI 用シナリオ（`chromium-mobile`）
-- [ ] カバレッジ 80% 以上
+- [x] 既存ナビゲーションに「予測精度」リンクを追加（既存ヘッダー / サイドバーに合わせる）
+- [x] レスポンシブ対応（Material-UI ブレークポイント）
+- [x] アクセシビリティ：グラフ値はテーブルで補助参照可能に
+- [x] コンポーネントユニットテスト（モックデータを fixture として利用）
+- [x] E2E：基本表示と期間切替の Fast CI 用シナリオ（`chromium-mobile`）
+- [x] カバレッジ 80% 以上
 
 **完了条件**: dev 環境で `/prediction-evaluation`（仮）が表示され、KPI / 推移 / シグナル別 / 銘柄別 / 取引所別 / AI 失敗件数 / 空状態 / エラー の主要状態が確認できる。
 


### PR DESCRIPTION
## 変更の概要

Issue #3018 の作業 1。Stock Tracer 予測精度ダッシュボードの UI を、ハードコードしたモックデータを使って先行実装する PoC。**backend / DB / 集計ロジックには一切触れない**。dev 環境で実物を確認できるようにし、作業 2 の要件・設計再確定のためのインプットを得る目的。

## 関連 Issue

作業 1（UI PoC）。親 Issue #3018、作業 Issue #3023。

`Closes #` は integration → develop の PR で付ける運用のため本 PR では付けない。

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加した（カバレッジ 80% 以上を確保）
- [x] 関連ドキュメントを更新した（`tasks/.../tasks.md` 進捗トラッカー）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラー / 型エラー / lint エラーがないことを確認した

## 追加内容

### スコープ

`services/stock-tracker/web/` 配下に新規追加：

| パス | 役割 |
|---|---|
| `lib/prediction-evaluation/types.ts` | `SummaryResponse` / `TickersResponse` 型（`design.md` §1.3 準拠） |
| `lib/prediction-evaluation/mock-data.ts` | 複数日 / 複数銘柄 / 複数取引所 / 高低精度 / 空状態（`judgedCount=0`）/ 部分欠損（`accuracy=null`）を網羅したハードコード JSON |
| `lib/prediction-evaluation/use-prediction-evaluation.ts` | `usePredictionEvaluationSummary` / `usePredictionEvaluationTickers` の 2 hook。**作業 7 で `fetch()` に差し替える唯一の差し替え点**。`?scenario=error` / `?scenario=loading` で UI 状態を切替確認可能 |
| `app/prediction-evaluation/page.tsx` | 認証ガード（`stocks:read`）、期間ステート、loading / 空 / エラー UI、PoC 段階を示す info アラート |
| `components/prediction-evaluation/` | `PeriodSelector` / `KpiCards` / `DailyTrendChart` / `SignalAccuracyChart` / `TickerAccuracyTable` / `ExchangeAccuracyTable` |
| `components/ThemeRegistry.tsx` | ナビゲーションに「予測精度」リンクを追加（`stocks:read` ガード） |

### UI / a11y

- Material-UI のブレークポイントでレスポンシブ対応（KPI カードは xs=2列、sm=3列、md=5列）
- グラフ値は隣接テーブルで補助参照可能（a11y）
- 状態に応じた表示：ローディング（`LoadingState`）、空（info Alert + 各セクション内テキスト）、エラー（`ErrorAlert`）、部分欠損は `—`

### グラフライブラリ

既存実装に合わせ **echarts + echarts-for-react** を採用（新規依存追加なし）。

## テスト内容

- **ユニットテスト**: 45 件追加（モック JSON 整合性、`applyMinCountFilter`、hook の状態遷移、6 コンポーネントのレンダリング・空状態・null 値処理）
  - `lib/prediction-evaluation`: stmts 95.34% / branches 81.25% / funcs 100% / lines 100%
  - `components/prediction-evaluation`: stmts 95.12% / branches 86.66% / funcs 96.87% / lines 95.52%
- **E2E**: chromium-mobile で 4 件
  - 主要セクション表示
  - 期間切替で別の集計が表示
  - `all` 期間で空状態メッセージ表示
  - `?scenario=error` でエラーアラート表示
- 型チェック・eslint も green

## レビューポイント

- UI レイアウト：作業 2 の PoC レビュー FB で変更される前提。実際に dev 環境で触ってみて気になる箇所を遠慮なく挙げてほしい
- モック JSON の内容：`design.md` §1.3 の型上は整合させているが、件数や精度の数値は調整余地あり
- 認証ガード方針：`SummariesPage` と同じく `useSession() + hasPermission('stocks:read')` で in-page 判定。middleware は追加していない
- ナビゲーション位置：「予測精度」を「サマリー」の直後に配置（同じ `stocks:read` 配下）

## スクリーンショット

dev 環境へのデプロイ後、`/prediction-evaluation` を確認すると以下の状態を切り替えて見られます：

- 通常表示：`/prediction-evaluation`
- 期間切替：`?period=...`（ページ内セレクター）
- 空状態：期間で「全期間（all）」を選択
- エラー：`/prediction-evaluation?scenario=error`
- ローディング永続：`/prediction-evaluation?scenario=loading`

## 補足事項

- 作業 2（要件・設計再確定）の **PoC レビュー前提**。本 PR の UI レイアウトおよびモック JSON の内容は変更される可能性がある
- `lib/prediction-evaluation/use-prediction-evaluation.ts` は作業 7 で fetch ベースに差し替え、`mock-data.ts` はテストフィクスチャに移動 or 削除予定
- `jest.config.ts` に新規パスを `collectCoverageFrom` 追加し、当該パスのみ 80% スレッショルドを上書き（既存ファイルの 100% は維持）

https://claude.ai/code/session_01BYwYgt1T78izSMgrtgSdK9

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYwYgt1T78izSMgrtgSdK9)_