### PR TITLE
fix(stock-tracker): アラート一覧から論理削除待ち（TTL 設定済み）を除外する

### DIFF
--- a/services/stock-tracker/core/src/repositories/alert.repository.interface.ts
+++ b/services/stock-tracker/core/src/repositories/alert.repository.interface.ts
@@ -9,12 +9,13 @@ import type { TemporaryAlertCandidate } from '../entities/temporary-alert-candid
 import type { PaginationOptions, PaginatedResult } from '@nagiyu/aws';
 
 /**
- * `getByUserId` のオプション。`enabledOnly: true` の場合、有効化済み（Enabled=true）の
- * アラートのみを返す。Web のアラート一覧表示など、無効化されたアラートを除外したい用途で使用する。
+ * `getByUserId` のオプション。
+ *
+ * 実装は常に「論理削除待ちのアラート（DynamoDB TTL 属性が設定されているアイテム）」を
+ * 結果から除外する。ユーザーが無効化したアラート（`Enabled=false` で TTL は未設定）は
+ * 引き続き返される。
  */
-export type GetByUserIdOptions = PaginationOptions & {
-  enabledOnly?: boolean;
-};
+export type GetByUserIdOptions = PaginationOptions;
 
 /**
  * Alert Repository インターフェース
@@ -35,7 +36,9 @@ export interface AlertRepository {
    * ユーザーのアラート一覧を取得
    *
    * @param userId - ユーザーID
-   * @param options - ページネーション + `enabledOnly` フィルタ
+   * 論理削除待ち（TTL 属性が設定済み）のアラートは常に結果から除外される。
+   *
+   * @param options - ページネーションオプション
    * @returns ページネーション結果
    */
   getByUserId(userId: string, options?: GetByUserIdOptions): Promise<PaginatedResult<AlertEntity>>;

--- a/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
@@ -76,7 +76,10 @@ export class DynamoDBAlertRepository implements AlertRepository {
 
   /**
    * ユーザーのアラート一覧を取得（GSI1使用）。
-   * `enabledOnly: true` を指定すると、有効化済み（Enabled=true）のアラートのみ返す。
+   *
+   * 論理削除待ち（TTL 属性が設定済み = 一時アラート失効バッチで `markTemporaryAsExpired`
+   * された）のアイテムは常に除外する。ユーザーが手動で無効化したアラート
+   * （`Enabled=false` で TTL は未設定）は引き続き返す。
    */
   public async getByUserId(
     userId: string,
@@ -92,26 +95,21 @@ export class DynamoDBAlertRepository implements AlertRepository {
       const expressionAttributeNames: Record<string, string> = {
         '#gsi1pk': 'GSI1PK',
         '#gsi1sk': 'GSI1SK',
+        '#ttl': 'TTL',
       };
       const expressionAttributeValues: Record<string, unknown> = {
         ':userId': userId,
         ':prefix': 'Alert#',
       };
-      let filterExpression: string | undefined;
-      if (options?.enabledOnly === true) {
-        expressionAttributeNames['#enabled'] = 'Enabled';
-        expressionAttributeValues[':enabledTrue'] = true;
-        filterExpression = '#enabled = :enabledTrue';
-      }
 
       result = await this.docClient.send(
         new QueryCommand({
           TableName: this.tableName,
           IndexName: 'UserIndex',
           KeyConditionExpression: '#gsi1pk = :userId AND begins_with(#gsi1sk, :prefix)',
+          FilterExpression: 'attribute_not_exists(#ttl)',
           ExpressionAttributeNames: expressionAttributeNames,
           ExpressionAttributeValues: expressionAttributeValues,
-          ...(filterExpression ? { FilterExpression: filterExpression } : {}),
           Limit: limit,
           ExclusiveStartKey: exclusiveStartKey,
         })

--- a/services/stock-tracker/core/src/repositories/in-memory-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/in-memory-alert.repository.ts
@@ -53,7 +53,9 @@ export class InMemoryAlertRepository implements AlertRepository {
   }
 
   /**
-   * ユーザーのアラート一覧を取得
+   * ユーザーのアラート一覧を取得。
+   *
+   * 論理削除待ち（TTL 属性が設定済み）のアイテムは DynamoDB 実装に合わせて常に除外する。
    */
   public async getByUserId(
     userId: string,
@@ -72,15 +74,15 @@ export class InMemoryAlertRepository implements AlertRepository {
       options
     );
 
-    let items = result.items.map((item) => this.mapper.toEntity(item));
-    if (options?.enabledOnly === true) {
-      items = items.filter((item) => item.Enabled === true);
-    }
+    const filteredRawItems = result.items.filter(
+      (item) => (item as Record<string, unknown>).TTL === undefined
+    );
+    const items = filteredRawItems.map((item) => this.mapper.toEntity(item));
 
     return {
       items,
       nextCursor: result.nextCursor,
-      count: options?.enabledOnly === true ? items.length : result.count,
+      count: items.length,
     };
   }
 

--- a/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
@@ -273,32 +273,19 @@ describe('DynamoDBAlertRepository', () => {
       await expect(repository.getByUserId('user-123')).rejects.toThrow(DatabaseError);
     });
 
-    it('enabledOnly: true 指定時に FilterExpression が Enabled=true を要求する', async () => {
-      mockDocClient.send.mockResolvedValueOnce({ Items: [], Count: 0 });
-
-      await repository.getByUserId('user-123', { enabledOnly: true });
-
-      const sendCall = mockDocClient.send.mock.calls[0][0] as {
-        input: {
-          FilterExpression?: string;
-          ExpressionAttributeNames?: Record<string, string>;
-          ExpressionAttributeValues?: Record<string, unknown>;
-        };
-      };
-      expect(sendCall.input.FilterExpression).toBe('#enabled = :enabledTrue');
-      expect(sendCall.input.ExpressionAttributeNames?.['#enabled']).toBe('Enabled');
-      expect(sendCall.input.ExpressionAttributeValues?.[':enabledTrue']).toBe(true);
-    });
-
-    it('enabledOnly 未指定時は FilterExpression を付けない', async () => {
+    it('論理削除待ち（TTL 設定済み）アラートを除外する FilterExpression が常に付与される', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Items: [], Count: 0 });
 
       await repository.getByUserId('user-123');
 
       const sendCall = mockDocClient.send.mock.calls[0][0] as {
-        input: { FilterExpression?: string };
+        input: {
+          FilterExpression?: string;
+          ExpressionAttributeNames?: Record<string, string>;
+        };
       };
-      expect(sendCall.input.FilterExpression).toBeUndefined();
+      expect(sendCall.input.FilterExpression).toBe('attribute_not_exists(#ttl)');
+      expect(sendCall.input.ExpressionAttributeNames?.['#ttl']).toBe('TTL');
     });
 
     it('無効なアラートデータをスキップし、有効なデータのみ返す', async () => {

--- a/services/stock-tracker/core/tests/unit/repositories/in-memory-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/in-memory-alert.repository.test.ts
@@ -433,7 +433,7 @@ describe('InMemoryAlertRepository', () => {
     });
   });
 
-  describe('getByUserId - enabledOnly', () => {
+  describe('getByUserId - 論理削除フィルタ', () => {
     const baseInput: CreateAlertInput = {
       UserID: 'user-123',
       TickerID: 'NSDQ:AAPL',
@@ -448,24 +448,30 @@ describe('InMemoryAlertRepository', () => {
       },
     };
 
-    it('enabledOnly: true で無効化済みアラートが除外される', async () => {
-      const enabled = await repository.create({ ...baseInput, Enabled: true });
-      const disabled = await repository.create({ ...baseInput, Enabled: false });
+    it('論理削除待ち（markTemporaryAsExpired で TTL 設定済み）アラートは結果から除外される', async () => {
+      const userDisabled = await repository.create({ ...baseInput, Enabled: false });
+      const pendingDeletion = await repository.create({
+        ...baseInput,
+        Temporary: true,
+        TemporaryExpireDate: '2026-03-04',
+      });
+      await repository.markTemporaryAsExpired('user-123', pendingDeletion.AlertID, 1234567890);
 
-      const result = await repository.getByUserId('user-123', { enabledOnly: true });
+      const result = await repository.getByUserId('user-123');
 
       const ids = result.items.map((a) => a.AlertID);
-      expect(ids).toContain(enabled.AlertID);
-      expect(ids).not.toContain(disabled.AlertID);
+      expect(ids).toContain(userDisabled.AlertID);
+      expect(ids).not.toContain(pendingDeletion.AlertID);
     });
 
-    it('enabledOnly 未指定では無効化済みアラートも返る', async () => {
+    it('ユーザーが手動で無効化したアラート（Enabled=false、TTL なし）は引き続き返る', async () => {
       await repository.create({ ...baseInput, Enabled: true });
       await repository.create({ ...baseInput, Enabled: false });
 
       const result = await repository.getByUserId('user-123');
 
       expect(result.items).toHaveLength(2);
+      expect(result.items.map((a) => a.Enabled).sort()).toEqual([false, true]);
     });
   });
 

--- a/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
@@ -33,11 +33,13 @@ describe('GET /api/alerts', () => {
     mockGetByUserId.mockResolvedValue({ items: [] });
   });
 
-  it('Web 一覧取得時に enabledOnly フィルタを付けずにリポジトリを呼ぶ', async () => {
+  it('Web 一覧取得時にページネーション以外のフィルタを付けずにリポジトリを呼ぶ', async () => {
     await GET(new NextRequest('http://localhost/api/alerts'));
 
     expect(mockGetByUserId).toHaveBeenCalledTimes(1);
     const [, options] = mockGetByUserId.mock.calls[0];
+    // 論理削除フィルタはリポジトリ側で常に適用されるため、ルート側は何も渡さない
+    expect(Object.keys(options)).toEqual(expect.arrayContaining(['limit', 'cursor']));
     expect(options).not.toHaveProperty('enabledOnly');
   });
 


### PR DESCRIPTION
## 変更の概要

`AlertRepository.getByUserId` で「論理削除待ち（DynamoDB TTL 属性が設定済みのアイテム）」を常に結果から除外するよう変更し、「ユーザー無効化 (`Enabled=false`、TTL なし)」と「一時アラート失効バッチによる論理削除 (`Enabled=false`、TTL 設定済み)」を実装レベルで区別する。

これにより、prod 環境で「一時アラート失効後、TTL 発火（最長 9 日）まで一覧に残ってしまう」症状が解消される。

## 関連 Issue

Refs #3038

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（インターフェース JSDoc を更新）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）→ 対象外
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（`tsc` クリーン）

## テスト内容

### Core（リポジトリ層）

- `DynamoDBAlertRepository.getByUserId` が `FilterExpression: attribute_not_exists(#ttl)` を常に付与することを検証
- `InMemoryAlertRepository.getByUserId` で
  - `markTemporaryAsExpired` で TTL を付与したアラートが結果から除外される
  - ユーザー無効化アラート（`Enabled=false`、TTL なし）は引き続き返る
- 既存の `enabledOnly` 関連テストは削除（オプション自体を撤去）

### Web（API GET）

- `GET /api/alerts` のオプションに `enabledOnly` が含まれないこと（リポジトリ側で常時適用するため）
- 無効化済みアラートがレスポンスに含まれる既存テストを維持

### テスト結果

- `services/stock-tracker/core`: 52 suites / 710 tests passed
- `services/stock-tracker/web`: 24 suites / 171 tests passed
- `services/stock-tracker/batch`: 8 suites / 90 tests passed
- 全パッケージで lint / prettier クリーン

## レビューポイント

1. **インターフェース変更**: `GetByUserIdOptions` から `enabledOnly` を削除しました。現状 `enabledOnly` を渡している呼び出し元はなく、削除によるリグレッションはありませんが、念のため確認ください。
2. **常時 FilterExpression を付与**: DynamoDB Query で常に FilterExpression が走るようになります。GSI1 でユーザー単位に絞ったあとの軽量フィルタなので RCU 影響は無視できる範囲と判断していますが、もし懸念があれば指摘ください。
3. **判定基準を「TTL 属性の有無」とした理由**: 専用フラグ（`IsExpired` 等）を追加する案もありましたが、既に `markTemporaryAsExpired` が TTL をセットしている既存仕様を活用するのが最小変更と判断しました。

## スクリーンショット（該当する場合）

UI 変更なし（API レスポンスから論理削除待ちアラートが消えるのみ）

## 補足事項

- `EXPIRED_ALERT_TTL_GRACE_DAYS = 7` 自体は本 PR では変更しません。grace 期間の短縮や、`Enabled` を触らない設計への変更は別 Issue にて検討予定です（#3038 「非対応」セクション参照）。
- CloudWatch Logs で確認した prod の状況: 2026-05-08 と 05-09 に計 6 件の論理削除済みアラートが存在し、TTL は 05-15〜05-16 に設定済み（物理削除待ち）。本 PR を反映後はこの 6 件が UI から即時非表示になる想定。


---
_Generated by [Claude Code](https://claude.ai/code/session_013Fo5xYzqYWxyd74V55BGX4)_