### PR TITLE
fix(stock-tracker): 失効バッチが手動無効化された一時アラートも回収するよう変更

### DIFF
--- a/services/stock-tracker/batch/src/temporary-alert-expiry.ts
+++ b/services/stock-tracker/batch/src/temporary-alert-expiry.ts
@@ -41,11 +41,11 @@ export interface HandlerResponse {
 interface BatchStatistics {
   totalAlerts: number;
   skippedNonTemporary: number;
-  skippedAlreadyDisabled: number;
   skippedInvalidData: number;
   skippedTradingHours: number;
   skippedNotExpired: number;
   deactivated: number;
+  deactivatedManually: number;
   errors: number;
 }
 
@@ -99,18 +99,23 @@ async function processCandidate(
   stats: BatchStatistics
 ): Promise<void> {
   try {
-    // getTemporaryCandidatesByFrequency 側で Temporary=true && Enabled=true に絞っているが、
+    // getTemporaryCandidatesByFrequency 側で Temporary=true && TTL 未設定 に絞っているが、
     // InMemory / 将来の実装の差異で漏れた場合の保険として再チェックする。
     if (!candidate.Temporary) {
       stats.skippedNonTemporary++;
       return;
     }
-    if (!candidate.Enabled) {
-      stats.skippedAlreadyDisabled++;
-      return;
-    }
     if (!candidate.TemporaryExpireDate) {
       stats.skippedInvalidData++;
+      return;
+    }
+
+    // ユーザーが手動で無効化した一時アラートは取引時間 / 期限到来を待たず、
+    // 即時に TTL を付与して物理削除予約する。
+    if (!candidate.Enabled) {
+      const ttlSeconds = calculateTtlSeconds(now);
+      await alertRepo.markTemporaryAsExpired(candidate.UserID, candidate.AlertID, ttlSeconds);
+      stats.deactivatedManually++;
       return;
     }
 
@@ -148,11 +153,11 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
   const stats: BatchStatistics = {
     totalAlerts: 0,
     skippedNonTemporary: 0,
-    skippedAlreadyDisabled: 0,
     skippedInvalidData: 0,
     skippedTradingHours: 0,
     skippedNotExpired: 0,
     deactivated: 0,
+    deactivatedManually: 0,
     errors: 0,
   };
 

--- a/services/stock-tracker/batch/tests/unit/temporary-alert-expiry.test.ts
+++ b/services/stock-tracker/batch/tests/unit/temporary-alert-expiry.test.ts
@@ -184,6 +184,28 @@ describe('temporary alert expiry batch handler', () => {
     expect(body.statistics.skippedNotExpired).toBe(1);
   });
 
+  it('ユーザー手動無効化された一時アラートは取引時間/期限を待たず即時 TTL 付与される', async () => {
+    const userDisabled = buildCandidate({ Enabled: false });
+
+    mockAlertRepo.getTemporaryCandidatesByFrequency
+      .mockResolvedValueOnce({ items: [userDisabled] })
+      .mockResolvedValueOnce({ items: [] });
+    // Enabled=false パスは exchange / trading hours を参照しない
+    (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
+    (tradingHoursChecker.getLastTradingDate as jest.Mock).mockReturnValue('1970-01-01');
+
+    const response = await handler(mockEvent);
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(mockExchangeRepo.getById).not.toHaveBeenCalled();
+    expect(tradingHoursChecker.isTradingHours).not.toHaveBeenCalled();
+    expect(mockAlertRepo.markTemporaryAsExpired).toHaveBeenCalledTimes(1);
+    expect(body.statistics.deactivatedManually).toBe(1);
+    expect(body.statistics.deactivated).toBe(0);
+    expect(body.statistics.skippedTradingHours).toBe(0);
+  });
+
   it('markTemporaryAsExpired が失敗しても errors を加算して処理を継続する', async () => {
     const a1 = buildCandidate({ AlertID: 'a1' });
     const a2 = buildCandidate({ AlertID: 'a2' });

--- a/services/stock-tracker/core/src/repositories/alert.repository.interface.ts
+++ b/services/stock-tracker/core/src/repositories/alert.repository.interface.ts
@@ -59,7 +59,9 @@ export interface AlertRepository {
    * 一時アラート失効バッチ用の軽量取得。
    *
    * subscription / ConditionList などバッチ処理に不要な属性を取得・検証せず、
-   * `Temporary = true AND Enabled = true` のアラートのみを返す。
+   * `Temporary = true AND TTL 未設定` のアラートを返す。
+   * 既に `markTemporaryAsExpired` 済み（TTL あり）は除外する。
+   * Enabled=false でもユーザー手動無効化された一時アラートはバッチで回収するため候補に含める。
    *
    * @param frequency - 通知頻度
    * @param options - ページネーションオプション

--- a/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
@@ -213,8 +213,9 @@ export class DynamoDBAlertRepository implements AlertRepository {
    * 一時アラート失効バッチ用の軽量取得（GSI2使用）。
    *
    * - ProjectionExpression で失効判定に必要な属性のみ取得し、subscription は読み込まない
-   * - FilterExpression で `Temporary = true AND Enabled = true` のアラートのみに絞る
-   *   （無効化済み一時アラートを再処理しない）
+   * - FilterExpression で `Temporary = true AND TTL 未設定` のアラートのみに絞る
+   *   （`markTemporaryAsExpired` 済みのものを再処理しない。Enabled=false でも
+   *   ユーザー手動無効化された一時アラートはバッチで回収して TTL を付与する）
    * - mapper.toTemporaryCandidate でアイテム単位検証し、失敗時は警告ログでスキップ
    */
   public async getTemporaryCandidatesByFrequency(
@@ -233,13 +234,14 @@ export class DynamoDBAlertRepository implements AlertRepository {
           TableName: this.tableName,
           IndexName: 'AlertIndex',
           KeyConditionExpression: '#gsi2pk = :pk',
-          FilterExpression: '#temporary = :true AND #enabled = :true',
+          FilterExpression: '#temporary = :true AND attribute_not_exists(#ttl)',
           ProjectionExpression:
             '#pk, #sk, #alertId, #userId, #exchangeId, #frequency, #enabled, #temporary, #temporaryExpireDate',
           ExpressionAttributeNames: {
             '#gsi2pk': 'GSI2PK',
             '#temporary': 'Temporary',
             '#enabled': 'Enabled',
+            '#ttl': 'TTL',
             '#pk': 'PK',
             '#sk': 'SK',
             '#alertId': 'AlertID',

--- a/services/stock-tracker/core/src/repositories/in-memory-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/in-memory-alert.repository.ts
@@ -191,7 +191,10 @@ export class InMemoryAlertRepository implements AlertRepository {
   }
 
   /**
-   * 一時アラート失効バッチ用の軽量取得（Temporary=true かつ Enabled=true のみ）
+   * 一時アラート失効バッチ用の軽量取得（Temporary=true かつ TTL 未設定）。
+   *
+   * 既に `markTemporaryAsExpired` 済み（TTL あり）は除外する。
+   * Enabled=false でもユーザー手動無効化された一時アラートはバッチで回収するため候補に含める。
    */
   public async getTemporaryCandidatesByFrequency(
     frequency: 'MINUTE_LEVEL' | 'HOURLY_LEVEL',
@@ -207,7 +210,10 @@ export class InMemoryAlertRepository implements AlertRepository {
 
     const items: TemporaryAlertCandidate[] = [];
     for (const item of result.items) {
-      if (item.Temporary !== true || item.Enabled !== true) {
+      if (item.Temporary !== true) {
+        continue;
+      }
+      if ((item as Record<string, unknown>).TTL !== undefined) {
         continue;
       }
       try {

--- a/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
@@ -932,7 +932,7 @@ describe('DynamoDBAlertRepository', () => {
       });
     });
 
-    it('Query には Temporary=true AND Enabled=true の FilterExpression と ProjectionExpression が指定される', async () => {
+    it('Query には Temporary=true AND TTL 未設定 の FilterExpression と ProjectionExpression が指定される', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Items: [], Count: 0 });
 
       await repository.getTemporaryCandidatesByFrequency('HOURLY_LEVEL');
@@ -945,7 +945,10 @@ describe('DynamoDBAlertRepository', () => {
           ExpressionAttributeValues?: Record<string, unknown>;
         };
       };
-      expect(sendCall.input.FilterExpression).toBe('#temporary = :true AND #enabled = :true');
+      expect(sendCall.input.FilterExpression).toBe(
+        '#temporary = :true AND attribute_not_exists(#ttl)'
+      );
+      expect(sendCall.input.ExpressionAttributeNames?.['#ttl']).toBe('TTL');
       expect(sendCall.input.ProjectionExpression).toContain('#alertId');
       // subscription 関連の属性は ProjectionExpression に含めない
       expect(sendCall.input.ProjectionExpression).not.toContain('subscription');

--- a/services/stock-tracker/core/tests/unit/repositories/in-memory-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/in-memory-alert.repository.test.ts
@@ -490,14 +490,14 @@ describe('InMemoryAlertRepository', () => {
       },
     };
 
-    it('Temporary かつ Enabled なアラートのみ候補として返す', async () => {
+    it('Temporary=true かつ TTL 未設定 のアラートを候補として返す（Enabled は問わない）', async () => {
       const temporaryEnabled = await repository.create({
         ...baseInput,
         Temporary: true,
         TemporaryExpireDate: '2026-03-04',
       });
       await repository.create({ ...baseInput }); // Temporary なし
-      await repository.create({
+      const temporaryUserDisabled = await repository.create({
         ...baseInput,
         Enabled: false,
         Temporary: true,
@@ -506,9 +506,21 @@ describe('InMemoryAlertRepository', () => {
 
       const result = await repository.getTemporaryCandidatesByFrequency('MINUTE_LEVEL');
 
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0].AlertID).toBe(temporaryEnabled.AlertID);
-      expect(result.items[0].TemporaryExpireDate).toBe('2026-03-04');
+      const ids = result.items.map((c) => c.AlertID).sort();
+      expect(ids).toEqual([temporaryEnabled.AlertID, temporaryUserDisabled.AlertID].sort());
+    });
+
+    it('TTL が既に設定済み（markTemporaryAsExpired 済み）のアラートは候補に含めない', async () => {
+      const expired = await repository.create({
+        ...baseInput,
+        Temporary: true,
+        TemporaryExpireDate: '2026-03-04',
+      });
+      await repository.markTemporaryAsExpired('user-123', expired.AlertID, 9999999999);
+
+      const result = await repository.getTemporaryCandidatesByFrequency('MINUTE_LEVEL');
+
+      expect(result.items.map((c) => c.AlertID)).not.toContain(expired.AlertID);
     });
   });
 


### PR DESCRIPTION
## 変更の概要

#3038 / PR #3039 の追加調査で判明した「ユーザーが UI から一時アラートを手動で無効化 (`Enabled=false`) すると、失効バッチに拾われず永遠に物理削除されない」バグを修正する。

失効バッチの候補取得フィルタを「`Enabled=true`」基準から「`TTL` 属性の有無」基準に切り替え、処理側で `Enabled` の状態に応じて分岐する。

## 関連 Issue

Refs #3038（PR #3039 で対応しきれなかったバッチ側の修正を本 PR で追加）

## 変更種別

- [x] バグ修正

## 実装内容

### 1. 候補取得フィルタの変更

`AlertRepository.getTemporaryCandidatesByFrequency`:
- 旧: `FilterExpression: Temporary = true AND Enabled = true`
- 新: `FilterExpression: Temporary = true AND attribute_not_exists(TTL)`

これにより:
- 既に `markTemporaryAsExpired` 済み（TTL あり）のアラートは除外（再処理回避）
- ユーザー手動無効化された一時アラート（Enabled=false かつ TTL なし）を候補に含める

### 2. `processCandidate` の分岐追加

- `Enabled=true` の候補 → 既存ロジック（取引時間・期限到来チェック後に `markTemporaryAsExpired`）
- `Enabled=false` の候補 → 取引時間・期限到来チェックをスキップし、即時 `markTemporaryAsExpired`（TTL 付与）

### 3. 統計の整理

- 新カウンタ `deactivatedManually`（手動無効化アラートの即時失効回数）を追加
- `skippedAlreadyDisabled` を削除（新フィルタにより到達不能なケース）

### 4. InMemory 実装の同期

`InMemoryAlertRepository.getTemporaryCandidatesByFrequency` も同じセマンティクス（Temporary=true かつ TTL 未設定）に揃える。

## テスト内容

### Core（リポジトリ層）

- `DynamoDBAlertRepository.getTemporaryCandidatesByFrequency` の FilterExpression が `Temporary=true AND attribute_not_exists(#ttl)` であることを検証
- `InMemoryAlertRepository.getTemporaryCandidatesByFrequency` で
  - Temporary=true かつ TTL 未設定（Enabled の値を問わない）のアラートが候補として返る
  - `markTemporaryAsExpired` 済み（TTL あり）のアラートは候補から除外される

### Batch

- ユーザー手動無効化された一時アラート（`Enabled=false`）に対して取引時間・期限チェックをスキップして即 `markTemporaryAsExpired` が呼ばれ、`deactivatedManually` カウンタが増えることを検証
- 既存の Enabled=true 失効パスのテストは継続パス

### テスト結果

- `services/stock-tracker/core`: 52 suites / **711** tests passed（+1）
- `services/stock-tracker/web`: 24 suites / 171 tests passed
- `services/stock-tracker/batch`: 8 suites / **91** tests passed（+1）
- 全パッケージで lint / prettier / `tsc` クリーン

## レビューポイント

1. **既存運用との後方互換**: 既存の `Temporary=true, Enabled=false, TTL なし` の "永久ゴミ" データが prod に存在する場合、本 PR 反映後の次回バッチで一気に拾われて TTL 付与される（7 日後に物理削除）。意図通りだが、件数が多い場合は CloudWatch で `deactivatedManually` カウンタを監視してください。
2. **Enabled=false 即時 TTL 付与の妥当性**: 「ユーザーが UI から無効化した = もう不要」と解釈して取引時間チェックすら省きました。「無効化したが将来再有効化したい」ユースケースがあれば一時アラート以外（通常アラート）で対応する想定です。
3. **統計フィールドの破壊的変更**: `skippedAlreadyDisabled` フィールドを削除しました。CloudWatch Insights クエリ等で参照していたら更新が必要です。

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

- 本 PR は PR #3039 の続編。Issue #3038 の本文を更新してスコープ 2 として明記しています。
- 本 PR マージ後、PR #3039 で確認した dev / prod の状況（手動無効化された一時アラートが残っている可能性）について、次回バッチ実行（毎時 XX:21 UTC / XX:30 UTC）で `deactivatedManually` が増えるかを確認すると挙動が裏取りできます。


---
_Generated by [Claude Code](https://claude.ai/code/session_013Fo5xYzqYWxyd74V55BGX4)_