### PR TITLE
fix(stock-tracker): 論理削除待ち / 手動無効化された一時アラートが一覧から消えない問題を修正

### DIFF
--- a/services/stock-tracker/batch/src/temporary-alert-expiry.ts
+++ b/services/stock-tracker/batch/src/temporary-alert-expiry.ts
@@ -41,11 +41,11 @@ export interface HandlerResponse {
 interface BatchStatistics {
   totalAlerts: number;
   skippedNonTemporary: number;
-  skippedAlreadyDisabled: number;
   skippedInvalidData: number;
   skippedTradingHours: number;
   skippedNotExpired: number;
   deactivated: number;
+  deactivatedManually: number;
   errors: number;
 }
 
@@ -99,18 +99,23 @@ async function processCandidate(
   stats: BatchStatistics
 ): Promise<void> {
   try {
-    // getTemporaryCandidatesByFrequency 側で Temporary=true && Enabled=true に絞っているが、
+    // getTemporaryCandidatesByFrequency 側で Temporary=true && TTL 未設定 に絞っているが、
     // InMemory / 将来の実装の差異で漏れた場合の保険として再チェックする。
     if (!candidate.Temporary) {
       stats.skippedNonTemporary++;
       return;
     }
-    if (!candidate.Enabled) {
-      stats.skippedAlreadyDisabled++;
-      return;
-    }
     if (!candidate.TemporaryExpireDate) {
       stats.skippedInvalidData++;
+      return;
+    }
+
+    // ユーザーが手動で無効化した一時アラートは取引時間 / 期限到来を待たず、
+    // 即時に TTL を付与して物理削除予約する。
+    if (!candidate.Enabled) {
+      const ttlSeconds = calculateTtlSeconds(now);
+      await alertRepo.markTemporaryAsExpired(candidate.UserID, candidate.AlertID, ttlSeconds);
+      stats.deactivatedManually++;
       return;
     }
 
@@ -148,11 +153,11 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
   const stats: BatchStatistics = {
     totalAlerts: 0,
     skippedNonTemporary: 0,
-    skippedAlreadyDisabled: 0,
     skippedInvalidData: 0,
     skippedTradingHours: 0,
     skippedNotExpired: 0,
     deactivated: 0,
+    deactivatedManually: 0,
     errors: 0,
   };
 

--- a/services/stock-tracker/batch/tests/unit/temporary-alert-expiry.test.ts
+++ b/services/stock-tracker/batch/tests/unit/temporary-alert-expiry.test.ts
@@ -184,6 +184,28 @@ describe('temporary alert expiry batch handler', () => {
     expect(body.statistics.skippedNotExpired).toBe(1);
   });
 
+  it('ユーザー手動無効化された一時アラートは取引時間/期限を待たず即時 TTL 付与される', async () => {
+    const userDisabled = buildCandidate({ Enabled: false });
+
+    mockAlertRepo.getTemporaryCandidatesByFrequency
+      .mockResolvedValueOnce({ items: [userDisabled] })
+      .mockResolvedValueOnce({ items: [] });
+    // Enabled=false パスは exchange / trading hours を参照しない
+    (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
+    (tradingHoursChecker.getLastTradingDate as jest.Mock).mockReturnValue('1970-01-01');
+
+    const response = await handler(mockEvent);
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(mockExchangeRepo.getById).not.toHaveBeenCalled();
+    expect(tradingHoursChecker.isTradingHours).not.toHaveBeenCalled();
+    expect(mockAlertRepo.markTemporaryAsExpired).toHaveBeenCalledTimes(1);
+    expect(body.statistics.deactivatedManually).toBe(1);
+    expect(body.statistics.deactivated).toBe(0);
+    expect(body.statistics.skippedTradingHours).toBe(0);
+  });
+
   it('markTemporaryAsExpired が失敗しても errors を加算して処理を継続する', async () => {
     const a1 = buildCandidate({ AlertID: 'a1' });
     const a2 = buildCandidate({ AlertID: 'a2' });

--- a/services/stock-tracker/core/src/repositories/alert.repository.interface.ts
+++ b/services/stock-tracker/core/src/repositories/alert.repository.interface.ts
@@ -9,12 +9,13 @@ import type { TemporaryAlertCandidate } from '../entities/temporary-alert-candid
 import type { PaginationOptions, PaginatedResult } from '@nagiyu/aws';
 
 /**
- * `getByUserId` のオプション。`enabledOnly: true` の場合、有効化済み（Enabled=true）の
- * アラートのみを返す。Web のアラート一覧表示など、無効化されたアラートを除外したい用途で使用する。
+ * `getByUserId` のオプション。
+ *
+ * 実装は常に「論理削除待ちのアラート（DynamoDB TTL 属性が設定されているアイテム）」を
+ * 結果から除外する。ユーザーが無効化したアラート（`Enabled=false` で TTL は未設定）は
+ * 引き続き返される。
  */
-export type GetByUserIdOptions = PaginationOptions & {
-  enabledOnly?: boolean;
-};
+export type GetByUserIdOptions = PaginationOptions;
 
 /**
  * Alert Repository インターフェース
@@ -35,7 +36,9 @@ export interface AlertRepository {
    * ユーザーのアラート一覧を取得
    *
    * @param userId - ユーザーID
-   * @param options - ページネーション + `enabledOnly` フィルタ
+   * 論理削除待ち（TTL 属性が設定済み）のアラートは常に結果から除外される。
+   *
+   * @param options - ページネーションオプション
    * @returns ページネーション結果
    */
   getByUserId(userId: string, options?: GetByUserIdOptions): Promise<PaginatedResult<AlertEntity>>;

--- a/services/stock-tracker/core/src/repositories/alert.repository.interface.ts
+++ b/services/stock-tracker/core/src/repositories/alert.repository.interface.ts
@@ -59,7 +59,9 @@ export interface AlertRepository {
    * 一時アラート失効バッチ用の軽量取得。
    *
    * subscription / ConditionList などバッチ処理に不要な属性を取得・検証せず、
-   * `Temporary = true AND Enabled = true` のアラートのみを返す。
+   * `Temporary = true AND TTL 未設定` のアラートを返す。
+   * 既に `markTemporaryAsExpired` 済み（TTL あり）は除外する。
+   * Enabled=false でもユーザー手動無効化された一時アラートはバッチで回収するため候補に含める。
    *
    * @param frequency - 通知頻度
    * @param options - ページネーションオプション

--- a/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
@@ -76,7 +76,10 @@ export class DynamoDBAlertRepository implements AlertRepository {
 
   /**
    * ユーザーのアラート一覧を取得（GSI1使用）。
-   * `enabledOnly: true` を指定すると、有効化済み（Enabled=true）のアラートのみ返す。
+   *
+   * 論理削除待ち（TTL 属性が設定済み = 一時アラート失効バッチで `markTemporaryAsExpired`
+   * された）のアイテムは常に除外する。ユーザーが手動で無効化したアラート
+   * （`Enabled=false` で TTL は未設定）は引き続き返す。
    */
   public async getByUserId(
     userId: string,
@@ -92,26 +95,21 @@ export class DynamoDBAlertRepository implements AlertRepository {
       const expressionAttributeNames: Record<string, string> = {
         '#gsi1pk': 'GSI1PK',
         '#gsi1sk': 'GSI1SK',
+        '#ttl': 'TTL',
       };
       const expressionAttributeValues: Record<string, unknown> = {
         ':userId': userId,
         ':prefix': 'Alert#',
       };
-      let filterExpression: string | undefined;
-      if (options?.enabledOnly === true) {
-        expressionAttributeNames['#enabled'] = 'Enabled';
-        expressionAttributeValues[':enabledTrue'] = true;
-        filterExpression = '#enabled = :enabledTrue';
-      }
 
       result = await this.docClient.send(
         new QueryCommand({
           TableName: this.tableName,
           IndexName: 'UserIndex',
           KeyConditionExpression: '#gsi1pk = :userId AND begins_with(#gsi1sk, :prefix)',
+          FilterExpression: 'attribute_not_exists(#ttl)',
           ExpressionAttributeNames: expressionAttributeNames,
           ExpressionAttributeValues: expressionAttributeValues,
-          ...(filterExpression ? { FilterExpression: filterExpression } : {}),
           Limit: limit,
           ExclusiveStartKey: exclusiveStartKey,
         })

--- a/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/dynamodb-alert.repository.ts
@@ -213,8 +213,9 @@ export class DynamoDBAlertRepository implements AlertRepository {
    * 一時アラート失効バッチ用の軽量取得（GSI2使用）。
    *
    * - ProjectionExpression で失効判定に必要な属性のみ取得し、subscription は読み込まない
-   * - FilterExpression で `Temporary = true AND Enabled = true` のアラートのみに絞る
-   *   （無効化済み一時アラートを再処理しない）
+   * - FilterExpression で `Temporary = true AND TTL 未設定` のアラートのみに絞る
+   *   （`markTemporaryAsExpired` 済みのものを再処理しない。Enabled=false でも
+   *   ユーザー手動無効化された一時アラートはバッチで回収して TTL を付与する）
    * - mapper.toTemporaryCandidate でアイテム単位検証し、失敗時は警告ログでスキップ
    */
   public async getTemporaryCandidatesByFrequency(
@@ -233,13 +234,14 @@ export class DynamoDBAlertRepository implements AlertRepository {
           TableName: this.tableName,
           IndexName: 'AlertIndex',
           KeyConditionExpression: '#gsi2pk = :pk',
-          FilterExpression: '#temporary = :true AND #enabled = :true',
+          FilterExpression: '#temporary = :true AND attribute_not_exists(#ttl)',
           ProjectionExpression:
             '#pk, #sk, #alertId, #userId, #exchangeId, #frequency, #enabled, #temporary, #temporaryExpireDate',
           ExpressionAttributeNames: {
             '#gsi2pk': 'GSI2PK',
             '#temporary': 'Temporary',
             '#enabled': 'Enabled',
+            '#ttl': 'TTL',
             '#pk': 'PK',
             '#sk': 'SK',
             '#alertId': 'AlertID',

--- a/services/stock-tracker/core/src/repositories/in-memory-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/in-memory-alert.repository.ts
@@ -53,7 +53,9 @@ export class InMemoryAlertRepository implements AlertRepository {
   }
 
   /**
-   * ユーザーのアラート一覧を取得
+   * ユーザーのアラート一覧を取得。
+   *
+   * 論理削除待ち（TTL 属性が設定済み）のアイテムは DynamoDB 実装に合わせて常に除外する。
    */
   public async getByUserId(
     userId: string,
@@ -72,15 +74,15 @@ export class InMemoryAlertRepository implements AlertRepository {
       options
     );
 
-    let items = result.items.map((item) => this.mapper.toEntity(item));
-    if (options?.enabledOnly === true) {
-      items = items.filter((item) => item.Enabled === true);
-    }
+    const filteredRawItems = result.items.filter(
+      (item) => (item as Record<string, unknown>).TTL === undefined
+    );
+    const items = filteredRawItems.map((item) => this.mapper.toEntity(item));
 
     return {
       items,
       nextCursor: result.nextCursor,
-      count: options?.enabledOnly === true ? items.length : result.count,
+      count: items.length,
     };
   }
 

--- a/services/stock-tracker/core/src/repositories/in-memory-alert.repository.ts
+++ b/services/stock-tracker/core/src/repositories/in-memory-alert.repository.ts
@@ -191,7 +191,10 @@ export class InMemoryAlertRepository implements AlertRepository {
   }
 
   /**
-   * 一時アラート失効バッチ用の軽量取得（Temporary=true かつ Enabled=true のみ）
+   * 一時アラート失効バッチ用の軽量取得（Temporary=true かつ TTL 未設定）。
+   *
+   * 既に `markTemporaryAsExpired` 済み（TTL あり）は除外する。
+   * Enabled=false でもユーザー手動無効化された一時アラートはバッチで回収するため候補に含める。
    */
   public async getTemporaryCandidatesByFrequency(
     frequency: 'MINUTE_LEVEL' | 'HOURLY_LEVEL',
@@ -207,7 +210,10 @@ export class InMemoryAlertRepository implements AlertRepository {
 
     const items: TemporaryAlertCandidate[] = [];
     for (const item of result.items) {
-      if (item.Temporary !== true || item.Enabled !== true) {
+      if (item.Temporary !== true) {
+        continue;
+      }
+      if ((item as Record<string, unknown>).TTL !== undefined) {
         continue;
       }
       try {

--- a/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
@@ -273,32 +273,19 @@ describe('DynamoDBAlertRepository', () => {
       await expect(repository.getByUserId('user-123')).rejects.toThrow(DatabaseError);
     });
 
-    it('enabledOnly: true 指定時に FilterExpression が Enabled=true を要求する', async () => {
-      mockDocClient.send.mockResolvedValueOnce({ Items: [], Count: 0 });
-
-      await repository.getByUserId('user-123', { enabledOnly: true });
-
-      const sendCall = mockDocClient.send.mock.calls[0][0] as {
-        input: {
-          FilterExpression?: string;
-          ExpressionAttributeNames?: Record<string, string>;
-          ExpressionAttributeValues?: Record<string, unknown>;
-        };
-      };
-      expect(sendCall.input.FilterExpression).toBe('#enabled = :enabledTrue');
-      expect(sendCall.input.ExpressionAttributeNames?.['#enabled']).toBe('Enabled');
-      expect(sendCall.input.ExpressionAttributeValues?.[':enabledTrue']).toBe(true);
-    });
-
-    it('enabledOnly 未指定時は FilterExpression を付けない', async () => {
+    it('論理削除待ち（TTL 設定済み）アラートを除外する FilterExpression が常に付与される', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Items: [], Count: 0 });
 
       await repository.getByUserId('user-123');
 
       const sendCall = mockDocClient.send.mock.calls[0][0] as {
-        input: { FilterExpression?: string };
+        input: {
+          FilterExpression?: string;
+          ExpressionAttributeNames?: Record<string, string>;
+        };
       };
-      expect(sendCall.input.FilterExpression).toBeUndefined();
+      expect(sendCall.input.FilterExpression).toBe('attribute_not_exists(#ttl)');
+      expect(sendCall.input.ExpressionAttributeNames?.['#ttl']).toBe('TTL');
     });
 
     it('無効なアラートデータをスキップし、有効なデータのみ返す', async () => {

--- a/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/dynamodb-alert.repository.test.ts
@@ -932,7 +932,7 @@ describe('DynamoDBAlertRepository', () => {
       });
     });
 
-    it('Query には Temporary=true AND Enabled=true の FilterExpression と ProjectionExpression が指定される', async () => {
+    it('Query には Temporary=true AND TTL 未設定 の FilterExpression と ProjectionExpression が指定される', async () => {
       mockDocClient.send.mockResolvedValueOnce({ Items: [], Count: 0 });
 
       await repository.getTemporaryCandidatesByFrequency('HOURLY_LEVEL');
@@ -945,7 +945,10 @@ describe('DynamoDBAlertRepository', () => {
           ExpressionAttributeValues?: Record<string, unknown>;
         };
       };
-      expect(sendCall.input.FilterExpression).toBe('#temporary = :true AND #enabled = :true');
+      expect(sendCall.input.FilterExpression).toBe(
+        '#temporary = :true AND attribute_not_exists(#ttl)'
+      );
+      expect(sendCall.input.ExpressionAttributeNames?.['#ttl']).toBe('TTL');
       expect(sendCall.input.ProjectionExpression).toContain('#alertId');
       // subscription 関連の属性は ProjectionExpression に含めない
       expect(sendCall.input.ProjectionExpression).not.toContain('subscription');

--- a/services/stock-tracker/core/tests/unit/repositories/in-memory-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/in-memory-alert.repository.test.ts
@@ -433,7 +433,7 @@ describe('InMemoryAlertRepository', () => {
     });
   });
 
-  describe('getByUserId - enabledOnly', () => {
+  describe('getByUserId - 論理削除フィルタ', () => {
     const baseInput: CreateAlertInput = {
       UserID: 'user-123',
       TickerID: 'NSDQ:AAPL',
@@ -448,24 +448,30 @@ describe('InMemoryAlertRepository', () => {
       },
     };
 
-    it('enabledOnly: true で無効化済みアラートが除外される', async () => {
-      const enabled = await repository.create({ ...baseInput, Enabled: true });
-      const disabled = await repository.create({ ...baseInput, Enabled: false });
+    it('論理削除待ち（markTemporaryAsExpired で TTL 設定済み）アラートは結果から除外される', async () => {
+      const userDisabled = await repository.create({ ...baseInput, Enabled: false });
+      const pendingDeletion = await repository.create({
+        ...baseInput,
+        Temporary: true,
+        TemporaryExpireDate: '2026-03-04',
+      });
+      await repository.markTemporaryAsExpired('user-123', pendingDeletion.AlertID, 1234567890);
 
-      const result = await repository.getByUserId('user-123', { enabledOnly: true });
+      const result = await repository.getByUserId('user-123');
 
       const ids = result.items.map((a) => a.AlertID);
-      expect(ids).toContain(enabled.AlertID);
-      expect(ids).not.toContain(disabled.AlertID);
+      expect(ids).toContain(userDisabled.AlertID);
+      expect(ids).not.toContain(pendingDeletion.AlertID);
     });
 
-    it('enabledOnly 未指定では無効化済みアラートも返る', async () => {
+    it('ユーザーが手動で無効化したアラート（Enabled=false、TTL なし）は引き続き返る', async () => {
       await repository.create({ ...baseInput, Enabled: true });
       await repository.create({ ...baseInput, Enabled: false });
 
       const result = await repository.getByUserId('user-123');
 
       expect(result.items).toHaveLength(2);
+      expect(result.items.map((a) => a.Enabled).sort()).toEqual([false, true]);
     });
   });
 

--- a/services/stock-tracker/core/tests/unit/repositories/in-memory-alert.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/in-memory-alert.repository.test.ts
@@ -490,14 +490,14 @@ describe('InMemoryAlertRepository', () => {
       },
     };
 
-    it('Temporary かつ Enabled なアラートのみ候補として返す', async () => {
+    it('Temporary=true かつ TTL 未設定 のアラートを候補として返す（Enabled は問わない）', async () => {
       const temporaryEnabled = await repository.create({
         ...baseInput,
         Temporary: true,
         TemporaryExpireDate: '2026-03-04',
       });
       await repository.create({ ...baseInput }); // Temporary なし
-      await repository.create({
+      const temporaryUserDisabled = await repository.create({
         ...baseInput,
         Enabled: false,
         Temporary: true,
@@ -506,9 +506,21 @@ describe('InMemoryAlertRepository', () => {
 
       const result = await repository.getTemporaryCandidatesByFrequency('MINUTE_LEVEL');
 
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0].AlertID).toBe(temporaryEnabled.AlertID);
-      expect(result.items[0].TemporaryExpireDate).toBe('2026-03-04');
+      const ids = result.items.map((c) => c.AlertID).sort();
+      expect(ids).toEqual([temporaryEnabled.AlertID, temporaryUserDisabled.AlertID].sort());
+    });
+
+    it('TTL が既に設定済み（markTemporaryAsExpired 済み）のアラートは候補に含めない', async () => {
+      const expired = await repository.create({
+        ...baseInput,
+        Temporary: true,
+        TemporaryExpireDate: '2026-03-04',
+      });
+      await repository.markTemporaryAsExpired('user-123', expired.AlertID, 9999999999);
+
+      const result = await repository.getTemporaryCandidatesByFrequency('MINUTE_LEVEL');
+
+      expect(result.items.map((c) => c.AlertID)).not.toContain(expired.AlertID);
     });
   });
 

--- a/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
@@ -33,11 +33,13 @@ describe('GET /api/alerts', () => {
     mockGetByUserId.mockResolvedValue({ items: [] });
   });
 
-  it('Web 一覧取得時に enabledOnly フィルタを付けずにリポジトリを呼ぶ', async () => {
+  it('Web 一覧取得時にページネーション以外のフィルタを付けずにリポジトリを呼ぶ', async () => {
     await GET(new NextRequest('http://localhost/api/alerts'));
 
     expect(mockGetByUserId).toHaveBeenCalledTimes(1);
     const [, options] = mockGetByUserId.mock.calls[0];
+    // 論理削除フィルタはリポジトリ側で常に適用されるため、ルート側は何も渡さない
+    expect(Object.keys(options)).toEqual(expect.arrayContaining(['limit', 'cursor']));
     expect(options).not.toHaveProperty('enabledOnly');
   });
 


### PR DESCRIPTION
## 変更の概要

Issue #3038 で報告された「論理削除待ち / 手動無効化された一時アラートが一覧から消えない」問題に対応した integration ブランチを develop へ反映する。

| サブ PR | スコープ |
|---|---|
| #3039 | `AlertRepository.getByUserId` で TTL 設定済みアラートを常時除外（論理削除待ちの非表示化） |
| #3040 | 失効バッチが `Enabled=false` の手動無効化済み一時アラートも回収して TTL 付与 |

## 関連 Issue

Closes #3038

## 変更種別

- [x] バグ修正

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ 80% 以上を確保）
- [x] 関連ドキュメントを更新した（インターフェース JSDoc を更新）
- [ ] CI/CD 設定を追加・更新した → 対象外
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

### サブ PR ごとの内容は #3039 / #3040 を参照

各サブ PR は `integration/3038-alert-list-exclude-pending-deletion` をベースにマージ済みで、Fast CI は両方とも全パス。

### dev 環境での実測検証

`integration/3038-...` ブランチが dev に自動デプロイされた状態で、テスト用一時アラート（`Enabled=false` 手動無効化）を作成し、`temporary-alert-expiry` バッチの動作を確認した。

**2026-05-11T13:30:39Z (JST 22:30:39) のバッチ実行ログ:**

```json
{
  "statistics": {
    "totalAlerts": 3,
    "skippedNonTemporary": 0,
    "skippedInvalidData": 0,
    "skippedTradingHours": 0,
    "skippedNotExpired": 0,
    "deactivated": 0,
    "deactivatedManually": 3,
    "errors": 0
  }
}
```

- 新カウンタ `deactivatedManually` が想定通り計上された（PR #3040 の効果）
- 旧 `skippedAlreadyDisabled` フィールドが消えており、新コード起動が確認できる
- `markTemporaryAsExpired` 経由で TTL が付与され、UI 上から該当アラートが消えることも確認済み（PR #3039 の効果）

## レビューポイント

1. **デプロイ後の prod 反映**: prod でも `Temporary=true, Enabled=false, TTL なし` の "永久ゴミ" レコードが存在する場合、本 PR デプロイ後の最初のバッチ実行で一気に回収されます。CloudWatch で `deactivatedManually` カウンタの急増を監視してください。
2. **統計フィールドの破壊的変更**: バッチ統計 JSON から `skippedAlreadyDisabled` を削除し `deactivatedManually` を追加しました。CloudWatch Insights クエリやダッシュボードで参照していたら更新が必要です。
3. **`enabledOnly` オプションの削除**: `GetByUserIdOptions.enabledOnly` を削除しました（全 caller で未使用、リポジトリ側で TTL ベース除外を常時適用するため）。

## スクリーンショット（該当する場合）

UI 変更なし。dev での「アラートがありません」表示は、PR #3039 + #3040 双方を反映した結果として想定通り。

## 補足事項

- `EXPIRED_ALERT_TTL_GRACE_DAYS = 7` は本 PR スコープ外（grace 期間の見直しは Issue #3038 「非対応」セクションで別 Issue 化予定）。
- 本 PR は CLAUDE.md の対応フロー（integration → develop は人の確認後に作成）に従い、dev 検証完了・人の承認を得てから作成しています。


---
_Generated by [Claude Code](https://claude.ai/code/session_013Fo5xYzqYWxyd74V55BGX4)_