### PR TITLE
fix(iam): nagiyu-claude-readonly に DynamoDB 経由の kms:Decrypt を許可

### DIFF
--- a/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
+++ b/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
@@ -16,6 +16,11 @@ import { Construct } from 'constructs';
  *     - KMS: Decrypt / Encrypt / GenerateDataKey 系を Deny
  *       （副作用として SSM SecureString も復号不可になる）
  *     - DynamoDB: nagiyu-auth-users-* テーブルへの読み取りを Deny
+ *
+ * 例外:
+ * - DynamoDB の Scan / Query / GetItem が KMS 暗号化済みテーブルに対して
+ *   成功するよう、kms:ViaService が DynamoDB の場合に限り kms:Decrypt を許可
+ *   （SSM SecureString / Secrets Manager 経由の復号は引き続き Deny）
  */
 export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
   public readonly policy: iam.IManagedPolicy;
@@ -128,6 +133,7 @@ export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
           resources: ['*'],
         }),
         // 復号経路を遮断（SecureString パラメータの値取得もこれで防げる）
+        // ただし DynamoDB 経由の復号（kms:ViaService = dynamodb.*）は例外として Allow を別途許可
         new iam.PolicyStatement({
           sid: 'DenyKmsDataOperations',
           effect: iam.Effect.DENY,
@@ -140,6 +146,24 @@ export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
             'kms:GenerateRandom',
           ],
           resources: ['*'],
+          conditions: {
+            StringNotEqualsIfExists: {
+              'kms:ViaService': ['dynamodb.us-east-1.amazonaws.com'],
+            },
+          },
+        }),
+        // DynamoDB が KMS 暗号化テーブルを読む際に内部で呼び出す Decrypt を許可
+        // kms:ViaService 条件で DynamoDB 経由のみに限定（CLI 直叩きや他サービス経由は許可されない）
+        new iam.PolicyStatement({
+          sid: 'AllowKmsDecryptViaDynamoDB',
+          effect: iam.Effect.ALLOW,
+          actions: ['kms:Decrypt'],
+          resources: ['*'],
+          conditions: {
+            StringEquals: {
+              'kms:ViaService': ['dynamodb.us-east-1.amazonaws.com'],
+            },
+          },
         }),
         // PII を含む auth-users テーブルへの読み取りを遮断
         new iam.PolicyStatement({


### PR DESCRIPTION
## 変更の概要

`nagiyu-claude-readonly-policy` の明示 Deny が KMS 暗号化済み DynamoDB テーブルの読み取りを阻害していたため、`kms:ViaService` 条件を使って「DynamoDB 経由の `kms:Decrypt` だけ通す」よう調整した。

具体的な変更は `infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts` のみ：

1. **`DenyKmsDataOperations` に `StringNotEqualsIfExists` 条件を追加**
   `kms:ViaService = dynamodb.us-east-1.amazonaws.com` のときだけ Deny を不発動。
   ViaService キーが無いケース（CLI から直接 `aws kms decrypt` を叩く等）は `IfExists` の挙動により条件 true となり、引き続き Deny される。

2. **`AllowKmsDecryptViaDynamoDB` ステートメントを新規追加**
   `kms:Decrypt` を `StringEquals` 条件で DynamoDB 経由のみ Allow。
   元の Allow 文には `kms:Decrypt` が含まれていなかったため、Deny を条件付きに変えるだけでは暗黙拒否に落ちる点に対応。

## 関連 Issue

<!-- integration → develop の PR でのみ Closes # を使う -->

Refs #3042

## 変更種別

- [x] バグ修正
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）
  - `infra/shared` 配下に既存のテストスイートが無いため新規テストは追加していない。スコープ的にも CDK の `Stack` 構築テストは未整備
- [x] 関連ドキュメントを更新した（ヘッダーコメントに例外条件の意図を追記）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
  - `npx tsc --noEmit` を実行し、本変更ファイルに型エラーがないことを確認
- [x] ビルドエラーがないことを確認した

## テスト内容

- 修正前の事象確認（`nagiyu-claude-readonly` のアクセスキーで実行）
  - `aws dynamodb scan --table-name nagiyu-admin-main-dev --region us-east-1` → `kms:Decrypt` の explicit deny で AccessDeniedException
  - 同じテーブルに対する `aws dynamodb describe-table` は成功（KMS を介さないため）

### Ready 化前にデプロイ後 dev 環境で確認したい項目

- `nagiyu-claude-readonly` で以下が **成功する**
  - `aws dynamodb scan --table-name nagiyu-admin-main-dev --region us-east-1 --max-items 1`
  - `aws dynamodb get-item` / `aws dynamodb query` の主要テーブル
- `nagiyu-claude-readonly` で以下が **引き続き失敗する**
  - `aws kms decrypt --ciphertext-blob ... --region us-east-1`（直叩き）
  - `aws ssm get-parameter --with-decryption --name <SecureString>`
  - `aws secretsmanager get-secret-value --secret-id <id>`
  - `aws dynamodb scan --table-name nagiyu-auth-users-dev`

## レビューポイント

- `kms:ViaService` のリージョン値が `dynamodb.us-east-1.amazonaws.com` 固定で問題ないか
  - CDK 定義 (`infra/**/bin/*.ts`) と GitHub Actions ワークフロー (`.github/workflows/*.yml`) を確認した結果、本リポジトリで DynamoDB を扱うリージョンは us-east-1 のみ
  - 将来的に他リージョンへ DynamoDB を増やす場合は、本ポリシーの ViaService 値の追加が必要
- `StringNotEqualsIfExists` を使った Deny 条件の意図（ViaService が存在しない場合も Deny を発動させる）が設計通りか
- 機密保護経路（Secrets Manager / SSM SecureString / auth-users テーブル）の遮断が引き続き有効か

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

- 本 PR のターゲットは `integration/3042-claude-readonly-kms-decrypt`
- integration → develop の PR は、本 PR がマージされ dev 環境で動作確認できた後に別途作成する（人の承認後）


---
_Generated by [Claude Code](https://claude.ai/code/session_01D4LkDcxGJCc9fG9T5xoss1)_