### PR TITLE
fix(iam): nagiyu-claude-readonly に DynamoDB 経由の kms:Decrypt を許可

### DIFF
--- a/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
+++ b/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
@@ -16,6 +16,11 @@ import { Construct } from 'constructs';
  *     - KMS: Decrypt / Encrypt / GenerateDataKey 系を Deny
  *       （副作用として SSM SecureString も復号不可になる）
  *     - DynamoDB: nagiyu-auth-users-* テーブルへの読み取りを Deny
+ *
+ * 例外:
+ * - DynamoDB の Scan / Query / GetItem が KMS 暗号化済みテーブルに対して
+ *   成功するよう、kms:ViaService が DynamoDB の場合に限り kms:Decrypt を許可
+ *   （SSM SecureString / Secrets Manager 経由の復号は引き続き Deny）
  */
 export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
   public readonly policy: iam.IManagedPolicy;
@@ -128,6 +133,7 @@ export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
           resources: ['*'],
         }),
         // 復号経路を遮断（SecureString パラメータの値取得もこれで防げる）
+        // ただし DynamoDB 経由の復号（kms:ViaService = dynamodb.*）は例外として Allow を別途許可
         new iam.PolicyStatement({
           sid: 'DenyKmsDataOperations',
           effect: iam.Effect.DENY,
@@ -140,6 +146,24 @@ export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
             'kms:GenerateRandom',
           ],
           resources: ['*'],
+          conditions: {
+            StringNotEqualsIfExists: {
+              'kms:ViaService': ['dynamodb.us-east-1.amazonaws.com'],
+            },
+          },
+        }),
+        // DynamoDB が KMS 暗号化テーブルを読む際に内部で呼び出す Decrypt を許可
+        // kms:ViaService 条件で DynamoDB 経由のみに限定（CLI 直叩きや他サービス経由は許可されない）
+        new iam.PolicyStatement({
+          sid: 'AllowKmsDecryptViaDynamoDB',
+          effect: iam.Effect.ALLOW,
+          actions: ['kms:Decrypt'],
+          resources: ['*'],
+          conditions: {
+            StringEquals: {
+              'kms:ViaService': ['dynamodb.us-east-1.amazonaws.com'],
+            },
+          },
         }),
         // PII を含む auth-users テーブルへの読み取りを遮断
         new iam.PolicyStatement({


### PR DESCRIPTION
## 変更の概要

`nagiyu-claude-readonly-policy` の明示 Deny が KMS 暗号化済み DynamoDB テーブルの読み取りを阻害していた問題を修正する。`kms:ViaService` 条件で「DynamoDB 経由の `kms:Decrypt` だけ通す」例外を追加し、他の経路（SSM SecureString / Secrets Manager / 直接 KMS 呼び出し）は引き続き Deny されたまま。

変更ファイル: `infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts`

1. `DenyKmsDataOperations` に `StringNotEqualsIfExists` 条件を追加し、`kms:ViaService = dynamodb.us-east-1.amazonaws.com` の場合のみ Deny を不発動にする
2. `AllowKmsDecryptViaDynamoDB` ステートメントを新規追加し、同じ ViaService 条件で `kms:Decrypt` を Allow する

## 関連 Issue

Closes #3042

## 変更種別

- [x] バグ修正
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）
  - `infra/shared` 配下に既存のテストスイートが無いため新規テストは追加していない
- [x] 関連ドキュメントを更新した（ヘッダーコメントに例外条件の意図を追記）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

dev 環境（`nagiyu-claude-readonly` のアクセスキー）で以下を実行し設計通り動作することを確認済み：

### 成功するべき経路（修正対象）

- `aws dynamodb scan --table-name nagiyu-admin-main-dev --region us-east-1` → ✅ 成功
- `aws dynamodb scan --table-name nagiyu-share-together-main-dev --region us-east-1` → ✅ 成功

### Deny されるべき経路（機密保護）

- `aws dynamodb scan --table-name nagiyu-auth-users-dev` → ✅ AccessDeniedException（DynamoDB 側 Deny）
- `aws secretsmanager list-secrets` → ✅ AccessDeniedException
- IAM Policy Simulator で `kms:Decrypt` 直接呼び出し → ✅ `explicitDeny`
- IAM Policy Simulator で `kms:Decrypt` SSM 経由（ViaService=ssm.us-east-1.amazonaws.com）→ ✅ `explicitDeny`
- IAM Policy Simulator で `kms:Decrypt` DynamoDB 経由（ViaService=dynamodb.us-east-1.amazonaws.com）→ ✅ `allowed`

## レビューポイント

- `kms:ViaService` のリージョン値が `dynamodb.us-east-1.amazonaws.com` 固定で問題ないか
  - CDK 定義 (`infra/**/bin/*.ts`) と GitHub Actions ワークフロー (`.github/workflows/*.yml`) を確認した結果、本リポジトリで DynamoDB を扱うリージョンは us-east-1 のみ
  - 将来的に他リージョンへ DynamoDB を増やす場合は、本ポリシーの ViaService 値の追加が必要
- `StringNotEqualsIfExists` を使った Deny 条件の意図（ViaService が存在しない場合も Deny を発動させる）が設計通りか

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

- 作業ブランチ → integration の PR は #3043 でマージ済み
- dev 環境で動作確認済み（上記テスト内容セクション参照）


---
_Generated by [Claude Code](https://claude.ai/code/session_01D4LkDcxGJCc9fG9T5xoss1)_