### PR TITLE
refactor(errors): エラーメッセージを libs/common に集約 (#3051)

### DIFF
--- a/services/codec-converter/web/src/app/api/jobs/[jobId]/route.ts
+++ b/services/codec-converter/web/src/app/api/jobs/[jobId]/route.ts
@@ -1,20 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
 import { GetCommand } from '@aws-sdk/lib-dynamodb';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getAwsClients } from '@nagiyu/aws';
 import { type Job } from '@nagiyu/codec-converter-core';
 import type { ErrorResponse } from '@nagiyu/common';
+import { ERROR_MESSAGES } from '@/lib/constants/errors';
 
 // Presigned URLの有効期限（24時間 = 86400秒）
 const PRESIGNED_URL_EXPIRES_IN = 86400;
-
-// エラーメッセージ定数
-const ERROR_MESSAGES = {
-  JOB_NOT_FOUND: COMMON_ERROR_MESSAGES.JOB_NOT_FOUND,
-  INTERNAL_SERVER_ERROR: 'ジョブの取得に失敗しました',
-} as const;
 
 /**
  * 環境変数を取得
@@ -96,7 +90,7 @@ export async function GET(
     return NextResponse.json(
       {
         error: 'INTERNAL_SERVER_ERROR',
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+        message: ERROR_MESSAGES.JOB_FETCH_FAILED,
       },
       { status: 500 }
     );

--- a/services/codec-converter/web/src/app/api/jobs/[jobId]/submit/route.ts
+++ b/services/codec-converter/web/src/app/api/jobs/[jobId]/submit/route.ts
@@ -1,20 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
 import { GetCommand } from '@aws-sdk/lib-dynamodb';
 import { HeadObjectCommand } from '@aws-sdk/client-s3';
 import { SubmitJobCommand } from '@aws-sdk/client-batch';
 import { getAwsClients } from '@nagiyu/aws';
 import { type Job, type JobStatus, selectJobDefinition } from '@nagiyu/codec-converter-core';
 import type { ErrorResponse } from '@nagiyu/common';
-
-// エラーメッセージ定数
-const ERROR_MESSAGES = {
-  JOB_NOT_FOUND: COMMON_ERROR_MESSAGES.JOB_NOT_FOUND,
-  INVALID_STATUS: 'ジョブは既に実行中または完了しています',
-  FILE_NOT_FOUND: '入力ファイルが見つかりません',
-  INVALID_JOB_DEFINITION: 'ジョブ定義の選択に失敗しました',
-  INTERNAL_SERVER_ERROR: 'ジョブの投入に失敗しました',
-} as const;
+import { ERROR_MESSAGES } from '@/lib/constants/errors';
 
 /**
  * 環境変数を取得
@@ -182,7 +173,7 @@ export async function POST(
     return NextResponse.json(
       {
         error: 'INTERNAL_SERVER_ERROR',
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+        message: ERROR_MESSAGES.JOB_SUBMISSION_FAILED,
       },
       { status: 500 }
     );

--- a/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
+++ b/services/codec-converter/web/src/app/jobs/[jobId]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
 import { useRouter } from 'next/navigation';
 import {
   type Job,
@@ -16,12 +15,7 @@ import { Button, Chip, ErrorAlert } from '@nagiyu/ui';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DownloadIcon from '@mui/icons-material/Download';
 import AddIcon from '@mui/icons-material/Add';
-
-// エラーメッセージ定数
-const ERROR_MESSAGES = {
-  FETCH_FAILED: 'ジョブ情報の取得に失敗しました',
-  JOB_NOT_FOUND: COMMON_ERROR_MESSAGES.JOB_NOT_FOUND,
-} as const;
+import { ERROR_MESSAGES } from '@/lib/constants/errors';
 
 // ステータスバッジの色設定（WCAG AA準拠）
 const STATUS_COLORS: Record<JobStatus, 'warning' | 'primary' | 'success' | 'danger'> = {
@@ -135,7 +129,7 @@ export default function JobDetailsPage({ params }: JobDetailsPageProps) {
           if (response.status === 404) {
             setError(ERROR_MESSAGES.JOB_NOT_FOUND);
           } else {
-            setError(ERROR_MESSAGES.FETCH_FAILED);
+            setError(ERROR_MESSAGES.JOB_INFO_FETCH_FAILED);
           }
           return;
         }
@@ -145,7 +139,7 @@ export default function JobDetailsPage({ params }: JobDetailsPageProps) {
         // Validate response structure
         if (!isGetJobResponse(data)) {
           console.error('Invalid job response structure:', data);
-          setError(ERROR_MESSAGES.FETCH_FAILED);
+          setError(ERROR_MESSAGES.JOB_INFO_FETCH_FAILED);
           return;
         }
 
@@ -153,7 +147,7 @@ export default function JobDetailsPage({ params }: JobDetailsPageProps) {
         setDownloadUrl(data.downloadUrl || null);
       } catch (err) {
         console.error('Failed to fetch job details:', err);
-        setError(ERROR_MESSAGES.FETCH_FAILED);
+        setError(ERROR_MESSAGES.JOB_INFO_FETCH_FAILED);
       } finally {
         setIsLoading(false);
         setIsRefreshing(false);

--- a/services/codec-converter/web/src/lib/constants/errors.ts
+++ b/services/codec-converter/web/src/lib/constants/errors.ts
@@ -1,10 +1,23 @@
+import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
+
 /**
  * エラーメッセージ定数
  *
- * ユーザー向けエラーメッセージを一元管理する
+ * ユーザー向けエラーメッセージを一元管理する。
+ * 汎用メッセージは `@nagiyu/common` の COMMON_ERROR_MESSAGES を踏襲し、
+ * codec-converter 固有のメッセージのみを追加する。
  */
 export const ERROR_MESSAGES = {
+  ...COMMON_ERROR_MESSAGES,
+
+  // ジョブ作成・投入
   MISSING_REQUIRED_FIELDS: '必須フィールドが不足しています',
   INVALID_CODEC: '無効なコーデックが指定されました',
   JOB_CREATION_FAILED: 'ジョブの作成に失敗しました',
+  JOB_SUBMISSION_FAILED: 'ジョブの投入に失敗しました',
+  JOB_FETCH_FAILED: 'ジョブの取得に失敗しました',
+  JOB_INFO_FETCH_FAILED: 'ジョブ情報の取得に失敗しました',
+  INVALID_STATUS: 'ジョブは既に実行中または完了しています',
+  FILE_NOT_FOUND: '入力ファイルが見つかりません',
+  INVALID_JOB_DEFINITION: 'ジョブ定義の選択に失敗しました',
 } as const;

--- a/services/share-together/core/src/libs/todo.ts
+++ b/services/share-together/core/src/libs/todo.ts
@@ -6,7 +6,7 @@ const ERROR_MESSAGES = {
   TODO_ID_REQUIRED: 'ToDo IDは必須です',
   USER_ID_REQUIRED: 'ユーザーIDは必須です',
   TITLE_INVALID: 'ToDoのタイトルは1〜200文字で入力してください',
-  UPDATE_FIELDS_REQUIRED: '更新内容が指定されていません',
+  UPDATE_FIELDS_REQUIRED: '更新するフィールドが指定されていません',
   TODO_NOT_FOUND: 'ToDoが見つかりません',
 } as const;
 

--- a/services/share-together/core/tests/unit/libs/todo.test.ts
+++ b/services/share-together/core/tests/unit/libs/todo.test.ts
@@ -109,7 +109,7 @@ describe('TodoService', () => {
 
   it('ToDo更新時に更新項目がない場合はエラーになる', async () => {
     await expect(todoService.updateTodo('list-1', 'todo-1', {}, 'user-1')).rejects.toThrow(
-      '更新内容が指定されていません'
+      '更新するフィールドが指定されていません'
     );
     expect(todoRepository.update).not.toHaveBeenCalled();
   });

--- a/services/share-together/web/src/lib/constants/errors.ts
+++ b/services/share-together/web/src/lib/constants/errors.ts
@@ -1,11 +1,13 @@
 import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
 
+/**
+ * エラーメッセージ定数
+ *
+ * 汎用メッセージは `@nagiyu/common` の COMMON_ERROR_MESSAGES を踏襲し、
+ * share-together 固有のメッセージのみを追加する。
+ */
 export const ERROR_MESSAGES = {
-  UNAUTHORIZED: COMMON_ERROR_MESSAGES.UNAUTHORIZED,
-  FORBIDDEN: COMMON_ERROR_MESSAGES.FORBIDDEN,
-  NOT_FOUND: COMMON_ERROR_MESSAGES.NOT_FOUND,
-  VALIDATION_ERROR: COMMON_ERROR_MESSAGES.VALIDATION_ERROR,
-  INTERNAL_SERVER_ERROR: COMMON_ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+  ...COMMON_ERROR_MESSAGES,
 
   CONFLICT: 'データの競合が発生しました',
 
@@ -13,7 +15,6 @@ export const ERROR_MESSAGES = {
   LIST_ID_REQUIRED: 'リストIDは必須です',
   TODO_ID_REQUIRED: 'ToDo IDは必須です',
   TODO_TITLE_INVALID: 'ToDoのタイトルは1〜200文字で入力してください',
-  UPDATE_FIELDS_REQUIRED: '更新内容が指定されていません',
   TODO_NOT_FOUND: 'ToDoが見つかりません',
   PERSONAL_LIST_NOT_FOUND: '個人リストが見つかりません',
   LIST_NAME_INVALID: 'リスト名は1〜100文字で入力してください',

--- a/services/share-together/web/tests/unit/app/api/lists/[listId]/todos/[todoId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/lists/[listId]/todos/[todoId]/route.test.ts
@@ -179,7 +179,7 @@ describe('/api/lists/[listId]/todos/[todoId] route handlers', () => {
         id: 'user-1',
       },
     } as SessionOrUnauthorized);
-    mockUpdateTodo.mockRejectedValue(new Error('更新内容が指定されていません'));
+    mockUpdateTodo.mockRejectedValue(new Error('更新するフィールドが指定されていません'));
 
     const response = await PUT(createRequest({}), createContext());
 

--- a/services/share-together/web/tests/unit/lib/constants/errors.test.ts
+++ b/services/share-together/web/tests/unit/lib/constants/errors.test.ts
@@ -1,19 +1,18 @@
+import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 
 describe('ERROR_MESSAGES', () => {
-  it('主要なエラーメッセージを日本語で提供する', () => {
-    expect(ERROR_MESSAGES).toEqual({
-      UNAUTHORIZED: '認証が必要です',
-      FORBIDDEN: 'この操作を実行する権限がありません',
-      NOT_FOUND: '対象のデータが見つかりません',
-      VALIDATION_ERROR: '入力内容が不正です',
+  it('共通エラーメッセージを取り込んでいる', () => {
+    expect(ERROR_MESSAGES).toMatchObject(COMMON_ERROR_MESSAGES);
+  });
+
+  it('share-together 固有のエラーメッセージを日本語で提供する', () => {
+    expect(ERROR_MESSAGES).toMatchObject({
       CONFLICT: 'データの競合が発生しました',
-      INTERNAL_SERVER_ERROR: 'サーバーエラーが発生しました',
       USER_ID_REQUIRED: 'ユーザーIDは必須です',
       LIST_ID_REQUIRED: 'リストIDは必須です',
       TODO_ID_REQUIRED: 'ToDo IDは必須です',
       TODO_TITLE_INVALID: 'ToDoのタイトルは1〜200文字で入力してください',
-      UPDATE_FIELDS_REQUIRED: '更新内容が指定されていません',
       TODO_NOT_FOUND: 'ToDoが見つかりません',
       PERSONAL_LIST_NOT_FOUND: '個人リストが見つかりません',
       LIST_NAME_INVALID: 'リスト名は1〜100文字で入力してください',


### PR DESCRIPTION
## 変更の概要

Issue #3051（A1: エラーメッセージ定数の集約）に対応。
4 service の汎用エラーメッセージを `@nagiyu/common` の `COMMON_ERROR_MESSAGES` 経由で共有する形に整理した。

### codec-converter
- `web/src/lib/constants/errors.ts` を `...COMMON_ERROR_MESSAGES` でスプレッドする集約版に書き換え
- 各 route / page (`api/jobs/[jobId]/route.ts`, `api/jobs/[jobId]/submit/route.ts`, `app/jobs/[jobId]/page.tsx`) に散在していたローカル `ERROR_MESSAGES` 再定義を削除し、`@/lib/constants/errors` を import する形に統一
- ジョブ操作向けの専用文言（`JOB_FETCH_FAILED` / `JOB_SUBMISSION_FAILED` / `JOB_INFO_FETCH_FAILED` / `INVALID_STATUS` / `FILE_NOT_FOUND` / `INVALID_JOB_DEFINITION`）も `lib/constants/errors.ts` に集約

### share-together
- `web/src/lib/constants/errors.ts` の手動エイリアス（`UNAUTHORIZED: COMMON_ERROR_MESSAGES.UNAUTHORIZED` 等）を `...COMMON_ERROR_MESSAGES` スプレッドに置換
- `UPDATE_FIELDS_REQUIRED` の文言が共通と service 側で異なっていた問題を解消し、共通側の「更新するフィールドが指定されていません」に統一
- `share-together-core` の `TodoService` 内ローカル定義も同文言に揃え、API が validation エラーとして判定するための Set 比較が引き続き機能することを確認
- 影響するユニットテスト 3 件（`core/tests/unit/libs/todo.test.ts`, `web/tests/unit/app/api/lists/[listId]/todos/[todoId]/route.test.ts`, `web/tests/unit/lib/constants/errors.test.ts`）を新文言に追従

### 対応不要だった service
- `niconico-mylist-assistant`: 既に `...COMMON_ERROR_MESSAGES` スプレッド済み
- `stock-tracker`: 既に `...COMMON_ERROR_MESSAGES` スプレッド済み

## 関連 Issue

Refs #3051

（`Closes #` は付けない。Issue のクローズは `integration/3050-code-consolidation → develop` のマージ時に行う）

## 変更種別

- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存ユニットテストを新文言に追従）
- [ ] 関連ドキュメントを更新した（ドキュメント変更は不要と判断）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（既存の `share-together-core/factory.ts` の `noImplicitAny` エラーは本 PR と無関係の既存問題）

## テスト内容

ローカルで以下を実行し全件 pass を確認:

- `npm run test --workspace=@nagiyu/common` → 253/253 passed
- `npm run test --workspace=@nagiyu/share-together-core` → 149/149 passed
- `npm run test --workspace=@nagiyu/share-together-web` → 209/209 passed
- `npm run lint --workspace=@nagiyu/codec-converter-web` → エラーなし
- `npm run lint --workspace=@nagiyu/share-together-web` → エラーなし（既存の `react-hooks/exhaustive-deps` warning のみ）
- `npx tsc --noEmit` (codec-converter/web, share-together/web) → エラーなし

## レビューポイント

- `share-together` の `UPDATE_FIELDS_REQUIRED` の文言を共通側に揃えた結果、ユーザー向け表示が「更新内容が指定されていません」→「更新するフィールドが指定されていません」に変わります。API の挙動（400 を返す挙動）は core 側の throw メッセージも合わせて更新しているため維持されています
- codec-converter の `INTERNAL_SERVER_ERROR` レスポンスのメッセージは、これまで route ごとに「ジョブの取得に失敗しました」「ジョブの投入に失敗しました」と上書きしていたため、それぞれ `JOB_FETCH_FAILED` / `JOB_SUBMISSION_FAILED` という専用キーに退避させてユーザー文言を維持しています（汎用 `INTERNAL_SERVER_ERROR` には変えていません）

## 補足事項

- `quick-clip` でも `'更新内容が指定されていません'` という文字列が独立して使われていますが、本 Issue の対象 service 外なので変更していません


---
_Generated by [Claude Code](https://claude.ai/code/session_016rFsV7FBktLxJQCNemhED8)_