### PR TITLE
feat(stock-tracker): DailySummaryEntity に Evaluation* フィールドと採点用 Repository メソッドを追加（#3025）

### DIFF
--- a/services/stock-tracker/core/src/entities/daily-summary.entity.ts
+++ b/services/stock-tracker/core/src/entities/daily-summary.entity.ts
@@ -38,6 +38,18 @@ export interface DailySummaryEntity {
   AiAnalysisResult?: AiAnalysisResult;
   /** AI 解析生成失敗時のエラー情報 */
   AiAnalysisError?: string;
+  /** 採点に使った翌営業日 (YYYY-MM-DD)。採点バッチが書き込む */
+  EvaluationDate?: string;
+  /** 採点終値 (EvaluationDate の終値) */
+  EvaluationClose?: number;
+  /** 実績リターン (%)。(EvaluationClose - Close) / Close * 100 */
+  ActualReturn?: number;
+  /** 採点結果（予測シグナルと閾値に基づく Hit/Miss） */
+  Hit?: boolean;
+  /** 採点に使った閾値 (%)。Phase 1 では 0.5 固定 */
+  EvaluationThresholdPercent?: number;
+  /** 採点実行時刻 (Unix timestamp ms)。存在で採点済みと判定する */
+  EvaluatedAt?: number;
   /** 作成日時 (Unix timestamp ms) */
   CreatedAt: number;
   /** 更新日時 (Unix timestamp ms) */

--- a/services/stock-tracker/core/src/index.ts
+++ b/services/stock-tracker/core/src/index.ts
@@ -49,7 +49,10 @@ export type { AlertRepository } from './repositories/alert.repository.interface.
 export type { HoldingRepository } from './repositories/holding.repository.interface.js';
 export type { TickerRepository } from './repositories/ticker.repository.interface.js';
 export type { ExchangeRepository } from './repositories/exchange.repository.interface.js';
-export type { DailySummaryRepository } from './repositories/daily-summary.repository.interface.js';
+export type {
+  DailySummaryRepository,
+  DailySummaryEvaluationFields,
+} from './repositories/daily-summary.repository.interface.js';
 
 // Entities (explicit exports to avoid conflicts with types.ts)
 export type {

--- a/services/stock-tracker/core/src/mappers/daily-summary.mapper.ts
+++ b/services/stock-tracker/core/src/mappers/daily-summary.mapper.ts
@@ -6,6 +6,7 @@
 
 import type { DynamoDBItem } from '@nagiyu/aws';
 import {
+  validateBooleanField,
   validateNumberField,
   validateStringField,
   validateTimestampField,
@@ -109,6 +110,14 @@ export class DailySummaryMapper implements EntityMapper<DailySummaryEntity, Dail
         ? { AiAnalysisResult: JSON.stringify(entity.AiAnalysisResult) }
         : {}),
       ...(entity.AiAnalysisError !== undefined ? { AiAnalysisError: entity.AiAnalysisError } : {}),
+      ...(entity.EvaluationDate !== undefined ? { EvaluationDate: entity.EvaluationDate } : {}),
+      ...(entity.EvaluationClose !== undefined ? { EvaluationClose: entity.EvaluationClose } : {}),
+      ...(entity.ActualReturn !== undefined ? { ActualReturn: entity.ActualReturn } : {}),
+      ...(entity.Hit !== undefined ? { Hit: entity.Hit } : {}),
+      ...(entity.EvaluationThresholdPercent !== undefined
+        ? { EvaluationThresholdPercent: entity.EvaluationThresholdPercent }
+        : {}),
+      ...(entity.EvaluatedAt !== undefined ? { EvaluatedAt: entity.EvaluatedAt } : {}),
       CreatedAt: entity.CreatedAt,
       UpdatedAt: entity.UpdatedAt,
     };
@@ -164,6 +173,27 @@ export class DailySummaryMapper implements EntityMapper<DailySummaryEntity, Dail
         item.AiAnalysisError === undefined
           ? undefined
           : validateStringField(item.AiAnalysisError, 'AiAnalysisError'),
+      EvaluationDate:
+        item.EvaluationDate === undefined
+          ? undefined
+          : validateStringField(item.EvaluationDate, 'EvaluationDate'),
+      EvaluationClose:
+        item.EvaluationClose === undefined
+          ? undefined
+          : validateNumberField(item.EvaluationClose, 'EvaluationClose'),
+      ActualReturn:
+        item.ActualReturn === undefined
+          ? undefined
+          : validateNumberField(item.ActualReturn, 'ActualReturn'),
+      Hit: item.Hit === undefined ? undefined : validateBooleanField(item.Hit, 'Hit'),
+      EvaluationThresholdPercent:
+        item.EvaluationThresholdPercent === undefined
+          ? undefined
+          : validateNumberField(item.EvaluationThresholdPercent, 'EvaluationThresholdPercent'),
+      EvaluatedAt:
+        item.EvaluatedAt === undefined
+          ? undefined
+          : validateTimestampField(item.EvaluatedAt, 'EvaluatedAt'),
       CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
       UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
     };

--- a/services/stock-tracker/core/src/repositories/daily-summary.repository.interface.ts
+++ b/services/stock-tracker/core/src/repositories/daily-summary.repository.interface.ts
@@ -6,8 +6,27 @@
 
 import type {
   DailySummaryEntity,
+  DailySummaryKey,
   CreateDailySummaryInput,
 } from '../entities/daily-summary.entity.js';
+
+/**
+ * `markAsEvaluated` で 1 回の書き込みとして反映する採点結果フィールド集合
+ */
+export interface DailySummaryEvaluationFields {
+  /** 採点に使った翌営業日 (YYYY-MM-DD) */
+  EvaluationDate: string;
+  /** 採点終値 */
+  EvaluationClose: number;
+  /** 実績リターン (%) */
+  ActualReturn: number;
+  /** Hit / Miss 判定 */
+  Hit: boolean;
+  /** 採点に使った閾値 (%) */
+  EvaluationThresholdPercent: number;
+  /** 採点実行時刻 (Unix timestamp ms) */
+  EvaluatedAt: number;
+}
 
 /**
  * Daily Summary Repository インターフェース
@@ -34,10 +53,40 @@ export interface DailySummaryRepository {
   getByExchange(exchangeId: string, date?: string): Promise<DailySummaryEntity[]>;
 
   /**
+   * 取引所IDと日付範囲でサマリーを取得（GSI4 Query）
+   *
+   * 採点バッチ / 集計 API 用。既存 `getByExchange` は単一日付 / 最新日に特化しているため
+   * 期間範囲対応を新設する。範囲は両端含む（inclusive）。
+   *
+   * @param exchangeId - 取引所ID
+   * @param fromDate - 開始日 (YYYY-MM-DD、含む)
+   * @param toDate - 終了日 (YYYY-MM-DD、含む)
+   * @returns 期間内の全サマリー配列
+   */
+  getByExchangeAndDateRange(
+    exchangeId: string,
+    fromDate: string,
+    toDate: string
+  ): Promise<DailySummaryEntity[]>;
+
+  /**
    * サマリーを保存（既存の場合は上書き）
    *
    * @param input - 日次サマリーデータ
    * @returns 保存されたサマリー
    */
   upsert(input: CreateDailySummaryInput): Promise<DailySummaryEntity>;
+
+  /**
+   * 採点結果を既存 DailySummary に書き込む
+   *
+   * 条件: `attribute_not_exists(EvaluatedAt)`（二重採点防止）。
+   * 既に採点済みの場合は `EntityAlreadyExistsError` を投げ、呼び出し側で skip 判定できる。
+   *
+   * @param key - 対象 DailySummary のキー
+   * @param fields - 採点結果フィールド一式
+   * @throws {EntityAlreadyExistsError} 既に採点済みの場合
+   * @throws {EntityNotFoundError} 対象の DailySummary が存在しない場合
+   */
+  markAsEvaluated(key: DailySummaryKey, fields: DailySummaryEvaluationFields): Promise<void>;
 }

--- a/services/stock-tracker/core/src/repositories/dynamodb-daily-summary.repository.ts
+++ b/services/stock-tracker/core/src/repositories/dynamodb-daily-summary.repository.ts
@@ -8,12 +8,22 @@ import {
   GetCommand,
   PutCommand,
   QueryCommand,
+  UpdateCommand,
   type DynamoDBDocumentClient,
 } from '@aws-sdk/lib-dynamodb';
-import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
-import type { DailySummaryRepository } from './daily-summary.repository.interface.js';
+import {
+  DatabaseError,
+  EntityAlreadyExistsError,
+  EntityNotFoundError,
+  type DynamoDBItem,
+} from '@nagiyu/aws';
+import type {
+  DailySummaryEvaluationFields,
+  DailySummaryRepository,
+} from './daily-summary.repository.interface.js';
 import type {
   DailySummaryEntity,
+  DailySummaryKey,
   CreateDailySummaryInput,
 } from '../entities/daily-summary.entity.js';
 import { DailySummaryMapper } from '../mappers/daily-summary.mapper.js';
@@ -120,6 +130,52 @@ export class DynamoDBDailySummaryRepository implements DailySummaryRepository {
   }
 
   /**
+   * 取引所IDと日付範囲でサマリーを取得（GSI4使用、両端含む）
+   *
+   * GSI4SK は `DATE#{Date}#{TickerID}` 形式のため、`DATE#{toDate}` の prefix だけでは
+   * `toDate` の項目を漏らしてしまう。よって ASCII でほぼ最大の `~` を末尾に付けて
+   * `DATE#{toDate}#~` まで含める。
+   */
+  public async getByExchangeAndDateRange(
+    exchangeId: string,
+    fromDate: string,
+    toDate: string
+  ): Promise<DailySummaryEntity[]> {
+    try {
+      const items: DynamoDBItem[] = [];
+      let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+      do {
+        const result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            IndexName: 'ExchangeSummaryIndex',
+            KeyConditionExpression: '#gsi4pk = :exchangeId AND #gsi4sk BETWEEN :from AND :to',
+            ExpressionAttributeNames: {
+              '#gsi4pk': 'GSI4PK',
+              '#gsi4sk': 'GSI4SK',
+            },
+            ExpressionAttributeValues: {
+              ':exchangeId': exchangeId,
+              ':from': `DATE#${fromDate}`,
+              ':to': `DATE#${toDate}#~`,
+            },
+            ExclusiveStartKey: lastEvaluatedKey,
+          })
+        );
+
+        items.push(...((result.Items as DynamoDBItem[] | undefined) ?? []));
+        lastEvaluatedKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+      } while (lastEvaluatedKey);
+
+      return items.map((item) => this.mapper.toEntity(item));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  /**
    * サマリーを保存（既存の場合は上書き）
    */
   public async upsert(input: CreateDailySummaryInput): Promise<DailySummaryEntity> {
@@ -141,6 +197,64 @@ export class DynamoDBDailySummaryRepository implements DailySummaryRepository {
 
       return entity;
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  /**
+   * 採点結果を既存 DailySummary に書き込む（条件付き UpdateItem）
+   *
+   * - 条件 `attribute_exists(PK)` で対象 DailySummary が存在することを保証
+   * - 条件 `attribute_not_exists(EvaluatedAt)` で二重採点を防止
+   * - いずれか違反時は `ConditionalCheckFailedException` が発生し、
+   *   存在しない場合は `EntityNotFoundError`、既採点の場合は `EntityAlreadyExistsError` に変換する
+   */
+  public async markAsEvaluated(
+    key: DailySummaryKey,
+    fields: DailySummaryEvaluationFields
+  ): Promise<void> {
+    try {
+      const { pk, sk } = this.mapper.buildKeys(key);
+      const now = Date.now();
+
+      await this.docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+          UpdateExpression:
+            'SET #evaluationDate = :evaluationDate, #evaluationClose = :evaluationClose, #actualReturn = :actualReturn, #hit = :hit, #evaluationThresholdPercent = :evaluationThresholdPercent, #evaluatedAt = :evaluatedAt, #updatedAt = :updatedAt',
+          ExpressionAttributeNames: {
+            '#evaluationDate': 'EvaluationDate',
+            '#evaluationClose': 'EvaluationClose',
+            '#actualReturn': 'ActualReturn',
+            '#hit': 'Hit',
+            '#evaluationThresholdPercent': 'EvaluationThresholdPercent',
+            '#evaluatedAt': 'EvaluatedAt',
+            '#updatedAt': 'UpdatedAt',
+          },
+          ExpressionAttributeValues: {
+            ':evaluationDate': fields.EvaluationDate,
+            ':evaluationClose': fields.EvaluationClose,
+            ':actualReturn': fields.ActualReturn,
+            ':hit': fields.Hit,
+            ':evaluationThresholdPercent': fields.EvaluationThresholdPercent,
+            ':evaluatedAt': fields.EvaluatedAt,
+            ':updatedAt': now,
+          },
+          ConditionExpression: 'attribute_exists(PK) AND attribute_not_exists(EvaluatedAt)',
+        })
+      );
+    } catch (error) {
+      if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
+        const identifier = `${key.tickerId}#${key.date}`;
+        // 既採点 vs 未存在を区別するために GetItem で再確認
+        const existing = await this.getByTickerAndDate(key.tickerId, key.date);
+        if (!existing) {
+          throw new EntityNotFoundError('DailySummary', identifier);
+        }
+        throw new EntityAlreadyExistsError('DailySummaryEvaluation', identifier);
+      }
       const message = error instanceof Error ? error.message : String(error);
       throw new DatabaseError(message, error instanceof Error ? error : undefined);
     }

--- a/services/stock-tracker/core/src/repositories/in-memory-daily-summary.repository.ts
+++ b/services/stock-tracker/core/src/repositories/in-memory-daily-summary.repository.ts
@@ -4,10 +4,18 @@
  * InMemorySingleTableStoreを使用したDailySummaryRepositoryの実装
  */
 
-import { InMemorySingleTableStore } from '@nagiyu/aws';
-import type { DailySummaryRepository } from './daily-summary.repository.interface.js';
+import {
+  EntityAlreadyExistsError,
+  EntityNotFoundError,
+  InMemorySingleTableStore,
+} from '@nagiyu/aws';
+import type {
+  DailySummaryEvaluationFields,
+  DailySummaryRepository,
+} from './daily-summary.repository.interface.js';
 import type {
   DailySummaryEntity,
+  DailySummaryKey,
   CreateDailySummaryInput,
 } from '../entities/daily-summary.entity.js';
 import { DailySummaryMapper } from '../mappers/daily-summary.mapper.js';
@@ -75,6 +83,27 @@ export class InMemoryDailySummaryRepository implements DailySummaryRepository {
   }
 
   /**
+   * 取引所IDと日付範囲でサマリーを取得（GSI4 をシミュレート、両端含む）
+   */
+  public async getByExchangeAndDateRange(
+    exchangeId: string,
+    fromDate: string,
+    toDate: string
+  ): Promise<DailySummaryEntity[]> {
+    const result = this.store.queryByAttribute({
+      attributeName: 'GSI4PK',
+      attributeValue: exchangeId,
+      sk: {
+        attributeName: 'GSI4SK',
+        operator: 'between' as const,
+        value: [`DATE#${fromDate}`, `DATE#${toDate}#~`],
+      },
+    });
+
+    return result.items.map((item) => this.mapper.toEntity(item));
+  }
+
+  /**
    * サマリーを保存（既存の場合は上書き）
    */
   public async upsert(input: CreateDailySummaryInput): Promise<DailySummaryEntity> {
@@ -88,5 +117,35 @@ export class InMemoryDailySummaryRepository implements DailySummaryRepository {
 
     this.store.put(this.mapper.toItem(entity));
     return entity;
+  }
+
+  /**
+   * 採点結果を既存 DailySummary に書き込む
+   *
+   * - 対象が存在しない場合は `EntityNotFoundError`
+   * - 既に採点済み（`EvaluatedAt` あり）の場合は `EntityAlreadyExistsError`
+   */
+  public async markAsEvaluated(
+    key: DailySummaryKey,
+    fields: DailySummaryEvaluationFields
+  ): Promise<void> {
+    const existing = await this.getByTickerAndDate(key.tickerId, key.date);
+    const identifier = `${key.tickerId}#${key.date}`;
+
+    if (!existing) {
+      throw new EntityNotFoundError('DailySummary', identifier);
+    }
+    if (existing.EvaluatedAt !== undefined) {
+      throw new EntityAlreadyExistsError('DailySummaryEvaluation', identifier);
+    }
+
+    const now = Date.now();
+    const updated: DailySummaryEntity = {
+      ...existing,
+      ...fields,
+      UpdatedAt: now,
+    };
+
+    this.store.put(this.mapper.toItem(updated));
   }
 }

--- a/services/stock-tracker/core/tests/unit/mappers/daily-summary.mapper.test.ts
+++ b/services/stock-tracker/core/tests/unit/mappers/daily-summary.mapper.test.ts
@@ -406,4 +406,187 @@ describe('DailySummaryMapper', () => {
       });
     });
   });
+
+  describe('Evaluation* フィールドのマッピング', () => {
+    const evaluationFields = {
+      EvaluationDate: '2026-02-28',
+      EvaluationClose: 184.5,
+      ActualReturn: 0.65,
+      Hit: true,
+      EvaluationThresholdPercent: 0.5,
+      EvaluatedAt: 1709078400000,
+    } as const;
+
+    it('全 Evaluation* フィールドが round-trip で保持される', () => {
+      const entity: DailySummaryEntity = {
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        ...evaluationFields,
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1709078400000,
+      };
+
+      const item = mapper.toItem(entity);
+
+      expect(item.EvaluationDate).toBe('2026-02-28');
+      expect(item.EvaluationClose).toBe(184.5);
+      expect(item.ActualReturn).toBe(0.65);
+      expect(item.Hit).toBe(true);
+      expect(item.EvaluationThresholdPercent).toBe(0.5);
+      expect(item.EvaluatedAt).toBe(1709078400000);
+
+      const convertedEntity = mapper.toEntity(item);
+      expect(convertedEntity).toEqual(entity);
+    });
+
+    it('Hit が false の場合も正しく round-trip する', () => {
+      const entity: DailySummaryEntity = {
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        ...evaluationFields,
+        Hit: false,
+        ActualReturn: -1.2,
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1709078400000,
+      };
+
+      const item = mapper.toItem(entity);
+      expect(item.Hit).toBe(false);
+      expect(item.ActualReturn).toBe(-1.2);
+
+      const convertedEntity = mapper.toEntity(item);
+      expect(convertedEntity.Hit).toBe(false);
+      expect(convertedEntity.ActualReturn).toBe(-1.2);
+    });
+
+    it('Evaluation* が全て不在のときは Item / Entity ともに undefined のまま', () => {
+      const entity: DailySummaryEntity = {
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1708992000000,
+      };
+
+      const item = mapper.toItem(entity);
+
+      expect(item.EvaluationDate).toBeUndefined();
+      expect(item.EvaluationClose).toBeUndefined();
+      expect(item.ActualReturn).toBeUndefined();
+      expect(item.Hit).toBeUndefined();
+      expect(item.EvaluationThresholdPercent).toBeUndefined();
+      expect(item.EvaluatedAt).toBeUndefined();
+
+      const convertedEntity = mapper.toEntity(item);
+      expect(convertedEntity.EvaluationDate).toBeUndefined();
+      expect(convertedEntity.Hit).toBeUndefined();
+      expect(convertedEntity.EvaluatedAt).toBeUndefined();
+    });
+
+    it('partial（Evaluation* の一部のみ）でも round-trip する', () => {
+      const entity: DailySummaryEntity = {
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        EvaluationDate: '2026-02-28',
+        EvaluationClose: 184.5,
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1708992000000,
+      };
+
+      const item = mapper.toItem(entity);
+      expect(item.EvaluationDate).toBe('2026-02-28');
+      expect(item.EvaluationClose).toBe(184.5);
+      expect(item.ActualReturn).toBeUndefined();
+      expect(item.Hit).toBeUndefined();
+
+      const convertedEntity = mapper.toEntity(item);
+      expect(convertedEntity.EvaluationDate).toBe('2026-02-28');
+      expect(convertedEntity.EvaluationClose).toBe(184.5);
+      expect(convertedEntity.ActualReturn).toBeUndefined();
+      expect(convertedEntity.Hit).toBeUndefined();
+    });
+
+    it('Hit の型が boolean でない場合は toEntity でエラー', () => {
+      const item: DynamoDBItem = {
+        PK: 'SUMMARY#NSDQ:AAPL',
+        SK: 'DATE#2026-02-27',
+        Type: 'DailySummary',
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        Hit: 'true',
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1708992000000,
+      } as DynamoDBItem;
+
+      expect(() => mapper.toEntity(item)).toThrow();
+    });
+
+    it('EvaluatedAt の型が不正な場合は toEntity でエラー', () => {
+      const item: DynamoDBItem = {
+        PK: 'SUMMARY#NSDQ:AAPL',
+        SK: 'DATE#2026-02-27',
+        Type: 'DailySummary',
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        EvaluatedAt: -1,
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1708992000000,
+      };
+
+      expect(() => mapper.toEntity(item)).toThrow();
+    });
+
+    it('既存フィールド（AiAnalysisResult / PatternResults）と共存できる', () => {
+      const entity: DailySummaryEntity = {
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        PatternResults: { 'morning-star': 'MATCHED' },
+        BuyPatternCount: 1,
+        SellPatternCount: 0,
+        AiAnalysisResult: mockAiAnalysisResult,
+        ...evaluationFields,
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1709078400000,
+      };
+
+      const item = mapper.toItem(entity);
+      const convertedEntity = mapper.toEntity(item);
+
+      expect(convertedEntity).toEqual(entity);
+    });
+  });
 });

--- a/services/stock-tracker/core/tests/unit/repositories/dynamodb-daily-summary.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/dynamodb-daily-summary.repository.test.ts
@@ -8,11 +8,13 @@ import {
   GetCommand,
   PutCommand,
   QueryCommand,
+  UpdateCommand,
   type DynamoDBDocumentClient,
 } from '@aws-sdk/lib-dynamodb';
-import { DatabaseError } from '@nagiyu/aws';
+import { DatabaseError, EntityAlreadyExistsError, EntityNotFoundError } from '@nagiyu/aws';
 import { DynamoDBDailySummaryRepository } from '../../../src/repositories/dynamodb-daily-summary.repository.js';
 import type { CreateDailySummaryInput } from '../../../src/entities/daily-summary.entity.js';
+import type { DailySummaryEvaluationFields } from '../../../src/repositories/daily-summary.repository.interface.js';
 
 describe('DynamoDBDailySummaryRepository', () => {
   let repository: DynamoDBDailySummaryRepository;
@@ -344,6 +346,213 @@ describe('DynamoDBDailySummaryRepository', () => {
           Low: 181.44,
           Close: 183.31,
         })
+      ).rejects.toThrow(DatabaseError);
+    });
+  });
+
+  describe('getByExchangeAndDateRange', () => {
+    it('GSI4 を BETWEEN クエリで利用し、期間内の項目を返す', async () => {
+      mockDocClient.send.mockResolvedValueOnce({
+        Items: [
+          {
+            PK: 'SUMMARY#NSDQ:AAPL',
+            SK: 'DATE#2026-02-27',
+            Type: 'DailySummary',
+            GSI4PK: 'NASDAQ',
+            GSI4SK: 'DATE#2026-02-27#NSDQ:AAPL',
+            TickerID: 'NSDQ:AAPL',
+            ExchangeID: 'NASDAQ',
+            Date: '2026-02-27',
+            Open: 182.15,
+            High: 183.92,
+            Low: 181.44,
+            Close: 183.31,
+            CreatedAt: 1708992000000,
+            UpdatedAt: 1708992000000,
+          },
+        ],
+      });
+
+      const result = await repository.getByExchangeAndDateRange(
+        'NASDAQ',
+        '2026-02-20',
+        '2026-02-27'
+      );
+
+      expect(result).toHaveLength(1);
+      const command = mockDocClient.send.mock.calls[0][0] as QueryCommand;
+      expect(command).toBeInstanceOf(QueryCommand);
+      expect(command.input).toMatchObject({
+        TableName: TABLE_NAME,
+        IndexName: 'ExchangeSummaryIndex',
+        KeyConditionExpression: '#gsi4pk = :exchangeId AND #gsi4sk BETWEEN :from AND :to',
+        ExpressionAttributeNames: {
+          '#gsi4pk': 'GSI4PK',
+          '#gsi4sk': 'GSI4SK',
+        },
+        ExpressionAttributeValues: {
+          ':exchangeId': 'NASDAQ',
+          ':from': 'DATE#2026-02-20',
+          ':to': 'DATE#2026-02-27#~',
+        },
+      });
+    });
+
+    it('複数ページを LastEvaluatedKey で連結して取得する', async () => {
+      mockDocClient.send
+        .mockResolvedValueOnce({
+          Items: [
+            {
+              PK: 'SUMMARY#NSDQ:AAPL',
+              SK: 'DATE#2026-02-26',
+              Type: 'DailySummary',
+              GSI4PK: 'NASDAQ',
+              GSI4SK: 'DATE#2026-02-26#NSDQ:AAPL',
+              TickerID: 'NSDQ:AAPL',
+              ExchangeID: 'NASDAQ',
+              Date: '2026-02-26',
+              Open: 180.0,
+              High: 181.0,
+              Low: 179.0,
+              Close: 180.5,
+              CreatedAt: 1708905600000,
+              UpdatedAt: 1708905600000,
+            },
+          ],
+          LastEvaluatedKey: { PK: 'SUMMARY#NSDQ:AAPL', SK: 'DATE#2026-02-26' },
+        })
+        .mockResolvedValueOnce({
+          Items: [
+            {
+              PK: 'SUMMARY#NSDQ:MSFT',
+              SK: 'DATE#2026-02-27',
+              Type: 'DailySummary',
+              GSI4PK: 'NASDAQ',
+              GSI4SK: 'DATE#2026-02-27#NSDQ:MSFT',
+              TickerID: 'NSDQ:MSFT',
+              ExchangeID: 'NASDAQ',
+              Date: '2026-02-27',
+              Open: 405.0,
+              High: 408.0,
+              Low: 404.0,
+              Close: 407.5,
+              CreatedAt: 1708992000000,
+              UpdatedAt: 1708992000000,
+            },
+          ],
+        });
+
+      const result = await repository.getByExchangeAndDateRange(
+        'NASDAQ',
+        '2026-02-26',
+        '2026-02-27'
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.map((item) => item.TickerID)).toEqual(['NSDQ:AAPL', 'NSDQ:MSFT']);
+      expect(mockDocClient.send).toHaveBeenCalledTimes(2);
+
+      const second = mockDocClient.send.mock.calls[1][0] as QueryCommand;
+      expect(second.input.ExclusiveStartKey).toEqual({
+        PK: 'SUMMARY#NSDQ:AAPL',
+        SK: 'DATE#2026-02-26',
+      });
+    });
+
+    it('データベースエラー時にDatabaseErrorをスローする', async () => {
+      mockDocClient.send.mockRejectedValueOnce(new Error('Database connection failed'));
+
+      await expect(
+        repository.getByExchangeAndDateRange('NASDAQ', '2026-02-20', '2026-02-27')
+      ).rejects.toThrow(DatabaseError);
+    });
+  });
+
+  describe('markAsEvaluated', () => {
+    const fields: DailySummaryEvaluationFields = {
+      EvaluationDate: '2026-02-28',
+      EvaluationClose: 184.5,
+      ActualReturn: 0.65,
+      Hit: true,
+      EvaluationThresholdPercent: 0.5,
+      EvaluatedAt: 1709078400000,
+    };
+
+    it('UpdateItem を条件付きで送信し、Evaluation* と UpdatedAt を SET する', async () => {
+      const now = 1709100000000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+
+      mockDocClient.send.mockResolvedValueOnce({ $metadata: {} });
+
+      await repository.markAsEvaluated({ tickerId: 'NSDQ:AAPL', date: '2026-02-27' }, fields);
+
+      expect(mockDocClient.send).toHaveBeenCalledTimes(1);
+      const command = mockDocClient.send.mock.calls[0][0] as UpdateCommand;
+      expect(command).toBeInstanceOf(UpdateCommand);
+      expect(command.input).toMatchObject({
+        TableName: TABLE_NAME,
+        Key: { PK: 'SUMMARY#NSDQ:AAPL', SK: 'DATE#2026-02-27' },
+        ConditionExpression: 'attribute_exists(PK) AND attribute_not_exists(EvaluatedAt)',
+      });
+      expect(command.input.ExpressionAttributeValues).toMatchObject({
+        ':evaluationDate': '2026-02-28',
+        ':evaluationClose': 184.5,
+        ':actualReturn': 0.65,
+        ':hit': true,
+        ':evaluationThresholdPercent': 0.5,
+        ':evaluatedAt': 1709078400000,
+        ':updatedAt': now,
+      });
+    });
+
+    it('既採点（条件式違反）の場合は EntityAlreadyExistsError をスローする', async () => {
+      const conditionalError = new Error('The conditional request failed');
+      conditionalError.name = 'ConditionalCheckFailedException';
+
+      mockDocClient.send
+        .mockRejectedValueOnce(conditionalError)
+        // 再確認の GetItem は既存レコードを返す
+        .mockResolvedValueOnce({
+          Item: {
+            PK: 'SUMMARY#NSDQ:AAPL',
+            SK: 'DATE#2026-02-27',
+            Type: 'DailySummary',
+            TickerID: 'NSDQ:AAPL',
+            ExchangeID: 'NASDAQ',
+            Date: '2026-02-27',
+            Open: 182.15,
+            High: 183.92,
+            Low: 181.44,
+            Close: 183.31,
+            EvaluatedAt: 1709000000000,
+            CreatedAt: 1708992000000,
+            UpdatedAt: 1709000000000,
+          },
+        });
+
+      await expect(
+        repository.markAsEvaluated({ tickerId: 'NSDQ:AAPL', date: '2026-02-27' }, fields)
+      ).rejects.toBeInstanceOf(EntityAlreadyExistsError);
+    });
+
+    it('対象 DailySummary が存在しない場合は EntityNotFoundError をスローする', async () => {
+      const conditionalError = new Error('The conditional request failed');
+      conditionalError.name = 'ConditionalCheckFailedException';
+
+      mockDocClient.send
+        .mockRejectedValueOnce(conditionalError)
+        .mockResolvedValueOnce({ Item: undefined });
+
+      await expect(
+        repository.markAsEvaluated({ tickerId: 'NSDQ:AAPL', date: '2026-02-27' }, fields)
+      ).rejects.toBeInstanceOf(EntityNotFoundError);
+    });
+
+    it('その他のデータベースエラーは DatabaseError に変換される', async () => {
+      mockDocClient.send.mockRejectedValueOnce(new Error('Throughput exceeded'));
+
+      await expect(
+        repository.markAsEvaluated({ tickerId: 'NSDQ:AAPL', date: '2026-02-27' }, fields)
       ).rejects.toThrow(DatabaseError);
     });
   });

--- a/services/stock-tracker/core/tests/unit/repositories/in-memory-daily-summary.repository.test.ts
+++ b/services/stock-tracker/core/tests/unit/repositories/in-memory-daily-summary.repository.test.ts
@@ -5,8 +5,13 @@
  */
 
 import { InMemoryDailySummaryRepository } from '../../../src/repositories/in-memory-daily-summary.repository.js';
-import { InMemorySingleTableStore } from '@nagiyu/aws';
+import {
+  EntityAlreadyExistsError,
+  EntityNotFoundError,
+  InMemorySingleTableStore,
+} from '@nagiyu/aws';
 import type { CreateDailySummaryInput } from '../../../src/entities/daily-summary.entity.js';
+import type { DailySummaryEvaluationFields } from '../../../src/repositories/daily-summary.repository.interface.js';
 
 describe('InMemoryDailySummaryRepository', () => {
   let repository: InMemoryDailySummaryRepository;
@@ -152,6 +157,138 @@ describe('InMemoryDailySummaryRepository', () => {
       expect(byDate[0].Open).toBe(101);
       expect(byDate[0].Close).toBe(109);
       expect(byDate[0].Volume).toBe(1200000);
+    });
+  });
+
+  describe('getByExchangeAndDateRange', () => {
+    beforeEach(async () => {
+      await repository.upsert({
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-25',
+        Open: 100,
+        High: 110,
+        Low: 95,
+        Close: 105,
+      });
+      await repository.upsert({
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 105,
+        High: 112,
+        Low: 104,
+        Close: 110,
+      });
+      await repository.upsert({
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-03-01',
+        Open: 110,
+        High: 115,
+        Low: 109,
+        Close: 113,
+      });
+      await repository.upsert({
+        TickerID: 'NYSE:IBM',
+        ExchangeID: 'NYSE',
+        Date: '2026-02-26',
+        Open: 200,
+        High: 205,
+        Low: 198,
+        Close: 204,
+      });
+    });
+
+    it('指定 Exchange × 日付範囲（両端含む）のサマリーのみ返す', async () => {
+      const result = await repository.getByExchangeAndDateRange(
+        'NASDAQ',
+        '2026-02-25',
+        '2026-02-27'
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.Date).sort()).toEqual(['2026-02-25', '2026-02-27']);
+      expect(result.every((r) => r.ExchangeID === 'NASDAQ')).toBe(true);
+    });
+
+    it('範囲外（toDate より後）のサマリーは含まれない', async () => {
+      const result = await repository.getByExchangeAndDateRange(
+        'NASDAQ',
+        '2026-02-25',
+        '2026-02-28'
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.some((r) => r.Date === '2026-03-01')).toBe(false);
+    });
+
+    it('該当なしの場合は空配列を返す', async () => {
+      const result = await repository.getByExchangeAndDateRange(
+        'NASDAQ',
+        '2025-01-01',
+        '2025-01-31'
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('markAsEvaluated', () => {
+    const fields: DailySummaryEvaluationFields = {
+      EvaluationDate: '2026-02-28',
+      EvaluationClose: 110,
+      ActualReturn: 1.85,
+      Hit: true,
+      EvaluationThresholdPercent: 0.5,
+      EvaluatedAt: 1709078400000,
+    };
+
+    const base: CreateDailySummaryInput = {
+      TickerID: 'NSDQ:AAPL',
+      ExchangeID: 'NASDAQ',
+      Date: '2026-02-27',
+      Open: 105,
+      High: 112,
+      Low: 104,
+      Close: 108,
+    };
+
+    it('正常系: Evaluation* が書き込まれ getByTickerAndDate で取得できる', async () => {
+      await repository.upsert(base);
+
+      await repository.markAsEvaluated({ tickerId: base.TickerID, date: base.Date }, fields);
+
+      const after = await repository.getByTickerAndDate(base.TickerID, base.Date);
+      expect(after).not.toBeNull();
+      expect(after).toMatchObject(fields);
+      expect(after?.Open).toBe(base.Open);
+    });
+
+    it('対象 DailySummary が存在しないとき EntityNotFoundError', async () => {
+      await expect(
+        repository.markAsEvaluated({ tickerId: 'NSDQ:UNKNOWN', date: '2026-02-27' }, fields)
+      ).rejects.toBeInstanceOf(EntityNotFoundError);
+    });
+
+    it('既に採点済みのとき EntityAlreadyExistsError（二重採点防止）', async () => {
+      await repository.upsert(base);
+      await repository.markAsEvaluated({ tickerId: base.TickerID, date: base.Date }, fields);
+
+      await expect(
+        repository.markAsEvaluated({ tickerId: base.TickerID, date: base.Date }, fields)
+      ).rejects.toBeInstanceOf(EntityAlreadyExistsError);
+    });
+
+    it('採点後でも upsert は通常通り上書きできる（既存メソッドへの影響なし）', async () => {
+      await repository.upsert(base);
+      await repository.markAsEvaluated({ tickerId: base.TickerID, date: base.Date }, fields);
+
+      const updated = await repository.upsert({ ...base, Close: 120 });
+
+      expect(updated.Close).toBe(120);
+      // upsert は Evaluation* を保持しない（CreateDailySummaryInput には Evaluation* がないため）
+      expect(updated.EvaluatedAt).toBeUndefined();
     });
   });
 });

--- a/tasks/stock-tracer-prediction-evaluation/tasks.md
+++ b/tasks/stock-tracer-prediction-evaluation/tasks.md
@@ -131,7 +131,7 @@ UI を先行実装し、dev 環境で実物を確認できる状態にする。A
 
 A 案を採用し、独立エンティティではなく既存 `DailySummaryEntity` に Evaluation\* optional フィールドを追加する。新規 mapper / repository / GSI は作成しない。
 
-- [ ] `core/src/entities/daily-summary.entity.ts` を更新
+- [x] `core/src/entities/daily-summary.entity.ts` を更新
     - 以下 6 つの optional フィールドを追加（`design.md` §2.1 参照。作業 2 の FB で増減する可能性あり）
         - `EvaluationDate?: string`
         - `EvaluationClose?: number`
@@ -140,24 +140,25 @@ A 案を採用し、独立エンティティではなく既存 `DailySummaryEnti
         - `EvaluationThresholdPercent?: number`
         - `EvaluatedAt?: number`
     - 既存の `CreateDailySummaryInput` 型は `Omit<...>` ベースなので追加対応のみ
-- [ ] `core/src/mappers/daily-summary.mapper.ts` を更新
+- [x] `core/src/mappers/daily-summary.mapper.ts` を更新
     - `toItem`：Evaluation\* を spread 条件付きで item に含める（既存 `AiAnalysisResult` 等と同パターン）
     - `toEntity`：Evaluation\* を validation 関数で読み出す（不在時 undefined）
-- [ ] `core/src/repositories/daily-summary.repository.interface.ts` を更新
+- [x] `core/src/repositories/daily-summary.repository.interface.ts` を更新
     - `markAsEvaluated(key, fields)` メソッド追加（`design.md` §3.3 参照）
     - `getByExchangeAndDateRange(exchangeId, fromDate, toDate)` メソッド追加（既存 `getByExchange` は単一日付 / 最新日のみ対応のため、期間集計用に新設）
-- [ ] `core/src/repositories/dynamodb-daily-summary.repository.ts`（既存）を更新
-    - `markAsEvaluated` を実装。`UpdateItemCommand` で `SET` 句、条件式 `attribute_not_exists(EvaluatedAt)`
-    - `ConditionalCheckFailedException` を独自エラーに変換するか throw 直し（呼び出し側で skip 判定可能にする）
-    - `getByExchangeAndDateRange` を実装。GSI4 で `KeyConditionExpression: #gsi4pk = :exchangeId AND #gsi4sk BETWEEN :from AND :to`、`:from = "DATE#" + fromDate`、`:to = "DATE#" + toDate + "#~"`（`#~` は最大ソート文字、ticker 横断で当該日付までを含めるため）
-- [ ] `core/src/repositories/in-memory-daily-summary.repository.ts`（既存があれば）を更新
-    - `markAsEvaluated` / `getByExchangeAndDateRange` を実装。前者は既に `EvaluatedAt` がある場合に同じ条件でエラーを投げる
-- [ ] `core/src/index.ts` の export はインタフェース経由なので追加対応最小
-- [ ] ユニットテスト
-    - mapper：Evaluation\* 全 6 フィールドの round-trip、optional 不在時、partial（一部のみ存在）の場合の挙動を網羅
-    - dynamodb repository：`markAsEvaluated` の正常系・条件式違反・既存 update メソッドへの影響なし
-    - in-memory repository：`markAsEvaluated` の正常系と二重採点エラー
-- [ ] カバレッジ 80% 以上を確認
+    - 採点結果フィールド集合を `DailySummaryEvaluationFields` として型エクスポート（呼び出し側で再利用）
+- [x] `core/src/repositories/dynamodb-daily-summary.repository.ts`（既存）を更新
+    - `markAsEvaluated` を実装。`UpdateCommand` で `SET` 句、条件式 `attribute_exists(PK) AND attribute_not_exists(EvaluatedAt)`
+    - `ConditionalCheckFailedException` を `EntityNotFoundError` / `EntityAlreadyExistsError` に変換（再 GetItem で 404 と既採点を区別、呼び出し側で skip 判定可能）
+    - `getByExchangeAndDateRange` を実装。GSI4 で `KeyConditionExpression: #gsi4pk = :exchangeId AND #gsi4sk BETWEEN :from AND :to`、`:from = "DATE#" + fromDate`、`:to = "DATE#" + toDate + "#~"`（`#~` は最大ソート文字、ticker 横断で当該日付までを含めるため）。LastEvaluatedKey ループ対応
+- [x] `core/src/repositories/in-memory-daily-summary.repository.ts` を更新
+    - `markAsEvaluated` / `getByExchangeAndDateRange` を実装。前者は既に `EvaluatedAt` がある場合に `EntityAlreadyExistsError`、対象不在時に `EntityNotFoundError` を投げる
+- [x] `core/src/index.ts` から `DailySummaryEvaluationFields` を追加 export
+- [x] ユニットテスト
+    - mapper：Evaluation\* 全 6 フィールドの round-trip、optional 不在時、partial（一部のみ存在）、boolean / timestamp 型不正、AI/Pattern との共存を網羅
+    - dynamodb repository：`markAsEvaluated` の正常系・条件式違反（既採点 / 未存在の区別）・DB エラー、`getByExchangeAndDateRange` の BETWEEN クエリ・ページング・DB エラー
+    - in-memory repository：`markAsEvaluated` の正常系・二重採点エラー・未存在エラー、`getByExchangeAndDateRange` の範囲フィルタ・空配列
+- [x] カバレッジ 80% 以上を確認（mapper 87.87% / dynamodb 100% statements / in-memory 100% statements）
 
 **完了条件**: PR レビューが通り、`@nagiyu/stock-tracker-core` の既存テストがすべて green かつ追加テストも green、integration にマージ。
 


### PR DESCRIPTION
## 変更の概要

親 Issue #3018（Stock Tracer 予測精度の自動採点・可視化基盤 / Phase 1）の **作業 3**。
採点バッチ・集計 API のための基盤として、既存 `DailySummaryEntity` に Evaluation\* フィールド 6 個を統合し、`DailySummaryRepository` に採点用の 2 メソッドを追加する。

採点結果は独立エンティティとせず既存 DailySummary に統合する方針（A 案、`design.md` §2.1）。新規 mapper / repository / GSI は追加しない。

## 関連 Issue

#3025

<!-- Issue は integration → develop マージ後にクローズするため Closes は付けない -->

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（`tasks/stock-tracer-prediction-evaluation/tasks.md` の作業 3 チェックボックス更新）
- [x] ローカルでテストが全て通ることを確認した（52 suites / 732 tests passed）
- [x] ビルドエラーがないことを確認した（`tsc` clean、`eslint` clean、`prettier --check` clean）

## 主な変更

### Entity
- `DailySummaryEntity` に optional 6 フィールド追加: `EvaluationDate` / `EvaluationClose` / `ActualReturn` / `Hit` / `EvaluationThresholdPercent` / `EvaluatedAt`

### Mapper
- `toItem` / `toEntity` に Evaluation\* の入出力を追加（既存 `AiAnalysisResult` パターン踏襲）
- `validateBooleanField` を `Hit` に、`validateTimestampField` を `EvaluatedAt` に適用

### Repository Interface
- 採点結果フィールド集合を `DailySummaryEvaluationFields` 型として export
- `markAsEvaluated(key, fields): Promise<void>` を追加
- `getByExchangeAndDateRange(exchangeId, fromDate, toDate): Promise<DailySummaryEntity[]>` を追加

### DynamoDB 実装
- `markAsEvaluated`: 条件付き `UpdateCommand`（`attribute_exists(PK) AND attribute_not_exists(EvaluatedAt)`）。`ConditionalCheckFailedException` を `EntityNotFoundError` / `EntityAlreadyExistsError` に変換し、再 `GetItem` で 404 と既採点を区別する
- `getByExchangeAndDateRange`: GSI4（`ExchangeSummaryIndex`）を `BETWEEN DATE#{from} AND DATE#{to}#~` で Query。`~` で `toDate` の全 ticker を含める。`LastEvaluatedKey` ループ対応

### InMemory 実装
- 同等実装。`EvaluatedAt` が既存の場合 `EntityAlreadyExistsError`、対象不在時 `EntityNotFoundError`

## テスト内容

- **mapper**: Evaluation\* 全 6 フィールドの round-trip、`Hit=false` ケース、optional 全不在、partial（一部のみ）、`Hit` の型不正、`EvaluatedAt` の型不正、既存（AiAnalysisResult / PatternResults）との共存
- **dynamodb repository**:
  - `markAsEvaluated`: 正常系（UpdateCommand 内容検証）、既採点で `EntityAlreadyExistsError`、未存在で `EntityNotFoundError`、DB エラーで `DatabaseError`
  - `getByExchangeAndDateRange`: BETWEEN クエリ生成、複数ページの連結、DB エラー
- **in-memory repository**:
  - `markAsEvaluated`: 正常系、二重採点エラー、未存在エラー、採点後の upsert 動作
  - `getByExchangeAndDateRange`: 範囲フィルタ、範囲外除外、空配列

### カバレッジ

| ファイル | Statement | Branch | Function | Line |
|---|---|---|---|---|
| `daily-summary.mapper.ts` | 87.87% | 93.58% | 100% | 87.87% |
| `dynamodb-daily-summary.repository.ts` | 100% | 73.91% | 100% | 100% |
| `in-memory-daily-summary.repository.ts` | 100% | 100% | 100% | 100% |

いずれも 80% threshold をクリア。

## レビューポイント

- **境界文字 `~`**: GSI4SK の BETWEEN で `toDate#~` を上限としているが、これは `~` (0x7E) が ASCII で `#` (0x23) より大きく、ticker ID に通常含まれない文字であることを前提とした実装。`design.md` §2.2 の方針に準拠
- **`ConditionalCheckFailedException` の取り扱い**: 条件式が `attribute_exists(PK) AND attribute_not_exists(EvaluatedAt)` の複合のため、違反理由を区別するには再 GetItem が必要。N+1 ではあるが採点バッチでは 1 件ずつの書き込みなのでコストは許容できる判断
- **`upsert` は Evaluation\* を保持しない**: `CreateDailySummaryInput` 経由で Evaluation\* を渡せば書き込めるが、既存呼び出し側は Evaluation\* を知らないため実質的に `upsert` は採点状態をクリアする挙動。in-memory test の最後にこの挙動をドキュメント化。実害が出るのは「採点後に同日の summary を再生成」する場合のみで、現状そういう運用はないため Phase 1 では対応不要と判断

## 補足事項

- `tasks/stock-tracer-prediction-evaluation/tasks.md` の作業 3 チェックボックスを完了状態に更新
- 次の作業 4（`prediction-judger.ts` / `prediction-aggregator.ts`）は本 PR の `DailySummaryEvaluationFields` 型と `EvaluatedDailySummary` の派生型を利用する想定


---
_Generated by [Claude Code](https://claude.ai/code/session_017EkihmtiLCsUfyCAcv1xAz)_