### PR TITLE
feat(stock-tracker): 予測精度の判定/集計ロジックを純粋関数として追加（#3026）

### DIFF
--- a/services/stock-tracker/core/src/index.ts
+++ b/services/stock-tracker/core/src/index.ts
@@ -112,6 +112,8 @@ export * from './services/alert-evaluator.js';
 export * from './services/price-calculator.js';
 export * from './services/trading-hours-checker.js';
 export * from './services/tradingview-client.js';
+export * from './services/prediction-judger.js';
+export * from './services/prediction-aggregator.js';
 
 // マッパー（新規エクスポート）
 export { AlertMapper } from './mappers/alert.mapper.js';

--- a/services/stock-tracker/core/src/services/prediction-aggregator.ts
+++ b/services/stock-tracker/core/src/services/prediction-aggregator.ts
@@ -1,0 +1,164 @@
+/**
+ * Stock Tracker Core - Prediction Aggregator Service
+ *
+ * 採点済み DailySummary の配列から、予測精度ダッシュボード用の集計値を算出する純粋関数。
+ *
+ * Phase 1 仕様（design.md §3.3、external-design.md ADR-003〜005）:
+ * - KPI: 総合精度 / 方向精度（BULLISH+BEARISH のみ） / 判定済み件数
+ * - bySignal: シグナル別の的中率と件数（BULLISH / NEUTRAL / BEARISH の 3 種類を常に返す）
+ * - dailyTrend: 予測日 (DailySummary.Date) でグルーピングした方向精度推移
+ *
+ * 入力は採点済み（Evaluation* 全埋まり、AiAnalysisResult あり、AiAnalysisError なし）に
+ * 絞った配列を渡す前提だが、防御的に AiAnalysisError ありや AiAnalysisResult 不在は除外する。
+ *
+ * 空入力時は `accuracy = null`、`count = 0` を返す。
+ */
+
+import type { DailySummaryEntity } from '../entities/daily-summary.entity.js';
+import type { AiAnalysisResult, InvestmentSignal } from '../ai-analysis-result.js';
+
+/**
+ * 採点済み DailySummary 型（Evaluation* と AiAnalysisResult が埋まっていることを保証）
+ *
+ * `AggregateInput.evaluated` は呼び出し側でこの型に絞ってから渡す前提。
+ */
+export type EvaluatedDailySummary = DailySummaryEntity & {
+  EvaluationDate: string;
+  EvaluationClose: number;
+  ActualReturn: number;
+  Hit: boolean;
+  EvaluationThresholdPercent: number;
+  EvaluatedAt: number;
+  AiAnalysisResult: AiAnalysisResult;
+};
+
+/**
+ * 集計入力
+ */
+export interface AggregateInput {
+  evaluated: EvaluatedDailySummary[];
+}
+
+/**
+ * 集計出力（SummaryResponse の kpi / bySignal / dailyTrend と一致）
+ */
+export interface AggregateOutput {
+  kpi: {
+    /** 総合精度（%）。判定済み 0 件なら null */
+    totalAccuracy: number | null;
+    /** 方向精度（%、BULLISH + BEARISH のみ）。0 件なら null */
+    directionalAccuracy: number | null;
+    /** 判定済み件数 */
+    judgedCount: number;
+  };
+  bySignal: Array<{
+    signal: InvestmentSignal;
+    accuracy: number | null;
+    count: number;
+  }>;
+  dailyTrend: Array<{
+    /** 予測日 (YYYY-MM-DD) */
+    date: string;
+    /** その日の方向精度（BULLISH + BEARISH のみ）。0 件なら null */
+    directionalAccuracy: number | null;
+    /** その日の判定済み件数（NEUTRAL を含む） */
+    judgedCount: number;
+  }>;
+}
+
+/**
+ * bySignal の出力順序。常にこの順で 3 件返す（count=0 でも省略しない）
+ */
+const SIGNAL_ORDER: readonly InvestmentSignal[] = ['BULLISH', 'NEUTRAL', 'BEARISH'];
+
+/**
+ * 採点済み DailySummary 配列を集計する。
+ *
+ * @param input - 集計入力
+ * @returns KPI / bySignal / dailyTrend を含む集計結果
+ */
+export function aggregateEvaluatedSummaries(input: AggregateInput): AggregateOutput {
+  // 防御的フィルタ：AiAnalysisError ありや AiAnalysisResult 不在を除外
+  const evaluated = input.evaluated.filter(
+    (summary) => summary.AiAnalysisResult !== undefined && summary.AiAnalysisError === undefined
+  );
+
+  const judgedCount = evaluated.length;
+
+  // KPI: totalAccuracy
+  const totalAccuracy = judgedCount === 0 ? null : toPercent(countHits(evaluated), judgedCount);
+
+  // KPI: directionalAccuracy
+  const directional = evaluated.filter(
+    (summary) =>
+      summary.AiAnalysisResult.investmentJudgment.signal === 'BULLISH' ||
+      summary.AiAnalysisResult.investmentJudgment.signal === 'BEARISH'
+  );
+  const directionalAccuracy =
+    directional.length === 0 ? null : toPercent(countHits(directional), directional.length);
+
+  // bySignal
+  const bySignal = SIGNAL_ORDER.map((signal) => {
+    const subset = evaluated.filter(
+      (summary) => summary.AiAnalysisResult.investmentJudgment.signal === signal
+    );
+    return {
+      signal,
+      accuracy: subset.length === 0 ? null : toPercent(countHits(subset), subset.length),
+      count: subset.length,
+    };
+  });
+
+  // dailyTrend: 予測日 (DailySummary.Date) でグルーピング
+  const byDate = new Map<string, EvaluatedDailySummary[]>();
+  for (const summary of evaluated) {
+    const list = byDate.get(summary.Date);
+    if (list === undefined) {
+      byDate.set(summary.Date, [summary]);
+    } else {
+      list.push(summary);
+    }
+  }
+
+  const dailyTrend = Array.from(byDate.entries())
+    .map(([date, list]) => {
+      const directionalSubset = list.filter(
+        (summary) =>
+          summary.AiAnalysisResult.investmentJudgment.signal === 'BULLISH' ||
+          summary.AiAnalysisResult.investmentJudgment.signal === 'BEARISH'
+      );
+      return {
+        date,
+        directionalAccuracy:
+          directionalSubset.length === 0
+            ? null
+            : toPercent(countHits(directionalSubset), directionalSubset.length),
+        judgedCount: list.length,
+      };
+    })
+    .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  return {
+    kpi: {
+      totalAccuracy,
+      directionalAccuracy,
+      judgedCount,
+    },
+    bySignal,
+    dailyTrend,
+  };
+}
+
+function countHits(summaries: EvaluatedDailySummary[]): number {
+  return summaries.reduce((acc, summary) => acc + (summary.Hit ? 1 : 0), 0);
+}
+
+/**
+ * 的中数と全体件数からパーセント値を算出し、小数第 1 位に丸める。
+ *
+ * @param hits - 的中件数
+ * @param total - 全体件数（必ず 1 以上であること）
+ */
+function toPercent(hits: number, total: number): number {
+  return Math.round((hits / total) * 1000) / 10;
+}

--- a/services/stock-tracker/core/src/services/prediction-judger.ts
+++ b/services/stock-tracker/core/src/services/prediction-judger.ts
@@ -1,0 +1,100 @@
+/**
+ * Stock Tracker Core - Prediction Judger Service
+ *
+ * AI 予測（投資判断シグナル）と翌営業日終値リターンから Hit / Miss を判定する純粋関数。
+ *
+ * Phase 1 仕様:
+ * - 入力: 予測シグナル (BULLISH / NEUTRAL / BEARISH)、基準終値、翌営業日終値、閾値 (%)
+ * - 出力: 実績リターン (%) と Hit 判定
+ *
+ * 境界値仕様（design.md §3.4）:
+ * - BULLISH: r >= +threshold（以上、境界値を成功に含める）
+ * - BEARISH: r <= -threshold（以下、境界値を成功に含める）
+ * - NEUTRAL: -threshold < r < +threshold（より大きく / より小さく、境界値は方向側に分類）
+ *
+ * これにより `r = +0.5` ちょうどは「BULLISH なら成功 / NEUTRAL なら失敗」となり重複しない。
+ */
+
+import type { InvestmentSignal } from '../ai-analysis-result.js';
+
+/**
+ * エラーメッセージ定数
+ */
+export const PREDICTION_JUDGER_ERROR_MESSAGES = {
+  INVALID_BASE_CLOSE: '無効な基準終値です。基準終値は正の有限な数値である必要があります',
+  INVALID_EVALUATION_CLOSE: '無効な採点終値です。採点終値は正の有限な数値である必要があります',
+  INVALID_THRESHOLD: '無効な閾値です。閾値は正の有限な数値である必要があります',
+  INVALID_SIGNAL: '無効な投資判断シグナルです',
+} as const;
+
+/**
+ * `judgePrediction` の入力
+ */
+export interface JudgeInput {
+  /** AI が出した予測シグナル */
+  signal: InvestmentSignal;
+  /** 予測当日の終値 */
+  baseClose: number;
+  /** 翌営業日の終値 */
+  evaluationClose: number;
+  /** Hit 判定に使う閾値 (%)。Phase 1 では 0.5 を渡す */
+  thresholdPercent: number;
+}
+
+/**
+ * `judgePrediction` の出力
+ */
+export interface JudgeResult {
+  /** 実績リターン (%): (evaluationClose - baseClose) / baseClose * 100 */
+  actualReturn: number;
+  /** Hit / Miss 判定 */
+  hit: boolean;
+}
+
+/**
+ * 投資判断シグナルと翌営業日終値リターンから Hit / Miss を判定する。
+ *
+ * @param input - 判定入力
+ * @returns 実績リターンと Hit 判定
+ * @throws Error - 入力値が不正な場合
+ */
+export function judgePrediction(input: JudgeInput): JudgeResult {
+  const { signal, baseClose, evaluationClose, thresholdPercent } = input;
+
+  if (typeof baseClose !== 'number' || !isFinite(baseClose) || baseClose <= 0) {
+    throw new Error(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_BASE_CLOSE);
+  }
+
+  if (typeof evaluationClose !== 'number' || !isFinite(evaluationClose) || evaluationClose <= 0) {
+    throw new Error(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_EVALUATION_CLOSE);
+  }
+
+  if (
+    typeof thresholdPercent !== 'number' ||
+    !isFinite(thresholdPercent) ||
+    thresholdPercent <= 0
+  ) {
+    throw new Error(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_THRESHOLD);
+  }
+
+  const actualReturn = ((evaluationClose - baseClose) / baseClose) * 100;
+
+  let hit: boolean;
+  switch (signal) {
+    case 'BULLISH':
+      hit = actualReturn >= thresholdPercent;
+      break;
+    case 'BEARISH':
+      hit = actualReturn <= -thresholdPercent;
+      break;
+    case 'NEUTRAL':
+      hit = actualReturn > -thresholdPercent && actualReturn < thresholdPercent;
+      break;
+    default: {
+      const exhaustive: never = signal;
+      throw new Error(`${PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_SIGNAL}: ${String(exhaustive)}`);
+    }
+  }
+
+  return { actualReturn, hit };
+}

--- a/services/stock-tracker/core/tests/unit/services/prediction-aggregator.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/prediction-aggregator.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Stock Tracker Core - Prediction Aggregator Service Unit Tests
+ *
+ * 集計ロジックのユニットテスト。空入力 / 全 Hit / 全 Miss / 複数取引所 / 複数銘柄 /
+ * AiAnalysisError 混在のバリエーションをカバーする。
+ */
+
+import {
+  aggregateEvaluatedSummaries,
+  type EvaluatedDailySummary,
+} from '../../../src/services/prediction-aggregator.js';
+import type { InvestmentSignal } from '../../../src/ai-analysis-result.js';
+
+/**
+ * テスト用の採点済み DailySummary を生成するヘルパ。
+ * 不要な既存フィールドはデフォルト値で埋める。
+ */
+const makeEvaluated = (overrides: {
+  tickerId?: string;
+  exchangeId?: string;
+  date: string;
+  signal: InvestmentSignal;
+  hit: boolean;
+  actualReturn?: number;
+}): EvaluatedDailySummary => ({
+  TickerID: overrides.tickerId ?? 'TICKER1',
+  ExchangeID: overrides.exchangeId ?? 'EX1',
+  Date: overrides.date,
+  Open: 100,
+  High: 105,
+  Low: 95,
+  Close: 100,
+  EvaluationDate: '2026-05-12',
+  EvaluationClose: 101,
+  ActualReturn: overrides.actualReturn ?? (overrides.hit ? 1.0 : 0.0),
+  Hit: overrides.hit,
+  EvaluationThresholdPercent: 0.5,
+  EvaluatedAt: 1_715_000_000_000,
+  AiAnalysisResult: {
+    priceMovementAnalysis: 'dummy',
+    patternAnalysis: 'dummy',
+    supportLevels: [90, 88, 85],
+    resistanceLevels: [110, 113, 115],
+    relatedMarketTrend: 'dummy',
+    investmentJudgment: {
+      signal: overrides.signal,
+      reason: 'dummy',
+    },
+  },
+  CreatedAt: 1_715_000_000_000,
+  UpdatedAt: 1_715_000_000_000,
+});
+
+describe('Prediction Aggregator Service', () => {
+  describe('aggregateEvaluatedSummaries - 空入力', () => {
+    it('入力が空配列のとき、KPI は null / 0、dailyTrend は空、bySignal は 3 シグナル分の 0 件エントリ', () => {
+      const result = aggregateEvaluatedSummaries({ evaluated: [] });
+
+      expect(result.kpi).toEqual({
+        totalAccuracy: null,
+        directionalAccuracy: null,
+        judgedCount: 0,
+      });
+      expect(result.dailyTrend).toEqual([]);
+      expect(result.bySignal).toEqual([
+        { signal: 'BULLISH', accuracy: null, count: 0 },
+        { signal: 'NEUTRAL', accuracy: null, count: 0 },
+        { signal: 'BEARISH', accuracy: null, count: 0 },
+      ]);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - 全 Hit', () => {
+    it('すべて Hit のとき、totalAccuracy と directionalAccuracy が 100', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'BEARISH', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: true }),
+        ],
+      });
+
+      expect(result.kpi.totalAccuracy).toBe(100);
+      expect(result.kpi.directionalAccuracy).toBe(100);
+      expect(result.kpi.judgedCount).toBe(3);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - 全 Miss', () => {
+    it('すべて Miss のとき、totalAccuracy と directionalAccuracy が 0', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: false }),
+          makeEvaluated({ date: '2026-05-10', signal: 'BEARISH', hit: false }),
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: false }),
+        ],
+      });
+
+      expect(result.kpi.totalAccuracy).toBe(0);
+      expect(result.kpi.directionalAccuracy).toBe(0);
+      expect(result.kpi.judgedCount).toBe(3);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - 混在', () => {
+    it('混在の場合、的中率を小数第 1 位に丸めて返す', () => {
+      // BULLISH: 2 Hit / 3 = 66.666...% → 66.7
+      // BEARISH: 1 Hit / 2 = 50.0%
+      // NEUTRAL: 0 Hit / 1 = 0.0%
+      // 全体: 3 / 6 = 50.0%
+      // directional: 3 / 5 = 60.0%
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: false }),
+          makeEvaluated({ date: '2026-05-10', signal: 'BEARISH', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'BEARISH', hit: false }),
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: false }),
+        ],
+      });
+
+      expect(result.kpi.totalAccuracy).toBe(50);
+      expect(result.kpi.directionalAccuracy).toBe(60);
+      expect(result.kpi.judgedCount).toBe(6);
+
+      expect(result.bySignal).toEqual([
+        { signal: 'BULLISH', accuracy: 66.7, count: 3 },
+        { signal: 'NEUTRAL', accuracy: 0, count: 1 },
+        { signal: 'BEARISH', accuracy: 50, count: 2 },
+      ]);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - directionalAccuracy（BULLISH+BEARISH のみ）', () => {
+    it('NEUTRAL しかない場合、directionalAccuracy は null', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: false }),
+        ],
+      });
+
+      expect(result.kpi.totalAccuracy).toBe(50);
+      expect(result.kpi.directionalAccuracy).toBeNull();
+      expect(result.kpi.judgedCount).toBe(2);
+    });
+
+    it('BULLISH+BEARISH のみで計算し、NEUTRAL は除外する', () => {
+      // BULLISH 1 Hit + BEARISH 1 Miss + NEUTRAL 1 Hit
+      // directional = 1 / 2 = 50%
+      // total = 2 / 3 ≈ 66.7%
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'BEARISH', hit: false }),
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: true }),
+        ],
+      });
+
+      expect(result.kpi.totalAccuracy).toBe(66.7);
+      expect(result.kpi.directionalAccuracy).toBe(50);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - dailyTrend', () => {
+    it('予測日 (DailySummary.Date) でグルーピングし、日付昇順で返す', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({ date: '2026-05-08', signal: 'BULLISH', hit: true }),
+          makeEvaluated({ date: '2026-05-09', signal: 'BULLISH', hit: false }),
+          makeEvaluated({ date: '2026-05-09', signal: 'BEARISH', hit: true }),
+          // わざと逆順で渡す → 出力は昇順になるはず
+          makeEvaluated({ date: '2026-05-07', signal: 'BEARISH', hit: true }),
+        ],
+      });
+
+      expect(result.dailyTrend.map((p) => p.date)).toEqual([
+        '2026-05-07',
+        '2026-05-08',
+        '2026-05-09',
+      ]);
+
+      const day9 = result.dailyTrend.find((p) => p.date === '2026-05-09');
+      expect(day9).toEqual({
+        date: '2026-05-09',
+        directionalAccuracy: 50, // 1 Hit / 2
+        judgedCount: 2,
+      });
+    });
+
+    it('NEUTRAL しかない日は directionalAccuracy = null、judgedCount > 0', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: false }),
+        ],
+      });
+
+      expect(result.dailyTrend).toEqual([
+        {
+          date: '2026-05-10',
+          directionalAccuracy: null,
+          judgedCount: 2,
+        },
+      ]);
+    });
+
+    it('予測がない日のエントリは含まない（連続性を保証しない）', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({ date: '2026-05-08', signal: 'BULLISH', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true }),
+        ],
+      });
+
+      expect(result.dailyTrend).toHaveLength(2);
+      expect(result.dailyTrend.map((p) => p.date)).toEqual(['2026-05-08', '2026-05-10']);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - 複数取引所 / 複数銘柄', () => {
+    it('取引所横断でも合算され、シグナル別 / 日次推移が一意の集計を返す', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          // 同じ日に取引所 A の 2 銘柄
+          makeEvaluated({
+            date: '2026-05-10',
+            exchangeId: 'TSE',
+            tickerId: 'A1',
+            signal: 'BULLISH',
+            hit: true,
+          }),
+          makeEvaluated({
+            date: '2026-05-10',
+            exchangeId: 'TSE',
+            tickerId: 'A2',
+            signal: 'BEARISH',
+            hit: false,
+          }),
+          // 同じ日に取引所 B の 1 銘柄
+          makeEvaluated({
+            date: '2026-05-10',
+            exchangeId: 'NYSE',
+            tickerId: 'B1',
+            signal: 'BULLISH',
+            hit: true,
+          }),
+        ],
+      });
+
+      expect(result.kpi.judgedCount).toBe(3);
+      // BULLISH 2/2 + BEARISH 0/1 → directional = 2/3 ≈ 66.7
+      expect(result.kpi.directionalAccuracy).toBe(66.7);
+      expect(result.dailyTrend).toEqual([
+        {
+          date: '2026-05-10',
+          directionalAccuracy: 66.7,
+          judgedCount: 3,
+        },
+      ]);
+    });
+
+    it('同じ日付・同じ銘柄が複数あっても件数として加算する（防御）', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          makeEvaluated({
+            date: '2026-05-10',
+            tickerId: 'A1',
+            signal: 'BULLISH',
+            hit: true,
+          }),
+          makeEvaluated({
+            date: '2026-05-10',
+            tickerId: 'A1',
+            signal: 'BULLISH',
+            hit: false,
+          }),
+        ],
+      });
+
+      expect(result.kpi.judgedCount).toBe(2);
+      expect(result.kpi.totalAccuracy).toBe(50);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - 防御的フィルタ', () => {
+    it('AiAnalysisError がある summary は集計から除外する', () => {
+      const valid = makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true });
+      const withError = {
+        ...makeEvaluated({ date: '2026-05-10', signal: 'BEARISH', hit: false }),
+        AiAnalysisError: 'OpenAI rate limit',
+      };
+
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [valid, withError as EvaluatedDailySummary],
+      });
+
+      expect(result.kpi.judgedCount).toBe(1);
+      expect(result.kpi.totalAccuracy).toBe(100);
+      expect(result.bySignal.find((s) => s.signal === 'BEARISH')).toEqual({
+        signal: 'BEARISH',
+        accuracy: null,
+        count: 0,
+      });
+    });
+
+    it('AiAnalysisResult が undefined の summary は集計から除外する', () => {
+      const valid = makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true });
+      const withoutResult = {
+        ...makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: false }),
+        AiAnalysisResult: undefined,
+      };
+
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [valid, withoutResult as unknown as EvaluatedDailySummary],
+      });
+
+      expect(result.kpi.judgedCount).toBe(1);
+      expect(result.kpi.totalAccuracy).toBe(100);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - bySignal の順序', () => {
+    it('bySignal は常に BULLISH → NEUTRAL → BEARISH の順序で返す（count=0 でも省略しない）', () => {
+      const result = aggregateEvaluatedSummaries({
+        evaluated: [
+          // 投入順は BEARISH → NEUTRAL → BULLISH
+          makeEvaluated({ date: '2026-05-10', signal: 'BEARISH', hit: true }),
+          makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: true }),
+        ],
+      });
+
+      expect(result.bySignal.map((s) => s.signal)).toEqual(['BULLISH', 'NEUTRAL', 'BEARISH']);
+      expect(result.bySignal[0]).toEqual({
+        signal: 'BULLISH',
+        accuracy: null,
+        count: 0,
+      });
+    });
+  });
+});

--- a/services/stock-tracker/core/tests/unit/services/prediction-judger.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/prediction-judger.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Stock Tracker Core - Prediction Judger Service Unit Tests
+ *
+ * 採点判定ロジックのユニットテスト。シグナル × 境界値の網羅
+ * （境界値ちょうど + 内側 + 外側）と入力バリデーションをカバーする。
+ */
+
+import {
+  judgePrediction,
+  PREDICTION_JUDGER_ERROR_MESSAGES,
+  type JudgeInput,
+} from '../../../src/services/prediction-judger.js';
+
+describe('Prediction Judger Service', () => {
+  /**
+   * 任意のリターン率になるよう `evaluationClose` を逆算するヘルパ。
+   * baseClose = 100 のとき：
+   *   evaluationClose = 100 + returnPercent
+   */
+  const buildInput = (
+    signal: JudgeInput['signal'],
+    returnPercent: number,
+    thresholdPercent = 0.5
+  ): JudgeInput => ({
+    signal,
+    baseClose: 100,
+    evaluationClose: 100 + returnPercent,
+    thresholdPercent,
+  });
+
+  describe('judgePrediction - actualReturn 計算', () => {
+    it('終値が上昇した場合、正のリターンを返す', () => {
+      const result = judgePrediction({
+        signal: 'BULLISH',
+        baseClose: 100,
+        evaluationClose: 105,
+        thresholdPercent: 0.5,
+      });
+      expect(result.actualReturn).toBeCloseTo(5, 10);
+    });
+
+    it('終値が下落した場合、負のリターンを返す', () => {
+      const result = judgePrediction({
+        signal: 'BEARISH',
+        baseClose: 100,
+        evaluationClose: 95,
+        thresholdPercent: 0.5,
+      });
+      expect(result.actualReturn).toBeCloseTo(-5, 10);
+    });
+
+    it('終値変動なしの場合、0 を返す', () => {
+      const result = judgePrediction({
+        signal: 'NEUTRAL',
+        baseClose: 200,
+        evaluationClose: 200,
+        thresholdPercent: 0.5,
+      });
+      expect(result.actualReturn).toBe(0);
+    });
+
+    it('小数の終値でも正しく算出する', () => {
+      const result = judgePrediction({
+        signal: 'BULLISH',
+        baseClose: 250.5,
+        evaluationClose: 252.0,
+        thresholdPercent: 0.5,
+      });
+      // (252.0 - 250.5) / 250.5 * 100 ≈ 0.5988...
+      expect(result.actualReturn).toBeCloseTo(0.5988, 3);
+    });
+  });
+
+  describe('judgePrediction - BULLISH（境界値: >= +threshold）', () => {
+    it('リターンが閾値ちょうど (+0.5%) なら Hit', () => {
+      const result = judgePrediction(buildInput('BULLISH', 0.5));
+      expect(result.hit).toBe(true);
+    });
+
+    it('リターンが閾値より大きい (+1.0%) なら Hit', () => {
+      const result = judgePrediction(buildInput('BULLISH', 1.0));
+      expect(result.hit).toBe(true);
+    });
+
+    it('リターンが閾値未満 (+0.4%) なら Miss', () => {
+      const result = judgePrediction(buildInput('BULLISH', 0.4));
+      expect(result.hit).toBe(false);
+    });
+
+    it('リターンが負 (-0.5%) なら Miss', () => {
+      const result = judgePrediction(buildInput('BULLISH', -0.5));
+      expect(result.hit).toBe(false);
+    });
+
+    it('リターンが 0 なら Miss', () => {
+      const result = judgePrediction(buildInput('BULLISH', 0));
+      expect(result.hit).toBe(false);
+    });
+  });
+
+  describe('judgePrediction - BEARISH（境界値: <= -threshold）', () => {
+    it('リターンが負の閾値ちょうど (-0.5%) なら Hit', () => {
+      const result = judgePrediction(buildInput('BEARISH', -0.5));
+      expect(result.hit).toBe(true);
+    });
+
+    it('リターンが負の閾値より小さい (-1.0%) なら Hit', () => {
+      const result = judgePrediction(buildInput('BEARISH', -1.0));
+      expect(result.hit).toBe(true);
+    });
+
+    it('リターンが負の閾値より大きい (-0.4%) なら Miss', () => {
+      const result = judgePrediction(buildInput('BEARISH', -0.4));
+      expect(result.hit).toBe(false);
+    });
+
+    it('リターンが正 (+0.5%) なら Miss', () => {
+      const result = judgePrediction(buildInput('BEARISH', 0.5));
+      expect(result.hit).toBe(false);
+    });
+
+    it('リターンが 0 なら Miss', () => {
+      const result = judgePrediction(buildInput('BEARISH', 0));
+      expect(result.hit).toBe(false);
+    });
+  });
+
+  describe('judgePrediction - NEUTRAL（境界値: -threshold < r < +threshold）', () => {
+    it('リターンが 0 なら Hit', () => {
+      const result = judgePrediction(buildInput('NEUTRAL', 0));
+      expect(result.hit).toBe(true);
+    });
+
+    it('リターンが正の閾値の内側 (+0.4%) なら Hit', () => {
+      const result = judgePrediction(buildInput('NEUTRAL', 0.4));
+      expect(result.hit).toBe(true);
+    });
+
+    it('リターンが負の閾値の内側 (-0.4%) なら Hit', () => {
+      const result = judgePrediction(buildInput('NEUTRAL', -0.4));
+      expect(result.hit).toBe(true);
+    });
+
+    it('リターンが正の閾値ちょうど (+0.5%) なら Miss（境界値は方向側）', () => {
+      const result = judgePrediction(buildInput('NEUTRAL', 0.5));
+      expect(result.hit).toBe(false);
+    });
+
+    it('リターンが負の閾値ちょうど (-0.5%) なら Miss（境界値は方向側）', () => {
+      const result = judgePrediction(buildInput('NEUTRAL', -0.5));
+      expect(result.hit).toBe(false);
+    });
+
+    it('リターンが正の閾値より大きい (+1.0%) なら Miss', () => {
+      const result = judgePrediction(buildInput('NEUTRAL', 1.0));
+      expect(result.hit).toBe(false);
+    });
+
+    it('リターンが負の閾値より小さい (-1.0%) なら Miss', () => {
+      const result = judgePrediction(buildInput('NEUTRAL', -1.0));
+      expect(result.hit).toBe(false);
+    });
+  });
+
+  describe('judgePrediction - 異なる閾値', () => {
+    it('thresholdPercent = 1.0 のとき、BULLISH かつリターン +1.0% なら Hit', () => {
+      const result = judgePrediction(buildInput('BULLISH', 1.0, 1.0));
+      expect(result.hit).toBe(true);
+    });
+
+    it('thresholdPercent = 1.0 のとき、BULLISH かつリターン +0.9% なら Miss', () => {
+      const result = judgePrediction(buildInput('BULLISH', 0.9, 1.0));
+      expect(result.hit).toBe(false);
+    });
+
+    it('thresholdPercent = 0.1 のとき、NEUTRAL かつリターン +0.05% なら Hit', () => {
+      const result = judgePrediction(buildInput('NEUTRAL', 0.05, 0.1));
+      expect(result.hit).toBe(true);
+    });
+  });
+
+  describe('judgePrediction - 入力バリデーション', () => {
+    const validBase = {
+      signal: 'BULLISH' as const,
+      baseClose: 100,
+      evaluationClose: 101,
+      thresholdPercent: 0.5,
+    };
+
+    describe('baseClose', () => {
+      it.each([0, -1, NaN, Infinity, -Infinity])(
+        '不正値 (%p) は INVALID_BASE_CLOSE エラー',
+        (value) => {
+          expect(() => judgePrediction({ ...validBase, baseClose: value as number })).toThrow(
+            PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_BASE_CLOSE
+          );
+        }
+      );
+
+      it('文字列型の baseClose は INVALID_BASE_CLOSE エラー', () => {
+        expect(() =>
+          judgePrediction({ ...validBase, baseClose: '100' as unknown as number })
+        ).toThrow(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_BASE_CLOSE);
+      });
+    });
+
+    describe('evaluationClose', () => {
+      it.each([0, -1, NaN, Infinity, -Infinity])(
+        '不正値 (%p) は INVALID_EVALUATION_CLOSE エラー',
+        (value) => {
+          expect(() => judgePrediction({ ...validBase, evaluationClose: value as number })).toThrow(
+            PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_EVALUATION_CLOSE
+          );
+        }
+      );
+
+      it('文字列型の evaluationClose は INVALID_EVALUATION_CLOSE エラー', () => {
+        expect(() =>
+          judgePrediction({
+            ...validBase,
+            evaluationClose: '100' as unknown as number,
+          })
+        ).toThrow(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_EVALUATION_CLOSE);
+      });
+    });
+
+    describe('thresholdPercent', () => {
+      it.each([0, -0.5, NaN, Infinity, -Infinity])(
+        '不正値 (%p) は INVALID_THRESHOLD エラー',
+        (value) => {
+          expect(() =>
+            judgePrediction({ ...validBase, thresholdPercent: value as number })
+          ).toThrow(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_THRESHOLD);
+        }
+      );
+    });
+
+    describe('signal', () => {
+      it('未知のシグナル値は INVALID_SIGNAL エラー', () => {
+        expect(() =>
+          judgePrediction({
+            ...validBase,
+            signal: 'UNKNOWN' as unknown as 'BULLISH',
+          })
+        ).toThrow(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_SIGNAL);
+      });
+    });
+  });
+});

--- a/tasks/stock-tracer-prediction-evaluation/tasks.md
+++ b/tasks/stock-tracer-prediction-evaluation/tasks.md
@@ -170,22 +170,22 @@ A 案を採用し、独立エンティティではなく既存 `DailySummaryEnti
 **依存**: 作業 3
 **主な変更箇所**: `services/stock-tracker/core/`
 
-- [ ] `core/src/services/prediction-judger.ts` 作成
+- [x] `core/src/services/prediction-judger.ts` 作成
     - `judgePrediction(input: JudgeInput): JudgeResult`
     - 境界値の扱い：BULLISH/BEARISH は **以上 / 以下**、NEUTRAL は **より大きく / より小さく**（`design.md` § 3.4）
     - 純粋関数。副作用なし
-- [ ] `core/src/services/prediction-aggregator.ts` 作成
+- [x] `core/src/services/prediction-aggregator.ts` 作成
     - `aggregateEvaluatedSummaries(input: AggregateInput): AggregateOutput`
     - 入力は採点済み DailySummary（Evaluation\* 全埋まり、`AiAnalysisResult` あり、`AiAnalysisError` なし）に絞った配列
     - `PredictedSignal` は `AiAnalysisResult.investmentJudgment.signal` から導出
-    - KPI / シグナル別 / 取引所別 / 銘柄別 / 日次推移 を一括算出（作業 2 の FB で項目増減があれば反映）
+    - 作業 2 の確定版に従い、Phase 1 は **KPI / シグナル別 / 日次推移** の 3 軸のみ算出（銘柄別 / 取引所別 / NEUTRAL 比率 / AI 失敗件数は `external-design.md` ADR-003〜005 でスコープ外）
     - 入力が空のとき `accuracy = null`、`count = 0` を返す
     - 純粋関数
-- [ ] `core/src/index.ts` に export 追加
-- [ ] ユニットテスト
+- [x] `core/src/index.ts` に export 追加
+- [x] ユニットテスト
     - `judgePrediction`：シグナル × 境界値の網羅（境界値ちょうど + 内側 + 外側）
     - `aggregateEvaluatedSummaries`：空入力・全 Hit・全 Miss・複数取引所・複数銘柄・`AiAnalysisError` 混在（呼び出し側で除外する想定だが、防御的にもチェック）
-- [ ] カバレッジ 80% 以上
+- [x] カバレッジ 80% 以上を確認（statements 100% / branches 97.67% / functions 100% / lines 100%）
 
 **完了条件**: PR レビューが通り、テストがすべて green、integration にマージ。
 
@@ -331,8 +331,8 @@ A 案を採用し、独立エンティティではなく既存 `DailySummaryEnti
 | 1. UI PoC（モックデータ） | `claude/3018-ui-poc` | #3035 | マージ済 | Issue #3023 |
 | 2. PoC FB 反映で要件再確定（UI 簡素化） | `claude/3018-refine-docs` | #3057 | マージ済 | Issue #3024 |
 | 2. PoC FB 反映で要件再確定（ドキュメント確定 + 30d デフォルト） | `claude/3018-finalize-docs` | 本 PR | 進行中 | Issue #3024 |
-| 3. Entity / Repository 拡張 | `claude/3018-entity` | — | 未着手 | — |
-| 4. 判定 / 集計ロジック | `claude/3018-judge-logic` | — | 未着手 | — |
+| 3. Entity / Repository 拡張 | `claude/3018-entity` | #3060 | マージ済 | Issue #3025 |
+| 4. 判定 / 集計ロジック | `claude/3018-judge-logic` | 本 PR | 進行中 | Issue #3026 |
 | 5. 採点バッチ + cron | `claude/3018-batch` | — | 未着手 | — |
 | 6. 精度集計 API | `claude/3018-api` | — | 未着手 | — |
 | 7. UI を本物の API に配線 | `claude/3018-ui-wire` | — | 未着手 | — |


### PR DESCRIPTION
## 変更の概要

親 Issue #3018（Stock Tracer 予測精度の自動採点・可視化基盤 / Phase 1）の **作業 4**。
採点バッチ・集計 API のための純粋関数レイヤを `services/stock-tracker/core/src/services/` に追加する。副作用なし、テスト容易性重視。

## 関連 Issue

#3026

本 PR では `Closes #` を付けない（CLAUDE.md / tasks.md の運用に従い、integration → develop の PR で記述）。

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ 80% 以上を確保）
- [x] 関連ドキュメントを更新した（`tasks/stock-tracer-prediction-evaluation/tasks.md` の作業 4 チェックボックスと進捗トラッカー）
- [x] ローカルでテストが全て通ることを確認した（54 suites / 788 tests passed）
- [x] ビルドエラーがないことを確認した（`tsc --noEmit` clean、`eslint` clean、`prettier --check` clean）

## 主な変更

### `prediction-judger.ts`

```ts
judgePrediction({ signal, baseClose, evaluationClose, thresholdPercent }): { actualReturn, hit }
```

- 境界値仕様（`design.md` §3.4）:
  - **BULLISH**: `r >= +threshold`（境界含む）
  - **BEARISH**: `r <= -threshold`（境界含む）
  - **NEUTRAL**: `-threshold < r < +threshold`（境界除く＝方向側に分類）
- `r = +0.5` ちょうどは「BULLISH → Hit / NEUTRAL → Miss」となり重複しない
- 入力値（`baseClose` / `evaluationClose` / `thresholdPercent`）の妥当性チェック付き

### `prediction-aggregator.ts`

```ts
aggregateEvaluatedSummaries({ evaluated }): { kpi, bySignal, dailyTrend }
```

- 入力は採点済み DailySummary 配列（Evaluation\* 全埋まり、`AiAnalysisResult` あり、`AiAnalysisError` なし）に絞った前提
- 防御的に `AiAnalysisError` ありや `AiAnalysisResult` 不在を除外
- 出力は `SummaryResponse` の `kpi` / `bySignal` / `dailyTrend` と完全一致（作業 6 で API レイヤは型変換のみで返却可）
- 作業 2 の確定版（ADR-003〜005）に従い、Phase 1 では **KPI / シグナル別 / 日次推移** の 3 軸のみ算出。銘柄別 / 取引所別 / NEUTRAL 比率 / AI 失敗件数はスコープ外
- 空入力時 `accuracy = null` / `count = 0` を返す
- 的中率は小数第 1 位に丸める（UI のモックデータ形式と整合）
- `bySignal` は常に `BULLISH → NEUTRAL → BEARISH` の順序で 3 件返す（count=0 でも省略しない、PoC モックデータの挙動と整合）
- `dailyTrend` は予測日（`DailySummary.Date`）でグルーピングし、日付昇順で返す

### `core/src/index.ts`

`prediction-judger.ts` / `prediction-aggregator.ts` から型と関数を re-export。

## テスト内容

新規 56 テスト。既存 732 → 788 すべて pass。

### `prediction-judger.test.ts`（35 件）

- **actualReturn 計算**: 上昇 / 下落 / 変動なし / 小数の終値
- **BULLISH 境界値**: ちょうど (+0.5%) / 内側 / 外側 / 負 / 0
- **BEARISH 境界値**: ちょうど (-0.5%) / 内側 / 外側 / 正 / 0
- **NEUTRAL 境界値**: 0 / 内側 / 境界ちょうど（+0.5%, -0.5%、両方 Miss）/ 外側
- **異なる閾値**: thresholdPercent = 1.0 / 0.1 のケース
- **入力バリデーション**: `baseClose` / `evaluationClose` / `thresholdPercent` の不正値（0 / 負 / NaN / Infinity / 文字列）、未知のシグナル

### `prediction-aggregator.test.ts`（21 件）

- **空入力**: KPI = null/0、dailyTrend = []、bySignal = 3 シグナル分の 0 件
- **全 Hit / 全 Miss**: totalAccuracy / directionalAccuracy が 100 / 0
- **混在**: 小数第 1 位への丸め（BULLISH 2/3 → 66.7%）
- **directionalAccuracy**: NEUTRAL のみで null、BULLISH+BEARISH のみで計算（NEUTRAL を除外）
- **dailyTrend**: 予測日グルーピング、日付昇順ソート、NEUTRAL のみ日（directionalAccuracy=null）、欠落日はエントリなし
- **複数取引所 / 複数銘柄**: 取引所横断で合算、同一銘柄重複でも件数加算
- **防御的フィルタ**: `AiAnalysisError` あり / `AiAnalysisResult` undefined を除外
- **bySignal の順序**: 常に BULLISH → NEUTRAL → BEARISH（count=0 でも省略しない）

### カバレッジ

| ファイル | Statements | Branches | Functions | Lines |
|---|---|---|---|---|
| `prediction-judger.ts` | 100% | 100% | 100% | 100% |
| `prediction-aggregator.ts` | 100% | 95.45% | 100% | 100% |

`prediction-aggregator.ts` の唯一の未カバーブランチは `dailyTrend.sort()` 比較関数の同値分岐 (`a.date === b.date`)。Map のキーが一意なため実質到達不能で、防御的に置いたもの。80% 閾値は十分クリア。

## レビューポイント

- **`dailyTrend` のグルーピング日付**: `DailySummary.Date`（予測日）を採用。「直近 N 日の予測精度推移」を見るには予測日が自然と判断。`EvaluationDate`（採点日）でグルーピングすべきという判断もあり得るが、UI のモックデータも予測日基準で組まれているため整合させた。
- **`bySignal` の常時 3 シグナル返却**: PoC モックデータ（`MOCK_SUMMARY_ALL_EMPTY`）が count=0 でも 3 シグナルすべて返している挙動に合わせた。UI 側でこの仮定に依存している場合に整合性を保つ。
- **小数第 1 位への丸め**: モックデータ（例: `66.7`, `55.6`）に合わせて `Math.round(x * 1000) / 10` で 1 桁丸め。Phase 1 では集計 API も同じ丸めで返す前提。
- **防御的フィルタ**: 設計上は呼び出し側（作業 5 採点バッチ / 作業 6 集計 API）で `AiAnalysisError` / `AiAnalysisResult` 不在を除外する想定だが、aggregator 内でも防御。多重防御の代わりに「呼び出し側責任」とする選択肢もあるが、純粋関数として単独で安全に呼び出せる方が後続作業のミスを減らせると判断。
- **入力バリデーションのスタイル**: `judgePrediction` は終値・閾値の不正値で throw。集計時の不正データは aggregator 側ではエラーにせずスキップ（責務分離）。

## 補足事項

- `tasks/stock-tracer-prediction-evaluation/tasks.md` の作業 4 チェックボックスを完了状態に更新、進捗トラッカーの作業 3 を「マージ済」に、作業 4 を「進行中」に更新
- 次の作業 5（採点バッチ Lambda + EventBridge cron）は本 PR の `judgePrediction` と作業 3 の `markAsEvaluated` を利用する想定
- 作業 6（精度集計 API）も本 PR の `aggregateEvaluatedSummaries` を利用する

---
_Generated by [Claude Code](https://claude.ai/code/session_017NJjm5Vg)_