### PR TITLE
feat(stock-tracker): 予測精度集計 API と stocks:read-evaluation 権限を追加（作業 6）

### DIFF
--- a/libs/common/src/auth/roles.ts
+++ b/libs/common/src/auth/roles.ts
@@ -63,7 +63,12 @@ export const ROLES = {
     id: 'stock-admin',
     name: 'Stock 管理者',
     description: 'Stock Tracker のマスタデータ管理が可能',
-    permissions: ['stocks:read', 'stocks:write-own', 'stocks:manage-data', 'stocks:read-evaluation'],
+    permissions: [
+      'stocks:read',
+      'stocks:write-own',
+      'stocks:manage-data',
+      'stocks:read-evaluation',
+    ],
   },
 } as const satisfies Record<string, RoleDefinition>;
 

--- a/libs/common/src/auth/roles.ts
+++ b/libs/common/src/auth/roles.ts
@@ -63,7 +63,7 @@ export const ROLES = {
     id: 'stock-admin',
     name: 'Stock 管理者',
     description: 'Stock Tracker のマスタデータ管理が可能',
-    permissions: ['stocks:read', 'stocks:write-own', 'stocks:manage-data'],
+    permissions: ['stocks:read', 'stocks:write-own', 'stocks:manage-data', 'stocks:read-evaluation'],
   },
 } as const satisfies Record<string, RoleDefinition>;
 

--- a/libs/common/src/auth/types.ts
+++ b/libs/common/src/auth/types.ts
@@ -49,6 +49,7 @@ export interface Session {
  * - stocks:read - View charts, exchanges, and tickers
  * - stocks:write-own - Manage own alerts and holdings
  * - stocks:manage-data - Manage master data (exchanges and tickers)
+ * - stocks:read-evaluation - View prediction accuracy dashboard (stock-admin only)
  *
  * Auth Service permissions:
  * - auth:read - View auth configuration and user data
@@ -63,6 +64,7 @@ export type Permission =
   | 'stocks:read'
   | 'stocks:write-own'
   | 'stocks:manage-data'
+  | 'stocks:read-evaluation'
   | 'auth:read'
   | 'auth:write';
 

--- a/libs/common/tests/unit/auth/permissions.test.ts
+++ b/libs/common/tests/unit/auth/permissions.test.ts
@@ -233,6 +233,32 @@ describe('Permission Functions', () => {
       it('should have stocks:manage-data permission', () => {
         expect(hasPermission(['stock-admin'], 'stocks:manage-data')).toBe(true);
       });
+
+      it('should have stocks:read-evaluation permission', () => {
+        expect(hasPermission(['stock-admin'], 'stocks:read-evaluation')).toBe(true);
+      });
+    });
+
+    describe('stocks:read-evaluation permission', () => {
+      it('stock-admin should have stocks:read-evaluation', () => {
+        expect(hasPermission(['stock-admin'], 'stocks:read-evaluation')).toBe(true);
+      });
+
+      it('stock-viewer should not have stocks:read-evaluation', () => {
+        expect(hasPermission(['stock-viewer'], 'stocks:read-evaluation')).toBe(false);
+      });
+
+      it('stock-user should not have stocks:read-evaluation', () => {
+        expect(hasPermission(['stock-user'], 'stocks:read-evaluation')).toBe(false);
+      });
+
+      it('admin should not have stocks:read-evaluation', () => {
+        expect(hasPermission(['admin'], 'stocks:read-evaluation')).toBe(false);
+      });
+
+      it('user-manager should not have stocks:read-evaluation', () => {
+        expect(hasPermission(['user-manager'], 'stocks:read-evaluation')).toBe(false);
+      });
     });
 
     describe('Permission hierarchy validation', () => {
@@ -252,7 +278,7 @@ describe('Permission Functions', () => {
         expect(
           hasAllPermissions(
             ['stock-admin'],
-            ['stocks:read', 'stocks:write-own', 'stocks:manage-data']
+            ['stocks:read', 'stocks:write-own', 'stocks:manage-data', 'stocks:read-evaluation']
           )
         ).toBe(true);
       });
@@ -261,6 +287,7 @@ describe('Permission Functions', () => {
         expect(hasPermission(['admin'], 'stocks:read')).toBe(false);
         expect(hasPermission(['admin'], 'stocks:write-own')).toBe(false);
         expect(hasPermission(['admin'], 'stocks:manage-data')).toBe(false);
+        expect(hasPermission(['admin'], 'stocks:read-evaluation')).toBe(false);
       });
     });
 
@@ -277,6 +304,16 @@ describe('Permission Functions', () => {
 
       it('should not throw for stock-admin with stocks:manage-data', () => {
         expect(() => requirePermission(['stock-admin'], 'stocks:manage-data')).not.toThrow();
+      });
+
+      it('should not throw for stock-admin with stocks:read-evaluation', () => {
+        expect(() => requirePermission(['stock-admin'], 'stocks:read-evaluation')).not.toThrow();
+      });
+
+      it('should throw for stock-viewer with stocks:read-evaluation', () => {
+        expect(() => requirePermission(['stock-viewer'], 'stocks:read-evaluation')).toThrow(
+          'Permission denied: stocks:read-evaluation'
+        );
       });
     });
   });

--- a/libs/common/tests/unit/auth/roles.test.ts
+++ b/libs/common/tests/unit/auth/roles.test.ts
@@ -116,7 +116,22 @@ describe('ROLES', () => {
       expect(ROLES['stock-admin'].permissions).toContain('stocks:read');
       expect(ROLES['stock-admin'].permissions).toContain('stocks:write-own');
       expect(ROLES['stock-admin'].permissions).toContain('stocks:manage-data');
-      expect(ROLES['stock-admin'].permissions).toHaveLength(3);
+      expect(ROLES['stock-admin'].permissions).toContain('stocks:read-evaluation');
+      expect(ROLES['stock-admin'].permissions).toHaveLength(4);
+    });
+
+    it('stocks:read-evaluation 権限を持つべき（予測精度ダッシュボード閲覧）', () => {
+      expect(ROLES['stock-admin'].permissions).toContain('stocks:read-evaluation');
+    });
+  });
+
+  describe('stocks:read-evaluation 権限の付与範囲', () => {
+    it('stock-admin のみが stocks:read-evaluation を持つべき', () => {
+      expect(ROLES['stock-admin'].permissions).toContain('stocks:read-evaluation');
+      expect(ROLES['stock-viewer'].permissions).not.toContain('stocks:read-evaluation');
+      expect(ROLES['stock-user'].permissions).not.toContain('stocks:read-evaluation');
+      expect(ROLES.admin.permissions).not.toContain('stocks:read-evaluation');
+      expect(ROLES['user-manager'].permissions).not.toContain('stocks:read-evaluation');
     });
   });
 });

--- a/services/stock-tracker/web/app/api/prediction-evaluation/summary/route.ts
+++ b/services/stock-tracker/web/app/api/prediction-evaluation/summary/route.ts
@@ -11,7 +11,10 @@ import {
   createDailySummaryRepository,
   createExchangeRepository,
 } from '../../../../lib/repository-factory';
-import type { EvaluationPeriod, SummaryResponse } from '../../../../lib/prediction-evaluation/types';
+import type {
+  EvaluationPeriod,
+  SummaryResponse,
+} from '../../../../lib/prediction-evaluation/types';
 
 const EVALUATION_PERIODS = ['7d', '30d', '90d', 'all'] as const;
 

--- a/services/stock-tracker/web/app/api/prediction-evaluation/summary/route.ts
+++ b/services/stock-tracker/web/app/api/prediction-evaluation/summary/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  aggregateEvaluatedSummaries,
+  type DailySummaryEntity,
+  type EvaluatedDailySummary,
+} from '@nagiyu/stock-tracker-core';
+import type { ErrorResponse } from '@nagiyu/common';
+import { withAuth } from '@nagiyu/nextjs';
+import { getSession } from '../../../../lib/auth';
+import {
+  createDailySummaryRepository,
+  createExchangeRepository,
+} from '../../../../lib/repository-factory';
+import type { EvaluationPeriod, SummaryResponse } from '../../../../lib/prediction-evaluation/types';
+
+const EVALUATION_PERIODS = ['7d', '30d', '90d', 'all'] as const;
+
+const ERROR_MESSAGES = {
+  INVALID_PERIOD: `period は ${EVALUATION_PERIODS.join(' / ')} のいずれかを指定してください`,
+  INTERNAL_ERROR: '予測精度サマリーの取得に失敗しました',
+} as const;
+
+function isEvaluationPeriod(value: string | null): value is EvaluationPeriod {
+  return EVALUATION_PERIODS.includes(value as EvaluationPeriod);
+}
+
+function toUtcDateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function resolveDateRange(period: EvaluationPeriod): { fromDate: string; toDate: string } {
+  const today = new Date();
+  const toDate = toUtcDateString(today);
+
+  if (period === 'all') {
+    return { fromDate: '0000-01-01', toDate };
+  }
+
+  const days = period === '7d' ? 7 : period === '30d' ? 30 : 90;
+  const from = new Date(today);
+  from.setUTCDate(from.getUTCDate() - (days - 1));
+  return { fromDate: toUtcDateString(from), toDate };
+}
+
+function isEvaluatedDailySummary(summary: DailySummaryEntity): summary is EvaluatedDailySummary {
+  return (
+    summary.EvaluatedAt !== undefined &&
+    summary.AiAnalysisResult !== undefined &&
+    summary.AiAnalysisError === undefined
+  );
+}
+
+export const GET = withAuth(
+  getSession,
+  'stocks:read-evaluation',
+  async (
+    _session,
+    request: NextRequest
+  ): Promise<NextResponse<SummaryResponse | ErrorResponse>> => {
+    try {
+      const { searchParams } = new URL(request.url);
+      const period = searchParams.get('period');
+
+      if (!isEvaluationPeriod(period)) {
+        return NextResponse.json(
+          {
+            error: 'VALIDATION_ERROR',
+            message: ERROR_MESSAGES.INVALID_PERIOD,
+          },
+          { status: 400 }
+        );
+      }
+
+      const { fromDate, toDate } = resolveDateRange(period);
+
+      const exchangeRepository = createExchangeRepository();
+      const dailySummaryRepository = createDailySummaryRepository();
+
+      const exchanges = await exchangeRepository.getAll();
+
+      const allSummaries = (
+        await Promise.all(
+          exchanges.map((exchange) =>
+            dailySummaryRepository.getByExchangeAndDateRange(exchange.ExchangeID, fromDate, toDate)
+          )
+        )
+      ).flat();
+
+      const evaluated = allSummaries.filter(isEvaluatedDailySummary);
+
+      const aggregated = aggregateEvaluatedSummaries({ evaluated });
+
+      const response: SummaryResponse = {
+        period,
+        evaluatedAt: Date.now(),
+        kpi: aggregated.kpi,
+        dailyTrend: aggregated.dailyTrend,
+        bySignal: aggregated.bySignal,
+      };
+
+      return NextResponse.json(response, { status: 200 });
+    } catch {
+      return NextResponse.json(
+        {
+          error: 'INTERNAL_ERROR',
+          message: ERROR_MESSAGES.INTERNAL_ERROR,
+        },
+        { status: 500 }
+      );
+    }
+  }
+);

--- a/services/stock-tracker/web/app/prediction-evaluation/page.tsx
+++ b/services/stock-tracker/web/app/prediction-evaluation/page.tsx
@@ -35,7 +35,7 @@ function PredictionEvaluationContent() {
     !!session?.user &&
     'roles' in session.user &&
     Array.isArray(session.user.roles) &&
-    hasPermission(session.user.roles, 'stocks:read');
+    hasPermission(session.user.roles, 'stocks:read-evaluation');
 
   if (!hasReadPermission) {
     return (

--- a/services/stock-tracker/web/components/ThemeRegistry.tsx
+++ b/services/stock-tracker/web/components/ThemeRegistry.tsx
@@ -14,18 +14,23 @@ interface ThemeRegistryProps {
 function ThemeRegistryContent({ children, version = '1.0.0' }: ThemeRegistryProps) {
   const { data: session } = useSession();
 
+  const hasStocksRead =
+    !!session?.user &&
+    'roles' in session.user &&
+    Array.isArray(session.user.roles) &&
+    hasPermission(session.user.roles, 'stocks:read');
+
+  const hasReadEvaluation =
+    !!session?.user &&
+    'roles' in session.user &&
+    Array.isArray(session.user.roles) &&
+    hasPermission(session.user.roles, 'stocks:read-evaluation');
+
   // ナビゲーションメニュー項目の定義
   const navigationItems: NavigationItem[] = [
     { label: 'チャート', href: '/' },
-    ...(session?.user &&
-    'roles' in session.user &&
-    Array.isArray(session.user.roles) &&
-    hasPermission(session.user.roles, 'stocks:read')
-      ? [
-          { label: 'サマリー', href: '/summaries' },
-          { label: '予測精度', href: '/prediction-evaluation' },
-        ]
-      : []),
+    ...(hasStocksRead ? [{ label: 'サマリー', href: '/summaries' }] : []),
+    ...(hasReadEvaluation ? [{ label: '予測精度', href: '/prediction-evaluation' }] : []),
     { label: '保有株式', href: '/holdings' },
     { label: 'アラート', href: '/alerts' },
     // 権限ベースの管理メニュー（stocks:manage-data 権限が必要）

--- a/services/stock-tracker/web/tests/unit/app/api/prediction-evaluation/summary-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/prediction-evaluation/summary-route.test.ts
@@ -1,0 +1,268 @@
+import { NextRequest } from 'next/server';
+import { GET } from '../../../../../app/api/prediction-evaluation/summary/route';
+import {
+  createDailySummaryRepository,
+  createExchangeRepository,
+} from '../../../../../lib/repository-factory';
+
+jest.mock('../../../../../lib/repository-factory', () => ({
+  createDailySummaryRepository: jest.fn(),
+  createExchangeRepository: jest.fn(),
+}));
+
+jest.mock('../../../../../lib/auth', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@nagiyu/nextjs', () => ({
+  withAuth: jest.fn((_auth, _permission, handler) => {
+    return async (...args: unknown[]) => handler({ user: { userId: 'test-user' } }, ...args);
+  }),
+}));
+
+type MockedCreateExchangeRepository = jest.MockedFunction<typeof createExchangeRepository>;
+type MockedCreateDailySummaryRepository = jest.MockedFunction<typeof createDailySummaryRepository>;
+
+const BASE_SUMMARY = {
+  TickerID: 'NSDQ:AAPL',
+  ExchangeID: 'NASDAQ',
+  Date: '2026-05-10',
+  Open: 180,
+  High: 185,
+  Low: 179,
+  Close: 183,
+  CreatedAt: 1000000,
+  UpdatedAt: 1000001,
+};
+
+const EVALUATED_SUMMARY = {
+  ...BASE_SUMMARY,
+  EvaluationDate: '2026-05-11',
+  EvaluationClose: 186,
+  ActualReturn: 1.64,
+  Hit: true,
+  EvaluationThresholdPercent: 0.5,
+  EvaluatedAt: 1747699200000,
+  AiAnalysisResult: {
+    priceMovementAnalysis: '上昇傾向',
+    patternAnalysis: 'パターン検出',
+    supportLevels: [175],
+    resistanceLevels: [190],
+    relatedMarketTrend: 'ナスダック上昇',
+    investmentJudgment: { signal: 'BULLISH', reason: '強気シグナル' },
+  },
+};
+
+describe('GET /api/prediction-evaluation/summary', () => {
+  const mockedCreateExchangeRepository = createExchangeRepository as MockedCreateExchangeRepository;
+  const mockedCreateDailySummaryRepository =
+    createDailySummaryRepository as MockedCreateDailySummaryRepository;
+
+  const mockGetAllExchanges = jest.fn();
+  const mockGetByExchangeAndDateRange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedCreateExchangeRepository.mockReturnValue({
+      getAll: mockGetAllExchanges,
+    } as ReturnType<typeof createExchangeRepository>);
+
+    mockedCreateDailySummaryRepository.mockReturnValue({
+      getByExchangeAndDateRange: mockGetByExchangeAndDateRange,
+    } as ReturnType<typeof createDailySummaryRepository>);
+  });
+
+  describe('バリデーション', () => {
+    it('period パラメータが欠落している場合は 400 を返す', async () => {
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('VALIDATION_ERROR');
+      expect(body.message).toContain('period');
+    });
+
+    it('period が不正な値の場合は 400 を返す', async () => {
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=invalid')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('VALIDATION_ERROR');
+    });
+
+    it('period が 14d など存在しない期間の場合は 400 を返す', async () => {
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=14d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('正常系', () => {
+    it('採点済みデータがある場合は SummaryResponse を返す', async () => {
+      mockGetAllExchanges.mockResolvedValue([{ ExchangeID: 'NASDAQ', Name: 'NASDAQ' }]);
+      mockGetByExchangeAndDateRange.mockResolvedValue([EVALUATED_SUMMARY]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.period).toBe('30d');
+      expect(typeof body.evaluatedAt).toBe('number');
+      expect(body.kpi.judgedCount).toBe(1);
+      expect(body.kpi.totalAccuracy).toBe(100);
+      expect(Array.isArray(body.dailyTrend)).toBe(true);
+      expect(body.bySignal).toHaveLength(3);
+    });
+
+    it('複数の取引所のデータを統合して集計する', async () => {
+      mockGetAllExchanges.mockResolvedValue([
+        { ExchangeID: 'NASDAQ', Name: 'NASDAQ' },
+        { ExchangeID: 'NYSE', Name: 'NYSE' },
+      ]);
+      const nyseEvaluated = {
+        ...EVALUATED_SUMMARY,
+        TickerID: 'NYSE:MSFT',
+        ExchangeID: 'NYSE',
+        Hit: false,
+        AiAnalysisResult: {
+          ...EVALUATED_SUMMARY.AiAnalysisResult,
+          investmentJudgment: { signal: 'BEARISH', reason: '弱気シグナル' },
+        },
+      };
+      mockGetByExchangeAndDateRange
+        .mockResolvedValueOnce([EVALUATED_SUMMARY])
+        .mockResolvedValueOnce([nyseEvaluated]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=7d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.kpi.judgedCount).toBe(2);
+    });
+
+    it('取引所が存在しない場合は空の集計を返す', async () => {
+      mockGetAllExchanges.mockResolvedValue([]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.kpi.judgedCount).toBe(0);
+      expect(body.kpi.totalAccuracy).toBeNull();
+      expect(body.kpi.directionalAccuracy).toBeNull();
+      expect(body.dailyTrend).toHaveLength(0);
+      expect(body.bySignal).toHaveLength(3);
+    });
+
+    it('採点済みデータが 0 件の場合は kpi.judgedCount=0 を返す', async () => {
+      mockGetAllExchanges.mockResolvedValue([{ ExchangeID: 'NASDAQ', Name: 'NASDAQ' }]);
+      mockGetByExchangeAndDateRange.mockResolvedValue([BASE_SUMMARY]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.kpi.judgedCount).toBe(0);
+      expect(body.kpi.totalAccuracy).toBeNull();
+    });
+
+    it('EvaluatedAt はあるが AiAnalysisResult がないサマリーは集計から除外する', async () => {
+      const noAiSummary = {
+        ...BASE_SUMMARY,
+        EvaluatedAt: 1747699200000,
+        EvaluationDate: '2026-05-11',
+        EvaluationClose: 186,
+        ActualReturn: 1.64,
+        Hit: true,
+        EvaluationThresholdPercent: 0.5,
+      };
+      mockGetAllExchanges.mockResolvedValue([{ ExchangeID: 'NASDAQ', Name: 'NASDAQ' }]);
+      mockGetByExchangeAndDateRange.mockResolvedValue([noAiSummary, EVALUATED_SUMMARY]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=7d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.kpi.judgedCount).toBe(1);
+    });
+
+    it('AiAnalysisError があるサマリーは集計から除外する', async () => {
+      const errorSummary = {
+        ...EVALUATED_SUMMARY,
+        AiAnalysisError: 'AI解析に失敗しました',
+      };
+      mockGetAllExchanges.mockResolvedValue([{ ExchangeID: 'NASDAQ', Name: 'NASDAQ' }]);
+      mockGetByExchangeAndDateRange.mockResolvedValue([errorSummary, EVALUATED_SUMMARY]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=7d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.kpi.judgedCount).toBe(1);
+    });
+
+    it.each([['7d'], ['30d'], ['90d'], ['all']] as const)(
+      'period=%s は正常に処理される',
+      async (period) => {
+        mockGetAllExchanges.mockResolvedValue([]);
+
+        const response = await GET(
+          new NextRequest(
+            `http://localhost/api/prediction-evaluation/summary?period=${period}`
+          )
+        );
+
+        expect(response.status).toBe(200);
+      }
+    );
+  });
+
+  describe('異常系', () => {
+    it('リポジトリエラー時は 500 を返す', async () => {
+      mockGetAllExchanges.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('INTERNAL_ERROR');
+      expect(body.message).toBe('予測精度サマリーの取得に失敗しました');
+    });
+
+    it('日次サマリー取得エラー時は 500 を返す', async () => {
+      mockGetAllExchanges.mockResolvedValue([{ ExchangeID: 'NASDAQ', Name: 'NASDAQ' }]);
+      mockGetByExchangeAndDateRange.mockRejectedValue(new Error('GSI クエリエラー'));
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('INTERNAL_ERROR');
+    });
+  });
+});

--- a/services/stock-tracker/web/tests/unit/app/api/prediction-evaluation/summary-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/prediction-evaluation/summary-route.test.ts
@@ -228,9 +228,7 @@ describe('GET /api/prediction-evaluation/summary', () => {
         mockGetAllExchanges.mockResolvedValue([]);
 
         const response = await GET(
-          new NextRequest(
-            `http://localhost/api/prediction-evaluation/summary?period=${period}`
-          )
+          new NextRequest(`http://localhost/api/prediction-evaluation/summary?period=${period}`)
         );
 
         expect(response.status).toBe(200);


### PR DESCRIPTION
## 変更の概要

作業 6（精度集計 API + 専用 permission 追加）の実装。

- `libs/common` に `stocks:read-evaluation` パーミッションを新設し、`stock-admin` ロールにのみ付与
- `GET /api/prediction-evaluation/summary` ルートを実装
  - `stocks:read-evaluation` 権限チェック（`withAuth`）
  - `period`（`7d` / `30d` / `90d` / `all`）の enum バリデーション
  - 全取引所の `getByExchangeAndDateRange` → メモリフィルタ（採点済み & AI 解析あり & AI エラーなし）→ `aggregateEvaluatedSummaries` → `SummaryResponse` 返却
- `page.tsx` の権限チェックを `stocks:read` → `stocks:read-evaluation` に差し替え
- `ThemeRegistry.tsx` のナビゲーション：「サマリー」は `stocks:read`・「予測精度」は `stocks:read-evaluation` で独立制御

## 関連 Issue

関連: #3018（integration → develop の PR でのみ Closes を記載）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ 80% 以上を確保）
- [x] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した（215 件 / web、78 件 / libs/common）
- [x] ビルドエラーがないことを確認した

## テスト内容

**libs/common** (`tests/unit/auth/roles.test.ts`, `permissions.test.ts`)
- `stock-admin` のみが `stocks:read-evaluation` を持つ（他 4 ロールは持たない）
- `hasPermission` / `requirePermission` で正常系・拒否系を網羅

**services/stock-tracker/web** (`tests/unit/app/api/prediction-evaluation/summary-route.test.ts` — 15 件)
- `period` バリデーション（欠落・無効値・存在しない期間）
- 採点済みデータあり → SummaryResponse を返す
- 複数取引所の統合集計
- 取引所なし・採点済み 0 件 → kpi.judgedCount=0, accuracy=null
- `EvaluatedAt` なし・`AiAnalysisError` あり → 集計から除外
- `period` 4 パターン（7d / 30d / 90d / all）がすべて正常処理
- リポジトリエラー → 500 INTERNAL_ERROR

## レビューポイント

- `ThemeRegistry.tsx`：従来は「サマリー」と「予測精度」が `stocks:read` の同一ブロックだったが、`stocks:read-evaluation` で独立制御するよう分離。これにより `stock-user` / `stock-viewer` は「サマリー」は見えるが「予測精度」は見えない。
- API の日付範囲計算は UTC 基準（`Date.prototype.getUTCDate()`）。`all` の fromDate は `0000-01-01`（`getByExchangeAndDateRange` の GSI4 クエリで FROM 側が存在しないデータより前なら問題なし）。
- 403 / 401 は `withAuth` 任せ（既存パターンと同一）。`libs/common` の tests で permission 拒否を担保。

## 補足事項

- `tasks/stock-tracer-prediction-evaluation/tasks.md` の作業 6 に対応
- 作業 5（採点バッチ）未完了でも本 API 単体は動く（採点済みデータが 0 件の場合は空集計を返す）
- カバレッジ: web 全体 98.73% statements / 94.64% branches（閾値 80% 超過）、libs/common auth テスト 100%

---
_Generated by [Claude Code](https://claude.ai/code/session_019tnTg9cwqFiLu1RwmkrEh4)_