### PR TITLE
fix(ci): デプロイワークフローに batch-evaluation Lambda の image update を追加（#3066）

### DIFF
--- a/.github/workflows/stock-tracker-deploy.yml
+++ b/.github/workflows/stock-tracker-deploy.yml
@@ -329,6 +329,11 @@ jobs:
             --image-uri "$BATCH_IMAGE_URI" \
             --region ${{ env.AWS_REGION }}
 
+          aws lambda update-function-code \
+            --function-name "nagiyu-stock-tracker-batch-evaluation-$ENVIRONMENT" \
+            --image-uri "$BATCH_IMAGE_URI" \
+            --region ${{ env.AWS_REGION }}
+
           echo "Lambda functions updated with latest images"
 
       - name: Wait for Lambda updates to complete
@@ -358,6 +363,10 @@ jobs:
 
           aws lambda wait function-updated \
             --function-name "nagiyu-stock-tracker-batch-temporary-alert-expiry-$ENVIRONMENT" \
+            --region ${{ env.AWS_REGION }}
+
+          aws lambda wait function-updated \
+            --function-name "nagiyu-stock-tracker-batch-evaluation-$ENVIRONMENT" \
             --region ${{ env.AWS_REGION }}
 
           echo "All Lambda functions updated successfully"


### PR DESCRIPTION
## 変更の概要

`stock-tracker-deploy.yml` の以下 2 ステップに `nagiyu-stock-tracker-batch-evaluation` Lambda の処理を追加。

- `Update Lambda functions with latest images` — `update-function-code` を追記
- `Wait for Lambda updates to complete` — `function-updated` 待機を追記

作業 5（#3027）で Lambda を追加した際、デプロイワークフローへの追記が漏れており、以降のデプロイで `batch-evaluation` Lambda のコードが更新されない状態になっていた（#3066）。

## 関連 Issue

#3066（#3018 Phase 1 積み残し）

## 変更種別

- [ ] 新機能
- [x] バグ修正 / 積み残し対応
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他

## 実装チェックリスト

- [x] ルールドキュメントを確認した
- [x] テストカバレッジ 80% 以上を確保（CI/CD YAML のみ変更のため対象外）
- [ ] ドキュメントを更新した（不要）
- [x] CI/CD 設定を更新した

## テスト内容

- YAML 修正のみで実行ロジックの変更なし
- 次回デプロイ後、AWS Console / CLI で `batch-evaluation-dev` の `LastModified` が他 Lambda と同時刻になっていることで確認

## レビューポイント

- 追加した 2 ブロックが他 Lambda の記述パターンと一致していること
- `BATCH_IMAGE_URI` を使用しており、他の batch Lambda と同じイメージを参照していること

---
_Generated by [Claude Code](https://claude.ai/code/session_014caVdc7gSsUa9JgMi2S1ne)_