### PR TITLE
feat(stock-tracker): 採点リトライ上限を導入し祝日連休で永久未採点になる予測を卒業させる（#3067）

### DIFF
--- a/services/stock-tracker/batch/src/lib/find-pending-evaluations.ts
+++ b/services/stock-tracker/batch/src/lib/find-pending-evaluations.ts
@@ -11,6 +11,7 @@
  */
 
 import {
+  countWeekdaysBetween,
   formatDateInTimezone,
   getLastTradingDate,
   getNextWeekday,
@@ -44,6 +45,7 @@ export interface FindPendingEvaluationsOptions {
 
 const DEFAULT_WINDOW_DAYS = 30;
 const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_EVALUATION_BUSINESS_DAYS = 5;
 
 function shiftDate(dateYmd: string, deltaDays: number): string {
   const base = new Date(`${dateYmd}T00:00:00Z`);
@@ -51,12 +53,17 @@ function shiftDate(dateYmd: string, deltaDays: number): string {
   return formatDateInTimezone(shifted.getTime(), 'UTC');
 }
 
-function isCandidate(summary: DailySummaryEntity): boolean {
-  return (
-    summary.AiAnalysisResult !== undefined &&
-    summary.AiAnalysisError === undefined &&
-    summary.EvaluatedAt === undefined
-  );
+function isCandidate(summary: DailySummaryEntity, lastTradingDate: string): boolean {
+  if (
+    summary.AiAnalysisResult === undefined ||
+    summary.AiAnalysisError !== undefined ||
+    summary.EvaluatedAt !== undefined
+  ) {
+    return false;
+  }
+  // 予測日から N 営業日経過しても採点できなければ卒業（祝日連休等で永久未採点になるのを防ぐ）
+  const businessDaysElapsed = countWeekdaysBetween(summary.Date, lastTradingDate);
+  return businessDaysElapsed < MAX_EVALUATION_BUSINESS_DAYS;
 }
 
 /**
@@ -82,7 +89,7 @@ export async function findPendingEvaluations(
     );
 
     for (const summary of summaries) {
-      if (!isCandidate(summary)) {
+      if (!isCandidate(summary, lastTradingDate)) {
         continue;
       }
       const evaluationDate = getNextWeekday(summary.Date);

--- a/services/stock-tracker/batch/tests/unit/lib/find-pending-evaluations.test.ts
+++ b/services/stock-tracker/batch/tests/unit/lib/find-pending-evaluations.test.ts
@@ -146,7 +146,11 @@ describe('findPendingEvaluations', () => {
       it('予測日からちょうど 5 営業日経過した予測は候補から除外される', async () => {
         await dailySummaryRepository.upsert(createSummaryInput({ Date: '2026-02-20' }));
 
-        const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, NOW);
+        const result = await findPendingEvaluations(
+          exchangeRepository,
+          dailySummaryRepository,
+          NOW
+        );
 
         expect(result).toHaveLength(0);
       });
@@ -158,7 +162,11 @@ describe('findPendingEvaluations', () => {
       it('予測日から 4 営業日経過（5 日未満）の予測は候補に含まれる', async () => {
         await dailySummaryRepository.upsert(createSummaryInput({ Date: '2026-02-23' }));
 
-        const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, NOW);
+        const result = await findPendingEvaluations(
+          exchangeRepository,
+          dailySummaryRepository,
+          NOW
+        );
 
         expect(result).toHaveLength(1);
         expect(result[0].summary.Date).toBe('2026-02-23');
@@ -168,7 +176,11 @@ describe('findPendingEvaluations', () => {
       it('予測日から 6 営業日経過した予測は候補から除外される', async () => {
         await dailySummaryRepository.upsert(createSummaryInput({ Date: '2026-02-19' }));
 
-        const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, NOW);
+        const result = await findPendingEvaluations(
+          exchangeRepository,
+          dailySummaryRepository,
+          NOW
+        );
 
         expect(result).toHaveLength(0);
       });

--- a/services/stock-tracker/batch/tests/unit/lib/find-pending-evaluations.test.ts
+++ b/services/stock-tracker/batch/tests/unit/lib/find-pending-evaluations.test.ts
@@ -85,10 +85,12 @@ describe('findPendingEvaluations', () => {
 
     it('週末を跨ぐ予測（金曜日）は翌週月曜が引け済みなら採点対象になる', async () => {
       // 予測日 2026-02-20（金）→ 翌営業日 2026-02-23（月）
-      // 現在 = 2026-02-27（金）、L = 2026-02-27、2026-02-23 <= L → 採点対象
+      // now = 2026-02-23 23:00 UTC → lastTradingDate = 2026-02-23
+      // businessDaysElapsed (2-20, 2-23] = 1 < 5 → 採点対象
+      const now = Date.UTC(2026, 1, 23, 23, 0, 0);
       await dailySummaryRepository.upsert(createSummaryInput({ Date: '2026-02-20' }));
 
-      const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, NOW);
+      const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, now);
 
       expect(result).toHaveLength(1);
       expect(result[0].evaluationDate).toBe('2026-02-23');
@@ -136,6 +138,40 @@ describe('findPendingEvaluations', () => {
       const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, NOW);
 
       expect(result).toHaveLength(0);
+    });
+
+    describe('採点リトライ上限（MAX_EVALUATION_BUSINESS_DAYS = 5）', () => {
+      // NOW = 2026-02-27 (金) 23:00 UTC, lastTradingDate = 2026-02-27
+      // 予測日 2026-02-20 (金) → (2-20, 2-27]: 2-23(月),2-24(火),2-25(水),2-26(木),2-27(金) = 5 営業日
+      it('予測日からちょうど 5 営業日経過した予測は候補から除外される', async () => {
+        await dailySummaryRepository.upsert(createSummaryInput({ Date: '2026-02-20' }));
+
+        const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, NOW);
+
+        expect(result).toHaveLength(0);
+      });
+
+      // 予測日 2026-02-21 (土) は土日なので getByExchangeAndDateRange の範囲には含まれにくいが、
+      // 仮に含まれた場合: (2-21, 2-27]: 2-23,2-24,2-25,2-26,2-27 = 5 営業日 → 除外
+      // 代わりに 2026-02-23 (月) を使う:
+      // (2-23, 2-27]: 2-24(火),2-25(水),2-26(木),2-27(金) = 4 営業日 → 候補に残る
+      it('予測日から 4 営業日経過（5 日未満）の予測は候補に含まれる', async () => {
+        await dailySummaryRepository.upsert(createSummaryInput({ Date: '2026-02-23' }));
+
+        const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, NOW);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].summary.Date).toBe('2026-02-23');
+      });
+
+      // 予測日 2026-02-19 (木): (2-19, 2-27]: 2-20,2-23,2-24,2-25,2-26,2-27 = 6 営業日 → 除外
+      it('予測日から 6 営業日経過した予測は候補から除外される', async () => {
+        await dailySummaryRepository.upsert(createSummaryInput({ Date: '2026-02-19' }));
+
+        const result = await findPendingEvaluations(exchangeRepository, dailySummaryRepository, NOW);
+
+        expect(result).toHaveLength(0);
+      });
     });
 
     it('windowDays より古い予測は走査対象外', async () => {

--- a/services/stock-tracker/core/src/services/trading-hours-checker.ts
+++ b/services/stock-tracker/core/src/services/trading-hours-checker.ts
@@ -103,6 +103,34 @@ export function getNextWeekday(dateYmd: string): string {
 }
 
 /**
+ * from から to までに経過した平日数を返す（左開・右閉: (from, to]）
+ *
+ * - from == to のとき 0
+ * - from > to のとき 0（防御的）
+ * - 土日はカウント対象外、祝日は Phase 1 では平日扱い
+ *
+ * 採点バッチで「予測日から何営業日経過したか」を計算するために使う。
+ */
+export function countWeekdaysBetween(fromYmd: string, toYmd: string): number {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const fromMs = new Date(`${fromYmd}T00:00:00Z`).getTime();
+  const toMs = new Date(`${toYmd}T00:00:00Z`).getTime();
+  if (toMs <= fromMs) {
+    return 0;
+  }
+  let count = 0;
+  let cursor = fromMs + DAY_MS;
+  while (cursor <= toMs) {
+    const dow = new Date(cursor).getUTCDay();
+    if (dow !== 0 && dow !== 6) {
+      count++;
+    }
+    cursor += DAY_MS;
+  }
+  return count;
+}
+
+/**
  * Unix timestamp (ms) を指定タイムゾーンの YYYY-MM-DD に変換する
  *
  * TradingView API の日足バーから取引日を取り出す用途で、core 側に集約する。

--- a/services/stock-tracker/core/tests/unit/services/trading-hours-checker.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/trading-hours-checker.test.ts
@@ -8,6 +8,7 @@ import {
   isTradingHours,
   getLastTradingDate,
   calculateTemporaryExpireDate,
+  countWeekdaysBetween,
   formatDateInTimezone,
   getNextWeekday,
   TRADING_HOURS_ERROR_MESSAGES,
@@ -452,6 +453,42 @@ describe('Trading Hours Checker Service', () => {
           TRADING_HOURS_ERROR_MESSAGES.INVALID_CURRENT_TIME
         );
       });
+    });
+  });
+
+  describe('countWeekdaysBetween', () => {
+    it('同日は 0 を返す', () => {
+      expect(countWeekdaysBetween('2026-04-28', '2026-04-28')).toBe(0);
+    });
+
+    it('to < from のとき 0 を返す（防御的）', () => {
+      expect(countWeekdaysBetween('2026-04-28', '2026-04-27')).toBe(0);
+    });
+
+    it('翌平日（火→水）は 1 を返す', () => {
+      expect(countWeekdaysBetween('2026-04-28', '2026-04-29')).toBe(1);
+    });
+
+    it('週またぎ（金→月）は 1 を返す（土日をスキップ）', () => {
+      // 2026-05-01 (金) → 2026-05-04 (月)
+      expect(countWeekdaysBetween('2026-05-01', '2026-05-04')).toBe(1);
+    });
+
+    it('通常週の平日 5 日分は 5 を返す', () => {
+      // 月→翌週月: 月火水木金 = 5
+      // 2026-04-20 (月) → 2026-04-27 (月)
+      expect(countWeekdaysBetween('2026-04-20', '2026-04-27')).toBe(5);
+    });
+
+    it('GW 連休またぎ（祝日は平日扱い）: 2026-04-28 → 2026-05-05 は 5 を返す', () => {
+      // (4-28, 5-05]: 4-29(水),4-30(木),5-01(金),5-04(月),5-05(火) = 5
+      // 祝日（4-29昭和の日、5-04みどりの日、5-05こどもの日）は土日でないためカウント対象
+      expect(countWeekdaysBetween('2026-04-28', '2026-05-05')).toBe(5);
+    });
+
+    it('GW 連休またぎ: 2026-04-28 → 2026-05-06 は 6 を返す', () => {
+      // (4-28, 5-06]: 4-29,4-30,5-01,5-04,5-05,5-06 = 6
+      expect(countWeekdaysBetween('2026-04-28', '2026-05-06')).toBe(6);
     });
   });
 });

--- a/tasks/stock-tracer-prediction-evaluation/tasks.md
+++ b/tasks/stock-tracer-prediction-evaluation/tasks.md
@@ -340,7 +340,8 @@ A 案を採用し、独立エンティティではなく既存 `DailySummaryEnti
 | 4. 判定 / 集計ロジック | `claude/3018-judge-logic` | #3061 | マージ済 | Issue #3026 |
 | 5. 採点バッチ + cron | `claude/3018-batch` | #3063 | マージ済 | Issue #3027 |
 | 6. 精度集計 API | `claude/3018-api` | #3064 | マージ済 | Issue #3028 |
-| 7. UI を本物の API に配線 | `claude/3018-ui-wire` | 本 PR | 進行中 | Issue #3029 |
+| 7. UI を本物の API に配線 | `claude/3018-ui-wire` | #3065 | マージ済 | Issue #3029 |
 | 8. docs/ 統合 & tasks/ 削除 | `claude/3018-docs-finalize` | — | 未着手 | — |
+| 9. 採点リトライ上限の導入（祝日連休で永久未採点になる予測を卒業させる） | `claude/3067-evaluation-retry-limit` | — | 進行中 | Issue #3067 |
 
 各作業 PR が出たら本テーブルを更新する。


### PR DESCRIPTION
## 変更の概要

Issue #3067 の実装。GW・年末年始等の連休クラスタで `evaluationDate` が祝日に重なる予測が永久に未採点のままになる問題を、リトライ上限（5 営業日）で解消する。

**変更内容:**
- `trading-hours-checker.ts` に `countWeekdaysBetween(from, to)` を追加（左開・右閉区間 `(from, to]` の平日数を返す。土日スキップ、祝日は Phase 1 では平日扱い）
- `find-pending-evaluations.ts` の `isCandidate` に「予測日から 5 営業日経過で採点候補から除外」の条件を追加（`MAX_EVALUATION_BUSINESS_DAYS = 5`）
- 既存テスト「週末を跨ぐ予測」の NOW を調整（予測日から 5 営業日経過すると除外される仕様により `2026-02-20` × `NOW=2026-02-27` の組み合わせが除外されるため、`NOW=2026-02-23` に変更）

**設計判断:**
- 比較演算子は `>=`（5 営業日経過で卒業。Issue 本文の擬似コードは `>` だったが、テスト要件「5 営業日経過 → 除外」と自然に一致する `>=` を採用）
- DB フラグ（`EvaluationError` 等）は立てない（変更最小化、後で再評価したい場合に複雑性を残さない）

## 関連 Issue

関連: #3067（親: #3018）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ 80% 以上を確保）
- [x] 関連ドキュメントを更新した（`tasks.md` 進捗トラッカーに本タスクを追加）
- [ ] CI/CD 設定を追加・更新した（変更なし）
- [x] ローカルでテストが全て通ることを確認した（core: 803 件 / batch: 114 件 全 pass）
- [x] ビルドエラーがないことを確認した

## テスト内容

### `trading-hours-checker.test.ts`（7 件追加）

- 同日 → 0
- to < from → 0（防御的）
- 翌平日（火→水）→ 1
- 週またぎ（金→月）→ 1（土日スキップ）
- 通常週の平日 5 日分 → 5
- GW またぎ（2026-04-28 → 2026-05-05）→ 5（祝日は平日扱い）
- GW またぎ（2026-04-28 → 2026-05-06）→ 6

### `find-pending-evaluations.test.ts`（3 件追加、1 件修正）

- ちょうど 5 営業日経過した予測 → 候補から除外される
- 4 営業日経過（5 日未満）の予測 → 候補に含まれる
- 6 営業日経過した予測 → 候補から除外される
- 「週末を跨ぐ予測」テストの NOW を調整（`2026-02-27` → `2026-02-23`）

## レビューポイント

- 比較演算子 `>=`（Issue 本文の擬似コードは `>` だったが、テスト要件との整合で `>=` を採用した判断）
- `isCandidate` に `lastTradingDate` を渡す形へのシグネチャ変更が既存の他の呼び出し箇所に影響しないこと（`isCandidate` はファイルスコープの private 関数のため影響なし）

## 補足事項

- 作業 8（docs 統合）への申し送り内容（ADR 追記 / `requirements.md` UC-001 修正）は本 PR には含めない。作業 8 のスコープで対応する。
- dev 環境デプロイ後、次の cron 起動時に「翌営業日終値がチャートに存在しないため次回 cron で再試行します」ログが 10 件分消えることで動作確認する

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyFnVeLG6By7AZQAYtRTZ7)_