### PR TITLE
refactor: 価格・数量バリデーションを isValidNumber + presets に統一 (#3053)

### DIFF
--- a/services/stock-tracker/core/src/validation/helpers.ts
+++ b/services/stock-tracker/core/src/validation/helpers.ts
@@ -1,8 +1,12 @@
 /**
  * Stock Tracker Core - Validation Helpers
  *
- * Stock Tracker 固有のバリデーション用ヘルパー関数
+ * Stock Tracker 固有のバリデーション用ヘルパー関数。
+ * 値域は presets.ts に切り出し、汎用 `isValidNumber` に委譲する。
  */
+
+import { isValidNumber } from '@nagiyu/common';
+import { PRICE_RANGE, QUANTITY_RANGE } from './presets.js';
 
 /**
  * 価格が有効な範囲内かチェック
@@ -10,7 +14,7 @@
  * @returns 有効な場合は true
  */
 export function isValidPrice(price: number): boolean {
-  return price >= 0.01 && price <= 1_000_000;
+  return isValidNumber(price, PRICE_RANGE.min, PRICE_RANGE.max);
 }
 
 /**
@@ -19,5 +23,5 @@ export function isValidPrice(price: number): boolean {
  * @returns 有効な場合は true
  */
 export function isValidQuantity(quantity: number): boolean {
-  return quantity >= 0.0001 && quantity <= 1_000_000_000;
+  return isValidNumber(quantity, QUANTITY_RANGE.min, QUANTITY_RANGE.max);
 }

--- a/services/stock-tracker/core/src/validation/presets.ts
+++ b/services/stock-tracker/core/src/validation/presets.ts
@@ -1,0 +1,16 @@
+/**
+ * Stock Tracker Core - Validation Presets
+ *
+ * Stock Tracker 固有のバリデーション値域定義。
+ * `isValidNumber(value, min, max)` と組み合わせて利用する。
+ */
+
+export const PRICE_RANGE = {
+  min: 0.01,
+  max: 1_000_000,
+} as const;
+
+export const QUANTITY_RANGE = {
+  min: 0.0001,
+  max: 1_000_000_000,
+} as const;

--- a/services/stock-tracker/core/tests/unit/validation/helpers.test.ts
+++ b/services/stock-tracker/core/tests/unit/validation/helpers.test.ts
@@ -33,6 +33,12 @@ describe('Validation Helpers', () => {
       expect(isValidPrice(0.01)).toBe(true); // minimum
       expect(isValidPrice(1_000_000)).toBe(true); // maximum
     });
+
+    it('should reject non-finite numbers', () => {
+      expect(isValidPrice(NaN)).toBe(false);
+      expect(isValidPrice(Infinity)).toBe(false);
+      expect(isValidPrice(-Infinity)).toBe(false);
+    });
   });
 
   describe('isValidQuantity', () => {
@@ -58,6 +64,12 @@ describe('Validation Helpers', () => {
     it('should handle edge cases', () => {
       expect(isValidQuantity(0.0001)).toBe(true); // minimum
       expect(isValidQuantity(1_000_000_000)).toBe(true); // maximum
+    });
+
+    it('should reject non-finite numbers', () => {
+      expect(isValidQuantity(NaN)).toBe(false);
+      expect(isValidQuantity(Infinity)).toBe(false);
+      expect(isValidQuantity(-Infinity)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## 変更の概要

#3053（A3: バリデーションヘルパーの集約）への対応。

`services/stock-tracker/core/src/validation/helpers.ts` に独自実装されていた `isValidPrice` / `isValidQuantity` を、`libs/common` の汎用 `isValidNumber(value, min, max)` へ委譲する薄いラッパーに変更。値域定数は新規追加した `services/stock-tracker/core/src/validation/presets.ts` に切り出し、ドメイン固有性を service 側に保持する構成とした。

`libs/common` 側には新たな preset 型を追加していない（YAGNI 観点。将来 2 サービス目で同様の需要が出た時点で昇格させる方針）。

## 関連 Issue

- 親 Issue: #3050
- 対応 Issue: #3053

<!-- integration → develop の PR で Closes を付与するため、本 PR では付けない -->

## 変更種別

- [x] リファクタリング

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [ ] 関連ドキュメントを更新した（対象なし）
- [ ] CI/CD 設定を追加・更新した（対象なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `services/stock-tracker/core/tests/unit/validation/helpers.test.ts` の `isValidPrice` / `isValidQuantity` に NaN / Infinity / -Infinity を reject するケースを追加
- ローカル実行結果:
  - `npm run build --workspace @nagiyu/stock-tracker-core` … 成功
  - `npm run lint --workspace @nagiyu/stock-tracker-core` … 成功
  - `npm run test --workspace @nagiyu/stock-tracker-core` … 52 suites / 713 tests pass
  - `npm run test --workspace @nagiyu/common` … 20 suites / 262 tests pass

## レビューポイント

- **設計判断**: Issue の設計メモでは「`libs/common` に preset 機構（型）だけを置く」案が推奨されていたが、現状利用者が stock-tracker のみのため preset 型は導入せず、値域定数を service 側に置く構成とした。`libs/common` への昇格が必要になった時点で型を追加する想定。
- **挙動変更**: 旧 `isValidPrice` / `isValidQuantity` は `Number.isFinite` チェックを行わず NaN / Infinity を通していた。`isValidNumber` へ統一したことで `NaN` / `±Infinity` が新たに reject される。バリデーションとして望ましい方向の変更だが、もし旧挙動を期待する呼び出し元があった場合は破壊的になり得る（コードベース内では `services/stock-tracker/core/src/validation/index.ts` のみで利用されており、いずれもバリデーション失敗を返す文脈なので問題なし）。
- `ERROR_MESSAGES.HOLDING_QUANTITY_INVALID` 等のメッセージに値域がハードコードされている件は、本 PR のスコープ外（必要なら別 Issue で扱う）。

## 補足事項

- ベースブランチ: `integration/3050-code-consolidation`
- Draft で作成。Ready 化・マージは人力で実施。


---
_Generated by [Claude Code](https://claude.ai/code/session_01S4MdZbniz75DXa94jtfNam)_