### PR TITLE
fix(stock-tracker): 手動無効化された一時アラートを取引時間中に TTL 付与しないよう修正

### DIFF
--- a/services/stock-tracker/batch/src/temporary-alert-expiry.ts
+++ b/services/stock-tracker/batch/src/temporary-alert-expiry.ts
@@ -110,15 +110,6 @@ async function processCandidate(
       return;
     }
 
-    // ユーザーが手動で無効化した一時アラートは取引時間 / 期限到来を待たず、
-    // 即時に TTL を付与して物理削除予約する。
-    if (!candidate.Enabled) {
-      const ttlSeconds = calculateTtlSeconds(now);
-      await alertRepo.markTemporaryAsExpired(candidate.UserID, candidate.AlertID, ttlSeconds);
-      stats.deactivatedManually++;
-      return;
-    }
-
     const exchange = await exchangeRepo.getById(candidate.ExchangeID);
     if (!exchange) {
       stats.errors++;
@@ -127,6 +118,14 @@ async function processCandidate(
 
     if (isTradingHours(exchange, now)) {
       stats.skippedTradingHours++;
+      return;
+    }
+
+    // ユーザーが手動で無効化した一時アラートは、期限到来を待たずに即時 TTL を付与して物理削除予約する。
+    if (!candidate.Enabled) {
+      const ttlSeconds = calculateTtlSeconds(now);
+      await alertRepo.markTemporaryAsExpired(candidate.UserID, candidate.AlertID, ttlSeconds);
+      stats.deactivatedManually++;
       return;
     }
 

--- a/services/stock-tracker/batch/tests/unit/temporary-alert-expiry.test.ts
+++ b/services/stock-tracker/batch/tests/unit/temporary-alert-expiry.test.ts
@@ -184,26 +184,59 @@ describe('temporary alert expiry batch handler', () => {
     expect(body.statistics.skippedNotExpired).toBe(1);
   });
 
-  it('ユーザー手動無効化された一時アラートは取引時間/期限を待たず即時 TTL 付与される', async () => {
-    const userDisabled = buildCandidate({ Enabled: false });
+  it('手動無効化された一時アラートは取引時間外であれば期限到来を待たず即時 TTL 付与される', async () => {
+    const userDisabled = buildCandidate({ Enabled: false, TemporaryExpireDate: '2099-12-31' });
 
     mockAlertRepo.getTemporaryCandidatesByFrequency
       .mockResolvedValueOnce({ items: [userDisabled] })
       .mockResolvedValueOnce({ items: [] });
-    // Enabled=false パスは exchange / trading hours を参照しない
-    (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
-    (tradingHoursChecker.getLastTradingDate as jest.Mock).mockReturnValue('1970-01-01');
+    mockExchangeRepo.getById.mockResolvedValue(NASDAQ);
+    (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(false);
 
     const response = await handler(mockEvent);
     const body = JSON.parse(response.body);
 
     expect(response.statusCode).toBe(200);
-    expect(mockExchangeRepo.getById).not.toHaveBeenCalled();
-    expect(tradingHoursChecker.isTradingHours).not.toHaveBeenCalled();
+    expect(mockExchangeRepo.getById).toHaveBeenCalledTimes(1);
+    expect(tradingHoursChecker.isTradingHours).toHaveBeenCalledTimes(1);
     expect(mockAlertRepo.markTemporaryAsExpired).toHaveBeenCalledTimes(1);
     expect(body.statistics.deactivatedManually).toBe(1);
     expect(body.statistics.deactivated).toBe(0);
     expect(body.statistics.skippedTradingHours).toBe(0);
+  });
+
+  it('手動無効化された一時アラートは取引時間中であればスキップされる', async () => {
+    const userDisabled = buildCandidate({ Enabled: false });
+
+    mockAlertRepo.getTemporaryCandidatesByFrequency
+      .mockResolvedValueOnce({ items: [userDisabled] })
+      .mockResolvedValueOnce({ items: [] });
+    mockExchangeRepo.getById.mockResolvedValue(NASDAQ);
+    (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
+
+    const response = await handler(mockEvent);
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(mockAlertRepo.markTemporaryAsExpired).not.toHaveBeenCalled();
+    expect(body.statistics.skippedTradingHours).toBe(1);
+    expect(body.statistics.deactivatedManually).toBe(0);
+  });
+
+  it('手動無効化された一時アラートで取引所情報が見つからない場合は errors を加算する', async () => {
+    const userDisabled = buildCandidate({ Enabled: false });
+
+    mockAlertRepo.getTemporaryCandidatesByFrequency
+      .mockResolvedValueOnce({ items: [userDisabled] })
+      .mockResolvedValueOnce({ items: [] });
+    mockExchangeRepo.getById.mockResolvedValue(null);
+
+    const response = await handler(mockEvent);
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(mockAlertRepo.markTemporaryAsExpired).not.toHaveBeenCalled();
+    expect(body.statistics.errors).toBe(1);
   });
 
   it('markTemporaryAsExpired が失敗しても errors を加算して処理を継続する', async () => {


### PR DESCRIPTION
## 変更の概要

`temporary-alert-expiry` バッチの `processCandidate` にて、ユーザーが手動で無効化（`Enabled=false`）した一時アラートへの TTL 付与経路でも、`Enabled=true` の通常経路と同様に取引時間チェック（`isTradingHours`）を必ず通すよう修正した。

修正前は `Enabled=false` の場合に取引時間チェックをスキップして即時 TTL を付与していたが、要件は「取引時間中はいかなる一時アラートの状態変更（TTL 付与）も行わない」であるためバグとして修正した。

また、Exchange 取得失敗時のエラーハンドリングを `Enabled=true` 経路と同等にした。

## 関連 Issue

#3078

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

`services/stock-tracker/batch/tests/unit/temporary-alert-expiry.test.ts` を更新：

- 旧テスト「ユーザー手動無効化された一時アラートは取引時間/期限を待たず即時 TTL 付与される」を削除し、以下の3ケースに分割：
  1. **手動無効化 + 取引時間外** → 期限到来を待たず即時 TTL 付与（`deactivatedManually++`）
  2. **手動無効化 + 取引時間中** → TTL 付与をスキップ（`skippedTradingHours++`）
  3. **手動無効化 + 取引所情報なし** → エラー加算（`errors++`）

全 117 テスト（修正前 115 テスト + 新規 2 テスト）がパスすることを確認済み。

## レビューポイント

- `temporary-alert-expiry.ts` の `if (!candidate.Enabled)` ブロックを `isTradingHours` チェックの後に移動したことで、`Enabled=true` / `Enabled=false` の両経路が同一の取引時間ゲートを通る構造になっている。
- `Enabled=false` 経路では引き続き `getLastTradingDate` による期限到来判定は行わず、取引時間外であれば即時 TTL を付与する仕様を維持している（Issue #3078 の注意事項に従う）。

## 補足事項

- ブランチカバレッジが 78.41% で閾値（80%）を下回っているが、これは本 PR の変更前から存在していた問題（`evaluation.ts` や `summary.ts` 等の未カバー分岐）であり、本修正では悪化させていない。`temporary-alert-expiry.ts` 単体では 83.33% を確保している。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnzgY5Wrks1ExmQ7yw8xx4)_