### PR TITLE
[#3055] API レスポンス型を libs/common に集約し share-together を移行

### DIFF
--- a/libs/common/src/api/index.ts
+++ b/libs/common/src/api/index.ts
@@ -14,6 +14,8 @@ export type {
   APIErrorResponse,
   ErrorResponse,
   PaginatedResponse,
+  ApiSuccessResponse,
+  ApiResponse,
 } from './types.js';
 export { APIError } from './types.js';
 export { COMMON_ERROR_MESSAGES } from '../constants/error-messages.js';

--- a/libs/common/src/api/types.ts
+++ b/libs/common/src/api/types.ts
@@ -64,6 +64,18 @@ export interface PaginatedResponse<T> {
 }
 
 /**
+ * 成功レスポンス型
+ */
+export interface ApiSuccessResponse<T> {
+  data: T;
+}
+
+/**
+ * APIレスポンス型（成功・失敗のユニオン）
+ */
+export type ApiResponse<T> = ApiSuccessResponse<T> | APIErrorResponse;
+
+/**
  * APIエラー
  */
 export class APIError extends Error {

--- a/services/share-together/web/src/app/api/groups/[groupId]/lists/[listId]/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/lists/[listId]/route.ts
@@ -16,10 +16,8 @@ interface RouteParams {
 
 function createErrorResponse(code: string, message: string, status: number): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
 
   return NextResponse.json(response, { status });

--- a/services/share-together/web/src/app/api/groups/[groupId]/lists/[listId]/todos/[todoId]/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/lists/[listId]/todos/[todoId]/route.ts
@@ -37,10 +37,8 @@ const NOT_FOUND_ERROR_MESSAGES: Set<string> = new Set([ERROR_MESSAGES.TODO_NOT_F
 
 function createErrorResponse(code: string, message: string, status: number): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
 
   return NextResponse.json(response, { status });

--- a/services/share-together/web/src/app/api/groups/[groupId]/lists/[listId]/todos/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/lists/[listId]/todos/route.ts
@@ -16,10 +16,8 @@ type RouteParams = {
 
 function createErrorResponse(code: string, message: string, status: number): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
 
   return NextResponse.json(response, { status });

--- a/services/share-together/web/src/app/api/groups/[groupId]/lists/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/lists/route.ts
@@ -12,10 +12,8 @@ type RouteParams = {
 
 function createErrorResponse(code: string, message: string, status: number): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
 
   return NextResponse.json(response, { status });

--- a/services/share-together/web/src/app/api/groups/[groupId]/members/[userId]/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/members/[userId]/route.ts
@@ -14,10 +14,8 @@ import { createGroupRepository, createMembershipRepository } from '@nagiyu/share
 
 function createErrorResponse(code: string, message: string, status: number): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
 
   return NextResponse.json(response, { status });

--- a/services/share-together/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/members/route.ts
@@ -21,10 +21,8 @@ type InviteRequestBody = {
 
 function createErrorResponse(code: string, message: string, status: number): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
   return NextResponse.json(response, { status });
 }

--- a/services/share-together/web/src/app/api/groups/[groupId]/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/route.ts
@@ -24,18 +24,10 @@ interface UpdateGroupRequestBody {
   name?: string;
 }
 
-function createErrorResponse(
-  status: number,
-  code: string,
-  message: string,
-  details?: unknown
-): NextResponse {
+function createErrorResponse(status: number, code: string, message: string): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-      details,
-    },
+    error: code,
+    message,
   };
 
   return NextResponse.json(response, { status });

--- a/services/share-together/web/src/app/api/groups/route.ts
+++ b/services/share-together/web/src/app/api/groups/route.ts
@@ -12,10 +12,8 @@ interface GroupSummary extends Group {
 
 function createErrorResponse(status: number, code: string, message: string): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
 
   return NextResponse.json(response, { status });

--- a/services/share-together/web/src/app/api/invitations/[groupId]/route.ts
+++ b/services/share-together/web/src/app/api/invitations/[groupId]/route.ts
@@ -27,10 +27,8 @@ type InvitationUpdateResponse = {
 
 function createErrorResponse(code: string, message: string, status: number): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
   return NextResponse.json(response, { status });
 }

--- a/services/share-together/web/src/app/api/invitations/route.ts
+++ b/services/share-together/web/src/app/api/invitations/route.ts
@@ -14,10 +14,8 @@ const USER_META_SK = '#META#';
 
 function createValidationErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'VALIDATION_ERROR',
-      message: ERROR_MESSAGES.VALIDATION_ERROR,
-    },
+    error: 'VALIDATION_ERROR',
+    message: ERROR_MESSAGES.VALIDATION_ERROR,
   };
 
   return NextResponse.json(response, { status: 400 });
@@ -25,10 +23,8 @@ function createValidationErrorResponse(): NextResponse {
 
 function createInternalServerErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'INTERNAL_SERVER_ERROR',
-      message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-    },
+    error: 'INTERNAL_SERVER_ERROR',
+    message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
   };
 
   return NextResponse.json(response, { status: 500 });

--- a/services/share-together/web/src/app/api/lists/[listId]/route.ts
+++ b/services/share-together/web/src/app/api/lists/[listId]/route.ts
@@ -19,10 +19,8 @@ const VALIDATION_ERROR_MESSAGES: Set<string> = new Set([
 
 function createValidationErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'VALIDATION_ERROR',
-      message: ERROR_MESSAGES.VALIDATION_ERROR,
-    },
+    error: 'VALIDATION_ERROR',
+    message: ERROR_MESSAGES.VALIDATION_ERROR,
   };
 
   return NextResponse.json(response, { status: 400 });
@@ -30,10 +28,8 @@ function createValidationErrorResponse(): NextResponse {
 
 function createNotFoundErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'NOT_FOUND',
-      message: ERROR_MESSAGES.NOT_FOUND,
-    },
+    error: 'NOT_FOUND',
+    message: ERROR_MESSAGES.NOT_FOUND,
   };
 
   return NextResponse.json(response, { status: 404 });
@@ -41,10 +37,8 @@ function createNotFoundErrorResponse(): NextResponse {
 
 function createDefaultListNotDeletableResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'DEFAULT_LIST_NOT_DELETABLE',
-      message: ERROR_MESSAGES.DEFAULT_LIST_NOT_DELETABLE,
-    },
+    error: 'DEFAULT_LIST_NOT_DELETABLE',
+    message: ERROR_MESSAGES.DEFAULT_LIST_NOT_DELETABLE,
   };
 
   return NextResponse.json(response, { status: 400 });
@@ -52,10 +46,8 @@ function createDefaultListNotDeletableResponse(): NextResponse {
 
 function createInternalServerErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'INTERNAL_SERVER_ERROR',
-      message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-    },
+    error: 'INTERNAL_SERVER_ERROR',
+    message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
   };
 
   return NextResponse.json(response, { status: 500 });

--- a/services/share-together/web/src/app/api/lists/[listId]/todos/[todoId]/route.ts
+++ b/services/share-together/web/src/app/api/lists/[listId]/todos/[todoId]/route.ts
@@ -28,10 +28,8 @@ interface UpdateTodoRequestBody {
 
 function createValidationErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'VALIDATION_ERROR',
-      message: ERROR_MESSAGES.VALIDATION_ERROR,
-    },
+    error: 'VALIDATION_ERROR',
+    message: ERROR_MESSAGES.VALIDATION_ERROR,
   };
 
   return NextResponse.json(response, { status: 400 });
@@ -39,10 +37,8 @@ function createValidationErrorResponse(): NextResponse {
 
 function createNotFoundErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'NOT_FOUND',
-      message: ERROR_MESSAGES.NOT_FOUND,
-    },
+    error: 'NOT_FOUND',
+    message: ERROR_MESSAGES.NOT_FOUND,
   };
 
   return NextResponse.json(response, { status: 404 });
@@ -50,10 +46,8 @@ function createNotFoundErrorResponse(): NextResponse {
 
 function createForbiddenErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'FORBIDDEN',
-      message: ERROR_MESSAGES.FORBIDDEN,
-    },
+    error: 'FORBIDDEN',
+    message: ERROR_MESSAGES.FORBIDDEN,
   };
 
   return NextResponse.json(response, { status: 403 });
@@ -61,10 +55,8 @@ function createForbiddenErrorResponse(): NextResponse {
 
 function createInternalServerErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'INTERNAL_SERVER_ERROR',
-      message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-    },
+    error: 'INTERNAL_SERVER_ERROR',
+    message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
   };
 
   return NextResponse.json(response, { status: 500 });

--- a/services/share-together/web/src/app/api/lists/[listId]/todos/route.ts
+++ b/services/share-together/web/src/app/api/lists/[listId]/todos/route.ts
@@ -24,10 +24,8 @@ const VALIDATION_ERROR_MESSAGES: Set<string> = new Set([
 
 function createValidationErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'VALIDATION_ERROR',
-      message: ERROR_MESSAGES.VALIDATION_ERROR,
-    },
+    error: 'VALIDATION_ERROR',
+    message: ERROR_MESSAGES.VALIDATION_ERROR,
   };
 
   return NextResponse.json(response, { status: 400 });
@@ -35,10 +33,8 @@ function createValidationErrorResponse(): NextResponse {
 
 function createNotFoundErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'NOT_FOUND',
-      message: ERROR_MESSAGES.NOT_FOUND,
-    },
+    error: 'NOT_FOUND',
+    message: ERROR_MESSAGES.NOT_FOUND,
   };
 
   return NextResponse.json(response, { status: 404 });
@@ -46,10 +42,8 @@ function createNotFoundErrorResponse(): NextResponse {
 
 function createInternalServerErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'INTERNAL_SERVER_ERROR',
-      message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-    },
+    error: 'INTERNAL_SERVER_ERROR',
+    message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
   };
 
   return NextResponse.json(response, { status: 500 });

--- a/services/share-together/web/src/app/api/lists/route.ts
+++ b/services/share-together/web/src/app/api/lists/route.ts
@@ -13,10 +13,8 @@ const VALIDATION_ERROR_MESSAGES: Set<string> = new Set([
 
 function createValidationErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'VALIDATION_ERROR',
-      message: ERROR_MESSAGES.VALIDATION_ERROR,
-    },
+    error: 'VALIDATION_ERROR',
+    message: ERROR_MESSAGES.VALIDATION_ERROR,
   };
 
   return NextResponse.json(response, { status: 400 });
@@ -24,10 +22,8 @@ function createValidationErrorResponse(): NextResponse {
 
 function createInternalServerErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'INTERNAL_SERVER_ERROR',
-      message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-    },
+    error: 'INTERNAL_SERVER_ERROR',
+    message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
   };
 
   return NextResponse.json(response, { status: 500 });
@@ -35,10 +31,8 @@ function createInternalServerErrorResponse(): NextResponse {
 
 function createConflictResponse(code: string, message: string): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code,
-      message,
-    },
+    error: code,
+    message,
   };
 
   return NextResponse.json(response, { status: 409 });

--- a/services/share-together/web/src/app/api/test/reset/route.ts
+++ b/services/share-together/web/src/app/api/test/reset/route.ts
@@ -71,7 +71,7 @@ async function seedInMemoryData(seedData: ResetSeedData): Promise<void> {
 async function handleReset(request?: Request): Promise<NextResponse> {
   if (!isTestMode()) {
     return NextResponse.json(
-      { error: { code: 'NOT_FOUND', message: ERROR_MESSAGES.NOT_FOUND } },
+      { error: 'NOT_FOUND', message: ERROR_MESSAGES.NOT_FOUND },
       { status: 404 }
     );
   }
@@ -96,7 +96,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   } catch (error) {
     console.error('/api/test/reset POST の実行に失敗しました', { error });
     return NextResponse.json(
-      { error: { code: 'INTERNAL_SERVER_ERROR', message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR } },
+      { error: 'INTERNAL_SERVER_ERROR', message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR },
       { status: 500 }
     );
   }
@@ -108,7 +108,7 @@ export async function DELETE(): Promise<NextResponse> {
   } catch (error) {
     console.error('/api/test/reset DELETE の実行に失敗しました', { error });
     return NextResponse.json(
-      { error: { code: 'INTERNAL_SERVER_ERROR', message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR } },
+      { error: 'INTERNAL_SERVER_ERROR', message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR },
       { status: 500 }
     );
   }

--- a/services/share-together/web/src/app/api/users/route.ts
+++ b/services/share-together/web/src/app/api/users/route.ts
@@ -36,10 +36,8 @@ async function getSessionWithRoles(): Promise<UsersRouteSession | null> {
 
 function createValidationErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'VALIDATION_ERROR',
-      message: ERROR_MESSAGES.VALIDATION_ERROR,
-    },
+    error: 'VALIDATION_ERROR',
+    message: ERROR_MESSAGES.VALIDATION_ERROR,
   };
 
   return NextResponse.json(response, { status: 400 });
@@ -47,10 +45,8 @@ function createValidationErrorResponse(): NextResponse {
 
 function createInternalServerErrorResponse(): NextResponse {
   const response: ApiErrorResponse = {
-    error: {
-      code: 'INTERNAL_SERVER_ERROR',
-      message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-    },
+    error: 'INTERNAL_SERVER_ERROR',
+    message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
   };
 
   return NextResponse.json(response, { status: 500 });

--- a/services/share-together/web/src/components/GroupDetailClient.tsx
+++ b/services/share-together/web/src/components/GroupDetailClient.tsx
@@ -74,9 +74,9 @@ export function GroupDetailClient({
 
   const getErrorMessage = async (response: Response): Promise<string> => {
     try {
-      const data = (await response.json()) as { error?: { message?: string } };
-      if (typeof data.error?.message === 'string') {
-        return data.error.message;
+      const data = (await response.json()) as { message?: string };
+      if (typeof data.message === 'string') {
+        return data.message;
       }
     } catch {
       // noop

--- a/services/share-together/web/src/components/InviteForm.tsx
+++ b/services/share-together/web/src/components/InviteForm.tsx
@@ -38,10 +38,10 @@ export function InviteForm({ groupId, isOwner, memberCount }: InviteFormProps) {
 
       if (!response.ok) {
         const body = (await response.json().catch(() => null)) as {
-          error?: { message?: string };
+          message?: string;
         } | null;
         setSubmitted(false);
-        setErrorMessage(body?.error?.message ?? ERROR_MESSAGES.INVITATION_SEND_FAILED);
+        setErrorMessage(body?.message ?? ERROR_MESSAGES.INVITATION_SEND_FAILED);
         return;
       }
 

--- a/services/share-together/web/src/components/ListSidebar.tsx
+++ b/services/share-together/web/src/components/ListSidebar.tsx
@@ -54,8 +54,8 @@ const ERROR_MESSAGES = {
 async function getErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
   try {
     const body = (await response.json()) as ApiErrorResponse;
-    if (body?.error?.message && typeof body.error.message === 'string') {
-      return body.error.message;
+    if (body?.message && typeof body.message === 'string') {
+      return body.message;
     }
   } catch {
     // no-op

--- a/services/share-together/web/src/components/ListWorkspace.tsx
+++ b/services/share-together/web/src/components/ListWorkspace.tsx
@@ -55,9 +55,9 @@ export function ListWorkspace({
 
   const getErrorMessage = async (response: Response): Promise<string> => {
     try {
-      const data = (await response.json()) as { error?: { message?: string } };
-      if (typeof data.error?.message === 'string') {
-        return data.error.message;
+      const data = (await response.json()) as { message?: string };
+      if (typeof data.message === 'string') {
+        return data.message;
       }
     } catch {
       // noop

--- a/services/share-together/web/src/lib/auth/session.ts
+++ b/services/share-together/web/src/lib/auth/session.ts
@@ -39,10 +39,8 @@ export const getSession = getSessionFromAuth;
 export function createUnauthorizedResponse(): NextResponse {
   return NextResponse.json(
     {
-      error: {
-        code: 'UNAUTHORIZED',
-        message: ERROR_MESSAGES.UNAUTHORIZED,
-      },
+      error: 'UNAUTHORIZED',
+      message: ERROR_MESSAGES.UNAUTHORIZED,
     },
     { status: 401 }
   );

--- a/services/share-together/web/src/middleware.ts
+++ b/services/share-together/web/src/middleware.ts
@@ -20,10 +20,8 @@ export default auth(
       console.error(LOG_MESSAGES.AUTH_URL_NOT_SET);
       return NextResponse.json(
         {
-          error: {
-            code: 'INTERNAL_SERVER_ERROR',
-            message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-          },
+          error: 'INTERNAL_SERVER_ERROR',
+          message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
         },
         { status: 500 }
       );

--- a/services/share-together/web/src/types/index.ts
+++ b/services/share-together/web/src/types/index.ts
@@ -10,21 +10,11 @@ import type { DefaultSession } from 'next-auth';
 
 export type { TodoItem };
 
-export interface ApiError {
-  code: string;
-  message: string;
-  details?: unknown;
-}
-
-export interface ApiSuccessResponse<T> {
-  data: T;
-}
-
-export interface ApiErrorResponse {
-  error: ApiError;
-}
-
-export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;
+export type {
+  ApiSuccessResponse,
+  ApiResponse,
+  ErrorResponse as ApiErrorResponse,
+} from '@nagiyu/common';
 
 export type HealthResponse = ApiSuccessResponse<{ status: 'ok' }>;
 export type UserResponse = ApiSuccessResponse<User>;

--- a/services/share-together/web/src/types/index.ts
+++ b/services/share-together/web/src/types/index.ts
@@ -10,11 +10,8 @@ import type { DefaultSession } from 'next-auth';
 
 export type { TodoItem };
 
-export type {
-  ApiSuccessResponse,
-  ApiResponse,
-  ErrorResponse as ApiErrorResponse,
-} from '@nagiyu/common';
+import type { ApiSuccessResponse, ApiResponse, ErrorResponse as ApiErrorResponse } from '@nagiyu/common';
+export type { ApiSuccessResponse, ApiResponse, ApiErrorResponse };
 
 export type HealthResponse = ApiSuccessResponse<{ status: 'ok' }>;
 export type UserResponse = ApiSuccessResponse<User>;

--- a/services/share-together/web/src/types/index.ts
+++ b/services/share-together/web/src/types/index.ts
@@ -7,10 +7,13 @@ import type {
   TodoItem,
 } from '@nagiyu/share-together-core';
 import type { DefaultSession } from 'next-auth';
+import type {
+  ApiSuccessResponse,
+  ApiResponse,
+  ErrorResponse as ApiErrorResponse,
+} from '@nagiyu/common';
 
 export type { TodoItem };
-
-import type { ApiSuccessResponse, ApiResponse, ErrorResponse as ApiErrorResponse } from '@nagiyu/common';
 export type { ApiSuccessResponse, ApiResponse, ApiErrorResponse };
 
 export type HealthResponse = ApiSuccessResponse<{ status: 'ok' }>;

--- a/services/share-together/web/tests/unit/GroupDetailClient.test.tsx
+++ b/services/share-together/web/tests/unit/GroupDetailClient.test.tsx
@@ -173,7 +173,7 @@ describe('GroupDetailClient', () => {
   it('メンバー削除に失敗した場合はAPIエラーメッセージを表示する', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: false,
-      json: async () => ({ error: { message: 'この操作はオーナーのみ実行できます' } }),
+      json: async () => ({ error: 'OWNER_ONLY', message: 'この操作はオーナーのみ実行できます' }),
     } as Response);
 
     render(

--- a/services/share-together/web/tests/unit/InviteForm.test.tsx
+++ b/services/share-together/web/tests/unit/InviteForm.test.tsx
@@ -99,7 +99,7 @@ describe('InviteForm', () => {
   it('API がエラーを返した場合はエラーメッセージを表示する', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
-      json: async () => ({ error: { message: '既に招待済みです' } }),
+      json: async () => ({ error: 'ALREADY_INVITED', message: '既に招待済みです' }),
     } as Response);
     render(<InviteForm groupId="group-1" isOwner={true} memberCount={1} />);
 

--- a/services/share-together/web/tests/unit/ListSidebar.test.tsx
+++ b/services/share-together/web/tests/unit/ListSidebar.test.tsx
@@ -119,7 +119,8 @@ describe('ListSidebar', () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: false,
       json: async () => ({
-        error: { message: '一覧取得に失敗しました。' },
+        error: 'INTERNAL_SERVER_ERROR',
+        message: '一覧取得に失敗しました。',
       }),
     } as Response);
     Object.defineProperty(globalThis, 'fetch', {

--- a/services/share-together/web/tests/unit/ListWorkspace.test.tsx
+++ b/services/share-together/web/tests/unit/ListWorkspace.test.tsx
@@ -46,9 +46,8 @@ describe('ListWorkspace', () => {
               ok: false,
               status: 400,
               json: async () => ({
-                error: {
-                  message: '共有リスト名が不正です',
-                },
+                error: 'VALIDATION_ERROR',
+                message: '共有リスト名が不正です',
               }),
             } as Response);
           }

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/lists/[listId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/lists/[listId]/route.test.ts
@@ -142,10 +142,8 @@ describe('/api/groups/[groupId]/lists/[listId] route', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'FORBIDDEN',
-        message: 'この操作を実行する権限がありません',
-      },
+      error: 'FORBIDDEN',
+      message: 'この操作を実行する権限がありません',
     });
   });
 

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/lists/[listId]/todos/[todoId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/lists/[listId]/todos/[todoId]/route.test.ts
@@ -142,10 +142,8 @@ describe('/api/groups/[groupId]/lists/[listId]/todos/[todoId] route', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'FORBIDDEN',
-        message: 'この操作を実行する権限がありません',
-      },
+      error: 'FORBIDDEN',
+      message: 'この操作を実行する権限がありません',
     });
   });
 
@@ -271,10 +269,8 @@ describe('/api/groups/[groupId]/lists/[listId]/todos/[todoId] route', () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'NOT_FOUND',
-        message: '対象のデータが見つかりません',
-      },
+      error: 'NOT_FOUND',
+      message: '対象のデータが見つかりません',
     });
   });
 });

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/lists/[listId]/todos/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/lists/[listId]/todos/route.test.ts
@@ -131,10 +131,8 @@ describe('/api/groups/[groupId]/lists/[listId]/todos route', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'FORBIDDEN',
-        message: 'この操作を実行する権限がありません',
-      },
+      error: 'FORBIDDEN',
+      message: 'この操作を実行する権限がありません',
     });
   });
 

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/lists/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/lists/route.test.ts
@@ -106,10 +106,8 @@ describe('/api/groups/[groupId]/lists route', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'FORBIDDEN',
-        message: 'この操作を実行する権限がありません',
-      },
+      error: 'FORBIDDEN',
+      message: 'この操作を実行する権限がありません',
     });
   });
 

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/members/[userId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/members/[userId]/route.test.ts
@@ -151,7 +151,8 @@ describe('DELETE /api/groups/[groupId]/members/[userId]', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'OWNER_ONLY', message: 'この操作はオーナーのみ実行できます' },
+      error: 'OWNER_ONLY',
+      message: 'この操作はオーナーのみ実行できます',
     });
     expect(mockRemoveMember).not.toHaveBeenCalled();
   });
@@ -191,7 +192,8 @@ describe('DELETE /api/groups/[groupId]/members/[userId]', () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'NOT_FOUND', message: '対象のデータが見つかりません' },
+      error: 'NOT_FOUND',
+      message: '対象のデータが見つかりません',
     });
   });
 
@@ -207,7 +209,8 @@ describe('DELETE /api/groups/[groupId]/members/[userId]', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'OWNER_CANNOT_LEAVE', message: 'オーナーはグループを脱退できません' },
+      error: 'OWNER_CANNOT_LEAVE',
+      message: 'オーナーはグループを脱退できません',
     });
   });
 
@@ -224,7 +227,8 @@ describe('DELETE /api/groups/[groupId]/members/[userId]', () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'NOT_FOUND', message: '対象のデータが見つかりません' },
+      error: 'NOT_FOUND',
+      message: '対象のデータが見つかりません',
     });
   });
 
@@ -241,7 +245,8 @@ describe('DELETE /api/groups/[groupId]/members/[userId]', () => {
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'INTERNAL_SERVER_ERROR', message: 'サーバーエラーが発生しました' },
+      error: 'INTERNAL_SERVER_ERROR',
+      message: 'サーバーエラーが発生しました',
     });
   });
 });

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/members/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/members/route.test.ts
@@ -143,10 +143,8 @@ describe('/api/groups/[groupId]/members route', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'FORBIDDEN',
-        message: 'この操作を実行する権限がありません',
-      },
+      error: 'FORBIDDEN',
+      message: 'この操作を実行する権限がありません',
     });
   });
 
@@ -233,10 +231,8 @@ describe('/api/groups/[groupId]/members route', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'OWNER_ONLY',
-        message: 'この操作はオーナーのみ実行できます',
-      },
+      error: 'OWNER_ONLY',
+      message: 'この操作はオーナーのみ実行できます',
     });
   });
 
@@ -327,10 +323,8 @@ describe('/api/groups/[groupId]/members route', () => {
 
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'ALREADY_INVITED',
-        message: '既に招待済みです',
-      },
+      error: 'ALREADY_INVITED',
+      message: '既に招待済みです',
     });
   });
 
@@ -367,10 +361,8 @@ describe('/api/groups/[groupId]/members route', () => {
 
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'MEMBER_LIMIT_EXCEEDED',
-        message: 'グループメンバーは最大5名です',
-      },
+      error: 'MEMBER_LIMIT_EXCEEDED',
+      message: 'グループメンバーは最大5名です',
     });
   });
 });

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
@@ -155,11 +155,8 @@ describe('/api/groups/[groupId] route handlers', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'OWNER_ONLY',
-        message: 'この操作はオーナーのみ実行できます',
-        details: undefined,
-      },
+      error: 'OWNER_ONLY',
+      message: 'この操作はオーナーのみ実行できます',
     });
   });
 
@@ -204,11 +201,8 @@ describe('/api/groups/[groupId] route handlers', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'OWNER_ONLY',
-        message: 'この操作はオーナーのみ実行できます',
-        details: undefined,
-      },
+      error: 'OWNER_ONLY',
+      message: 'この操作はオーナーのみ実行できます',
     });
     expect(mockDeleteByGroupId).not.toHaveBeenCalled();
     expect(mockDelete).not.toHaveBeenCalled();
@@ -235,11 +229,8 @@ describe('/api/groups/[groupId] route handlers', () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'VALIDATION_ERROR',
-        message: '入力内容が不正です',
-        details: undefined,
-      },
+      error: 'VALIDATION_ERROR',
+      message: '入力内容が不正です',
     });
   });
 });

--- a/services/share-together/web/tests/unit/app/api/invitations/[groupId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/invitations/[groupId]/route.test.ts
@@ -117,10 +117,8 @@ describe('PUT /api/invitations/[groupId]', () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'VALIDATION_ERROR',
-        message: '入力内容が不正です',
-      },
+      error: 'VALIDATION_ERROR',
+      message: '入力内容が不正です',
     });
   });
 
@@ -178,10 +176,8 @@ describe('PUT /api/invitations/[groupId]', () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'NOT_FOUND',
-        message: '対象のデータが見つかりません',
-      },
+      error: 'NOT_FOUND',
+      message: '対象のデータが見つかりません',
     });
   });
 
@@ -231,10 +227,8 @@ describe('PUT /api/invitations/[groupId]', () => {
 
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'ALREADY_RESPONDED',
-        message: 'この招待には既に応答済みです',
-      },
+      error: 'ALREADY_RESPONDED',
+      message: 'この招待には既に応答済みです',
     });
   });
 });

--- a/services/share-together/web/tests/unit/app/api/invitations/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/invitations/route.test.ts
@@ -161,10 +161,8 @@ describe('GET /api/invitations', () => {
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'サーバーエラーが発生しました',
-      },
+      error: 'INTERNAL_SERVER_ERROR',
+      message: 'サーバーエラーが発生しました',
     });
   });
 });

--- a/services/share-together/web/tests/unit/app/api/lists/[listId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/lists/[listId]/route.test.ts
@@ -180,10 +180,8 @@ describe('/api/lists/[listId] route handlers', () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'DEFAULT_LIST_NOT_DELETABLE',
-        message: ERROR_MESSAGES.DEFAULT_LIST_NOT_DELETABLE,
-      },
+      error: 'DEFAULT_LIST_NOT_DELETABLE',
+      message: ERROR_MESSAGES.DEFAULT_LIST_NOT_DELETABLE,
     });
   });
 });

--- a/services/share-together/web/tests/unit/app/api/lists/[listId]/todos/[todoId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/lists/[listId]/todos/[todoId]/route.test.ts
@@ -211,10 +211,8 @@ describe('/api/lists/[listId]/todos/[todoId] route handlers', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'FORBIDDEN',
-        message: ERROR_MESSAGES.FORBIDDEN,
-      },
+      error: 'FORBIDDEN',
+      message: ERROR_MESSAGES.FORBIDDEN,
     });
     expect(mockUpdateTodo).not.toHaveBeenCalled();
   });
@@ -259,10 +257,8 @@ describe('/api/lists/[listId]/todos/[todoId] route handlers', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'FORBIDDEN',
-        message: ERROR_MESSAGES.FORBIDDEN,
-      },
+      error: 'FORBIDDEN',
+      message: ERROR_MESSAGES.FORBIDDEN,
     });
     expect(mockDeleteTodo).not.toHaveBeenCalled();
   });

--- a/services/share-together/web/tests/unit/app/api/lists/[listId]/todos/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/lists/[listId]/todos/route.test.ts
@@ -186,10 +186,8 @@ describe('/api/lists/[listId]/todos route handlers', () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'NOT_FOUND',
-        message: '対象のデータが見つかりません',
-      },
+      error: 'NOT_FOUND',
+      message: '対象のデータが見つかりません',
     });
   });
 

--- a/services/share-together/web/tests/unit/app/api/lists/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/lists/route.test.ts
@@ -199,10 +199,8 @@ describe('/api/lists route handlers', () => {
 
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'PERSONAL_LIST_LIMIT_EXCEEDED',
-        message: ERROR_MESSAGES.PERSONAL_LIST_LIMIT_EXCEEDED,
-      },
+      error: 'PERSONAL_LIST_LIMIT_EXCEEDED',
+      message: ERROR_MESSAGES.PERSONAL_LIST_LIMIT_EXCEEDED,
     });
   });
 });

--- a/services/share-together/web/tests/unit/app/api/test/reset/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/test/reset/route.test.ts
@@ -54,14 +54,15 @@ describe('POST /api/test/reset', () => {
     jest.clearAllMocks();
   });
 
-  it('テストモード以外は 404 を { error: { code, message } } 形式で返す', async () => {
+  it('テストモード以外は 404 を { error, message } 形式で返す', async () => {
     process.env.USE_IN_MEMORY_DB = 'false';
 
     const response = await POST(createRequest());
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'NOT_FOUND', message: '対象のデータが見つかりません' },
+      error: 'NOT_FOUND',
+      message: '対象のデータが見つかりません',
     });
   });
 
@@ -73,14 +74,15 @@ describe('POST /api/test/reset', () => {
     await expect(response.json()).resolves.toEqual({ data: { success: true } });
   });
 
-  it('例外発生時は 500 を { error: { code, message } } 形式で返す', async () => {
+  it('例外発生時は 500 を { error, message } 形式で返す', async () => {
     mockGetSessionOrUnauthorized.mockRejectedValue(new Error('予期しないエラー'));
 
     const response = await POST(createRequest());
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'INTERNAL_SERVER_ERROR', message: 'サーバーエラーが発生しました' },
+      error: 'INTERNAL_SERVER_ERROR',
+      message: 'サーバーエラーが発生しました',
     });
   });
 });
@@ -100,14 +102,15 @@ describe('DELETE /api/test/reset', () => {
     jest.clearAllMocks();
   });
 
-  it('テストモード以外は 404 を { error: { code, message } } 形式で返す', async () => {
+  it('テストモード以外は 404 を { error, message } 形式で返す', async () => {
     process.env.USE_IN_MEMORY_DB = 'false';
 
     const response = await DELETE();
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'NOT_FOUND', message: '対象のデータが見つかりません' },
+      error: 'NOT_FOUND',
+      message: '対象のデータが見つかりません',
     });
   });
 
@@ -119,14 +122,15 @@ describe('DELETE /api/test/reset', () => {
     await expect(response.json()).resolves.toEqual({ data: { success: true } });
   });
 
-  it('例外発生時は 500 を { error: { code, message } } 形式で返す', async () => {
+  it('例外発生時は 500 を { error, message } 形式で返す', async () => {
     mockGetSessionOrUnauthorized.mockRejectedValue(new Error('予期しないエラー'));
 
     const response = await DELETE();
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
-      error: { code: 'INTERNAL_SERVER_ERROR', message: 'サーバーエラーが発生しました' },
+      error: 'INTERNAL_SERVER_ERROR',
+      message: 'サーバーエラーが発生しました',
     });
   });
 });

--- a/services/share-together/web/tests/unit/lib/auth/session.test.ts
+++ b/services/share-together/web/tests/unit/lib/auth/session.test.ts
@@ -26,10 +26,8 @@ describe('session helper', () => {
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({
-      error: {
-        code: 'UNAUTHORIZED',
-        message: '認証が必要です',
-      },
+      error: 'UNAUTHORIZED',
+      message: '認証が必要です',
     });
   });
 

--- a/services/share-together/web/tests/unit/middleware.test.ts
+++ b/services/share-together/web/tests/unit/middleware.test.ts
@@ -118,10 +118,8 @@ describe('middleware', () => {
       type: 'json',
       status: 500,
       body: {
-        error: {
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'サーバーエラーが発生しました',
-        },
+        error: 'INTERNAL_SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
       },
     });
     expect(consoleErrorSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
## 変更の概要

`ApiSuccessResponse<T>` / `ApiResponse<T>` を `libs/common/src/api/types.ts` に新規追加し、`share-together` が独自定義していた API レスポンス型を廃止して `@nagiyu/common` に集約する。

あわせて、`share-together` の `ApiErrorResponse`（ネスト形式: `{ error: { code, message } }`）を、`libs/common` の既存型 `ErrorResponse`（フラット形式: `{ error: string; message: string }`）に統一した。他 service（codec-converter, stock-tracker）はすでにフラット形式を使用しており、share-together 独自の形状を採用する明確な理由が存在しなかったため。

### 変更ファイル

- `libs/common/src/api/types.ts` — `ApiSuccessResponse<T>` / `ApiResponse<T>` を追加
- `libs/common/src/api/index.ts` — 上記 2 型をエクスポート
- `services/share-together/web/src/types/index.ts` — 重複型を削除し `@nagiyu/common` から re-export
- `services/share-together/web/src/app/api/**/route.ts`（15 ファイル）— エラーレスポンス構築を `{ error: code, message }` に変更
- `services/share-together/web/src/components/ListSidebar.tsx` — `body.error.message` → `body.message`

## 関連 Issue

#3055（親: #3050）

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した
- [x] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [ ] ローカルでテストが全て通ることを確認した（環境依存のため CI で確認）
- [ ] ビルドエラーがないことを確認した（環境依存のため CI で確認）

## テスト内容

- 型定義は純粋型なのでランタイムテストは不要
- 型整合性は TypeScript コンパイラが CI で検証（local は npm install 未実行のため skip）
- 既存の route.ts / ListSidebar.tsx のユニットテスト・E2E テストが通ることで動作を確認

## レビューポイント

1. `ErrorResponse`（フラット）へ統一した判断の妥当性
   - `error.code` はルート側で書き込んでいるが、クライアント側（ListSidebar.tsx）では一切参照していなかったため機能影響なし
2. `share-together/types/index.ts` で `ErrorResponse as ApiErrorResponse` と alias re-export しているため、route.ts 群の import パスは変更せずに済む
3. `groups/[groupId]/route.ts` の `createErrorResponse` から `details?: unknown` 引数を削除（実際の呼び出しで使用されていなかったため）

## 補足事項

- `libs/common` の `APIErrorResponse`（大文字）と今回追加の `ApiSuccessResponse`（小文字）で命名規則に揺れがあるが、既存命名を壊す影響が大きいため現状維持
- 他 service（codec-converter / stock-tracker）の既存コードは変更なし


---
_Generated by [Claude Code](https://claude.ai/code/session_01PU6VBvmFLxzbxhmu5TJfQf)_