### PR TITLE
feat(stock-tracker): TickerAlertListCard に「一時/常設」Chip を追加

### DIFF
--- a/services/stock-tracker/web/components/TickerAlertListCard.tsx
+++ b/services/stock-tracker/web/components/TickerAlertListCard.tsx
@@ -178,6 +178,9 @@ export default function TickerAlertListCard({
                 <Chip size="sm" variant="outline">
                   {alert.enabled ? '有効' : '無効'}
                 </Chip>
+                <Chip size="sm" color={alert.temporary ? 'warning' : 'neutral'}>
+                  {alert.temporary ? '一時' : '常設'}
+                </Chip>
                 <Tooltip title="編集">
                   <IconButton
                     size="small"


### PR DESCRIPTION
## 変更の概要

トップ画面・Holding管理画面のアラートカード（`TickerAlertListCard`）に、一時通知かどうかを示す Chip を追加した。

- `alert.temporary === true` → 「一時」Chip（warning 色）を表示
- それ以外 → 「常設」Chip（neutral 色）を表示
- 既存の「有効/無効」Chip の直後に配置

`TickerAlertListCard` はトップ画面（`HomePageClient`）と Holding管理画面（`/holdings`）の両方で使われているため、1ファイルの修正で両画面に反映される。

## 関連 Issue

#3077

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] ローカルでテストが全て通ることを確認した（215件 全通過）
- [x] ビルドエラーがないことを確認した

## テスト内容

- 既存 215 件のユニットテストがすべてパスすることを確認
- E2E テストは CI で確認予定

## レビューポイント

- `TickerAlertListCard.tsx:178` の「有効/無効」Chip の直後に追加。配置・色が既存の `/alerts` 管理画面と統一されているか確認してください。
- `alert.temporary` が `undefined` の既存データは「常設」として表示される。この挙動が妥当か確認してください。

## スクリーンショット（該当する場合）

UI 環境が利用不可のため省略

## 補足事項

- `TickerAlertListCard` を使っている箇所はトップ画面・Holdings 画面の2か所。このコンポーネントのみ変更で両方に反映される。
- `/alerts` 管理画面は前の PR（#3080）で対応済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_01RuLjRS1RCgtkxnu24TcLeN)_