### PR TITLE
feat(stock-tracker): アラート画面・アラートカードに「一時通知」表示を追加

### DIFF
--- a/services/stock-tracker/web/app/alerts/page.tsx
+++ b/services/stock-tracker/web/app/alerts/page.tsx
@@ -355,6 +355,9 @@ function AlertsPageContent() {
                   状態
                 </TableCell>
                 <TableCell sx={{ color: 'white', fontWeight: 'bold' }} align="center">
+                  一時通知
+                </TableCell>
+                <TableCell sx={{ color: 'white', fontWeight: 'bold' }} align="center">
                   操作
                 </TableCell>
               </TableRow>
@@ -362,7 +365,7 @@ function AlertsPageContent() {
             <TableBody>
               {filteredAlerts.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={7} align="center" sx={{ py: 8, color: 'text.secondary' }}>
+                  <TableCell colSpan={8} align="center" sx={{ py: 8, color: 'text.secondary' }}>
                     {alerts.length === 0
                       ? 'アラートがありません'
                       : 'フィルタ条件に一致するアラートがありません'}
@@ -414,6 +417,11 @@ function AlertsPageContent() {
                       <TableCell align="center">
                         <Chip color={alert.enabled ? 'success' : 'neutral'} size="sm">
                           {alert.enabled ? '有効' : '無効'}
+                        </Chip>
+                      </TableCell>
+                      <TableCell align="center">
+                        <Chip color={alert.temporary ? 'warning' : 'neutral'} size="sm">
+                          {alert.temporary ? '一時' : '常設'}
                         </Chip>
                       </TableCell>
                       <TableCell align="center">

--- a/services/stock-tracker/web/components/TickerAlertListCard.tsx
+++ b/services/stock-tracker/web/components/TickerAlertListCard.tsx
@@ -178,6 +178,9 @@ export default function TickerAlertListCard({
                 <Chip size="sm" variant="outline">
                   {alert.enabled ? '有効' : '無効'}
                 </Chip>
+                <Chip size="sm" color={alert.temporary ? 'warning' : 'neutral'}>
+                  {alert.temporary ? '一時' : '常設'}
+                </Chip>
                 <Tooltip title="編集">
                   <IconButton
                     size="small"

--- a/services/stock-tracker/web/tests/e2e/alert-management.spec.ts
+++ b/services/stock-tracker/web/tests/e2e/alert-management.spec.ts
@@ -425,6 +425,75 @@ test.describe('アラート設定フロー (E2E-002 一部)', () => {
     });
   });
 
+  test.describe('アラート一覧の一時通知表示', () => {
+    // webkit-mobile では Service Worker の影響で API モックが不安定になるため、このスイートでは無効化する
+    test.use({ serviceWorkers: 'block' });
+
+    test('一時通知のアラートは「一時」、常設は「常設」が表示される', async ({ page }) => {
+      const suffix = Date.now().toString().slice(-6);
+      const temporarySymbol = `TMP${suffix}`;
+      const persistentSymbol = `PST${suffix}`;
+
+      await page.route('**/api/exchanges', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            exchanges: [{ exchangeId: `ex-${suffix}`, name: 'TEST', key: 'TEST' }],
+          }),
+        });
+      });
+
+      await page.route('**/api/alerts', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            alerts: [
+              {
+                alertId: `alert-tmp-${suffix}`,
+                tickerId: `TEST:${temporarySymbol}`,
+                symbol: temporarySymbol,
+                name: 'Temporary Alert',
+                mode: 'Buy',
+                frequency: 'MINUTE_LEVEL',
+                conditions: [{ field: 'price', operator: 'gte', value: 100 }],
+                enabled: true,
+                temporary: true,
+                temporaryExpireDate: '2026-12-31',
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+              },
+              {
+                alertId: `alert-pst-${suffix}`,
+                tickerId: `TEST:${persistentSymbol}`,
+                symbol: persistentSymbol,
+                name: 'Persistent Alert',
+                mode: 'Sell',
+                frequency: 'MINUTE_LEVEL',
+                conditions: [{ field: 'price', operator: 'gte', value: 200 }],
+                enabled: true,
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+              },
+            ],
+          }),
+        });
+      });
+
+      await page.goto('/alerts');
+      await page.waitForLoadState('networkidle');
+
+      const temporaryRow = page.locator('tbody tr', { hasText: temporarySymbol });
+      await expect(temporaryRow).toBeVisible();
+      await expect(temporaryRow.getByText('一時', { exact: true })).toBeVisible();
+
+      const persistentRow = page.locator('tbody tr', { hasText: persistentSymbol });
+      await expect(persistentRow).toBeVisible();
+      await expect(persistentRow.getByText('常設', { exact: true })).toBeVisible();
+    });
+  });
+
   test.describe('アラート編集の通知設定', () => {
     // webkit-mobile では Service Worker の影響で API モックが不安定になるため、このスイートでは無効化する
     test.use({ serviceWorkers: 'block' });

--- a/services/stock-tracker/web/tests/unit/app/alerts-page.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/alerts-page.test.ts
@@ -25,10 +25,14 @@ jest.mock('@nagiyu/ui', () => ({
 }));
 
 jest.mock('@mui/material', () => {
-  const create =
-    (tag: string) =>
-    ({ children }: Record<string, unknown>) =>
+  const create = (tag: string) => {
+    const MockComponent = ({ children }: Record<string, unknown>) =>
       React.createElement(tag, null, children);
+    MockComponent.displayName = `Mock${tag}`;
+    return MockComponent;
+  };
+  const CircularProgress = () => React.createElement('span', null, '読み込み中...');
+  CircularProgress.displayName = 'MockCircularProgress';
   return {
     Container: create('div'),
     Box: create('div'),
@@ -41,7 +45,7 @@ jest.mock('@mui/material', () => {
     TableRow: create('tr'),
     Paper: create('div'),
     Alert: create('div'),
-    CircularProgress: () => React.createElement('span', null, '読み込み中...'),
+    CircularProgress,
   };
 });
 

--- a/services/stock-tracker/web/tests/unit/app/alerts-page.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/alerts-page.test.ts
@@ -1,0 +1,72 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import AlertsPage from '../../../app/alerts/page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({ back: jest.fn(), push: jest.fn() })),
+  useSearchParams: jest.fn(() => ({ get: jest.fn(() => null) })),
+}));
+
+jest.mock('../../../components/AlertSettingsModal', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', null, 'AlertSettingsModalMock'),
+}));
+
+jest.mock('../../../components/AlertDeleteConfirmDialog', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', null, 'AlertDeleteConfirmDialogMock'),
+}));
+
+jest.mock('@nagiyu/ui', () => ({
+  Button: ({ children }: Record<string, unknown>) => React.createElement('button', null, children),
+  Chip: ({ children }: Record<string, unknown>) => React.createElement('span', null, children),
+  ErrorAlert: () => React.createElement('div', null, 'ErrorAlertMock'),
+  Select: ({ label }: Record<string, unknown>) => React.createElement('select', null, label),
+}));
+
+jest.mock('@mui/material', () => {
+  const create =
+    (tag: string) =>
+    ({ children }: Record<string, unknown>) =>
+      React.createElement(tag, null, children);
+  return {
+    Container: create('div'),
+    Box: create('div'),
+    Typography: create('span'),
+    Table: create('table'),
+    TableBody: create('tbody'),
+    TableCell: create('td'),
+    TableContainer: create('div'),
+    TableHead: create('thead'),
+    TableRow: create('tr'),
+    Paper: create('div'),
+    Alert: create('div'),
+    CircularProgress: () => React.createElement('span', null, '読み込み中...'),
+  };
+});
+
+jest.mock('@mui/icons-material', () => ({
+  Edit: () => React.createElement('span', null, 'EditIcon'),
+  Delete: () => React.createElement('span', null, 'DeleteIcon'),
+  ArrowBack: () => React.createElement('span', null, 'ArrowBackIcon'),
+}));
+
+describe('AlertsPage', () => {
+  let html: string;
+
+  beforeAll(() => {
+    html = renderToStaticMarkup(React.createElement(AlertsPage));
+  });
+
+  it('初期ローディング状態でクラッシュしない', () => {
+    expect(html).toBeTruthy();
+  });
+
+  it('ローディングスピナーを表示する', () => {
+    expect(html).toContain('読み込み中...');
+  });
+
+  it('アラート管理の見出しを表示する', () => {
+    expect(html).toContain('アラート管理');
+  });
+});


### PR DESCRIPTION
## 変更の概要

StockTracker のアラート管理画面（`/alerts`）およびトップ画面・Holdings 画面のアラートカード（`TickerAlertListCard`）に、一時通知かどうかを示す表示を追加した。

- `alert.temporary === true` → 「一時」Chip（warning 色）を表示
- それ以外 → 「常設」Chip（neutral 色）を表示

### 含まれる変更（マージ済み内部 PR）

- #3080: アラート管理画面（`/alerts`）の表に「一時通知」カラムを追加
- #3085: `TickerAlertListCard` に「一時/常設」Chip を追加（トップ画面・Holdings 画面）

### dev 環境での確認

- アラート管理画面: 一時通知/常設の表示を確認済み
- トップ画面: 一時通知/常設の表示を確認済み
- Holdings 画面: TickerAlertListCard 経由で同じ表示が反映されていることを確認済み

## 関連 Issue

Closes #3077

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した
- [x] dev 環境で動作確認した

## テスト内容

- ユニットテスト: `tests/unit/app/alerts-page.test.ts` を新規追加（3件、全パス）
- E2E テスト: `tests/e2e/alert-management.spec.ts` に「アラート一覧の一時通知表示」テストを追加（1件、ローカル chromium-mobile で合格を確認）
- 各内部 PR の Fast Verification CI 全パスを確認済み

## レビューポイント

- 一時通知の表示位置・色（warning 色 = オレンジ系）が、既存の「有効/無効」Chip と並んで違和感ないか確認してください。
- `alert.temporary` が `undefined` のアラート（過去データ）は「常設」として表示されます。

## スクリーンショット（該当する場合）

dev 環境で確認済み（人力）

## 補足事項

今回のスコープ外で、別途検討すべき箇所として以下が確認されています（必要であれば別 Issue 化）：

- `StockChart` のアラートラインで一時/常設を視覚的に区別する
- `/summaries` のアラート数カウントに一時通知の内訳を追加する
- Holding 削除確認ダイアログで関連アラートの一時通知状態を表示する


---
_Generated by [Claude Code](https://claude.ai/code/session_01RuLjRS1RCgtkxnu24TcLeN)_