### PR TITLE
CI: verify ワークフローの PR 出力を統一する

### DIFF
--- a/.github/workflows/admin-verify.yml
+++ b/.github/workflows/admin-verify.yml
@@ -1,5 +1,9 @@
 name: Admin App - Verification
 
+env:
+  SERVICE_ID: admin
+  SERVICE_DISPLAY_NAME: Admin App
+
 on:
   pull_request:
     branches:
@@ -119,7 +123,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: coverage-report
+          name: ${{ env.SERVICE_ID }}-coverage-report
           path: services/admin/web/coverage/
           retention-days: 30
 
@@ -168,7 +172,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-mobile
           path: services/admin/web/playwright-report/
           retention-days: 30
 
@@ -176,7 +180,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-mobile
           path: services/admin/web/test-results/
           retention-days: 30
 
@@ -241,7 +245,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-desktop
           path: services/admin/web/playwright-report/
           retention-days: 30
 
@@ -249,7 +253,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-desktop
           path: services/admin/web/test-results/
           retention-days: 30
 
@@ -314,7 +318,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-webkit-mobile
           path: services/admin/web/playwright-report/
           retention-days: 30
 
@@ -322,7 +326,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-webkit-mobile
           path: services/admin/web/test-results/
           retention-days: 30
 
@@ -442,8 +446,8 @@ jobs:
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
-              ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
-              : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
+              ? (isFull ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed' : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed')
+              : (isFull ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed' : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed');
 
             let body = `${header}\n\n`;
             body += isFull

--- a/.github/workflows/all-verify.yml
+++ b/.github/workflows/all-verify.yml
@@ -1,4 +1,8 @@
-name: All Workspaces - Quality Checks
+name: All Workspaces - Verification
+
+env:
+  SERVICE_ID: all
+  SERVICE_DISPLAY_NAME: All Workspaces
 
 on:
   pull_request:
@@ -71,11 +75,10 @@ jobs:
 
             const allSuccess = Object.values(results).every(r => r === 'success');
             const header = allSuccess
-              ? '## ✅ All Quality Checks Passed'
-              : '## ❌ Some Quality Checks Failed';
+              ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Passed'
+              : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Failed';
 
             let body = `${header}\n\n`;
-            body += '**All Workspaces Quality Checks**\n\n';
             body += '| Job | Status |\n';
             body += '|-----|--------|\n';
 

--- a/.github/workflows/auth-verify-app.yml
+++ b/.github/workflows/auth-verify-app.yml
@@ -1,5 +1,9 @@
 name: Auth App - Verification
 
+env:
+  SERVICE_ID: auth-app
+  SERVICE_DISPLAY_NAME: Auth App
+
 on:
   pull_request:
     branches:
@@ -165,7 +169,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-mobile
           path: services/auth/web/playwright-report/
           retention-days: 30
 
@@ -173,7 +177,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-mobile
           path: services/auth/web/test-results/
           retention-days: 30
 
@@ -237,7 +241,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-desktop
           path: services/auth/web/playwright-report/
           retention-days: 30
 
@@ -245,7 +249,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-desktop
           path: services/auth/web/test-results/
           retention-days: 30
 
@@ -309,7 +313,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-webkit-mobile
           path: services/auth/web/playwright-report/
           retention-days: 30
 
@@ -317,7 +321,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-webkit-mobile
           path: services/auth/web/test-results/
           retention-days: 30
 
@@ -439,8 +443,8 @@ jobs:
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
-              ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
-              : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
+              ? (isFull ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed' : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed')
+              : (isFull ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed' : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed');
 
             let body = `${header}\n\n`;
             body += isFull

--- a/.github/workflows/auth-verify.yml
+++ b/.github/workflows/auth-verify.yml
@@ -1,4 +1,8 @@
-name: Auth Infrastructure - Verify
+name: Auth Infrastructure - Verification
+
+env:
+  SERVICE_ID: auth
+  SERVICE_DISPLAY_NAME: Auth Infrastructure
 
 on:
   pull_request:
@@ -98,7 +102,7 @@ jobs:
       - name: Upload CDK outputs as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cdk-out
+          name: ${{ env.SERVICE_ID }}-cdk-out
           path: infra/auth/cdk.out/
           retention-days: 7
 
@@ -133,8 +137,8 @@ jobs:
 
             const allSuccess = Object.values(results).every(r => r === 'success');
             const header = allSuccess
-              ? '## ✅ Auth Infrastructure Verification Passed'
-              : '## ❌ Auth Infrastructure Verification Failed';
+              ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Passed'
+              : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Failed';
 
             let body = `${header}\n\n`;
             body += '| Job | Status |\n';

--- a/.github/workflows/browser-verify.yml
+++ b/.github/workflows/browser-verify.yml
@@ -1,5 +1,9 @@
 name: Browser Library - Verification
 
+env:
+  SERVICE_ID: browser
+  SERVICE_DISPLAY_NAME: Browser Library
+
 on:
   pull_request:
     branches:
@@ -131,11 +135,10 @@ jobs:
 
             const allSuccess = Object.values(results).every(r => r === 'success');
             const header = allSuccess
-              ? '## ✅ All Checks Passed'
-              : '## ❌ Some Checks Failed';
+              ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Passed'
+              : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Failed';
 
             let body = `${header}\n\n`;
-            body += '**Browser Library Verification**\n\n';
             body += '| Job | Status |\n';
             body += '|-----|--------|\n';
 

--- a/.github/workflows/codec-converter-verify.yml
+++ b/.github/workflows/codec-converter-verify.yml
@@ -1,5 +1,9 @@
 name: Codec Converter - Verification
 
+env:
+  SERVICE_ID: codec-converter
+  SERVICE_DISPLAY_NAME: Codec Converter
+
 on:
   pull_request:
     branches:
@@ -159,7 +163,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-mobile
           path: services/codec-converter/web/playwright-report/
           retention-days: 30
 
@@ -167,7 +171,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-mobile
           path: services/codec-converter/web/test-results/
           retention-days: 30
 
@@ -229,7 +233,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-desktop
           path: services/codec-converter/web/playwright-report/
           retention-days: 30
 
@@ -237,7 +241,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-desktop
           path: services/codec-converter/web/test-results/
           retention-days: 30
 
@@ -299,7 +303,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-webkit-mobile
           path: services/codec-converter/web/playwright-report/
           retention-days: 30
 
@@ -307,7 +311,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-webkit-mobile
           path: services/codec-converter/web/test-results/
           retention-days: 30
 
@@ -327,7 +331,7 @@ jobs:
             --delete --no-progress
 
   lint:
-    name: Lint Check
+    name: Lint Code
     runs-on: ubuntu-latest
 
     permissions:
@@ -480,7 +484,7 @@ jobs:
                'Integration Tests (chromium-mobile)': '${{ needs.integration-test-chromium-mobile.result }}',
                'Integration Tests (chromium-desktop)': '${{ needs.integration-test-chromium-desktop.result }}',
                'Integration Tests (webkit-mobile)': '${{ needs.integration-test-webkit-mobile.result }}',
-              'Lint Check': '${{ needs.lint.result }}',
+              'Lint Code': '${{ needs.lint.result }}',
               'Format Check': '${{ needs.format-check.result }}',
               'Infra Format Check': '${{ needs.infra-format-check.result }}',
               'Infra Type Check': '${{ needs.infra-type-check.result }}',
@@ -504,8 +508,8 @@ jobs:
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop' || github.base_ref === 'master';
             const header = allSuccess
-              ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
-              : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
+              ? (isFull ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed' : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed')
+              : (isFull ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed' : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed');
 
             let body = `${header}\n\n`;
             body += isFull

--- a/.github/workflows/common-verify.yml
+++ b/.github/workflows/common-verify.yml
@@ -1,5 +1,9 @@
 name: Common Library - Verification
 
+env:
+  SERVICE_ID: common
+  SERVICE_DISPLAY_NAME: Common Library
+
 on:
   pull_request:
     branches:
@@ -130,11 +134,10 @@ jobs:
 
             const allSuccess = Object.values(results).every(r => r === 'success');
             const header = allSuccess
-              ? '## ✅ All Checks Passed'
-              : '## ❌ Some Checks Failed';
+              ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Passed'
+              : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Failed';
 
             let body = `${header}\n\n`;
-            body += '**Common Library Verification**\n\n';
             body += '| Job | Status |\n';
             body += '|-----|--------|\n';
 

--- a/.github/workflows/infra-shared-verify.yml
+++ b/.github/workflows/infra-shared-verify.yml
@@ -1,4 +1,8 @@
-name: Infra Shared - Verify
+name: Infra Shared - Verification
+
+env:
+  SERVICE_ID: infra-shared
+  SERVICE_DISPLAY_NAME: Infra Shared
 
 on:
   pull_request:
@@ -112,7 +116,7 @@ jobs:
       - name: Upload CDK outputs as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cdk-out
+          name: ${{ env.SERVICE_ID }}-cdk-out
           path: infra/shared/cdk.out/
           retention-days: 7
 
@@ -149,8 +153,8 @@ jobs:
 
             const allSuccess = Object.values(results).every(r => r === 'success');
             const header = allSuccess
-              ? '## ✅ Shared Infrastructure Verification Passed'
-              : '## ❌ Shared Infrastructure Verification Failed';
+              ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Passed'
+              : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Failed';
 
             let body = `${header}\n\n`;
             body += '| Job | Status |\n';

--- a/.github/workflows/nextjs-verify.yml
+++ b/.github/workflows/nextjs-verify.yml
@@ -1,5 +1,9 @@
 name: Next.js Library - Verification
 
+env:
+  SERVICE_ID: nextjs
+  SERVICE_DISPLAY_NAME: Next.js Library
+
 on:
   pull_request:
     branches:
@@ -140,11 +144,10 @@ jobs:
 
             const allSuccess = Object.values(results).every(r => r === 'success');
             const header = allSuccess
-              ? '## ✅ All Checks Passed'
-              : '## ❌ Some Checks Failed';
+              ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Passed'
+              : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Failed';
 
             let body = `${header}\n\n`;
-            body += '**Next.js Library Verification**\n\n';
             body += '| Job | Status |\n';
             body += '|-----|--------|\n';
 

--- a/.github/workflows/niconico-mylist-assistant-verify.yml
+++ b/.github/workflows/niconico-mylist-assistant-verify.yml
@@ -1,5 +1,9 @@
 name: Niconico Mylist Assistant - Verification
 
+env:
+  SERVICE_ID: niconico-mylist-assistant
+  SERVICE_DISPLAY_NAME: Niconico Mylist Assistant
+
 on:
   pull_request:
     branches:
@@ -18,7 +22,7 @@ permissions:
 
 jobs:
   lint:
-    name: Lint Check
+    name: Lint Code
     runs-on: ubuntu-latest
 
     permissions:
@@ -382,7 +386,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-mobile
           path: services/niconico-mylist-assistant/web/playwright-report/
           retention-days: 30
 
@@ -390,7 +394,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-mobile
           path: services/niconico-mylist-assistant/web/test-results/
           retention-days: 30
 
@@ -461,7 +465,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-desktop
           path: services/niconico-mylist-assistant/web/playwright-report/
           retention-days: 30
 
@@ -469,7 +473,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-desktop
           path: services/niconico-mylist-assistant/web/test-results/
           retention-days: 30
 
@@ -540,7 +544,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-webkit-mobile
           path: services/niconico-mylist-assistant/web/playwright-report/
           retention-days: 30
 
@@ -548,7 +552,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-webkit-mobile
           path: services/niconico-mylist-assistant/web/test-results/
           retention-days: 30
 
@@ -670,8 +674,8 @@ jobs:
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
-              ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
-              : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
+              ? (isFull ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed' : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed')
+              : (isFull ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed' : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed');
 
             let body = `${header}\n\n`;
             body += isFull

--- a/.github/workflows/portal-verify.yml
+++ b/.github/workflows/portal-verify.yml
@@ -1,5 +1,9 @@
 name: Portal - Verification
 
+env:
+  SERVICE_ID: portal
+  SERVICE_DISPLAY_NAME: Portal
+
 on:
   pull_request:
     branches:
@@ -184,7 +188,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-chromium-mobile
           path: services/portal/web/playwright-report/
           retention-days: 30
 
@@ -192,7 +196,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-chromium-mobile
           path: services/portal/web/test-results/
           retention-days: 30
 
@@ -250,7 +254,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-chromium-desktop
           path: services/portal/web/playwright-report/
           retention-days: 30
 
@@ -258,7 +262,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-chromium-desktop
           path: services/portal/web/test-results/
           retention-days: 30
 
@@ -316,7 +320,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-webkit-mobile
           path: services/portal/web/playwright-report/
           retention-days: 30
 
@@ -324,7 +328,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-webkit-mobile
           path: services/portal/web/test-results/
           retention-days: 30
 
@@ -399,8 +403,8 @@ jobs:
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = '${{ github.base_ref }}' === 'develop';
             const header = allSuccess
-              ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
-              : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
+              ? (isFull ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed' : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed')
+              : (isFull ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed' : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed');
 
             let body = `${header}\n\n`;
             body += isFull

--- a/.github/workflows/quick-clip-verify.yml
+++ b/.github/workflows/quick-clip-verify.yml
@@ -1,5 +1,9 @@
 name: QuickClip - Verification
 
+env:
+  SERVICE_ID: quick-clip
+  SERVICE_DISPLAY_NAME: QuickClip
+
 on:
   pull_request:
     branches:
@@ -18,7 +22,7 @@ permissions:
 
 jobs:
   lint:
-    name: Lint Check
+    name: Lint Code
     runs-on: ubuntu-latest
 
     steps:
@@ -76,7 +80,7 @@ jobs:
         run: npm run format:check --workspace=@nagiyu/quick-clip-lambda-zip
 
   infra-lint:
-    name: Infrastructure Lint Check
+    name: Infrastructure Lint Code
     runs-on: ubuntu-latest
 
     steps:
@@ -564,7 +568,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-mobile
           path: services/quick-clip/web/playwright-report/
           retention-days: 30
 
@@ -572,7 +576,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-mobile
           path: services/quick-clip/web/test-results/
           retention-days: 30
 
@@ -632,7 +636,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-desktop
           path: services/quick-clip/web/playwright-report/
           retention-days: 30
 
@@ -640,7 +644,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-desktop
           path: services/quick-clip/web/test-results/
           retention-days: 30
 
@@ -700,7 +704,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-webkit-mobile
           path: services/quick-clip/web/playwright-report/
           retention-days: 30
 
@@ -708,7 +712,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-webkit-mobile
           path: services/quick-clip/web/test-results/
           retention-days: 30
 
@@ -769,7 +773,7 @@ jobs:
             const results = {
               'Lint': '${{ needs.lint.result }}',
               'Format Check': '${{ needs.format-check.result }}',
-              'Infra Lint Check': '${{ needs.infra-lint.result }}',
+              'Infra Lint Code': '${{ needs.infra-lint.result }}',
               'Infra Format Check': '${{ needs.infra-format-check.result }}',
               'Build Core': '${{ needs.build-core.result }}',
               'Build Web': '${{ needs.build-web.result }}',
@@ -809,8 +813,8 @@ jobs:
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = context.payload.pull_request?.base?.ref === 'develop';
             const header = allSuccess
-              ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
-              : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
+              ? (isFull ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed' : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed')
+              : (isFull ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed' : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed');
 
             let body = `${header}\n\n`;
             body += isFull ? '**QuickClip - Full Verification**\n\n' : '**QuickClip - Fast Verification**\n\n';

--- a/.github/workflows/react-verify.yml
+++ b/.github/workflows/react-verify.yml
@@ -1,5 +1,9 @@
 name: React Library - Verification
 
+env:
+  SERVICE_ID: react
+  SERVICE_DISPLAY_NAME: React Library
+
 on:
   pull_request:
     branches:
@@ -140,11 +144,10 @@ jobs:
 
             const allSuccess = Object.values(results).every(r => r === 'success');
             const header = allSuccess
-              ? '## ✅ All Checks Passed'
-              : '## ❌ Some Checks Failed';
+              ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Passed'
+              : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Failed';
 
             let body = `${header}\n\n`;
-            body += '**React Library Verification**\n\n';
             body += '| Job | Status |\n';
             body += '|-----|--------|\n';
 

--- a/.github/workflows/share-together-verify.yml
+++ b/.github/workflows/share-together-verify.yml
@@ -1,5 +1,9 @@
 name: Share Together - Verification
 
+env:
+  SERVICE_ID: share-together
+  SERVICE_DISPLAY_NAME: Share Together
+
 on:
   pull_request:
     branches:
@@ -18,7 +22,7 @@ permissions:
 
 jobs:
   lint:
-    name: Lint Check
+    name: Lint Code
     runs-on: ubuntu-latest
 
     steps:
@@ -249,7 +253,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-chromium-mobile
           path: services/share-together/web/playwright-report/
           retention-days: 30
 
@@ -257,7 +261,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-chromium-mobile
           path: services/share-together/web/test-results/
           retention-days: 30
 
@@ -322,7 +326,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-chromium-desktop
           path: services/share-together/web/playwright-report/
           retention-days: 30
 
@@ -330,7 +334,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-chromium-desktop
           path: services/share-together/web/test-results/
           retention-days: 30
 
@@ -395,7 +399,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-webkit-mobile
           path: services/share-together/web/playwright-report/
           retention-days: 30
 
@@ -403,7 +407,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-webkit-mobile
           path: services/share-together/web/test-results/
           retention-days: 30
 
@@ -505,11 +509,11 @@ jobs:
             );
             const header = allSuccess
               ? isFullVerification
-                ? '## ✅ All Full Checks Passed'
-                : '## ✅ All Fast Checks Passed'
+                ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed'
+                : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed'
               : isFullVerification
-                ? '## ❌ Some Full Checks Failed'
-                : '## ❌ Some Fast Checks Failed';
+                ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed'
+                : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed';
 
             const reportBaseUrl = `https://reports.nagiyu.com/share-together/pr-${context.issue.number}/${context.runId}`;
             const reportProjects = {

--- a/.github/workflows/stock-tracker-verify.yml
+++ b/.github/workflows/stock-tracker-verify.yml
@@ -1,5 +1,9 @@
 name: Stock Tracker - Verification
 
+env:
+  SERVICE_ID: stock-tracker
+  SERVICE_DISPLAY_NAME: Stock Tracker
+
 on:
   pull_request:
     branches:
@@ -332,7 +336,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-mobile
           path: services/stock-tracker/web/playwright-report/
           retention-days: 30
 
@@ -340,7 +344,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-mobile
           path: services/stock-tracker/web/test-results/
           retention-days: 30
 
@@ -427,7 +431,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-desktop
           path: services/stock-tracker/web/playwright-report/
           retention-days: 30
 
@@ -435,7 +439,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-desktop
           path: services/stock-tracker/web/test-results/
           retention-days: 30
 
@@ -522,7 +526,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-webkit-mobile
           path: services/stock-tracker/web/playwright-report/
           retention-days: 30
 
@@ -530,7 +534,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-webkit-mobile
           path: services/stock-tracker/web/test-results/
           retention-days: 30
 
@@ -682,8 +686,8 @@ jobs:
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
-              ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
-              : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
+              ? (isFull ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed' : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed')
+              : (isFull ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed' : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed');
 
             const reportBaseUrl = `https://reports.nagiyu.com/stock-tracker/pr-${context.issue.number}/${context.runId}`;
             const reportProjects = {

--- a/.github/workflows/tools-verify.yml
+++ b/.github/workflows/tools-verify.yml
@@ -1,5 +1,9 @@
 name: Tools App - Verification
 
+env:
+  SERVICE_ID: tools
+  SERVICE_DISPLAY_NAME: Tools App
+
 on:
   pull_request:
     branches:
@@ -142,7 +146,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-mobile
           path: services/tools/playwright-report/
           retention-days: 30
 
@@ -150,7 +154,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-mobile
           path: services/tools/test-results/
           retention-days: 30
 
@@ -213,7 +217,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-chromium-desktop
           path: services/tools/playwright-report/
           retention-days: 30
 
@@ -221,7 +225,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-chromium-desktop
+          name: ${{ env.SERVICE_ID }}-test-results-full-chromium-desktop
           path: services/tools/test-results/
           retention-days: 30
 
@@ -284,7 +288,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-playwright-report-full-webkit-mobile
           path: services/tools/playwright-report/
           retention-days: 30
 
@@ -292,7 +296,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-full-webkit-mobile
+          name: ${{ env.SERVICE_ID }}-test-results-full-webkit-mobile
           path: services/tools/test-results/
           retention-days: 30
 
@@ -401,8 +405,8 @@ jobs:
             const allSuccess = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const isFull = github.base_ref === 'develop';
             const header = allSuccess
-              ? (isFull ? '## ✅ All Full Checks Passed' : '## ✅ All Fast Checks Passed')
-              : (isFull ? '## ❌ Some Full Checks Failed' : '## ❌ Some Fast Checks Failed');
+              ? (isFull ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Passed' : '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Passed')
+              : (isFull ? '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Full Verification Failed' : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Fast Verification Failed');
 
             let body = `${header}\n\n`;
             body += isFull

--- a/.github/workflows/ui-verify.yml
+++ b/.github/workflows/ui-verify.yml
@@ -1,5 +1,9 @@
 name: UI Library - Verification
 
+env:
+  SERVICE_ID: ui
+  SERVICE_DISPLAY_NAME: UI Library
+
 on:
   pull_request:
     branches:
@@ -138,11 +142,10 @@ jobs:
 
             const allSuccess = Object.values(results).every(r => r === 'success');
             const header = allSuccess
-              ? '## ✅ All Checks Passed'
-              : '## ❌ Some Checks Failed';
+              ? '## ✅ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Passed'
+              : '## ❌ [${{ env.SERVICE_DISPLAY_NAME }}] Verification Failed';
 
             let body = `${header}\n\n`;
-            body += '**UI Library Verification**\n\n';
             body += '| Job | Status |\n';
             body += '|-----|--------|\n';
 


### PR DESCRIPTION
## 変更の概要

全 17 本の `*-verify.yml` ワークフローに以下の統一変更を適用しました。

1. **PR コメント先頭見出しの統一**  
   `## ✅ All Checks Passed` 等の汎用文言を `## ✅ [<DisplayName>] <Phase> Verification Passed` 書式に変更。PR タイムラインで複数サービスの CI 結果が並んでもどのサービスか一目で判別できます。

2. **artifact 名へのサービス ID プレフィクス付与**  
   `playwright-report-full-chromium-mobile` など汎用名だった artifact に `${{ env.SERVICE_ID }}-` プレフィクスを追加し、同一 PR で複数ワークフローが動いたときの衝突を防止します。

3. **workflow `name:` suffix の統一**  
   `- Verify` → `- Verification`、`Quality Checks` → `Verification` に揃えました。

4. **Lint ジョブ名の統一**  
   `Lint Check` → `Lint Code` に統一しました（対象: codec-converter / niconico-mylist-assistant / quick-clip / share-together）。

各ワークフロー先頭に追加した `env.SERVICE_ID` / `env.SERVICE_DISPLAY_NAME` が、コメント文字列・artifact 名双方の単一ソースとなります。

## 関連 Issue

#3096

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
  - CI ワークフローのみ変更のため、アプリケーション側テストへの影響なし
- [ ] 関連ドキュメントを更新した
- [x] CI/CD 設定を追加・更新した
- [ ] ローカルでテストが全て通ることを確認した
  - 実際の CI 実行は PR の Checks で確認が必要
- [ ] ビルドエラーがないことを確認した
  - YAML 構文は変更箇所が限定的（env ブロック追加・文字列置換のみ）で構造を崩していない

## テスト内容

- 全 17 ワークフローの変更箇所を目視確認
- `grep` による旧ヘッダ文字列・旧 artifact 名・`Lint Check` の残存がないことを確認済み
- 実際の CI 実行結果は当 PR に対してワークフローがトリガーされ次第確認予定

## レビューポイント

- `${{ env.SERVICE_DISPLAY_NAME }}` の表記が GitHub Actions YAML 内で正しく評価される点（`actions/github-script` の `script:` 内で `${{ }}` 式は実行前に展開される仕様）
- `quick-clip-verify.yml` の `Infra Lint Check` → `Infrastructure Lint Code` 変更が Branch protection の required status check に影響していないか
- artifact 名の変更により参照元（同一ワークフロー内の `download-artifact` 等）が壊れていないか（`grep` で確認済み：verify ワークフロー内に `download-artifact` の参照はなかった）

## 補足事項

- `infra-common-verify.yml` は PR コメント出力・artifact なし、`name:` も既に `- Verification` で揃っていたため変更なし
- deploy 系ワークフローの PR コメント統一は今回スコープ外（必要であれば別 Issue で対応）

---
_Generated by [Claude Code](https://claude.ai/code/session_01AygbySrwCMfDegkLowd8en)_