### PR TITLE
test(stock-tracker): webkit-mobile の入力阻害を回避（範囲内アラートバリデーション）

### DIFF
--- a/services/stock-tracker/web/tests/e2e/alert-management.spec.ts
+++ b/services/stock-tracker/web/tests/e2e/alert-management.spec.ts
@@ -750,6 +750,9 @@ test.describe('アラート設定フロー (E2E-002 一部)', () => {
         await page.getByLabel('条件タイプ').selectOption('range');
       }
       await expect(minPriceInput).toBeVisible({ timeout: 10000 });
+      // 条件タイプ変更時に上書き確認ダイアログが表示されると後続の input 操作を pointer events で
+      // 阻害するため、ここで先に解決しておく
+      await resolveNotificationOverwriteDialogIfVisible(page);
 
       // 不正な範囲を入力（最小価格 > 最大価格）
       const maxPriceInput = page.locator('#max-price');


### PR DESCRIPTION
## 変更の概要

PR #3095 の Full CI で発生した `services/stock-tracker/web` の webkit-mobile E2E 失敗を解消します。

### 失敗内容

`tests/e2e/alert-management.spec.ts` の「範囲内アラートで不正な範囲を入力するとバリデーションエラーが表示される」テストで、以下のエラー：

```
Error: expect(locator).toHaveValue(expected) failed
  Locator:  locator('#min-price')
  Expected: "110"
  Received: ""
```

### 根本原因

条件タイプを `range` に変更すると「通知本文を更新しますか？」ダイアログがオーバーレイで表示される。webkit-mobile では、このダイアログが表示されたまま `minPriceInput.fill('110')` を実行すると pointer events が阻害され、入力が反映されず value が空のまま残る。

同ファイル内の他テスト（「範囲外アラート」「範囲外バリデーション」「単一条件と範囲指定切り替え」）では条件タイプ変更直後に `resolveNotificationOverwriteDialogIfVisible(page)` を呼んでダイアログを解消しているが、**本テストだけ呼び出しが抜けていた**。

### 修正内容

`await expect(minPriceInput).toBeVisible(...)` の直後に既存ヘルパー `resolveNotificationOverwriteDialogIfVisible(page)` の呼び出しを 1 行追加。他テストと同じパターンで対処漏れを解消する。

```diff
   await expect(minPriceInput).toBeVisible({ timeout: 10000 });
+  // 条件タイプ変更時に上書き確認ダイアログが表示されると後続の input 操作を pointer events で
+  // 阻害するため、ここで先に解決しておく
+  await resolveNotificationOverwriteDialogIfVisible(page);

   // 不正な範囲を入力（最小価格 > 最大価格）
   const maxPriceInput = page.locator('#max-price');
   await minPriceInput.fill('110');
```

本番コードには影響なし。E2E テストの修正のみ。

## 関連 Issue

Refs #3022, #3095

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [x] その他（E2E テストの flake 解消）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（E2E テスト修正のため新規テストは追加なし）
- [x] 関連ドキュメントを更新した（変更なし）
- [x] CI/CD 設定を追加・更新した（変更なし）
- [x] ローカルでテストが全て通ることを確認した（webkit-mobile はローカル実行不可、CI で検証）
- [x] ビルドエラーがないことを確認した

## テスト内容

- 本 PR の Full CI で webkit-mobile を含む E2E が pass することを確認

## レビューポイント

- 修正方針が同ファイル内の他テストと一貫しているか
- 1 行追加のみで本番コードへの影響がないこと

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

PR #3095 (integration → develop) のフォローアップ。本 PR をマージしたあと、PR #3095 を rerun することで webkit-mobile の通過が確認できる見込み。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ti2ujWSZx2gL5W4Zzz5rXa)_