### PR TITLE
@nagiyu/aws に reportErrorEvent / createErrorReporter を追加

### DIFF
--- a/libs/aws/jest.config.ts
+++ b/libs/aws/jest.config.ts
@@ -10,6 +10,7 @@ const config: Config.InitialOptions = {
   // Support .js extensions in imports (ES modules)
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/common$': '<rootDir>/../../libs/common/src/index.ts',
   },
   // Common coverage settings
   coverageDirectory: 'coverage',

--- a/libs/aws/src/error-events/index.ts
+++ b/libs/aws/src/error-events/index.ts
@@ -18,3 +18,5 @@ export {
 export { DynamoDBErrorEventWriter } from './dynamodb-writer.js';
 export { InMemoryErrorEventWriter } from './in-memory-writer.js';
 export { createErrorEventWriter, resetErrorEventWriter } from './factory.js';
+export type { ReportErrorEventInput, ErrorReporter } from './report.js';
+export { reportErrorEvent, createErrorReporter } from './report.js';

--- a/libs/aws/src/error-events/report.ts
+++ b/libs/aws/src/error-events/report.ts
@@ -1,0 +1,86 @@
+/**
+ * アプリケーション層から Admin に ErrorEvent を報告するユーティリティ
+ *
+ * `source: 'application'` や `source: 'manual'` のイベントを DynamoDB に書き込む。
+ * CloudWatch Alarm 由来の取り込みには alarm-ingest を使用すること。
+ */
+
+import { generateEventId, type ErrorEvent, type ErrorSeverity, type ErrorSource } from '@nagiyu/common';
+import { getDynamoDBDocumentClient } from '../dynamodb/index.js';
+import { createErrorEventWriter } from './factory.js';
+
+const ERROR_MESSAGES = {
+  ERROR_EVENTS_TABLE_NAME_REQUIRED: 'ERROR_EVENTS_TABLE_NAME が設定されていません',
+} as const;
+
+export interface ReportErrorEventInput {
+  serviceId: string;
+  severity: ErrorSeverity;
+  title: string;
+  message: string;
+  /** デフォルト: 'application' */
+  source?: ErrorSource;
+  /** 任意の補足情報。JSON にシリアライズして保存する */
+  context?: Record<string, unknown>;
+  /** デフォルト: 呼び出し時点の UTC ISO-8601 */
+  occurredAt?: string;
+  /** デフォルト: UUID v4 自動採番 */
+  eventId?: string;
+}
+
+/**
+ * ErrorEvent を DynamoDB に書き込み、書き込んだイベントを返す。
+ *
+ * - `ERROR_EVENTS_TABLE_NAME` 環境変数が未設定の場合は例外を投げる
+ * - 書き込み失敗は呼び出し元に伝播する（無音失敗しない）
+ */
+export async function reportErrorEvent(input: ReportErrorEventInput): Promise<ErrorEvent> {
+  const tableName = process.env.ERROR_EVENTS_TABLE_NAME;
+  if (!tableName) {
+    throw new Error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);
+  }
+
+  const docClient =
+    process.env.USE_IN_MEMORY_DB === 'true' ? undefined : getDynamoDBDocumentClient();
+  const writer = createErrorEventWriter(docClient, tableName);
+
+  const event: ErrorEvent = {
+    eventId: input.eventId ?? generateEventId(),
+    serviceId: input.serviceId,
+    source: input.source ?? 'application',
+    severity: input.severity,
+    title: input.title,
+    message: input.message,
+    context: input.context !== undefined ? JSON.stringify(input.context) : '{}',
+    occurredAt: input.occurredAt ?? new Date().toISOString(),
+  };
+
+  await writer.put(event);
+  return event;
+}
+
+export interface ErrorReporter {
+  report: (
+    input: Omit<ReportErrorEventInput, 'serviceId'> & { serviceId?: string }
+  ) => Promise<ErrorEvent>;
+}
+
+/**
+ * serviceId を固定したレポーターを生成する。
+ *
+ * サービス・バッチごとに `serviceId` を毎回指定する手間を省く。
+ * 個別呼び出しで `serviceId` を渡した場合はそちらを優先する。
+ *
+ * @example
+ * const reporter = createErrorReporter({ serviceId: 'stock-tracker' });
+ * await reporter.report({ severity: 'error', title: '...', message: '...' });
+ */
+export function createErrorReporter(defaults: { serviceId: string }): ErrorReporter {
+  return {
+    report: (input) =>
+      reportErrorEvent({
+        ...input,
+        serviceId: input.serviceId ?? defaults.serviceId,
+      }),
+  };
+}

--- a/libs/aws/tests/unit/error-events/report.test.ts
+++ b/libs/aws/tests/unit/error-events/report.test.ts
@@ -1,0 +1,251 @@
+/**
+ * reportErrorEvent / createErrorReporter の単体テスト
+ */
+
+import {
+  reportErrorEvent,
+  createErrorReporter,
+} from '../../../src/error-events/report.js';
+import {
+  createErrorEventWriter,
+  resetErrorEventWriter,
+} from '../../../src/error-events/factory.js';
+import { InMemoryErrorEventWriter } from '../../../src/error-events/in-memory-writer.js';
+
+const TABLE_NAME = 'test-error-events';
+
+function getInMemoryWriter(): InMemoryErrorEventWriter {
+  return createErrorEventWriter() as InMemoryErrorEventWriter;
+}
+
+describe('reportErrorEvent', () => {
+  beforeEach(() => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    process.env.ERROR_EVENTS_TABLE_NAME = TABLE_NAME;
+    resetErrorEventWriter();
+  });
+
+  afterEach(() => {
+    delete process.env.USE_IN_MEMORY_DB;
+    delete process.env.ERROR_EVENTS_TABLE_NAME;
+    resetErrorEventWriter();
+  });
+
+  describe('デフォルト値', () => {
+    it('source のデフォルトは application', async () => {
+      const event = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'テストエラー',
+        message: 'エラーが発生しました',
+      });
+
+      expect(event.source).toBe('application');
+    });
+
+    it('context 未指定のとき "{}" が保存される', async () => {
+      const event = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'テスト',
+        message: 'メッセージ',
+      });
+
+      expect(event.context).toBe('{}');
+    });
+
+    it('eventId は自動採番される（UUID 形式）', async () => {
+      const event = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'テスト',
+        message: 'メッセージ',
+      });
+
+      expect(event.eventId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+      );
+    });
+
+    it('occurredAt は ISO-8601 UTC 形式で自動設定される', async () => {
+      const before = new Date().toISOString();
+      const event = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'テスト',
+        message: 'メッセージ',
+      });
+      const after = new Date().toISOString();
+
+      expect(event.occurredAt >= before).toBe(true);
+      expect(event.occurredAt <= after).toBe(true);
+    });
+  });
+
+  describe('任意パラメータの明示指定', () => {
+    it('source を manual に指定できる', async () => {
+      const event = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'info',
+        title: 'テスト',
+        message: 'メッセージ',
+        source: 'manual',
+      });
+
+      expect(event.source).toBe('manual');
+    });
+
+    it('context オブジェクトが JSON 文字列に変換される', async () => {
+      const ctx = { userId: '123', action: 'insert', count: 5 };
+      const event = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'warning',
+        title: 'テスト',
+        message: 'メッセージ',
+        context: ctx,
+      });
+
+      expect(event.context).toBe(JSON.stringify(ctx));
+    });
+
+    it('occurredAt を明示指定できる', async () => {
+      const ts = '2026-05-13T00:00:00.000Z';
+      const event = await reportErrorEvent({
+        serviceId: 'codec-converter',
+        severity: 'info',
+        title: 'テスト',
+        message: 'メッセージ',
+        occurredAt: ts,
+      });
+
+      expect(event.occurredAt).toBe(ts);
+    });
+
+    it('eventId を明示指定できる', async () => {
+      const event = await reportErrorEvent({
+        serviceId: 'codec-converter',
+        severity: 'info',
+        title: 'テスト',
+        message: 'メッセージ',
+        eventId: 'custom-event-id',
+      });
+
+      expect(event.eventId).toBe('custom-event-id');
+    });
+  });
+
+  describe('ライターへの書き込み', () => {
+    it('イベントが InMemoryErrorEventWriter に書き込まれる', async () => {
+      await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'テスト書き込み',
+        message: 'メッセージ',
+      });
+
+      const writer = getInMemoryWriter();
+      expect(writer.getRecords()).toHaveLength(1);
+      expect(writer.getRecords()[0].serviceId).toBe('stock-tracker');
+      expect(writer.getRecords()[0].title).toBe('テスト書き込み');
+    });
+
+    it('返り値と書き込まれたイベントが一致する', async () => {
+      const returned = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'critical',
+        title: 'クリティカルエラー',
+        message: '詳細メッセージ',
+      });
+
+      const writer = getInMemoryWriter();
+      const stored = writer.getRecords()[0];
+      expect(returned).toEqual(stored);
+    });
+
+    it('ライターのエラーは呼び出し元に伝播する', async () => {
+      const writer = getInMemoryWriter();
+      jest.spyOn(writer, 'put').mockRejectedValueOnce(new Error('書き込み失敗'));
+
+      await expect(
+        reportErrorEvent({
+          serviceId: 'stock-tracker',
+          severity: 'error',
+          title: 'テスト',
+          message: 'メッセージ',
+        })
+      ).rejects.toThrow('書き込み失敗');
+    });
+  });
+
+  describe('環境変数チェック', () => {
+    it('ERROR_EVENTS_TABLE_NAME 未設定のとき例外を投げる', async () => {
+      delete process.env.ERROR_EVENTS_TABLE_NAME;
+
+      await expect(
+        reportErrorEvent({
+          serviceId: 'stock-tracker',
+          severity: 'error',
+          title: 'テスト',
+          message: 'メッセージ',
+        })
+      ).rejects.toThrow('ERROR_EVENTS_TABLE_NAME が設定されていません');
+    });
+  });
+});
+
+describe('createErrorReporter', () => {
+  beforeEach(() => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    process.env.ERROR_EVENTS_TABLE_NAME = TABLE_NAME;
+    resetErrorEventWriter();
+  });
+
+  afterEach(() => {
+    delete process.env.USE_IN_MEMORY_DB;
+    delete process.env.ERROR_EVENTS_TABLE_NAME;
+    resetErrorEventWriter();
+  });
+
+  it('デフォルト serviceId が使われる', async () => {
+    const reporter = createErrorReporter({ serviceId: 'stock-tracker' });
+    const event = await reporter.report({
+      severity: 'error',
+      title: 'テスト',
+      message: 'メッセージ',
+    });
+
+    expect(event.serviceId).toBe('stock-tracker');
+  });
+
+  it('呼び出し側で serviceId をオーバーライドできる', async () => {
+    const reporter = createErrorReporter({ serviceId: 'default-service' });
+    const event = await reporter.report({
+      serviceId: 'override-service',
+      severity: 'warning',
+      title: 'テスト',
+      message: 'メッセージ',
+    });
+
+    expect(event.serviceId).toBe('override-service');
+  });
+
+  it('source デフォルトは application', async () => {
+    const reporter = createErrorReporter({ serviceId: 'stock-tracker' });
+    const event = await reporter.report({
+      severity: 'info',
+      title: 'テスト',
+      message: 'メッセージ',
+    });
+
+    expect(event.source).toBe('application');
+  });
+
+  it('複数回呼び出せる', async () => {
+    const reporter = createErrorReporter({ serviceId: 'codec-converter' });
+    await reporter.report({ severity: 'error', title: '1回目', message: 'msg' });
+    await reporter.report({ severity: 'warning', title: '2回目', message: 'msg' });
+
+    const writer = getInMemoryWriter();
+    expect(writer.getRecords()).toHaveLength(2);
+  });
+});

--- a/services/niconico-mylist-assistant/core/jest.config.ts
+++ b/services/niconico-mylist-assistant/core/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
   moduleFileExtensions: ['ts', 'js'],
   moduleNameMapper: {
     '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
+    '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1', // Remove .js extension for ts-jest
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],


### PR DESCRIPTION
## 変更の概要

アプリケーション層から Admin の DynamoDB テーブル（`nagiyu-error-events-{env}`）へ `ErrorEvent` を書き込むユーティリティを `@nagiyu/aws` に追加した。

- `reportErrorEvent(input)` — 必要最低限の入力を渡すだけで `ErrorEvent` を生成・永続化して返す。`eventId`・`occurredAt` は省略時に自動採番。`source` デフォルトは `'application'`
- `createErrorReporter({ serviceId })` — `serviceId` を固定したファクトリ。バッチやサービス初期化時に生成しておくと毎回 `serviceId` を指定する手間を省ける
- 既存の `DynamoDBErrorEventWriter`・`InMemoryErrorEventWriter`・シングルトンファクトリを再利用しており、既存の CloudWatch Alarm 経路と同じテーブル設計・TTL・GSI 属性で書き込む

## 関連 Issue

関連 #3103

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（report.ts カバレッジ: statements/functions/lines 100%、branches 92.85%）
- [x] ローカルでテストが全て通ることを確認した（libs/aws 168 件 pass）
- [x] ビルドエラーがないことを確認した

## テスト内容

`libs/aws/tests/unit/error-events/report.test.ts` を新設（16 件）。

- デフォルト値（source・eventId・occurredAt・context）
- 任意パラメータの明示指定（source='manual'・context オブジェクト→JSON・occurredAt・eventId）
- 書き込み確認（返り値と InMemoryErrorEventWriter.getRecords() の一致・エラー伝播）
- ERROR_EVENTS_TABLE_NAME 未設定時の例外
- createErrorReporter の serviceId デフォルト・オーバーライド・複数回呼び出し

## レビューポイント

- `libs/aws/jest.config.ts` に `@nagiyu/common` の moduleNameMapper を追加した。`report.ts` が `generateEventId`（値）をインポートするため必要。他パッケージ（services/admin/batch）と同じパターン
- libs/aws 全体のブランチカバレッジが 74.67% で閾値を下回っているが、`abstract-repository.ts` 起因の**既存問題**（本 PR 前も 73.48%）

## 補足事項

各サービスへの呼び出し追加は後続 Issue で段階的に進める。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTYPjWMz73pUiBMJNt8eYV)_