### PR TITLE
stock-tracker: E2E の CI を next dev → next start に切り替え

### DIFF
--- a/.github/workflows/stock-tracker-verify.yml
+++ b/.github/workflows/stock-tracker-verify.yml
@@ -314,6 +314,9 @@ jobs:
       - name: Build core package
         run: npm run build --workspace @nagiyu/stock-tracker-core
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/stock-tracker-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/stock-tracker/web
@@ -409,6 +412,9 @@ jobs:
       - name: Build core package
         run: npm run build --workspace @nagiyu/stock-tracker-core
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/stock-tracker-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/stock-tracker/web
@@ -503,6 +509,9 @@ jobs:
 
       - name: Build core package
         run: npm run build --workspace @nagiyu/stock-tracker-core
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/stock-tracker-web
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps webkit

--- a/services/stock-tracker/web/playwright.config.ts
+++ b/services/stock-tracker/web/playwright.config.ts
@@ -4,41 +4,38 @@ import { resolve } from 'path';
 
 config({ path: resolve(__dirname, '.env.test') });
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './tests/e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-mobile',
@@ -46,6 +43,7 @@ export default defineConfig({
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
     {
@@ -65,17 +63,15 @@ export default defineConfig({
       },
     },
   ].filter((project) => {
-    // Filter projects based on PROJECT environment variable
     const projectFilter = process.env.PROJECT;
     if (!projectFilter) return true;
     return project.name === projectFilter;
   }),
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 2 * 60 * 1000, // 2 minutes
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
   },
 });


### PR DESCRIPTION
## 変更の概要

PoC (PR #3106) と同じパターンを stock-tracker に横展開する。CI 時に `next start` で起動して `next dev` 由来の flaky を抑止する。

## 関連 Issue

#2987

## 変更種別

- [x] CI/CD 更新

## 変更内容

### `services/stock-tracker/web/playwright.config.ts`

- `isCI` フラグで `webServer.command` を `npm run start` / `npm run dev` に切替
- CI 用タイムアウトを share-together / auth に揃えて延長（test 60s / expect 15s / action 15s / navigation 30s）
- `chromium-mobile` に `serviceWorkers: 'block'` を追加

### `.github/workflows/stock-tracker-verify.yml`

- E2E 3 ジョブに `Build web application` ステップを追加（`npm run build --workspace @nagiyu/stock-tracker-web`）

### 変更不要

- `tsconfig.json`: 既に `playwright.config.ts` を `exclude` 済み
- `package.json`: 既に `start: next start` 存在

## 補足

横展開 2/7。次は codec-converter を予定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgJQzQWuTzWMGWKF6zjMmj)_