### PR TITLE
Prettier フォーマット修正（report.ts / report.test.ts）

### DIFF
--- a/libs/aws/src/error-events/report.ts
+++ b/libs/aws/src/error-events/report.ts
@@ -5,7 +5,12 @@
  * CloudWatch Alarm 由来の取り込みには alarm-ingest を使用すること。
  */
 
-import { generateEventId, type ErrorEvent, type ErrorSeverity, type ErrorSource } from '@nagiyu/common';
+import {
+  generateEventId,
+  type ErrorEvent,
+  type ErrorSeverity,
+  type ErrorSource,
+} from '@nagiyu/common';
 import { getDynamoDBDocumentClient } from '../dynamodb/index.js';
 import { createErrorEventWriter } from './factory.js';
 

--- a/libs/aws/tests/unit/error-events/report.test.ts
+++ b/libs/aws/tests/unit/error-events/report.test.ts
@@ -2,10 +2,7 @@
  * reportErrorEvent / createErrorReporter の単体テスト
  */
 
-import {
-  reportErrorEvent,
-  createErrorReporter,
-} from '../../../src/error-events/report.js';
+import { reportErrorEvent, createErrorReporter } from '../../../src/error-events/report.js';
 import {
   createErrorEventWriter,
   resetErrorEventWriter,


### PR DESCRIPTION
## 変更の概要

PR #3109（integration → develop）の **Format Check All Workspaces** 失敗対応。`report.ts` と `report.test.ts` の改行・引数フォーマットを Prettier 規約に揃える。

動作変更はなし、テストは引き続き 16 件 pass を確認済み。

## 関連 Issue

関連 #3103

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存テスト 16 件 pass を維持）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `npx prettier --check libs/aws/src/error-events/report.ts libs/aws/tests/unit/error-events/report.test.ts` が success
- `libs/aws` の `error-events/report` テスト 16 件 pass

## レビューポイント

- 純粋に Prettier 自動整形（`prettier --write`）の出力。手動編集なし
- 差分は引数の改行と import 文の折り返しのみ

## 補足事項

PR #3105 マージ後に Format Check 失敗が露見したのは、`claude/admin-logging-mechanism-Jw7Ss` が独自に走らせた format check（unit パッケージごとの）では通っていたが、リポジトリ全体の Format Check All Workspaces が `prettier` の異なる設定で動いていたため。本修正後は両方とも通る想定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTYPjWMz73pUiBMJNt8eYV)_