### PR TITLE
niconico-mylist-assistant: E2E の CI を next dev → next start に切り替え

### DIFF
--- a/services/niconico-mylist-assistant/web/playwright.config.ts
+++ b/services/niconico-mylist-assistant/web/playwright.config.ts
@@ -2,54 +2,43 @@ import { defineConfig, devices } from '@playwright/test';
 import { config } from 'dotenv';
 import { resolve } from 'path';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// テスト環境用の .env.test を読み込む
 config({ path: resolve(__dirname, '.env.test') });
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
-
-    /* Extra HTTP headers */
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
     extraHTTPHeaders: {
-      // テスト環境であることを示すヘッダー（オプション）
       'X-Test-Mode': 'true',
     },
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-desktop',
@@ -59,16 +48,15 @@ export default defineConfig({
         deviceScaleFactor: 1,
       },
     },
-
     {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
-
     {
       name: 'webkit-mobile',
       use: {
@@ -77,33 +65,19 @@ export default defineConfig({
         deviceScaleFactor: 3,
       },
     },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ].filter((project) => {
-    // Filter projects based on PROJECT environment variable
     const projectFilter = process.env.PROJECT;
     if (!projectFilter) return true;
     return project.name === projectFilter;
   }),
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000/api/health',
-    reuseExistingServer: !process.env.CI,
-    timeout: 2 * 60 * 1000, // 2 minutes
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
     env: {
-      // テスト環境ではインメモリDBを使用
       USE_IN_MEMORY_DB: 'true',
-      // 認証チェックをバイパス
       SKIP_AUTH_CHECK: 'true',
     },
   },

--- a/services/niconico-mylist-assistant/web/tsconfig.json
+++ b/services/niconico-mylist-assistant/web/tsconfig.json
@@ -22,5 +22,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "e2e", "tests"]
+  "exclude": ["node_modules", "playwright.config.ts", "e2e", "tests"]
 }


### PR DESCRIPTION
## 変更の概要

PoC (PR #3106) と同じパターンを niconico-mylist-assistant に横展開する。CI 時に `next start` で起動して `next dev` 由来の flaky を抑止する。

## 関連 Issue

#2987

## 変更種別

- [x] CI/CD 更新

## 変更内容

### `services/niconico-mylist-assistant/web/playwright.config.ts`

- `isCI` フラグで `webServer.command` を `npm run start` / `npm run dev` に切替
- CI 用タイムアウトを share-together / auth に揃えて延長
- `chromium-mobile` に `serviceWorkers: 'block'` を追加
- 既存の `extraHTTPHeaders: { 'X-Test-Mode': 'true' }` および `webServer.env: { USE_IN_MEMORY_DB, SKIP_AUTH_CHECK }` はそのまま維持

### `services/niconico-mylist-assistant/web/tsconfig.json`

- `playwright.config.ts` を `exclude` に追加

### 変更不要

- `niconico-mylist-assistant-verify.yml`: 既に E2E ジョブに `Build web application` ステップが存在
- `package.json`: 既に `start: next start` 存在

## 補足

横展開 4/7。次は quick-clip を予定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgJQzQWuTzWMGWKF6zjMmj)_