### PR TITLE
quick-clip: E2E の CI を next dev → next start に切り替え

### DIFF
--- a/services/quick-clip/web/playwright.config.ts
+++ b/services/quick-clip/web/playwright.config.ts
@@ -4,12 +4,24 @@ import { resolve } from 'path';
 
 config({ path: resolve(__dirname, '.env.test') });
 
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
@@ -20,6 +32,8 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
   projects: [
     {
@@ -28,6 +42,7 @@ export default defineConfig({
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
     {
@@ -52,9 +67,9 @@ export default defineConfig({
     return project.name === projectFilter;
   }),
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
     timeout: 2 * 60 * 1000,
   },
 });

--- a/services/quick-clip/web/tsconfig.json
+++ b/services/quick-clip/web/tsconfig.json
@@ -25,7 +25,7 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "playwright.config.ts"],
   "references": [
     {
       "path": "../core"


### PR DESCRIPTION
## 変更の概要

PoC (PR #3106) と同じパターンを quick-clip に横展開する。CI 時に `next start` で起動して `next dev` 由来の flaky を抑止する。

## 関連 Issue

#2987

## 変更種別

- [x] CI/CD 更新

## 変更内容

### `services/quick-clip/web/playwright.config.ts`

- `isCI` フラグで `webServer.command` を `npm run start` / `npm run dev` に切替
- CI 用タイムアウトを share-together / auth に揃えて延長
- `chromium-mobile` に `serviceWorkers: 'block'` を追加

### `services/quick-clip/web/tsconfig.json`

- `playwright.config.ts` を `exclude` に追加

### 変更不要

- `quick-clip-verify.yml`: 既に E2E ジョブに `Build web application` ステップが存在
- `package.json`: 既に `start: next start` 存在

## 補足

横展開 5/7。次は portal を予定（start スクリプト追加が必要）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgJQzQWuTzWMGWKF6zjMmj)_