### PR TITLE
portal: E2E の CI を next dev → next start に切り替え

### DIFF
--- a/.github/workflows/portal-verify.yml
+++ b/.github/workflows/portal-verify.yml
@@ -175,6 +175,9 @@ jobs:
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/portal-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/portal/web
@@ -241,6 +244,9 @@ jobs:
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/portal-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/portal/web
@@ -306,6 +312,9 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/portal-web
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps webkit

--- a/services/portal/web/package.json
+++ b/services/portal/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run build --workspace=@nagiyu/nextjs && next build --webpack",
+    "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/services/portal/web/playwright.config.ts
+++ b/services/portal/web/playwright.config.ts
@@ -1,40 +1,37 @@
 import { defineConfig, devices } from '@playwright/test';
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-desktop',
@@ -44,16 +41,15 @@ export default defineConfig({
         deviceScaleFactor: 1,
       },
     },
-
     {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
-
     {
       name: 'webkit-mobile',
       use: {
@@ -64,11 +60,10 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 2 * 60 * 1000, // 2 minutes
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
   },
 });

--- a/services/portal/web/tsconfig.json
+++ b/services/portal/web/tsconfig.json
@@ -22,5 +22,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "e2e"]
+  "exclude": ["node_modules", "playwright.config.ts", "e2e"]
 }


### PR DESCRIPTION
## 変更の概要

PoC (PR #3106) と同じパターンを portal に横展開する。CI 時に `next start` で起動して `next dev` 由来の flaky を抑止する。

## 関連 Issue

#2987

## 変更種別

- [x] CI/CD 更新

## 変更内容

### `services/portal/web/playwright.config.ts`

- `isCI` フラグで `webServer.command` を `npm run start` / `npm run dev` に切替
- CI 用タイムアウトを share-together / auth に揃えて延長
- `chromium-mobile` に `serviceWorkers: 'block'` を追加

### `services/portal/web/tsconfig.json`

- `playwright.config.ts` を `exclude` に追加

### `services/portal/web/package.json`

- `start: next start` スクリプトを追加（従来は `dev` のみ）

### `.github/workflows/portal-verify.yml`

- E2E 3 ジョブに `Build web application` ステップを追加（`npm run build --workspace @nagiyu/portal-web`）

## 補足

横展開 6/7。次は tools（最後、start スクリプト追加が必要、`web/` 不使用の特殊構造）を予定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgJQzQWuTzWMGWKF6zjMmj)_