### PR TITLE
E2E の flaky 解消: 8 サービスの CI を next dev → next start に切り替え

### DIFF
--- a/.github/workflows/admin-verify.yml
+++ b/.github/workflows/admin-verify.yml
@@ -154,6 +154,9 @@ jobs:
           npm run build --workspace @nagiyu/nextjs
           npm run build --workspace @nagiyu/admin-core
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/admin
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/admin/web
@@ -227,6 +230,9 @@ jobs:
           npm run build --workspace @nagiyu/nextjs
           npm run build --workspace @nagiyu/admin-core
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/admin
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/admin/web
@@ -299,6 +305,9 @@ jobs:
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
           npm run build --workspace @nagiyu/admin-core
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/admin
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps webkit

--- a/.github/workflows/auth-verify-app.yml
+++ b/.github/workflows/auth-verify-app.yml
@@ -151,6 +151,12 @@ jobs:
           npm run build --workspace @nagiyu/aws
           npm run build --workspace @nagiyu/nextjs
 
+      - name: Build auth-core
+        run: npm run build --workspace @nagiyu/auth-core
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/auth-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/auth/web
@@ -223,6 +229,12 @@ jobs:
           npm run build --workspace @nagiyu/aws
           npm run build --workspace @nagiyu/nextjs
 
+      - name: Build auth-core
+        run: npm run build --workspace @nagiyu/auth-core
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/auth-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/auth/web
@@ -294,6 +306,12 @@ jobs:
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/aws
           npm run build --workspace @nagiyu/nextjs
+
+      - name: Build auth-core
+        run: npm run build --workspace @nagiyu/auth-core
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/auth-web
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps webkit

--- a/.github/workflows/codec-converter-verify.yml
+++ b/.github/workflows/codec-converter-verify.yml
@@ -149,6 +149,9 @@ jobs:
       - name: Build codec-converter-core library
         run: npm run build --workspace=@nagiyu/codec-converter-core
 
+      - name: Build web application
+        run: npm run build --workspace=@nagiyu/codec-converter-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/codec-converter/web
@@ -219,6 +222,9 @@ jobs:
       - name: Build codec-converter-core library
         run: npm run build --workspace=@nagiyu/codec-converter-core
 
+      - name: Build web application
+        run: npm run build --workspace=@nagiyu/codec-converter-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/codec-converter/web
@@ -288,6 +294,9 @@ jobs:
 
       - name: Build codec-converter-core library
         run: npm run build --workspace=@nagiyu/codec-converter-core
+
+      - name: Build web application
+        run: npm run build --workspace=@nagiyu/codec-converter-web
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps webkit

--- a/.github/workflows/portal-verify.yml
+++ b/.github/workflows/portal-verify.yml
@@ -175,6 +175,9 @@ jobs:
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/portal-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/portal/web
@@ -241,6 +244,9 @@ jobs:
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/portal-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/portal/web
@@ -306,6 +312,9 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/portal-web
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps webkit

--- a/.github/workflows/stock-tracker-verify.yml
+++ b/.github/workflows/stock-tracker-verify.yml
@@ -314,6 +314,9 @@ jobs:
       - name: Build core package
         run: npm run build --workspace @nagiyu/stock-tracker-core
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/stock-tracker-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/stock-tracker/web
@@ -409,6 +412,9 @@ jobs:
       - name: Build core package
         run: npm run build --workspace @nagiyu/stock-tracker-core
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/stock-tracker-web
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/stock-tracker/web
@@ -503,6 +509,9 @@ jobs:
 
       - name: Build core package
         run: npm run build --workspace @nagiyu/stock-tracker-core
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/stock-tracker-web
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps webkit

--- a/.github/workflows/tools-verify.yml
+++ b/.github/workflows/tools-verify.yml
@@ -127,6 +127,9 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/tools
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/tools
@@ -198,6 +201,9 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
 
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/tools
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./services/tools
@@ -268,6 +274,9 @@ jobs:
           npm run build --workspace @nagiyu/common
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
+
+      - name: Build web application
+        run: npm run build --workspace @nagiyu/tools
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps webkit

--- a/services/admin/web/playwright.config.ts
+++ b/services/admin/web/playwright.config.ts
@@ -2,47 +2,40 @@ import { defineConfig, devices } from '@playwright/test';
 import { config } from 'dotenv';
 import { resolve } from 'path';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
 config({ path: resolve(__dirname, '.env.test') });
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './tests/e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-desktop',
@@ -52,16 +45,15 @@ export default defineConfig({
         deviceScaleFactor: 1,
       },
     },
-
     {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
-
     {
       name: 'webkit-mobile',
       use: {
@@ -70,27 +62,16 @@ export default defineConfig({
         deviceScaleFactor: 3,
       },
     },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ].filter((project) => {
-    // Filter projects based on PROJECT environment variable
     const projectFilter = process.env.PROJECT;
     if (!projectFilter) return true;
     return project.name === projectFilter;
   }),
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000/api/health',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
   },
 });

--- a/services/admin/web/tsconfig.json
+++ b/services/admin/web/tsconfig.json
@@ -22,5 +22,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "tests/e2e"]
+  "exclude": ["node_modules", "playwright.config.ts", "tests/e2e"]
 }

--- a/services/auth/web/package.json
+++ b/services/auth/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build --webpack",
+    "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/services/auth/web/playwright.config.ts
+++ b/services/auth/web/playwright.config.ts
@@ -2,48 +2,41 @@ import { defineConfig, devices } from '@playwright/test';
 import { config } from 'dotenv';
 import { resolve } from 'path';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
 // テスト環境用の .env.test を読み込む
 config({ path: resolve(__dirname, '.env.test') });
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-desktop',
@@ -53,16 +46,15 @@ export default defineConfig({
         deviceScaleFactor: 1,
       },
     },
-
     {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
-
     {
       name: 'webkit-mobile',
       use: {
@@ -71,28 +63,16 @@ export default defineConfig({
         deviceScaleFactor: 3,
       },
     },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ].filter((project) => {
-    // Filter projects based on PROJECT environment variable
     const projectFilter = process.env.PROJECT;
     if (!projectFilter) return true;
     return project.name === projectFilter;
   }),
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000/api/health',
-    reuseExistingServer: !process.env.CI,
-    timeout: 2 * 60 * 1000, // 2 minutes
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
   },
 });

--- a/services/auth/web/tsconfig.json
+++ b/services/auth/web/tsconfig.json
@@ -24,5 +24,5 @@
     ".next/dev/types/**/*.ts",
     "../core/src/types/**/*.d.ts"
   ],
-  "exclude": ["node_modules", "e2e", "tests"]
+  "exclude": ["node_modules", "playwright.config.ts", "e2e", "tests"]
 }

--- a/services/codec-converter/web/playwright.config.ts
+++ b/services/codec-converter/web/playwright.config.ts
@@ -1,41 +1,39 @@
 import { defineConfig, devices } from '@playwright/test';
 
-/**
- * Playwright configuration for Codec Converter E2E tests
- * @see https://playwright.dev/docs/test-configuration
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI
+  ? 'npm run start --workspace=@nagiyu/codec-converter-web'
+  : 'npm run dev --workspace=@nagiyu/codec-converter-web';
+
 export default defineConfig({
   testDir: './tests/integration',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-desktop',
@@ -45,16 +43,15 @@ export default defineConfig({
         deviceScaleFactor: 1,
       },
     },
-
     {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
-
     {
       name: 'webkit-mobile',
       use: {
@@ -64,18 +61,16 @@ export default defineConfig({
       },
     },
   ].filter((project) => {
-    // Filter projects based on PROJECT environment variable
     const projectFilter = process.env.PROJECT;
     if (!projectFilter) return true;
     return project.name === projectFilter;
   }),
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev --workspace=@nagiyu/codec-converter-web',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 3 * 60 * 1000, // 3 minutes
+    reuseExistingServer: !isCI,
+    timeout: 3 * 60 * 1000,
     cwd: '../../..',
   },
 });

--- a/services/codec-converter/web/tsconfig.json
+++ b/services/codec-converter/web/tsconfig.json
@@ -26,7 +26,7 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "playwright.config.ts"],
   "references": [
     {
       "path": "../core"

--- a/services/niconico-mylist-assistant/web/playwright.config.ts
+++ b/services/niconico-mylist-assistant/web/playwright.config.ts
@@ -2,54 +2,43 @@ import { defineConfig, devices } from '@playwright/test';
 import { config } from 'dotenv';
 import { resolve } from 'path';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// テスト環境用の .env.test を読み込む
 config({ path: resolve(__dirname, '.env.test') });
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
-
-    /* Extra HTTP headers */
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
     extraHTTPHeaders: {
-      // テスト環境であることを示すヘッダー（オプション）
       'X-Test-Mode': 'true',
     },
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-desktop',
@@ -59,16 +48,15 @@ export default defineConfig({
         deviceScaleFactor: 1,
       },
     },
-
     {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
-
     {
       name: 'webkit-mobile',
       use: {
@@ -77,33 +65,19 @@ export default defineConfig({
         deviceScaleFactor: 3,
       },
     },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ].filter((project) => {
-    // Filter projects based on PROJECT environment variable
     const projectFilter = process.env.PROJECT;
     if (!projectFilter) return true;
     return project.name === projectFilter;
   }),
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000/api/health',
-    reuseExistingServer: !process.env.CI,
-    timeout: 2 * 60 * 1000, // 2 minutes
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
     env: {
-      // テスト環境ではインメモリDBを使用
       USE_IN_MEMORY_DB: 'true',
-      // 認証チェックをバイパス
       SKIP_AUTH_CHECK: 'true',
     },
   },

--- a/services/niconico-mylist-assistant/web/tsconfig.json
+++ b/services/niconico-mylist-assistant/web/tsconfig.json
@@ -22,5 +22,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "e2e", "tests"]
+  "exclude": ["node_modules", "playwright.config.ts", "e2e", "tests"]
 }

--- a/services/portal/web/package.json
+++ b/services/portal/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run build --workspace=@nagiyu/nextjs && next build --webpack",
+    "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/services/portal/web/playwright.config.ts
+++ b/services/portal/web/playwright.config.ts
@@ -1,40 +1,37 @@
 import { defineConfig, devices } from '@playwright/test';
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-desktop',
@@ -44,16 +41,15 @@ export default defineConfig({
         deviceScaleFactor: 1,
       },
     },
-
     {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
-
     {
       name: 'webkit-mobile',
       use: {
@@ -64,11 +60,10 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 2 * 60 * 1000, // 2 minutes
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
   },
 });

--- a/services/portal/web/tsconfig.json
+++ b/services/portal/web/tsconfig.json
@@ -22,5 +22,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "e2e"]
+  "exclude": ["node_modules", "playwright.config.ts", "e2e"]
 }

--- a/services/quick-clip/web/playwright.config.ts
+++ b/services/quick-clip/web/playwright.config.ts
@@ -4,12 +4,24 @@ import { resolve } from 'path';
 
 config({ path: resolve(__dirname, '.env.test') });
 
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
@@ -20,6 +32,8 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
   projects: [
     {
@@ -28,6 +42,7 @@ export default defineConfig({
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
     {
@@ -52,9 +67,9 @@ export default defineConfig({
     return project.name === projectFilter;
   }),
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
     timeout: 2 * 60 * 1000,
   },
 });

--- a/services/quick-clip/web/tsconfig.json
+++ b/services/quick-clip/web/tsconfig.json
@@ -25,7 +25,7 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "playwright.config.ts"],
   "references": [
     {
       "path": "../core"

--- a/services/stock-tracker/web/playwright.config.ts
+++ b/services/stock-tracker/web/playwright.config.ts
@@ -4,41 +4,38 @@ import { resolve } from 'path';
 
 config({ path: resolve(__dirname, '.env.test') });
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const isCI = !!process.env.CI;
+
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './tests/e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-mobile',
@@ -46,6 +43,7 @@ export default defineConfig({
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
     {
@@ -65,17 +63,15 @@ export default defineConfig({
       },
     },
   ].filter((project) => {
-    // Filter projects based on PROJECT environment variable
     const projectFilter = process.env.PROJECT;
     if (!projectFilter) return true;
     return project.name === projectFilter;
   }),
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 2 * 60 * 1000, // 2 minutes
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
   },
 });

--- a/services/tools/package.json
+++ b/services/tools/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run build --workspace=@nagiyu/nextjs && next build --webpack",
+    "start": "next start",
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/services/tools/playwright.config.ts
+++ b/services/tools/playwright.config.ts
@@ -1,46 +1,37 @@
 import { defineConfig, devices } from '@playwright/test';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
+const isCI = !!process.env.CI;
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+// CI では本番ビルド済みの output に対して `next start` を使い、HMR / JIT compile /
+// React StrictMode の二重発火による flaky を抑止する。
+// ローカルでは開発体験のため `next dev` を維持する。
+const webServerCommand = isCI ? 'npm run start' : 'npm run dev';
+
 export default defineConfig({
   testDir: './e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  // CI のリソース変動を吸収するため、テスト全体のタイムアウトと expect の auto-retry を延長する。
+  timeout: isCI ? 60 * 1000 : 30 * 1000,
+  expect: {
+    timeout: isCI ? 15 * 1000 : 5 * 1000,
+  },
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/results.json' }],
     ['list'],
   ],
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-
-    /* Screenshot on failure */
     screenshot: 'only-on-failure',
-
-    /* Video on failure */
     video: 'retain-on-failure',
+    actionTimeout: isCI ? 15 * 1000 : 0,
+    navigationTimeout: isCI ? 30 * 1000 : 30 * 1000,
   },
 
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium-desktop',
@@ -50,16 +41,15 @@ export default defineConfig({
         deviceScaleFactor: 1,
       },
     },
-
     {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 5'],
         viewport: { width: 393, height: 851 },
         deviceScaleFactor: 2.75,
+        serviceWorkers: 'block',
       },
     },
-
     {
       name: 'webkit-mobile',
       use: {
@@ -68,28 +58,16 @@ export default defineConfig({
         deviceScaleFactor: 3,
       },
     },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ].filter((project) => {
-    // Filter projects based on PROJECT environment variable
     const projectFilter = process.env.PROJECT;
     if (!projectFilter) return true;
     return project.name === projectFilter;
   }),
 
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 2 * 60 * 1000, // 2 minutes
+    reuseExistingServer: !isCI,
+    timeout: 2 * 60 * 1000,
   },
 });

--- a/services/tools/tsconfig.json
+++ b/services/tools/tsconfig.json
@@ -22,5 +22,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "e2e"]
+  "exclude": ["node_modules", "playwright.config.ts", "e2e"]
 }


### PR DESCRIPTION
## 変更の概要

Issue #2987 の対応として、E2E テストの flaky 解消のため対象 8 サービスの CI 起動方式を `next dev` から `next start` に切り替えた。share-together（PR #2929）の前例パターンを踏襲し、本番ビルド済み output 上で `next start` を起動して HMR / JIT compile / React StrictMode 二重発火による flaky を恒久的に排除する。ローカル開発時は `next dev` を引き続き使用して DX を維持する。

## 関連 Issue

Closes #2987

## 変更種別

- [x] CI/CD 更新

## 含まれる内部 PR

| # | サービス | 説明 |
|---|---------|------|
| #3106 | auth (PoC) | 共通テンプレ確立 + tsconfig の `playwright.config.ts` 除外パターンを発見 |
| #3108 | admin | Build web application ステップ追加 |
| #3110 | stock-tracker | Build web application ステップ追加（tsconfig 既存対応済み） |
| #3112 | codec-converter | Build web 追加 + tsconfig 除外 |
| #3113 | niconico-mylist-assistant | tsconfig 除外のみ（Build web 既存） |
| #3114 | quick-clip | tsconfig 除外のみ（Build web 既存） |
| #3115 | portal | start script 追加 + Build web 追加 + tsconfig 除外 |
| #3116 | tools | start script 追加 + Build web 追加 + tsconfig 除外 |

## 共通の変更パターン

- `playwright.config.ts`: `isCI` フラグで `webServer.command` を `npm run start` / `npm run dev` に切替、CI 用タイムアウト群（test 60s / expect 15s / action 15s / navigation 30s）、`chromium-mobile` に `serviceWorkers: 'block'`
- `tsconfig.json`: `playwright.config.ts` を `exclude` に追加
- `package.json`: 必要な場合のみ `start: next start` スクリプト追加（portal / tools）
- `*-verify*.yml`: E2E 各ジョブに `Build web application` ステップ追加（既存対応済みのサービスを除く）

## テスト内容

各内部 PR の Fast CI（Lint / Format / Unit / E2E chromium-mobile / Build / Docker）が全パス済み。本 PR は develop 向け Full CI が走るため、追加で chromium-desktop / webkit-mobile の E2E と coverage の厳密チェックが実行される。

## 完了条件チェック

- [x] 8 サービス全ての `playwright.config.ts` で CI 時に `next start` が使われる構成
- [ ] 8 サービス全ての E2E が CI で安定して通る → 本 PR の Full CI で確認
- [x] ローカル開発時は引き続き `next dev` で動作する（`isCI` フラグで分岐）

## 補足

share-together は PR #2929 で先行対応済み（commit `46a964f`）。本 PR マージ後、PR を 5 回程度連続で走らせて flaky が再発しないことを確認する想定（Issue #2987 の完了条件）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgJQzQWuTzWMGWKF6zjMmj)_