### PR TITLE
#3121: error-events 書き込みヘルパーと safe 動作への改修

### DIFF
--- a/infra/admin/lib/batch-lambda-stack.ts
+++ b/infra/admin/lib/batch-lambda-stack.ts
@@ -8,6 +8,7 @@ import * as sns from 'aws-cdk-lib/aws-sns';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { SnsEventSource, DynamoEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Construct } from 'constructs';
+import { grantErrorEventsWrite } from '@nagiyu/infra-common';
 
 export interface BatchLambdaStackProps extends cdk.StackProps {
   environment: 'dev' | 'prod';
@@ -72,13 +73,7 @@ export class BatchLambdaStack extends cdk.Stack {
         iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
       ],
     });
-    alarmIngestRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['dynamodb:PutItem'],
-        resources: [errorEventsTableArn],
-      })
-    );
+    grantErrorEventsWrite(this, alarmIngestRole, environment);
 
     this.alarmIngestFunction = new lambda.Function(this, 'AlarmIngestFunction', {
       functionName: `nagiyu-admin-alarm-ingest-${environment}`,

--- a/infra/common/src/grants/error-events-writer.ts
+++ b/infra/common/src/grants/error-events-writer.ts
@@ -1,0 +1,24 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import type { Construct } from 'constructs';
+
+/**
+ * 指定の grantee に error-events テーブルへの書き込み権限を付与する。
+ *
+ * 内部で `nagiyu-error-events-table-arn-{environment}` を CloudFormation
+ * cross-stack import で取得し、`dynamodb:PutItem` を付与する。
+ */
+export function grantErrorEventsWrite(
+  _scope: Construct,
+  grantee: iam.IGrantable,
+  environment: 'dev' | 'prod'
+): void {
+  const tableArn = cdk.Fn.importValue(`nagiyu-error-events-table-arn-${environment}`);
+  grantee.grantPrincipal.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['dynamodb:PutItem'],
+      resources: [tableArn],
+    })
+  );
+}

--- a/infra/common/src/index.ts
+++ b/infra/common/src/index.ts
@@ -52,6 +52,9 @@ export {
   SECURITY_HEADERS,
 } from './constants/security-headers';
 
+// IAM grant helpers
+export { grantErrorEventsWrite } from './grants/error-events-writer';
+
 // Stack base classes
 export { EcrStackBase } from './stacks/ecr-stack-base';
 export type { EcrStackBaseProps } from './stacks/ecr-stack-base';

--- a/infra/common/tests/unit/grants/error-events-writer.test.ts
+++ b/infra/common/tests/unit/grants/error-events-writer.test.ts
@@ -1,0 +1,58 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Template } from 'aws-cdk-lib/assertions';
+import { grantErrorEventsWrite } from '../../../src/grants/error-events-writer';
+
+describe('grantErrorEventsWrite', () => {
+  let app: cdk.App;
+  let stack: cdk.Stack;
+  let role: iam.Role;
+
+  beforeEach(() => {
+    app = new cdk.App();
+    stack = new cdk.Stack(app, 'TestStack');
+    role = new iam.Role(stack, 'TestRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+  });
+
+  it('dynamodb:PutItem アクションを付与する', () => {
+    grantErrorEventsWrite(stack, role, 'dev');
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Effect: 'Allow',
+            Action: 'dynamodb:PutItem',
+          },
+        ],
+      },
+    });
+  });
+
+  it('dev 環境の CFN cross-stack export から ARN を取得する', () => {
+    grantErrorEventsWrite(stack, role, 'dev');
+
+    const template = Template.fromStack(stack);
+    const templateJson = JSON.stringify(template.toJSON());
+    expect(templateJson).toContain('nagiyu-error-events-table-arn-dev');
+    expect(templateJson).toContain('Fn::ImportValue');
+  });
+
+  it('prod 環境の CFN cross-stack export から ARN を取得する', () => {
+    grantErrorEventsWrite(stack, role, 'prod');
+
+    const template = Template.fromStack(stack);
+    const templateJson = JSON.stringify(template.toJSON());
+    expect(templateJson).toContain('nagiyu-error-events-table-arn-prod');
+  });
+
+  it('ロールに IAM::Policy が 1 件アタッチされる', () => {
+    grantErrorEventsWrite(stack, role, 'dev');
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::IAM::Policy', 1);
+  });
+});

--- a/libs/aws/src/error-events/report.ts
+++ b/libs/aws/src/error-events/report.ts
@@ -3,10 +3,14 @@
  *
  * `source: 'application'` や `source: 'manual'` のイベントを DynamoDB に書き込む。
  * CloudWatch Alarm 由来の取り込みには alarm-ingest を使用すること。
+ *
+ * 書き込み失敗時は例外を呼び出し元に伝播させず、logger.error で警告して null を返す。
+ * 書き込みは補助的なログ手段であり、アプリ本処理を巻き込まないことを優先する。
  */
 
 import {
   generateEventId,
+  logger,
   type ErrorEvent,
   type ErrorSeverity,
   type ErrorSource,
@@ -16,6 +20,7 @@ import { createErrorEventWriter } from './factory.js';
 
 const ERROR_MESSAGES = {
   ERROR_EVENTS_TABLE_NAME_REQUIRED: 'ERROR_EVENTS_TABLE_NAME が設定されていません',
+  WRITE_FAILED: '[reportErrorEvent] DynamoDB 書き込みに失敗しました',
 } as const;
 
 export interface ReportErrorEventInput {
@@ -36,13 +41,16 @@ export interface ReportErrorEventInput {
 /**
  * ErrorEvent を DynamoDB に書き込み、書き込んだイベントを返す。
  *
- * - `ERROR_EVENTS_TABLE_NAME` 環境変数が未設定の場合は例外を投げる
- * - 書き込み失敗は呼び出し元に伝播する（無音失敗しない）
+ * - `ERROR_EVENTS_TABLE_NAME` 環境変数が未設定の場合は logger.error で警告して null を返す
+ * - 書き込み失敗時も logger.error で警告して null を返す（例外は投げない）
  */
-export async function reportErrorEvent(input: ReportErrorEventInput): Promise<ErrorEvent> {
+export async function reportErrorEvent(
+  input: ReportErrorEventInput
+): Promise<ErrorEvent | null> {
   const tableName = process.env.ERROR_EVENTS_TABLE_NAME;
   if (!tableName) {
-    throw new Error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);
+    logger.error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);
+    return null;
   }
 
   const docClient =
@@ -60,14 +68,21 @@ export async function reportErrorEvent(input: ReportErrorEventInput): Promise<Er
     occurredAt: input.occurredAt ?? new Date().toISOString(),
   };
 
-  await writer.put(event);
-  return event;
+  try {
+    await writer.put(event);
+    return event;
+  } catch (error) {
+    logger.error(ERROR_MESSAGES.WRITE_FAILED, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 }
 
 export interface ErrorReporter {
   report: (
     input: Omit<ReportErrorEventInput, 'serviceId'> & { serviceId?: string }
-  ) => Promise<ErrorEvent>;
+  ) => Promise<ErrorEvent | null>;
 }
 
 /**

--- a/libs/aws/src/error-events/report.ts
+++ b/libs/aws/src/error-events/report.ts
@@ -44,9 +44,7 @@ export interface ReportErrorEventInput {
  * - `ERROR_EVENTS_TABLE_NAME` 環境変数が未設定の場合は logger.error で警告して null を返す
  * - 書き込み失敗時も logger.error で警告して null を返す（例外は投げない）
  */
-export async function reportErrorEvent(
-  input: ReportErrorEventInput
-): Promise<ErrorEvent | null> {
+export async function reportErrorEvent(input: ReportErrorEventInput): Promise<ErrorEvent | null> {
   const tableName = process.env.ERROR_EVENTS_TABLE_NAME;
   if (!tableName) {
     logger.error(ERROR_MESSAGES.ERROR_EVENTS_TABLE_NAME_REQUIRED);

--- a/libs/aws/tests/unit/error-events/report.test.ts
+++ b/libs/aws/tests/unit/error-events/report.test.ts
@@ -8,6 +8,7 @@ import {
   resetErrorEventWriter,
 } from '../../../src/error-events/factory.js';
 import { InMemoryErrorEventWriter } from '../../../src/error-events/in-memory-writer.js';
+import { logger } from '@nagiyu/common';
 
 const TABLE_NAME = 'test-error-events';
 
@@ -16,16 +17,20 @@ function getInMemoryWriter(): InMemoryErrorEventWriter {
 }
 
 describe('reportErrorEvent', () => {
+  let loggerErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     process.env.USE_IN_MEMORY_DB = 'true';
     process.env.ERROR_EVENTS_TABLE_NAME = TABLE_NAME;
     resetErrorEventWriter();
+    loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     delete process.env.USE_IN_MEMORY_DB;
     delete process.env.ERROR_EVENTS_TABLE_NAME;
     resetErrorEventWriter();
+    loggerErrorSpy.mockRestore();
   });
 
   describe('デフォルト値', () => {
@@ -37,7 +42,7 @@ describe('reportErrorEvent', () => {
         message: 'エラーが発生しました',
       });
 
-      expect(event.source).toBe('application');
+      expect(event?.source).toBe('application');
     });
 
     it('context 未指定のとき "{}" が保存される', async () => {
@@ -48,7 +53,7 @@ describe('reportErrorEvent', () => {
         message: 'メッセージ',
       });
 
-      expect(event.context).toBe('{}');
+      expect(event?.context).toBe('{}');
     });
 
     it('eventId は自動採番される（UUID 形式）', async () => {
@@ -59,7 +64,7 @@ describe('reportErrorEvent', () => {
         message: 'メッセージ',
       });
 
-      expect(event.eventId).toMatch(
+      expect(event?.eventId).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
       );
     });
@@ -74,8 +79,8 @@ describe('reportErrorEvent', () => {
       });
       const after = new Date().toISOString();
 
-      expect(event.occurredAt >= before).toBe(true);
-      expect(event.occurredAt <= after).toBe(true);
+      expect(event!.occurredAt >= before).toBe(true);
+      expect(event!.occurredAt <= after).toBe(true);
     });
   });
 
@@ -89,7 +94,7 @@ describe('reportErrorEvent', () => {
         source: 'manual',
       });
 
-      expect(event.source).toBe('manual');
+      expect(event?.source).toBe('manual');
     });
 
     it('context オブジェクトが JSON 文字列に変換される', async () => {
@@ -102,7 +107,7 @@ describe('reportErrorEvent', () => {
         context: ctx,
       });
 
-      expect(event.context).toBe(JSON.stringify(ctx));
+      expect(event?.context).toBe(JSON.stringify(ctx));
     });
 
     it('occurredAt を明示指定できる', async () => {
@@ -115,7 +120,7 @@ describe('reportErrorEvent', () => {
         occurredAt: ts,
       });
 
-      expect(event.occurredAt).toBe(ts);
+      expect(event?.occurredAt).toBe(ts);
     });
 
     it('eventId を明示指定できる', async () => {
@@ -127,7 +132,7 @@ describe('reportErrorEvent', () => {
         eventId: 'custom-event-id',
       });
 
-      expect(event.eventId).toBe('custom-event-id');
+      expect(event?.eventId).toBe('custom-event-id');
     });
   });
 
@@ -159,9 +164,27 @@ describe('reportErrorEvent', () => {
       expect(returned).toEqual(stored);
     });
 
-    it('ライターのエラーは呼び出し元に伝播する', async () => {
+    it('ライターのエラーは null を返し logger.error で警告する', async () => {
       const writer = getInMemoryWriter();
       jest.spyOn(writer, 'put').mockRejectedValueOnce(new Error('書き込み失敗'));
+
+      const result = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'テスト',
+        message: 'メッセージ',
+      });
+
+      expect(result).toBeNull();
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        '[reportErrorEvent] DynamoDB 書き込みに失敗しました',
+        expect.objectContaining({ error: '書き込み失敗' })
+      );
+    });
+
+    it('ライターのエラーで例外を投げない', async () => {
+      const writer = getInMemoryWriter();
+      jest.spyOn(writer, 'put').mockRejectedValueOnce(new Error('DynamoDB 障害'));
 
       await expect(
         reportErrorEvent({
@@ -170,12 +193,38 @@ describe('reportErrorEvent', () => {
           title: 'テスト',
           message: 'メッセージ',
         })
-      ).rejects.toThrow('書き込み失敗');
+      ).resolves.toBeNull();
     });
   });
 
   describe('環境変数チェック', () => {
-    it('ERROR_EVENTS_TABLE_NAME 未設定のとき例外を投げる', async () => {
+    it('ERROR_EVENTS_TABLE_NAME 未設定のとき null を返す', async () => {
+      delete process.env.ERROR_EVENTS_TABLE_NAME;
+
+      const result = await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'テスト',
+        message: 'メッセージ',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('ERROR_EVENTS_TABLE_NAME 未設定のとき logger.error で警告する', async () => {
+      delete process.env.ERROR_EVENTS_TABLE_NAME;
+
+      await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'テスト',
+        message: 'メッセージ',
+      });
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith('ERROR_EVENTS_TABLE_NAME が設定されていません');
+    });
+
+    it('ERROR_EVENTS_TABLE_NAME 未設定のとき例外を投げない', async () => {
       delete process.env.ERROR_EVENTS_TABLE_NAME;
 
       await expect(
@@ -185,22 +234,26 @@ describe('reportErrorEvent', () => {
           title: 'テスト',
           message: 'メッセージ',
         })
-      ).rejects.toThrow('ERROR_EVENTS_TABLE_NAME が設定されていません');
+      ).resolves.toBeNull();
     });
   });
 });
 
 describe('createErrorReporter', () => {
+  let loggerErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     process.env.USE_IN_MEMORY_DB = 'true';
     process.env.ERROR_EVENTS_TABLE_NAME = TABLE_NAME;
     resetErrorEventWriter();
+    loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     delete process.env.USE_IN_MEMORY_DB;
     delete process.env.ERROR_EVENTS_TABLE_NAME;
     resetErrorEventWriter();
+    loggerErrorSpy.mockRestore();
   });
 
   it('デフォルト serviceId が使われる', async () => {
@@ -211,7 +264,7 @@ describe('createErrorReporter', () => {
       message: 'メッセージ',
     });
 
-    expect(event.serviceId).toBe('stock-tracker');
+    expect(event?.serviceId).toBe('stock-tracker');
   });
 
   it('呼び出し側で serviceId をオーバーライドできる', async () => {
@@ -223,7 +276,7 @@ describe('createErrorReporter', () => {
       message: 'メッセージ',
     });
 
-    expect(event.serviceId).toBe('override-service');
+    expect(event?.serviceId).toBe('override-service');
   });
 
   it('source デフォルトは application', async () => {
@@ -234,7 +287,7 @@ describe('createErrorReporter', () => {
       message: 'メッセージ',
     });
 
-    expect(event.source).toBe('application');
+    expect(event?.source).toBe('application');
   });
 
   it('複数回呼び出せる', async () => {
@@ -244,5 +297,15 @@ describe('createErrorReporter', () => {
 
     const writer = getInMemoryWriter();
     expect(writer.getRecords()).toHaveLength(2);
+  });
+
+  it('書き込み失敗時は null を返す', async () => {
+    const writer = getInMemoryWriter();
+    jest.spyOn(writer, 'put').mockRejectedValueOnce(new Error('書き込み失敗'));
+
+    const reporter = createErrorReporter({ serviceId: 'stock-tracker' });
+    const result = await reporter.report({ severity: 'error', title: 'テスト', message: 'msg' });
+
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## 変更の概要

Issue #3121 の対応。各サービスへの `reportErrorEvent` 横展開に向けた 2 つの土台を整備した。

1. **`grantErrorEventsWrite` ヘルパー（`@nagiyu/infra-common`）**
   - `infra/common/src/grants/error-events-writer.ts` に追加
   - CFN cross-stack import で `nagiyu-error-events-table-arn-{env}` を取得し、`IGrantable` に `dynamodb:PutItem` を付与
   - `infra/admin/lib/batch-lambda-stack.ts` の直書き `PolicyStatement` をこのヘルパー 1 行に置き換え

2. **`reportErrorEvent` / `createErrorReporter` の safe 動作への統一**
   - 戻り値型を `Promise<ErrorEvent>` → `Promise<ErrorEvent | null>` に変更
   - 書き込み失敗・`ERROR_EVENTS_TABLE_NAME` 未設定時は `logger.error` で警告して `null` を返す（例外を呼び出し元に伝播しない）
   - safe 版/非 safe 版を並存させず、安全側をデフォルト動作に統一

## 関連 Issue

Closes #3121

## 変更種別

- [x] 新規機能
- [x] リファクタリング
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] Fast CI が全通過することを確認した（PR #3124 で確認済み）

## テスト内容

- **`infra/common/tests/unit/grants/error-events-writer.test.ts`（新規）**
  - `dynamodb:PutItem` アクションが付与されることを検証
  - dev / prod それぞれの CFN export キーが `Fn::ImportValue` として生成されることを検証
  - `AWS::IAM::Policy` が 1 件アタッチされることを検証

- **`libs/aws/tests/unit/error-events/report.test.ts`（更新）**
  - 書き込み失敗時に `null` を返すことを検証
  - 書き込み失敗時に例外を投げないことを検証
  - 書き込み失敗時に `logger.error` が呼ばれることを検証
  - `ERROR_EVENTS_TABLE_NAME` 未設定時に `null` を返し `logger.error` で警告することを検証

## レビューポイント

- `reportErrorEvent` の戻り値型変更（`ErrorEvent` → `ErrorEvent | null`）は後方互換を破る変更。現時点の呼び出し元は `alarm-ingest` のみで影響を確認済み（戻り値は使用していない）。後続で各サービスに導入する際は null チェックが必要になる。
- `grantErrorEventsWrite` の `_scope` パラメータは CDK 慣習として保持（現在は使用しないため `_` プレフィックス）。将来的に Construct ノードへの操作が必要になった場合に備えている。
- dev 環境で `alarm-ingest` Lambda の継続動作（SNS → DynamoDB 書き込み）を確認済み。

## 補足事項

- `infra/admin/package.json` にはすでに `"@nagiyu/infra-common": "*"` が含まれており、依存追加は不要だった。
- 後続の「各サービスへの `reportErrorEvent` 導入」は別 Issue で対応予定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01XG7gewpbdVSoX9QtC6C6H9)_