### PR TITLE
#3127: codec-converter への reportErrorEvent 導入

### DIFF
--- a/infra/codec-converter/lib/codec-converter-stack.ts
+++ b/infra/codec-converter/lib/codec-converter-stack.ts
@@ -12,7 +12,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-import { SSM_PARAMETERS } from '@nagiyu/infra-common';
+import { SSM_PARAMETERS, grantErrorEventsWrite } from '@nagiyu/infra-common';
 import { AppRuntimePolicy } from './policies/app-runtime-policy';
 import { LambdaExecutionRole } from './roles/lambda-execution-role';
 import { BatchJobRole } from './roles/batch-job-role';
@@ -141,6 +141,7 @@ export class CodecConverterStack extends cdk.Stack {
         storageBucket,
         jobsTable,
       });
+      grantErrorEventsWrite(this, batchJobRole, envName as 'dev' | 'prod');
 
       const vpcId = ssm.StringParameter.valueForStringParameter(
         this,
@@ -255,6 +256,10 @@ export class CodecConverterStack extends cdk.Stack {
                 name: 'AWS_REGION',
                 value: this.region,
               },
+              {
+                name: 'ERROR_EVENTS_TABLE_NAME',
+                value: `nagiyu-error-events-${envName}`,
+              },
             ],
           },
           retryStrategy: {
@@ -282,6 +287,7 @@ export class CodecConverterStack extends cdk.Stack {
       const lambdaExecutionRole = new LambdaExecutionRole(this, 'LambdaExecutionRole', {
         appRuntimePolicy,
       });
+      grantErrorEventsWrite(this, lambdaExecutionRole, envName as 'dev' | 'prod');
 
       // Development IAM User (shares the same runtime policy as Lambda)
       new DevUser(this, 'DevUser', {
@@ -312,6 +318,7 @@ export class CodecConverterStack extends cdk.Stack {
           S3_BUCKET: storageBucket.bucketName,
           BATCH_JOB_QUEUE: jobQueue.jobQueueName || `nagiyu-codec-converter-${envName}`,
           BATCH_JOB_DEFINITION_PREFIX: `nagiyu-codec-converter-${envName}`, // Prefix for all job definitions (e.g., nagiyu-codec-converter-dev-small)
+          ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${envName}`,
           // AWS_REGION is automatically provided by Lambda runtime
         },
         // Note: Lambda Web Adapter must be included in the Docker image itself

--- a/package-lock.json
+++ b/package-lock.json
@@ -14469,6 +14469,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14490,6 +14491,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14511,6 +14513,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14532,6 +14535,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14553,6 +14557,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14574,6 +14579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14595,6 +14601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14616,6 +14623,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14637,6 +14645,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14658,6 +14667,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14679,6 +14689,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -16650,6 +16661,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -19877,6 +19889,7 @@
         "@aws-sdk/client-dynamodb": "^3.1024.0",
         "@aws-sdk/client-s3": "^3.1024.0",
         "@aws-sdk/lib-dynamodb": "^3.1024.0",
+        "@nagiyu/aws": "*",
         "@nagiyu/codec-converter-core": "*"
       },
       "devDependencies": {

--- a/services/codec-converter/batch/Dockerfile
+++ b/services/codec-converter/batch/Dockerfile
@@ -23,6 +23,8 @@ COPY services/codec-converter ./services/codec-converter/
 RUN npm install --prefer-offline --no-audit
 
 # モノレポのルートからビルド（共通ライブラリも含めて）
+RUN npm run build --workspace=@nagiyu/common
+RUN npm run build --workspace=@nagiyu/aws
 RUN npm run build --workspace=@nagiyu/codec-converter-core
 RUN npm run build --workspace=@nagiyu/codec-converter-batch
 

--- a/services/codec-converter/batch/jest.config.ts
+++ b/services/codec-converter/batch/jest.config.ts
@@ -11,6 +11,8 @@ const config: Config.InitialOptions = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
+    '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
   },
   transform: {
     '^.+\\.ts$': [

--- a/services/codec-converter/batch/package.json
+++ b/services/codec-converter/batch/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/client-dynamodb": "^3.1024.0",
     "@aws-sdk/client-s3": "^3.1024.0",
     "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@nagiyu/aws": "*",
     "@nagiyu/codec-converter-core": "*"
   },
   "devDependencies": {

--- a/services/codec-converter/batch/src/index.ts
+++ b/services/codec-converter/batch/src/index.ts
@@ -350,7 +350,8 @@ export async function processJob(
         errorMessage
       );
     } catch (updateError) {
-      const updateErrorMessage = updateError instanceof Error ? updateError.message : String(updateError);
+      const updateErrorMessage =
+        updateError instanceof Error ? updateError.message : String(updateError);
       console.error('Failed to update job status to FAILED:', updateError);
       await reportErrorEvent({
         serviceId: 'codec-converter',
@@ -365,7 +366,8 @@ export async function processJob(
     try {
       await cleanup([inputPath, outputPath]);
     } catch (cleanupError) {
-      const cleanupErrorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      const cleanupErrorMessage =
+        cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
       console.error('Cleanup failed:', cleanupError);
       await reportErrorEvent({
         serviceId: 'codec-converter',

--- a/services/codec-converter/batch/src/index.ts
+++ b/services/codec-converter/batch/src/index.ts
@@ -6,6 +6,7 @@ import { createWriteStream, createReadStream, promises as fs } from 'fs';
 import { pipeline } from 'stream/promises';
 import { Readable } from 'stream';
 import type { CodecType } from '@nagiyu/codec-converter-core';
+import { reportErrorEvent } from '@nagiyu/aws';
 
 // エラーメッセージ定数
 const ERROR_MESSAGES = {
@@ -326,6 +327,17 @@ export async function processJob(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`Job ${env.JOB_ID} failed:`, errorMessage);
+    await reportErrorEvent({
+      serviceId: 'codec-converter',
+      severity: 'critical',
+      title: 'Batchジョブが失敗しました',
+      message: errorMessage,
+      context: {
+        jobId: env.JOB_ID,
+        outputCodec: env.OUTPUT_CODEC,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
 
     // ステータスをFAILEDに更新
     try {
@@ -338,14 +350,30 @@ export async function processJob(
         errorMessage
       );
     } catch (updateError) {
+      const updateErrorMessage = updateError instanceof Error ? updateError.message : String(updateError);
       console.error('Failed to update job status to FAILED:', updateError);
+      await reportErrorEvent({
+        serviceId: 'codec-converter',
+        severity: 'error',
+        title: 'ジョブステータスのFAILD更新に失敗しました',
+        message: updateErrorMessage,
+        context: { jobId: env.JOB_ID, originalError: errorMessage },
+      });
     }
 
     // クリーンアップを試みる（エラーは無視）
     try {
       await cleanup([inputPath, outputPath]);
     } catch (cleanupError) {
+      const cleanupErrorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
       console.error('Cleanup failed:', cleanupError);
+      await reportErrorEvent({
+        serviceId: 'codec-converter',
+        severity: 'warning',
+        title: '一時ファイルのクリーンアップに失敗しました',
+        message: cleanupErrorMessage,
+        context: { jobId: env.JOB_ID },
+      });
     }
 
     throw error;

--- a/services/codec-converter/batch/tests/integration/index.test.ts
+++ b/services/codec-converter/batch/tests/integration/index.test.ts
@@ -19,6 +19,13 @@ import type { ChildProcess } from 'child_process';
 import type { CodecType } from '@nagiyu/codec-converter-core';
 import type { SdkStream } from '@smithy/types';
 
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+import { reportErrorEvent } from '@nagiyu/aws';
+const reportErrorEventMock = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
+
 // AWS SDK モック
 const s3Mock = mockClient(S3Client);
 const dynamodbMock = mockClient(DynamoDBDocumentClient);
@@ -402,6 +409,41 @@ describe('convertWithFFmpeg', () => {
     );
   });
 
+  it('FFmpeg stderr に time= が含まれる場合は進捗ログを出力する', async () => {
+    const mockFFmpeg = {
+      stdout: { on: jest.fn() },
+      stderr: {
+        on: jest.fn((event, callback) => {
+          if (event === 'data') {
+            callback(Buffer.from('frame=10 time=00:00:05.00 bitrate=100'));
+          }
+        }),
+      },
+      on: jest.fn((event, callback) => {
+        if (event === 'close') callback(0);
+      }),
+    } as unknown as ChildProcess;
+    spawnMock.mockReturnValue(mockFFmpeg);
+
+    await convertWithFFmpeg('/tmp/input.mp4', '/tmp/output.mp4', 'h264');
+    expect(spawnMock).toHaveBeenCalled();
+  });
+
+  it('FFmpeg プロセス自体がエラーを発生させた場合はエラー', async () => {
+    const mockFFmpeg = {
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn((event, callback) => {
+        if (event === 'error') callback(new Error('spawn error'));
+      }),
+    } as unknown as ChildProcess;
+    spawnMock.mockReturnValue(mockFFmpeg);
+
+    await expect(convertWithFFmpeg('/tmp/input.mp4', '/tmp/output.mp4', 'h264')).rejects.toThrow(
+      'FFmpegの実行に失敗しました'
+    );
+  });
+
   it('FFmpegが失敗した場合はエラー', async () => {
     const mockFFmpeg = {
       stdout: { on: jest.fn() },
@@ -464,6 +506,132 @@ describe('processJob', () => {
     spawnMock.mockClear();
     unlinkMock.mockClear();
     unlinkMock.mockResolvedValue(undefined);
+    reportErrorEventMock.mockClear();
+  });
+
+  it('S3ダウンロード失敗時に reportErrorEvent が critical で呼ばれる', async () => {
+    s3Mock.on(GetObjectCommand).rejects(new Error('S3 download error'));
+    dynamodbMock.on(UpdateCommand).resolves({});
+
+    const env = {
+      S3_BUCKET: 'test-bucket',
+      DYNAMODB_TABLE: 'test-table',
+      AWS_REGION: 'ap-northeast-1',
+      JOB_ID: 'test-job-id',
+      OUTPUT_CODEC: 'h264' as CodecType,
+    };
+
+    const s3Client = new S3Client({ region: 'us-east-1' });
+    const dynamodbClient = createMockDynamoDBClient();
+
+    await expect(processJob(env, s3Client, dynamodbClient)).rejects.toThrow();
+
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'codec-converter',
+        severity: 'critical',
+        context: expect.objectContaining({ jobId: 'test-job-id' }),
+      })
+    );
+  });
+
+  it('FFmpeg失敗時に reportErrorEvent が critical で呼ばれる', async () => {
+    const mockBody = Readable.from(['test content']);
+    s3Mock.on(GetObjectCommand).resolves({ Body: mockBody as SdkStream<Readable> });
+    dynamodbMock.on(UpdateCommand).resolves({});
+
+    const mockFFmpeg = {
+      stdout: { on: jest.fn() },
+      stderr: {
+        on: jest.fn((event, callback) => {
+          if (event === 'data') callback(Buffer.from('ffmpeg error output'));
+        }),
+      },
+      on: jest.fn((event, callback) => {
+        if (event === 'close') callback(1); // 異常終了
+      }),
+    } as unknown as ChildProcess;
+    spawnMock.mockReturnValue(mockFFmpeg);
+
+    const env = {
+      S3_BUCKET: 'test-bucket',
+      DYNAMODB_TABLE: 'test-table',
+      AWS_REGION: 'ap-northeast-1',
+      JOB_ID: 'test-job-ffmpeg',
+      OUTPUT_CODEC: 'h264' as CodecType,
+    };
+
+    const s3Client = new S3Client({ region: 'us-east-1' });
+    const dynamodbClient = createMockDynamoDBClient();
+
+    await expect(processJob(env, s3Client, dynamodbClient)).rejects.toThrow();
+
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'codec-converter',
+        severity: 'critical',
+        context: expect.objectContaining({ jobId: 'test-job-ffmpeg', outputCodec: 'h264' }),
+      })
+    );
+  });
+
+  it('ジョブステータス更新失敗時に reportErrorEvent が error で呼ばれる', async () => {
+    s3Mock.on(GetObjectCommand).rejects(new Error('S3 error'));
+    // 1回目（PROCESSING更新）は成功、2回目（FAILED更新）は失敗
+    let callCount = 0;
+    dynamodbMock.on(UpdateCommand).callsFake(() => {
+      callCount++;
+      if (callCount === 2) throw new Error('DynamoDB update failed');
+      return {};
+    });
+
+    const env = {
+      S3_BUCKET: 'test-bucket',
+      DYNAMODB_TABLE: 'test-table',
+      AWS_REGION: 'ap-northeast-1',
+      JOB_ID: 'test-job-status',
+      OUTPUT_CODEC: 'vp9' as CodecType,
+    };
+
+    const s3Client = new S3Client({ region: 'us-east-1' });
+    const dynamodbClient = createMockDynamoDBClient();
+
+    await expect(processJob(env, s3Client, dynamodbClient)).rejects.toThrow();
+
+    // critical（ジョブ失敗）と error（ステータス更新失敗）の2回呼ばれる
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'codec-converter', severity: 'critical' })
+    );
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'codec-converter', severity: 'error' })
+    );
+  });
+
+  it('エラー後のクリーンアップ失敗時に reportErrorEvent が warning で呼ばれる', async () => {
+    s3Mock.on(GetObjectCommand).rejects(new Error('S3 error'));
+    dynamodbMock.on(UpdateCommand).resolves({});
+    // FAILED ステータス更新後にクリーンアップが失敗するようにモックを設定
+    const permissionError = new Error('Permission denied');
+    (permissionError as NodeJS.ErrnoException).code = 'EACCES';
+    const unlinkMock = fs.unlink as jest.MockedFunction<typeof fs.unlink>;
+    unlinkMock.mockRejectedValue(permissionError);
+
+    const env = {
+      S3_BUCKET: 'test-bucket',
+      DYNAMODB_TABLE: 'test-table',
+      AWS_REGION: 'ap-northeast-1',
+      JOB_ID: 'test-job-cleanup',
+      OUTPUT_CODEC: 'h264' as CodecType,
+    };
+
+    const s3Client = new S3Client({ region: 'us-east-1' });
+    const dynamodbClient = createMockDynamoDBClient();
+
+    await expect(processJob(env, s3Client, dynamodbClient)).rejects.toThrow();
+
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'codec-converter', severity: 'warning' })
+    );
   });
 
   it.skip('ジョブ処理が成功する', async () => {

--- a/services/codec-converter/web/src/app/api/jobs/[jobId]/submit/route.ts
+++ b/services/codec-converter/web/src/app/api/jobs/[jobId]/submit/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { GetCommand } from '@aws-sdk/lib-dynamodb';
 import { HeadObjectCommand } from '@aws-sdk/client-s3';
 import { SubmitJobCommand } from '@aws-sdk/client-batch';
-import { getAwsClients } from '@nagiyu/aws';
+import { getAwsClients, reportErrorEvent } from '@nagiyu/aws';
 import { type Job, type JobStatus, selectJobDefinition } from '@nagiyu/codec-converter-core';
 import type { ErrorResponse } from '@nagiyu/common';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
@@ -36,9 +36,10 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ jobId: string }> }
 ): Promise<NextResponse<SubmitJobResponse | ErrorResponse>> {
+  let jobId: string | undefined;
   try {
     // パスパラメータの取得
-    const { jobId } = await params;
+    ({ jobId } = await params);
 
     // AWS クライアントと環境変数の取得
     const { DYNAMODB_TABLE, S3_BUCKET, BATCH_JOB_QUEUE, BATCH_JOB_DEFINITION_PREFIX, AWS_REGION } =
@@ -85,7 +86,19 @@ export async function POST(
         })
       );
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Input file not found in S3:', error);
+      await reportErrorEvent({
+        serviceId: 'codec-converter',
+        severity: 'error',
+        title: '入力ファイルがS3に存在しません',
+        message: errorMessage,
+        context: {
+          jobId,
+          s3Key: job.inputFile,
+          errorStack: error instanceof Error ? error.stack : undefined,
+        },
+      });
       return NextResponse.json(
         {
           error: 'FILE_NOT_FOUND',
@@ -169,7 +182,18 @@ export async function POST(
       { status: 200 }
     );
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('Error submitting job:', error);
+    await reportErrorEvent({
+      serviceId: 'codec-converter',
+      severity: 'error',
+      title: 'Batchジョブの投入に失敗しました',
+      message: errorMessage,
+      context: {
+        jobId,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     return NextResponse.json(
       {
         error: 'INTERNAL_SERVER_ERROR',

--- a/services/codec-converter/web/src/app/api/jobs/route.ts
+++ b/services/codec-converter/web/src/app/api/jobs/route.ts
@@ -10,7 +10,7 @@ import {
   type CodecType,
 } from '@nagiyu/codec-converter-core';
 import type { ErrorResponse } from '@nagiyu/common';
-import { getAwsClients } from '@nagiyu/aws';
+import { getAwsClients, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 
 // Presigned URLの有効期限（1時間 = 3600秒）
@@ -149,7 +149,15 @@ export async function POST(
       { status: 201 }
     );
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('Error creating job:', error);
+    await reportErrorEvent({
+      serviceId: 'codec-converter',
+      severity: 'error',
+      title: 'ジョブ作成に失敗しました',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return NextResponse.json(
       {
         error: 'INTERNAL_SERVER_ERROR',


### PR DESCRIPTION
## 変更の概要

codec-converter（batch / web / infra）に `reportErrorEvent` を導入し、エラーイベントを Admin の `/errors` 画面で確認できるようにする。

- **batch**: `processJob` の各 catch ブロックに `reportErrorEvent` を追加
  - ジョブ全体失敗: `severity=critical`（jobId / outputCodec をコンテキストに含む）
  - FAILED ステータス更新失敗: `severity=error`
  - クリーンアップ失敗: `severity=warning`
- **web**: API ルートのエラー catch に `reportErrorEvent` を追加
  - `POST /api/jobs`: ジョブ作成失敗 → `severity=error`
  - `POST /api/jobs/[jobId]/submit`: S3 入力ファイル不在・Batch 投入失敗 → `severity=error`
- **infra**: `BatchJobRole` / `LambdaExecutionRole` に `grantErrorEventsWrite` を適用し、`ERROR_EVENTS_TABLE_NAME` 環境変数を追加

全レイヤで `serviceId='codec-converter'` に統一。ECS Batch タスクは fire-and-forget にならないよう `await` で完了を待つ。

## 関連 Issue

#3127

## 変更種別

- [x] 新規機能
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

`services/codec-converter/batch/tests/integration/index.test.ts` に以下のテストを追加:

- S3 ダウンロード失敗時に `reportErrorEvent` が `critical` で呼ばれること
- FFmpeg 失敗時に `reportErrorEvent` が `critical` で呼ばれること
- ジョブステータス更新失敗時に `reportErrorEvent` が `error` で呼ばれること
- クリーンアップ失敗時に `reportErrorEvent` が `warning` で呼ばれること
- FFmpeg stderr に `time=` が含まれる場合の進捗ログテスト
- FFmpeg プロセス自体のエラーイベントテスト

ブランチカバレッジ: 82.14%（閾値 80% 達成）

`jest.config.ts` に `@nagiyu/aws` / `@nagiyu/common` の `moduleNameMapper` を追加（ESM-only パッケージをテスト環境で解決するため）。

## レビューポイント

- `batch/jest.config.ts` の `moduleNameMapper` 追加: `@nagiyu/aws` が ESM exports のみ提供するため CJS ベースの Jest resolver が解決できず、TypeScript ソースへのエイリアスで対応
- `submit/route.ts` の `jobId` を `let` で try 外に宣言: 外側の catch でも jobId をコンテキストに含められるようにするための最小変更
- infra の `grantErrorEventsWrite` は BatchJobRole・LambdaExecutionRole の両方に適用済み
- Batch Job Definition の環境変数と Lambda 環境変数の両方に `ERROR_EVENTS_TABLE_NAME` を追加済み

## 補足事項

- web 側（Next.js）はユニットテストがなく E2E テスト（Playwright）のみのため、web の `reportErrorEvent` 呼び出しは手動テスト（dev 環境での動作確認）での確認が必要
- 既存の `console.error` は Issue の方針に従い撤去せず並行運用
- dev 環境での動作確認（Admin `/errors` 画面への流入確認）は integration ブランチへのマージ後に人力で実施

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJwvdDy4fHPGKTRMpzkY9r)_