### PR TITLE
#3128: niconico-mylist-assistant への reportErrorEvent 導入

### DIFF
--- a/infra/niconico-mylist-assistant/lib/batch-stack.ts
+++ b/infra/niconico-mylist-assistant/lib/batch-stack.ts
@@ -6,7 +6,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
-import { getEcrRepositoryName, getDynamoDBTableName, SSM_PARAMETERS } from '@nagiyu/infra-common';
+import { getEcrRepositoryName, getDynamoDBTableName, SSM_PARAMETERS, grantErrorEventsWrite } from '@nagiyu/infra-common';
 import { BatchRuntimePolicy } from './policies/batch-runtime-policy';
 
 export interface BatchStackProps extends cdk.StackProps {
@@ -134,6 +134,7 @@ export class BatchStack extends cdk.Stack {
       description: 'Role for Batch job container runtime',
       managedPolicies: [this.batchRuntimePolicy],
     });
+    grantErrorEventsWrite(this, batchJobRole, env);
 
     // Batch Compute Environment (Fargate) - L1 construct for assignPublicIp support
     const computeEnvironment = new batch.CfnComputeEnvironment(this, 'ComputeEnvironment', {
@@ -212,6 +213,10 @@ export class BatchStack extends cdk.Stack {
           {
             name: 'VAPID_PRIVATE_KEY',
             value: vapidPrivateKey,
+          },
+          {
+            name: 'ERROR_EVENTS_TABLE_NAME',
+            value: `nagiyu-error-events-${env}`,
           },
           ...(screenshotBucketName
             ? [

--- a/infra/niconico-mylist-assistant/lib/lambda-stack.ts
+++ b/infra/niconico-mylist-assistant/lib/lambda-stack.ts
@@ -5,6 +5,7 @@ import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
+import { grantErrorEventsWrite } from '@nagiyu/infra-common';
 import { WebRuntimePolicy } from './policies/web-runtime-policy';
 
 export interface LambdaStackProps extends cdk.StackProps {
@@ -87,6 +88,7 @@ export class LambdaStack extends cdk.Stack {
         this.webRuntimePolicy,
       ],
     });
+    grantErrorEventsWrite(this, webExecutionRole, environment as 'dev' | 'prod');
 
     // Web Lambda Function の作成
     this.webFunction = new lambda.Function(this, 'WebFunction', {
@@ -113,6 +115,7 @@ export class LambdaStack extends cdk.Stack {
         AWS_REGION_FOR_SDK: this.region,
         VAPID_PUBLIC_KEY: vapidPublicKey,
         VAPID_PRIVATE_KEY: vapidPrivateKey,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       tracing: lambda.Tracing.ACTIVE, // X-Ray トレーシング有効化
       logRetention: logs.RetentionDays.ONE_MONTH, // CloudWatch Logs 保持期間: 30日

--- a/package-lock.json
+++ b/package-lock.json
@@ -14469,6 +14469,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14490,6 +14491,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14511,6 +14513,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14532,6 +14535,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14553,6 +14557,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14574,6 +14579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14595,6 +14601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14616,6 +14623,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14637,6 +14645,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14658,6 +14667,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14679,6 +14689,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -16650,6 +16661,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/services/niconico-mylist-assistant/batch/jest.config.ts
+++ b/services/niconico-mylist-assistant/batch/jest.config.ts
@@ -13,6 +13,7 @@ const config: Config.InitialOptions = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/common/push$': '<rootDir>/../../../libs/common/src/push/index.ts',
   },

--- a/services/niconico-mylist-assistant/batch/src/index.ts
+++ b/services/niconico-mylist-assistant/batch/src/index.ts
@@ -6,6 +6,7 @@
 
 import { decrypt, updateBatchJob, getBatchJob } from '@nagiyu/niconico-mylist-assistant-core';
 import type { CryptoConfig } from '@nagiyu/niconico-mylist-assistant-core';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { sendWebPushNotification, getVapidConfig } from '@nagiyu/common/push';
 import { executeMylistRegistration } from './playwright-automation.js';
 import {
@@ -123,6 +124,16 @@ async function decryptPassword(encryptedData: string, config: CryptoConfig): Pro
     return password;
   } catch (error) {
     console.error('パスワードの復号化に失敗しました:', error);
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'critical',
+      title: 'パスワード復号化失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     throw new Error(
       `${ERROR_MESSAGES.DECRYPTION_FAILED}: ${error instanceof Error ? error.message : String(error)}`
     );
@@ -363,6 +374,19 @@ async function main() {
     console.error(`エラー時刻: ${getTimestamp()}`);
     console.error('エラー詳細:', error);
     console.error('========================================');
+
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'critical',
+      title: 'バッチジョブ全体の失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        jobId: params?.jobId,
+        userId: params?.userId,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    });
 
     // ジョブステータスを FAILED に更新
     if (params?.jobId && params?.userId) {

--- a/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
+++ b/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
@@ -13,7 +13,7 @@ import {
   VIDEO_REGISTRATION_WAIT,
 } from './constants.js';
 import { MylistRegistrationResult, LoginResult } from './types.js';
-import { createS3Client, uploadFile, getS3ObjectUrl } from '@nagiyu/aws';
+import { createS3Client, uploadFile, getS3ObjectUrl, reportErrorEvent } from '@nagiyu/aws';
 import { readFile } from 'fs/promises';
 
 const VIDEO_RETRY_OPTIONS: Pick<
@@ -71,6 +71,16 @@ export async function login(page: Page, email: string, password: string): Promis
     return { requires2FA: false };
   } catch (error) {
     console.error('ログイン失敗:', error);
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'ニコニコログイン失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        step: 'login',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
     throw new Error(ERROR_MESSAGES.LOGIN_FAILED);
   }
 }

--- a/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
+++ b/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
@@ -1,0 +1,59 @@
+jest.mock('@nagiyu/aws', () => ({
+  ...jest.requireActual('@nagiyu/aws'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+  createS3Client: jest.fn().mockReturnValue(null),
+  uploadFile: jest.fn().mockResolvedValue(undefined),
+  getS3ObjectUrl: jest.fn().mockReturnValue(''),
+}));
+
+jest.mock('playwright', () => ({
+  chromium: {
+    launch: jest.fn().mockResolvedValue({
+      newPage: jest.fn(),
+      close: jest.fn(),
+    }),
+  },
+}));
+
+import { login } from '../../src/playwright-automation';
+import { reportErrorEvent } from '@nagiyu/aws';
+import type { Page } from 'playwright';
+
+function createMockPage(overrides: Partial<Record<string, jest.Mock>> = {}): Page {
+  return {
+    goto: jest.fn().mockRejectedValue(new Error('Navigation timeout')),
+    fill: jest.fn(),
+    getByRole: jest.fn().mockReturnValue({ click: jest.fn() }),
+    waitForURL: jest.fn(),
+    url: jest.fn().mockReturnValue('https://example.com'),
+    screenshot: jest.fn().mockResolvedValue(Buffer.from('')),
+    locator: jest.fn().mockReturnValue({ all: jest.fn().mockResolvedValue([]) }),
+    on: jest.fn(),
+    ...overrides,
+  } as unknown as Page;
+}
+
+describe('playwright-automation', () => {
+  beforeEach(() => {
+    jest.mocked(reportErrorEvent).mockClear();
+  });
+
+  describe('login', () => {
+    it('ログイン失敗時に reportErrorEvent を呼ぶ', async () => {
+      const mockPage = createMockPage({
+        goto: jest.fn().mockRejectedValue(new Error('Navigation timeout')),
+      });
+
+      await expect(login(mockPage, 'test@example.com', 'password')).rejects.toThrow();
+
+      expect(jest.mocked(reportErrorEvent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'niconico-mylist-assistant',
+          severity: 'error',
+          title: 'ニコニコログイン失敗',
+          context: expect.objectContaining({ step: 'login' }),
+        })
+      );
+    });
+  });
+});

--- a/services/niconico-mylist-assistant/core/src/db/videos.ts
+++ b/services/niconico-mylist-assistant/core/src/db/videos.ts
@@ -1,4 +1,4 @@
-import { getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 import { createVideoRepository, createUserSettingRepository } from '../repositories/factory.js';
 import type { VideoRepository } from '../repositories/video.repository.interface.js';
 import type { UserSettingRepository } from '../repositories/user-setting.repository.interface.js';
@@ -43,8 +43,23 @@ function getUserSettingRepository(): UserSettingRepository {
 export async function createVideoBasicInfo(
   input: CreateVideoBasicInfoInput
 ): Promise<VideoBasicInfo> {
-  const entity = await getVideoRepository().create(input);
-  return entity as VideoBasicInfo;
+  try {
+    const entity = await getVideoRepository().create(input);
+    return entity as VideoBasicInfo;
+  } catch (error) {
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'DynamoDB 動画基本情報書き込み失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        videoId: input.videoId,
+        operation: 'createVideoBasicInfo',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    throw error;
+  }
 }
 
 /**
@@ -96,8 +111,24 @@ export async function createUserVideoSetting(
 export async function upsertUserVideoSetting(
   input: CreateUserSettingInput
 ): Promise<UserVideoSetting> {
-  const entity = await getUserSettingRepository().upsert(input);
-  return entity as UserVideoSetting;
+  try {
+    const entity = await getUserSettingRepository().upsert(input);
+    return entity as UserVideoSetting;
+  } catch (error) {
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'DynamoDB ユーザー設定書き込み失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        userId: input.userId,
+        videoId: input.videoId,
+        operation: 'upsertUserVideoSetting',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    throw error;
+  }
 }
 
 /**
@@ -122,8 +153,24 @@ export async function updateUserVideoSetting(
   videoId: string,
   update: VideoSettingUpdate
 ): Promise<UserVideoSetting> {
-  const entity = await getUserSettingRepository().update(userId, videoId, update);
-  return entity as UserVideoSetting;
+  try {
+    const entity = await getUserSettingRepository().update(userId, videoId, update);
+    return entity as UserVideoSetting;
+  } catch (error) {
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'DynamoDB ユーザー設定更新失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        userId,
+        videoId,
+        operation: 'updateUserVideoSetting',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    throw error;
+  }
 }
 
 /**

--- a/services/niconico-mylist-assistant/core/src/niconico/client.ts
+++ b/services/niconico-mylist-assistant/core/src/niconico/client.ts
@@ -1,4 +1,5 @@
 import { parseStringPromise } from 'xml2js';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { NICONICO_ERROR_MESSAGES } from './constants.js';
 
 export interface NiconicoVideoInfo {
@@ -81,6 +82,16 @@ export async function getVideoInfo(videoId: string): Promise<NiconicoVideoInfo> 
     };
   } catch (error) {
     if (error instanceof NiconicoAPIError) {
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'error',
+        title: 'Niconico API エラー',
+        message: error.message,
+        context: {
+          videoId: error.videoId,
+          errorCode: error.code,
+        },
+      });
       throw error;
     }
 

--- a/services/niconico-mylist-assistant/core/tests/unit/videos.test.ts
+++ b/services/niconico-mylist-assistant/core/tests/unit/videos.test.ts
@@ -1,6 +1,11 @@
 // テスト実行前にDYNAMODB_TABLE_NAMEを設定
 process.env.DYNAMODB_TABLE_NAME = 'test-table';
 
+jest.mock('@nagiyu/aws', () => ({
+  ...jest.requireActual('@nagiyu/aws'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
 import { mockClient } from 'aws-sdk-client-mock';
 import {
   DynamoDBDocumentClient,
@@ -22,6 +27,7 @@ import {
   listUserVideoSettings,
   deleteUserVideoSetting,
 } from '../../src/db/videos';
+import { reportErrorEvent } from '@nagiyu/aws';
 import type {
   CreateVideoBasicInfoInput,
   CreateUserSettingInput,
@@ -33,6 +39,7 @@ const ddbMock = mockClient(DynamoDBDocumentClient);
 describe('videos', () => {
   beforeEach(() => {
     ddbMock.reset();
+    jest.mocked(reportErrorEvent).mockClear();
   });
 
   describe('VIDEO エンティティ', () => {
@@ -81,6 +88,15 @@ describe('videos', () => {
         };
 
         await expect(createVideoBasicInfo(input)).rejects.toThrow('エンティティは既に存在します');
+
+        expect(jest.mocked(reportErrorEvent)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            serviceId: 'niconico-mylist-assistant',
+            severity: 'error',
+            title: 'DynamoDB 動画基本情報書き込み失敗',
+            context: expect.objectContaining({ videoId: 'sm12345678' }),
+          })
+        );
       });
     });
 
@@ -448,6 +464,15 @@ describe('videos', () => {
 
         await expect(updateUserVideoSetting('user123', 'sm99999999', update)).rejects.toThrow(
           'エンティティが見つかりません'
+        );
+
+        expect(jest.mocked(reportErrorEvent)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            serviceId: 'niconico-mylist-assistant',
+            severity: 'error',
+            title: 'DynamoDB ユーザー設定更新失敗',
+            context: expect.objectContaining({ userId: 'user123', videoId: 'sm99999999' }),
+          })
         );
       });
     });

--- a/services/niconico-mylist-assistant/web/src/app/api/mylist/register/route.ts
+++ b/services/niconico-mylist-assistant/web/src/app/api/mylist/register/route.ts
@@ -5,7 +5,7 @@ import {
   encrypt,
   createBatchJob,
 } from '@nagiyu/niconico-mylist-assistant-core';
-import { getBatchClient } from '@nagiyu/aws';
+import { getBatchClient, reportErrorEvent } from '@nagiyu/aws';
 import type { CryptoConfig } from '@nagiyu/niconico-mylist-assistant-core';
 import { getSession } from '@/lib/auth/session';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
@@ -254,6 +254,16 @@ export async function POST(
       encryptedPasswordJson = JSON.stringify(encryptedData);
     } catch (error) {
       console.error('パスワード暗号化エラー:', error);
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'error',
+        title: 'パスワード暗号化エラー',
+        message: error instanceof Error ? error.message : String(error),
+        context: {
+          userId: session.user.userId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
       return NextResponse.json(
         {
           error: 'ENCRYPTION_ERROR',
@@ -287,6 +297,16 @@ export async function POST(
     // ジョブIDの確認
     if (!submitResult.jobId) {
       console.error('Batch job submission returned no jobId:', submitResult.jobId);
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'error',
+        title: 'Batch ジョブ ID 未取得',
+        message: 'SubmitJob のレスポンスにジョブ ID が含まれていませんでした',
+        context: {
+          userId: session.user.userId,
+          jobName,
+        },
+      });
       return NextResponse.json(
         {
           error: 'BATCH_ERROR',
@@ -309,6 +329,17 @@ export async function POST(
       console.log(`バッチジョブレコードを作成しました: ${submitResult.jobId}`);
     } catch (error) {
       console.error('バッチジョブレコード作成エラー:', error);
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'error',
+        title: 'DynamoDB バッチジョブレコード作成失敗',
+        message: error instanceof Error ? error.message : String(error),
+        context: {
+          userId: session.user.userId,
+          jobId: submitResult.jobId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
       // DynamoDB への保存に失敗した場合はエラーを返す
       // ジョブステータスが照会できないため
       return NextResponse.json(
@@ -334,6 +365,16 @@ export async function POST(
     );
   } catch (error) {
     console.error('バッチジョブ投入エラー:', error);
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'Batch ジョブ投入エラー',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    });
 
     // AWS Batch エラー
     return NextResponse.json(


### PR DESCRIPTION
## 変更の概要

Issue #3128 の対応として、niconico-mylist-assistant の主要なエラー箇所に `reportErrorEvent` を導入した。バッチ・コア・Web の各層でエラーが発生した際に `nagiyu-error-events-{env}` テーブルへイベントを記録し、Admin の `/errors` 画面で確認できるようにする。

## 関連 Issue

関連: #3128（integration → develop の PR でのみ `Closes #` を付与）

## 変更種別

- [x] 新規機能
- [x] インフラ更新

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（ドキュメント変更なし、Issue 本文が仕様）
- [x] ローカルでテストが全て通ることを確認した（core: 219 テスト全通過、カバレッジ 80% 超）

## 変更ファイル一覧

### infra

| ファイル | 変更内容 |
|---|---|
| `infra/niconico-mylist-assistant/lib/batch-stack.ts` | Batch Job Role に `grantErrorEventsWrite` を適用、`ERROR_EVENTS_TABLE_NAME` を Batch Job Definition の環境変数に注入 |
| `infra/niconico-mylist-assistant/lib/lambda-stack.ts` | Web Lambda 実行ロールに `grantErrorEventsWrite` を適用、`ERROR_EVENTS_TABLE_NAME` を Lambda 環境変数に注入 |

### コード（services/niconico-mylist-assistant）

| ファイル | 追加箇所 | severity |
|---|---|---|
| `core/src/niconico/client.ts` | `NiconicoAPIError` 再スロー前 | `error` |
| `core/src/db/videos.ts` | `createVideoBasicInfo` / `upsertUserVideoSetting` / `updateUserVideoSetting` の catch | `error` |
| `batch/src/index.ts` | パスワード復号化失敗の catch | `critical` |
| `batch/src/index.ts` | main 最終 catch | `critical` |
| `batch/src/playwright-automation.ts` | `login` の catch | `error` |
| `web/src/app/api/mylist/register/route.ts` | パスワード暗号化エラー / Batch ジョブ ID 未取得 / DynamoDB 書き込みエラー / 最終 catch | `error` |

### テスト

| ファイル | 変更内容 |
|---|---|
| `batch/jest.config.ts` | `@nagiyu/aws` の moduleNameMapper を追加 |
| `core/tests/unit/videos.test.ts` | `@nagiyu/aws` の `reportErrorEvent` をモック化し、`createVideoBasicInfo` と `updateUserVideoSetting` のエラーパスで正しい引数で呼ばれることをアサート |
| `batch/tests/unit/playwright-automation.test.ts` | 新規作成。ログイン失敗時に `reportErrorEvent` が呼ばれることをテスト |

## テスト内容

- `core` の全 unit テスト（219 テスト）を実行し全通過
- カバレッジ: branches 81.71%, functions 98.11%, lines 97.76%, statements 97.81%（閾値 80% を超過）
- `batch` の `playwright-automation.test.ts` を新規作成・通過確認

## レビューポイント

- `videos.ts` の書き込み系 3 関数にのみ try/catch を追加している。読み取り系は Issue 本文の「最小限のカバー」方針に従い対象外とした
- `client.ts` は `NiconicoAPIError` の再スロー前にのみ `reportErrorEvent` を呼んでいる（fetch 失敗で変換される最外側の catch では二重レポートを避けるため未追加）
- infra は `BatchRuntimePolicy` に集約せず、admin のパターンに倣い `batch-stack.ts` / `lambda-stack.ts` で直接 `grantErrorEventsWrite` を呼ぶ形とした

## 補足事項

- dev 環境での動作確認（`/errors` 画面での表示）は integration → develop マージ後に人力で実施
- 既存の `console.error` は撤去せず並行運用（Issue 指示通り）


---
_Generated by [Claude Code](https://claude.ai/code/session_01SyeTdaTj4wMReGow53xq6o)_