### PR TITLE
#3128: バッチ処理の Playwright 失敗・全失敗時の reportErrorEvent を補完

### DIFF
--- a/services/niconico-mylist-assistant/batch/src/index.ts
+++ b/services/niconico-mylist-assistant/batch/src/index.ts
@@ -365,6 +365,18 @@ async function main() {
     // （全失敗の場合のみエラー終了）
     if (result.successVideoIds.length === 0 && result.failedVideoIds.length > 0) {
       console.error('全ての動画の登録に失敗しました');
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'critical',
+        title: 'バッチジョブ全失敗',
+        message: result.errorMessage ?? '全ての動画の登録に失敗しました',
+        context: {
+          jobId: params?.jobId,
+          userId: params?.userId,
+          failedCount: result.failedVideoIds.length,
+          errorMessage: result.errorMessage,
+        },
+      });
       process.exit(1);
     }
   } catch (error) {

--- a/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
+++ b/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
@@ -723,6 +723,18 @@ export async function executeMylistRegistration(
 
     console.error('マイリスト登録処理でエラーが発生しました:', errorMessage);
 
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'Playwright 自動化処理失敗',
+      message: errorMessage,
+      context: {
+        step: 'executeMylistRegistration',
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    });
+
     return {
       successVideoIds: [],
       failedVideoIds: videoIds,

--- a/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
+++ b/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
@@ -1,3 +1,5 @@
+const mockChromiumLaunch = jest.fn();
+
 jest.mock('@nagiyu/aws', () => ({
   ...jest.requireActual('@nagiyu/aws'),
   reportErrorEvent: jest.fn().mockResolvedValue(null),
@@ -8,14 +10,11 @@ jest.mock('@nagiyu/aws', () => ({
 
 jest.mock('playwright', () => ({
   chromium: {
-    launch: jest.fn().mockResolvedValue({
-      newPage: jest.fn(),
-      close: jest.fn(),
-    }),
+    launch: (...args: unknown[]) => mockChromiumLaunch(...args),
   },
 }));
 
-import { login } from '../../src/playwright-automation';
+import { login, executeMylistRegistration } from '../../src/playwright-automation';
 import { reportErrorEvent } from '@nagiyu/aws';
 import type { Page } from 'playwright';
 
@@ -52,6 +51,30 @@ describe('playwright-automation', () => {
           severity: 'error',
           title: 'ニコニコログイン失敗',
           context: expect.objectContaining({ step: 'login' }),
+        })
+      );
+    });
+  });
+
+  describe('executeMylistRegistration', () => {
+    it('ブラウザ起動失敗時に reportErrorEvent を呼ぶ', async () => {
+      mockChromiumLaunch.mockRejectedValue(new Error('Executable does not exist'));
+
+      const result = await executeMylistRegistration(
+        'test@example.com',
+        'password',
+        'test-mylist',
+        ['sm1', 'sm2']
+      );
+
+      expect(result.successVideoIds).toHaveLength(0);
+      expect(result.failedVideoIds).toEqual(['sm1', 'sm2']);
+      expect(jest.mocked(reportErrorEvent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'niconico-mylist-assistant',
+          severity: 'error',
+          title: 'Playwright 自動化処理失敗',
+          context: expect.objectContaining({ step: 'executeMylistRegistration' }),
         })
       );
     });

--- a/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
+++ b/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
@@ -161,11 +161,18 @@ test.describe('Video List Page', () => {
       .getByRole('button', { name: /お気に入り/ });
     await expect(favoriteButton).toBeVisible();
 
+    // waitForResponse は click より前に登録しないとレースコンディションが発生するため先行登録
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/videos/') &&
+        response.url().includes('/settings') &&
+        response.request().method() === 'PUT' &&
+        response.status() === 200
+    );
+
     // ボタンをクリック
     await favoriteButton.click();
-
-    // レスポンスを待つ（適切なAPI呼び出しが行われることを確認）
-    await page.waitForResponse((response) => response.url().includes('/api/videos/'));
+    await responsePromise;
   });
 
   test('should toggle skip on video card', async ({ page, request }) => {
@@ -193,11 +200,18 @@ test.describe('Video List Page', () => {
       .getByRole('button', { name: /スキップ/ });
     await expect(skipButton).toBeVisible();
 
+    // waitForResponse は click より前に登録しないとレースコンディションが発生するため先行登録
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/videos/') &&
+        response.url().includes('/settings') &&
+        response.request().method() === 'PUT' &&
+        response.status() === 200
+    );
+
     // ボタンをクリック
     await skipButton.click();
-
-    // レスポンスを待つ
-    await page.waitForResponse((response) => response.url().includes('/api/videos/'));
+    await responsePromise;
   });
 
   test('should filter videos by favorite', async ({ page, request }) => {


### PR DESCRIPTION
## 変更の概要

PR #3130 マージ後に dev 環境で動作確認したところ、ブラウザ起動失敗（Playwright バージョン不整合に起因）時に Admin の `/errors` 画面へイベントが流入しないことが判明したため、その漏れを補完する。

### 漏れの原因

`executeMylistRegistration` の catch ブロックは内部で発生した Playwright 関連エラー（`launchBrowser` / `login` / `createMylist` 等）を吸収して結果オブジェクトを返す設計のため、main の最終 catch には到達せず、その後の `process.exit(1)` 分岐も catch を経由しないため `reportErrorEvent` が呼ばれていなかった。

### 本 PR の対応（方針 C）

- **A.** `executeMylistRegistration` の catch で `reportErrorEvent` を呼ぶ（Playwright 自動化全般の失敗を一括カバー）
- **B.** main の「全失敗」分岐（`process.exit(1)` 前）で `reportErrorEvent` を呼ぶ（catch を経由しない失敗終了でもイベントが記録されるように）

## 関連 Issue

関連: #3128（同 Issue の追加対応。`Closes` は integration → develop の PR で付与）

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [x] ローカルでテストが全て通ることを確認した（batch: 44 テスト全通過）

## 変更内容

| ファイル | 追加箇所 | severity |
|---|---|---|
| `batch/src/playwright-automation.ts` | `executeMylistRegistration` の catch | `error` |
| `batch/src/index.ts` | main の `result.successVideoIds.length === 0 && failedVideoIds.length > 0` 分岐 | `critical` |
| `batch/tests/unit/playwright-automation.test.ts` | ブラウザ起動失敗時の `reportErrorEvent` 呼び出しテストを追加 |  |

## テスト内容

- `executeMylistRegistration` がブラウザ起動失敗時に `reportErrorEvent({ serviceId, severity: 'error', title: 'Playwright 自動化処理失敗', context: { step: 'executeMylistRegistration' } })` を呼ぶことをアサート
- batch unit テスト全 44 件パス

## レビューポイント

- A の `executeMylistRegistration` の catch は内部の子 catch（`login` 等）でも `reportErrorEvent` を呼んでいるため、ログイン失敗のような特定エラーでは `error` イベントが 2 件流入する（粒度の細かい子レベル + 包括的な親レベル）。これは context.step で区別可能。問題なければそのままで OK
- B の severity は「全失敗で exit(1)」を critical として扱っているが、原因によっては error の方が妥当な場合もある。判断はレビュアー任せ

## 補足事項

- 本 PR は #3128 の漏れ修正のため、`integration/3122-report-error-event-rollout` をそのまま base とした
- 別問題として Dockerfile の Playwright base image（1.59.1）と npm install 後の Playwright（1.60.0）のバージョン不整合があるが、これは本 PR の範囲外で別 Issue 化が必要


---
_Generated by [Claude Code](https://claude.ai/code/session_01SyeTdaTj4wMReGow53xq6o)_