### PR TITLE
fix(nma-e2e): waitForResponse レースコンディション修正 (#3133)

### DIFF
--- a/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
+++ b/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
@@ -161,11 +161,18 @@ test.describe('Video List Page', () => {
       .getByRole('button', { name: /お気に入り/ });
     await expect(favoriteButton).toBeVisible();
 
+    // waitForResponse は click より前に登録しないとレースコンディションが発生するため先行登録
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/videos/') &&
+        response.url().includes('/settings') &&
+        response.request().method() === 'PUT' &&
+        response.status() === 200
+    );
+
     // ボタンをクリック
     await favoriteButton.click();
-
-    // レスポンスを待つ（適切なAPI呼び出しが行われることを確認）
-    await page.waitForResponse((response) => response.url().includes('/api/videos/'));
+    await responsePromise;
   });
 
   test('should toggle skip on video card', async ({ page, request }) => {
@@ -193,11 +200,18 @@ test.describe('Video List Page', () => {
       .getByRole('button', { name: /スキップ/ });
     await expect(skipButton).toBeVisible();
 
+    // waitForResponse は click より前に登録しないとレースコンディションが発生するため先行登録
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/videos/') &&
+        response.url().includes('/settings') &&
+        response.request().method() === 'PUT' &&
+        response.status() === 200
+    );
+
     // ボタンをクリック
     await skipButton.click();
-
-    // レスポンスを待つ
-    await page.waitForResponse((response) => response.url().includes('/api/videos/'));
+    await responsePromise;
   });
 
   test('should filter videos by favorite', async ({ page, request }) => {


### PR DESCRIPTION
## 変更の概要

`video-list.spec.ts` の `should toggle favorite on video card` / `should toggle skip on video card` で発生していた `waitForResponse` のレースコンディションを修正する。

- `waitForResponse` の Promise 登録を `click()` より**前**に移動（Playwright 推奨パターン）
- URL 条件を `/api/videos/` のみから `/settings` + `method === 'PUT'` + `status === 200` に具体化し、初期一覧取得リクエストへの誤マッチを防ぐ

## 関連 Issue

#3133

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [x] テスト修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 実装チェックリスト

- [x] `should toggle favorite on video card` (L139-176) の `waitForResponse` を先行登録パターンに修正
- [x] `should toggle skip on video card` (L178-217) の `waitForResponse` を先行登録パターンに修正
- [x] HTTP method を `settings/route.ts` の実装（`PUT`）に合わせて確認

## テスト内容

- E2E: `npm run test:e2e -- video-list.spec.ts --project=chromium-mobile` でフレークしないことをローカル確認
- Fast CI の `E2E Tests (chromium-mobile)` がパスすること

## レビューポイント

- Issue 本文では仮置きで `PATCH` と書いていたが、実装側（`settings/route.ts`）は `PUT` を使っているため `PUT` に修正している点を確認してほしい
- スコープ外の `waitForResponse`（L77, L102, L219, L249 等）は別 Issue で対応予定のため本 PR では触っていない

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7oJW7gJVUsEKCdHa8FrDA)_