### PR TITLE
fix(nma-e2e): waitForResponse レースコンディション修正 (#3133)

### DIFF
--- a/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
+++ b/services/niconico-mylist-assistant/web/e2e/video-list.spec.ts
@@ -161,11 +161,18 @@ test.describe('Video List Page', () => {
       .getByRole('button', { name: /お気に入り/ });
     await expect(favoriteButton).toBeVisible();
 
+    // waitForResponse は click より前に登録しないとレースコンディションが発生するため先行登録
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/videos/') &&
+        response.url().includes('/settings') &&
+        response.request().method() === 'PUT' &&
+        response.status() === 200
+    );
+
     // ボタンをクリック
     await favoriteButton.click();
-
-    // レスポンスを待つ（適切なAPI呼び出しが行われることを確認）
-    await page.waitForResponse((response) => response.url().includes('/api/videos/'));
+    await responsePromise;
   });
 
   test('should toggle skip on video card', async ({ page, request }) => {
@@ -193,11 +200,18 @@ test.describe('Video List Page', () => {
       .getByRole('button', { name: /スキップ/ });
     await expect(skipButton).toBeVisible();
 
+    // waitForResponse は click より前に登録しないとレースコンディションが発生するため先行登録
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/videos/') &&
+        response.url().includes('/settings') &&
+        response.request().method() === 'PUT' &&
+        response.status() === 200
+    );
+
     // ボタンをクリック
     await skipButton.click();
-
-    // レスポンスを待つ
-    await page.waitForResponse((response) => response.url().includes('/api/videos/'));
+    await responsePromise;
   });
 
   test('should filter videos by favorite', async ({ page, request }) => {


### PR DESCRIPTION
## 変更の概要

`services/niconico-mylist-assistant/web/e2e/video-list.spec.ts` の `should toggle favorite on video card` / `should toggle skip on video card` で発生していた `waitForResponse` のレースコンディションを修正した。

- `waitForResponse` の Promise 登録を `click()` より**前**に移動（Playwright 推奨パターン）
- URL 条件を `/api/videos/` のみから `/settings` + `method === 'PUT'` + `status === 200` に具体化し、初期一覧取得リクエストへの誤マッチを防止

## 関連 Issue

Closes #3133

## 含まれる PR

- #3134

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [x] テスト修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 実装チェックリスト

- [x] `should toggle favorite on video card` の `waitForResponse` を先行登録パターンに修正
- [x] `should toggle skip on video card` の `waitForResponse` を先行登録パターンに修正
- [x] HTTP method を実装（`PUT` on `/api/videos/[id]/settings`）に合わせて設定
- [x] Fast Verification（E2E `chromium-mobile` 含む）パス確認済み
- [x] dev 環境への反映確認済み

## テスト内容

- Fast CI: Lint / Format / Build / Test Core / Test Batch / Docker Build / E2E (chromium-mobile) すべて success（PR #3134 の `runs/25869280776`）
- dev 環境での動作確認済み

## レビューポイント

- Issue 本文では仮置きで `PATCH` と書かれていたが、実装側（`settings/route.ts`）は `PUT` を使っているため `PUT` に揃えている
- スコープ外の他 `waitForResponse`（L77, L102, L219, L249 等）の網羅的リファクタは別 Issue で対応予定

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7oJW7gJVUsEKCdHa8FrDA)_