### PR TITLE
#3127: batch Dockerfile runner ステージに libs/common, libs/aws の dist をコピー

### DIFF
--- a/services/codec-converter/batch/Dockerfile
+++ b/services/codec-converter/batch/Dockerfile
@@ -39,6 +39,10 @@ COPY --from=builder /app/node_modules ./node_modules
 
 # 必要なビルド成果物とpackage.jsonをコピー
 COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/libs/common/package*.json ./libs/common/
+COPY --from=builder /app/libs/common/dist ./libs/common/dist
+COPY --from=builder /app/libs/aws/package*.json ./libs/aws/
+COPY --from=builder /app/libs/aws/dist ./libs/aws/dist
 COPY --from=builder /app/services/codec-converter/core/package*.json ./services/codec-converter/core/
 COPY --from=builder /app/services/codec-converter/core/dist ./services/codec-converter/core/dist
 COPY --from=builder /app/services/codec-converter/batch/package*.json ./services/codec-converter/batch/


### PR DESCRIPTION
## 変更の概要

`services/codec-converter/batch/Dockerfile` の runner ステージに `libs/common` と `libs/aws` の `package.json` + `dist/` のコピー処理を追加する。

## 関連 Issue

#3127

## 背景

PR #3129 で batch worker に `@nagiyu/aws` の `reportErrorEvent` を導入し Dockerfile の builder ステージに `libs/common` と `libs/aws` のビルド処理を追加したが、**runner ステージで `libs/*` の dist と package.json を COPY し忘れていた**。

dev 環境で動作確認したところ、ジョブ起動時に以下のエラーで即終了する状態:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@nagiyu/aws' imported from /app/services/codec-converter/batch/dist/src/index.js
```

`node_modules/@nagiyu/aws` は workspace の symlink（`../libs/aws` を指す）であり、builder の `node_modules` を runner にコピーしても **symlink 先の `libs/aws` 本体（package.json + dist）が存在しないと Node.js は ESM の `exports` を解決できない**。

## 変更内容

runner ステージに以下 4 行を追加:

```dockerfile
COPY --from=builder /app/libs/common/package*.json ./libs/common/
COPY --from=builder /app/libs/common/dist ./libs/common/dist
COPY --from=builder /app/libs/aws/package*.json ./libs/aws/
COPY --from=builder /app/libs/aws/dist ./libs/aws/dist
```

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（Dockerfile 変更のため CI の Docker Build が成否を判定）
- [ ] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した
- [x] ローカルでテストが全て通ることを確認した（Dockerfile 構造のみの追加）
- [x] ビルドエラーがないことを確認した

## テスト内容

- CI の `Docker Build Batch` ジョブで Docker イメージのビルドが通ること
- マージ後、dev 環境で codec-converter のジョブを投入して `ERR_MODULE_NOT_FOUND` が出ないこと
- 故意に失敗するジョブを投入して Admin `/errors` 画面に `serviceId=codec-converter` のレコードが流入することを確認

## レビューポイント

- 同パターンが他サービスにもあるか確認（参考: niconico-mylist-assistant の batch などは Dockerfile の構造が異なれば不要）
- runner で `libs/common` と `libs/aws` のみコピーで十分か（batch worker が import するのはこの 2 つの workspace パッケージのみ。`@nagiyu/codec-converter-core` は別途コピー済み）

## 補足事項

PR #3129 の追加修正。同じ Issue (#3127) のスコープ内のため新規 Issue は起票しない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJwvdDy4fHPGKTRMpzkY9r)_