### PR TITLE
[stock-tracker] 分次バッチ TradingView タイムアウト緩和 (#3139)

### DIFF
--- a/infra/stock-tracker/lib/lambda-stack.ts
+++ b/infra/stock-tracker/lib/lambda-stack.ts
@@ -169,7 +169,7 @@ export class LambdaStack extends cdk.Stack {
         VAPID_PRIVATE_KEY: vapidPrivateKey,
         OPENAI_API_KEY: openAiApiKey,
         MINUTE_BATCH_CONCURRENCY: '10',
-        MINUTE_BATCH_TIME_BUDGET_MS: '38000',
+        MINUTE_BATCH_TIME_BUDGET_MS: '30000',
       },
       tracing: lambda.Tracing.ACTIVE,
       logRetention: logs.RetentionDays.ONE_MONTH,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14469,6 +14469,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14490,6 +14491,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14511,6 +14513,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14532,6 +14535,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14553,6 +14557,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14574,6 +14579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14595,6 +14601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14616,6 +14623,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14637,6 +14645,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14658,6 +14667,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14679,6 +14689,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -16650,6 +16661,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/services/stock-tracker/batch/src/minute.ts
+++ b/services/stock-tracker/batch/src/minute.ts
@@ -101,9 +101,11 @@ async function processAlert(
     }
 
     // 4. TradingView API で現在価格取得
-    // timeout を 5s に短縮し maxRetries を 1 にすることで最悪所要時間を ~10.5s に抑える
+    // TradingView は呼び出しごとに WebSocket を張り直すため 5s では接続+初回ティック待ちで
+    // 誤タイムアウトが多発する。8s に緩和し、最悪所要時間を ~16.5s（8s + 0.5s + 8s）に抑える。
+    // 時間予算 30s 直前に開始したタスクでも 30 + 16.5 ≒ 46.5s < Lambda timeout 50s に収まる。
     const currentPrice = await withRetry<number>(
-      () => getCurrentPrice(alert.TickerID, { timeout: 5000 }),
+      () => getCurrentPrice(alert.TickerID, { timeout: 8000 }),
       {
         maxRetries: 1,
         initialDelayMs: 500,
@@ -190,9 +192,9 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
   };
 
   // 並列度・時間予算は環境変数で調整可能
-  // TIME_BUDGET_MS を 38s に設定し、in-flight タスクの完了（最大 ~10.5s）を含めて 50s 以内に収める
+  // TIME_BUDGET_MS を 30s に設定し、in-flight タスクの完了（最大 ~16.5s）を含めて 50s 以内に収める
   const concurrency = parseInt(process.env.MINUTE_BATCH_CONCURRENCY ?? '10', 10);
-  const timeBudgetMs = parseInt(process.env.MINUTE_BATCH_TIME_BUDGET_MS ?? '38000', 10);
+  const timeBudgetMs = parseInt(process.env.MINUTE_BATCH_TIME_BUDGET_MS ?? '30000', 10);
   const isBudgetExceeded = (): boolean => Date.now() - startTime > timeBudgetMs;
 
   try {

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -183,7 +183,7 @@ describe('minute batch handler', () => {
         expect.any(Number)
       );
       expect(tradingviewClient.getCurrentPrice).toHaveBeenCalledWith('NSDQ:AAPL', {
-        timeout: 5000,
+        timeout: 8000,
       });
       expect(alertEvaluator.evaluateAlert).toHaveBeenCalledWith(mockAlert, 205.0);
       expect(sendWebPushNotification).toHaveBeenCalledWith(


### PR DESCRIPTION
## 変更の概要

分次バッチ（`batch-minute`）で断続的に発生していた TradingView API タイムアウトを緩和する。

- `getCurrentPrice` の timeout を 5s → **8s** に引き上げ
- `MINUTE_BATCH_TIME_BUDGET_MS` を 38s → **30s** に短縮（Lambda timeout 50s との余裕を維持）
- コードコメントを新しい数値に合わせて更新
- テストのアサーション（`timeout: 5000` → `8000`）を更新

**不変条件の検証**
- 最悪所要時間（1アラート）: 8s + 0.5s(delay) + 8s = **~16.5s**
- 時間予算直前（30s）に開始: 30 + 16.5 ≒ **46.5s < Lambda timeout 50s** ✅

## 関連 Issue

#3139（`Closes #` は integration → develop PR でのみ記載）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリではないため対象外）
- [x] ローカルでテストが全て通ることを確認した（125件 pass）
- [x] ビルドエラーがないことを確認した

## テスト内容

- `services/stock-tracker/batch/tests/unit/minute.test.ts` 全15件 pass
- batch 全テストスイート: 125件 pass / 11スイート pass
- `minute.ts` 単体カバレッジ: Statements 98.7% / Functions 100% / Branches 85%
- **備考**: branch coverage 全体 79.32%（閾値 80%）は本変更前から存在する既存問題（`evaluation.ts` / `summary.ts` の未カバー分岐が起因、本 PR の変更ファイルではない）

## レビューポイント

- `minute.ts:107` — timeout 値 8000ms の妥当性（TradingView WS 接続+初回ティック取得に要する実測時間を踏まえた値）
- `lambda-stack.ts:172` — `MINUTE_BATCH_TIME_BUDGET_MS: '30000'` の値（Lambda timeout 50s / 最悪所要時間 ~16.5s から逆算。CDK デプロイにより dev/prod 両環境に反映される点を確認）

## スクリーンショット（該当する場合）

なし（バックエンドのみ）

## 補足事項

調査経緯・根本原因の詳細は Issue #3139 を参照。
日次バッチの別バグ（`subscription` 未定義による全体クラッシュ）は Issue #3140 で別追跡。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xh1FXVtBKPbV9sCEcbbxeB)_