### PR TITLE
fix(niconico-mylist-assistant): Playwright バージョン不整合によるマイリスト登録全件失敗を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@eslint/compat": "^2.0.4",
         "@eslint/js": "^10",
         "@jest/types": "^30.3.0",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "1.60.0",
         "@storybook/addon-a11y": "^10.3.6",
         "@storybook/addon-themes": "^10.3.6",
         "@storybook/react-vite": "^10.3.6",
@@ -567,12 +567,12 @@
       }
     },
     "node_modules/@aws-sdk/client-batch/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -633,12 +633,12 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -701,12 +701,12 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -780,12 +780,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -843,12 +843,12 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -881,12 +881,12 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1189,12 +1189,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/is-array-buffer": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.3.1.tgz",
-      "integrity": "sha512-9aVG6VjOFVFHC6Z4hGAzIIrsVWpp1QOO4ERQ2k1S19VrgCamUGIBE2ilAnMWCfr+mlowHlLRXBStsTk/2c5HfA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.3.2.tgz",
+      "integrity": "sha512-JYNfdKj1kr3ke+Pip+qxiuXW/OuSe8KlCyJz93bU25uKVq6wQGdm6H0/1g2XoFjehJFUmNdS+2/nM6Oabe6/+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1202,12 +1202,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1299,12 +1299,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1395,12 +1395,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
+      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5824,9 +5824,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.1.tgz",
-      "integrity": "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.2.tgz",
+      "integrity": "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -7057,9 +7057,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -12594,9 +12594,9 @@
       }
     },
     "node_modules/isomorphic-dompurify/node_modules/@csstools/css-calc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "funding": [
         {
           "type": "github",
@@ -12617,9 +12617,9 @@
       }
     },
     "node_modules/isomorphic-dompurify/node_modules/@csstools/css-color-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
       "funding": [
         {
           "type": "github",
@@ -12633,7 +12633,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.0"
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -14311,21 +14311,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/jszip/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/jszip/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/just-extend": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
@@ -14469,6 +14454,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14490,6 +14476,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14511,6 +14498,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14532,6 +14520,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14553,6 +14542,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14574,6 +14564,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14595,6 +14586,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14616,6 +14608,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14637,6 +14630,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14658,6 +14652,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14679,6 +14674,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -16618,7 +16614,6 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -16637,7 +16632,6 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -17341,13 +17335,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -17413,23 +17400,9 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
@@ -17947,12 +17920,12 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-length": {
@@ -19706,6 +19679,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -19919,55 +19910,11 @@
         "@nagiyu/common": "*",
         "@nagiyu/niconico-mylist-assistant-core": "*",
         "dotenv": "^17.4.1",
-        "playwright": "1.59.1",
+        "playwright": "1.60.0",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1"
-      }
-    },
-    "services/niconico-mylist-assistant/batch/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "services/niconico-mylist-assistant/batch/node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "services/niconico-mylist-assistant/batch/node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
+        "@playwright/test": "1.60.0"
       }
     },
     "services/niconico-mylist-assistant/core": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@eslint/compat": "^2.0.4",
     "@eslint/js": "^10",
     "@jest/types": "^30.3.0",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "1.60.0",
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-themes": "^10.3.6",
     "@storybook/react-vite": "^10.3.6",

--- a/services/niconico-mylist-assistant/batch/Dockerfile
+++ b/services/niconico-mylist-assistant/batch/Dockerfile
@@ -1,5 +1,5 @@
 # ベースイメージ: Playwright公式イメージ（ブラウザ含む）
-FROM mcr.microsoft.com/playwright:v1.59.1-jammy AS base
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy AS base
 
 # ビルドステージ
 FROM base AS builder
@@ -13,7 +13,7 @@ COPY services/niconico-mylist-assistant/core ./services/niconico-mylist-assistan
 COPY services/niconico-mylist-assistant/batch ./services/niconico-mylist-assistant/batch/
 
 # 依存関係をインストール（ソースコード存在下で実行）
-RUN npm install --omit=optional
+RUN npm ci --omit=optional
 
 # モノレポのルートからビルド（共通ライブラリも含めて）
 RUN npm run build --workspace=@nagiyu/common

--- a/services/niconico-mylist-assistant/batch/package.json
+++ b/services/niconico-mylist-assistant/batch/package.json
@@ -22,10 +22,10 @@
     "@nagiyu/common": "*",
     "@nagiyu/niconico-mylist-assistant-core": "*",
     "dotenv": "^17.4.1",
-    "playwright": "1.59.1",
+    "playwright": "1.60.0",
     "web-push": "^3.6.7"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1"
+    "@playwright/test": "1.60.0"
   }
 }


### PR DESCRIPTION
## 変更の概要

Niconico Mylist Assistant のマイリスト自動登録バッチが dev / prod 両環境で Playwright バージョン不整合により全件失敗していた問題を修正する。

**根本原因**: ルート `node_modules` の `playwright` / `playwright-core` / `@playwright/test` が 1.60.0 に上がっていたが、`batch/Dockerfile` の base image が `mcr.microsoft.com/playwright:v1.59.1-jammy` のままで、1.60.0 用の Chromium バイナリがコンテナ内に存在せず `browserType.launch: Executable doesn't exist` で失敗していた。

**変更内容**:
- `batch/package.json`: `playwright` を `1.59.1` → `1.60.0`、`@playwright/test` を `^1.59.1` → `1.60.0`（caret 削除で固定）
- `package.json`（ルート）: `@playwright/test` を `^1.59.1` → `1.60.0`（caret 削除で固定）
- `batch/Dockerfile`: base image を `v1.60.0-jammy` に更新、`npm install` → `npm ci` に変更（lockfile 厳守による再発防止）
- `package-lock.json`: 再生成（stale な `batch/node_modules/playwright@1.59.1` エントリも除去）

## 関連 Issue

Closes #3137

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] ローカルでテストが全て通ることを確認した（Jest 42 tests passed）
- [x] ビルドエラーがないことを確認した（shared libs + batch ビルド成功）
- [x] Fast CI 全パス（全サービス・全ライブラリ・全インフラ）

## テスト内容

- ローカル: `npm run test --workspace=@nagiyu/niconico-mylist-assistant-batch` → 42 tests passed、全 workspace ビルド成功
- Fast CI: 全サービス（niconico-mylist-assistant 含む）の Docker Build Batch / E2E chromium-mobile を含めて全パス
- **dev 環境実機検証**: 作業ブランチ → integration マージ後、dev 環境でマイリスト登録ジョブを実行し、CloudWatch Logs で `ブラウザ起動成功` を確認（修正前は `browserType.launch: Executable doesn't exist` で失敗していた）。Issue #3137 の解消を実機で確認済み。

## レビューポイント

- `batch/Dockerfile` の `npm install` → `npm ci` 変更により、今後 lockfile と package.json の整合が CI で保証され、同種のバージョンドリフトを防止する。
- ルート `@playwright/test` を `1.60.0` 固定にしたことで他 workspace の E2E も新バージョンで動作する。Fast CI で stock-tracker / admin / portal 等の E2E が全てグリーンであり回帰なしを確認済み。

## 補足事項

**本 Issue のスコープ外（別 Issue 起票予定）**:
1. 全件失敗時に `ジョブステータスを SUCCEEDED` に更新されるバグ（`batch/src/index.ts` 周辺）— dev 実機検証でも再現を確認
2. dev 環境の Web Push 401（VAPID 公開鍵と購読 endpoint 不一致）— 購読 endpoint 依存の可能性


---
_Generated by [Claude Code](https://claude.ai/code/session_012sG5ir5s8oqCB1T6S46pKJ)_