### PR TITLE
#3147: admin Web API への reportErrorEvent 導入（フェーズ1）

### DIFF
--- a/infra/admin/lib/lambda-stack.ts
+++ b/infra/admin/lib/lambda-stack.ts
@@ -58,10 +58,11 @@ export class LambdaStack extends LambdaStackBase {
           `arn:aws:dynamodb:*:*:table/nagiyu-admin-main-${environment}/index/*`,
         ],
       }),
-      // 共通エラーイベントテーブルへの読み取り権限（/errors UI / API 用）
+      // 共通エラーイベントテーブルへの読み取り権限（/errors UI / API 用）+
+      // アプリ層の自己監視（reportErrorEvent）のための書き込み権限
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['dynamodb:GetItem', 'dynamodb:Query'],
+        actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:PutItem'],
         resources: [
           `arn:aws:dynamodb:*:*:table/nagiyu-error-events-${environment}`,
           `arn:aws:dynamodb:*:*:table/nagiyu-error-events-${environment}/index/*`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19529,6 +19529,7 @@
       "version": "1.2.1",
       "dependencies": {
         "@nagiyu/admin-core": "*",
+        "@nagiyu/aws": "*",
         "@nagiyu/browser": "*",
         "@nagiyu/common": "*",
         "@nagiyu/nextjs": "*",

--- a/services/admin/web/jest.config.ts
+++ b/services/admin/web/jest.config.ts
@@ -18,6 +18,7 @@ const config: Config = {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/ui$': '<rootDir>/../../../libs/ui/src/index.ts',
     '^@nagiyu/browser$': '<rootDir>/../../../libs/browser/src/index.ts',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/nextjs$': '<rootDir>/../../../libs/nextjs/src/index.ts',
     '^@nagiyu/nextjs/(.*)$': '<rootDir>/../../../libs/nextjs/src/$1.ts',

--- a/services/admin/web/package.json
+++ b/services/admin/web/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@nagiyu/admin-core": "*",
+    "@nagiyu/aws": "*",
     "@nagiyu/browser": "*",
     "@nagiyu/common": "*",
     "@nagiyu/nextjs": "*",

--- a/services/admin/web/src/app/api/errors/[eventId]/route.ts
+++ b/services/admin/web/src/app/api/errors/[eventId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { COMMON_ERROR_MESSAGES, hasPermission } from '@nagiyu/common';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { createErrorEventReader } from '@nagiyu/admin-core';
 import { createErrorResponse } from '@nagiyu/nextjs';
 import { getSession } from '@/lib/auth/session';
@@ -62,6 +62,16 @@ export async function GET(
     return NextResponse.json(event, { status: 200 });
   } catch (error) {
     console.error('エラー詳細取得 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'admin',
+      severity: 'error',
+      title: 'エラー詳細取得 API の実行に失敗しました',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        endpoint: 'GET /api/errors/[eventId]',
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     return createErrorResponse(500, 'INTERNAL_ERROR', ERROR_MESSAGES.INTERNAL_ERROR);
   }
 }

--- a/services/admin/web/src/app/api/errors/route.ts
+++ b/services/admin/web/src/app/api/errors/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { COMMON_ERROR_MESSAGES, hasPermission } from '@nagiyu/common';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { createErrorEventReader, type ListErrorEventsQuery } from '@nagiyu/admin-core';
 import { createErrorResponse } from '@nagiyu/nextjs';
 import { getSession } from '@/lib/auth/session';
@@ -98,6 +98,16 @@ export async function GET(request: Request): Promise<NextResponse> {
     }
 
     console.error('エラー一覧取得 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'admin',
+      severity: 'error',
+      title: 'エラー一覧取得 API の実行に失敗しました',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        endpoint: 'GET /api/errors',
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     return createErrorResponse(500, 'INTERNAL_ERROR', ERROR_MESSAGES.INTERNAL_ERROR);
   }
 }

--- a/services/admin/web/tests/unit/app/api/errors-report.test.ts
+++ b/services/admin/web/tests/unit/app/api/errors-report.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ */
+import { GET as listErrors } from '@/app/api/errors/route';
+import { GET as getErrorDetail } from '@/app/api/errors/[eventId]/route';
+import { reportErrorEvent } from '@nagiyu/aws';
+import { createErrorEventReader } from '@nagiyu/admin-core';
+import { getSession } from '@/lib/auth/session';
+
+jest.mock('@nagiyu/aws', () => ({
+  getDynamoDBDocumentClient: jest.fn(),
+  reportErrorEvent: jest.fn(async () => null),
+}));
+
+jest.mock(
+  '@nagiyu/admin-core',
+  () => ({
+    createErrorEventReader: jest.fn(),
+  }),
+  { virtual: true }
+);
+
+jest.mock('@/lib/auth/session', () => ({
+  getSession: jest.fn(),
+}));
+
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
+const mockCreateErrorEventReader = createErrorEventReader as jest.MockedFunction<
+  typeof createErrorEventReader
+>;
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+
+describe('admin /api/errors の reportErrorEvent 連携', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.USE_IN_MEMORY_DB = 'true';
+    mockGetSession.mockResolvedValue({
+      user: {
+        id: 'test-user-id',
+        email: 'admin@example.com',
+        name: 'Admin',
+        roles: ['admin'],
+      },
+      expires: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    } as Awaited<ReturnType<typeof getSession>>);
+  });
+
+  it('一覧取得 API の内部エラー時に reportErrorEvent を呼ぶ', async () => {
+    mockCreateErrorEventReader.mockReturnValue({
+      list: jest.fn().mockRejectedValue(new Error('DynamoDB 接続失敗')),
+    } as unknown as ReturnType<typeof createErrorEventReader>);
+
+    const response = await listErrors(new Request('http://localhost/api/errors'));
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledTimes(1);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'admin',
+        severity: 'error',
+        title: 'エラー一覧取得 API の実行に失敗しました',
+        message: 'DynamoDB 接続失敗',
+        context: expect.objectContaining({ endpoint: 'GET /api/errors' }),
+      })
+    );
+  });
+
+  it('詳細取得 API の内部エラー時に reportErrorEvent を呼ぶ', async () => {
+    mockCreateErrorEventReader.mockReturnValue({
+      findById: jest.fn().mockRejectedValue(new Error('DynamoDB 読み取り失敗')),
+    } as unknown as ReturnType<typeof createErrorEventReader>);
+
+    const response = await getErrorDetail(
+      new Request('http://localhost/api/errors/evt-1?at=2026-05-16T00:00:00Z&serviceId=admin'),
+      { params: Promise.resolve({ eventId: 'evt-1' }) }
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledTimes(1);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'admin',
+        severity: 'error',
+        title: 'エラー詳細取得 API の実行に失敗しました',
+        message: 'DynamoDB 読み取り失敗',
+        context: expect.objectContaining({ endpoint: 'GET /api/errors/[eventId]' }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## 変更の概要

Issue #3147（親 #3122）のフェーズ1。admin 自身のアプリ層（Web API）の失敗を `reportErrorEvent` で `nagiyu-error-events` テーブルへ記録し、`/errors` 上で自己監視できるようにする。

- `services/admin/web/src/app/api/errors/route.ts`：一覧取得 API の内部エラー（500）catch に `reportErrorEvent` を追加
- `services/admin/web/src/app/api/errors/[eventId]/route.ts`：詳細取得 API の内部エラー（500）catch に `reportErrorEvent` を追加
- `serviceId='admin'` / `severity='error'` / `context` に endpoint・errorStack を付与（alarm-ingest 由来とは serviceId / context で区別可能）
- `services/admin/web/package.json` に `@nagiyu/aws` を依存追加
- `services/admin/web/jest.config.ts` に `@nagiyu/aws` の moduleNameMapper を追加（知見 C）
- `infra/admin/lib/lambda-stack.ts`：Web SSR 実行ロールの error-events ポリシーに `dynamodb:PutItem` を追加（`ERROR_EVENTS_TABLE_NAME` の注入は既存のまま・対応不要）

### やらないこと（重複防止）

- `batch/src/alarm-ingest.ts` / `stream-handler.ts` は対象外（既に直接 PutItem 済）
- フェーズ2（`notify/subscribe` / `notify/sns`）は本 PR では未対応

## 関連 Issue

#3147（`Closes` は integration → develop の PR で付与）

## 変更種別

- [x] 新規機能
- [x] インフラ更新

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [x] ローカルでテストが全て通ることを確認した（admin/web: 16 passed）
- [x] ビルドエラーがないことを確認した（infra/admin: tsc --noEmit クリーン）

## テスト内容

- `services/admin/web/tests/unit/app/api/errors-report.test.ts` を追加
  - 一覧取得 API の内部エラー時に `reportErrorEvent` が期待引数（serviceId/severity/title/message/context.endpoint）で呼ばれること
  - 詳細取得 API の内部エラー時に同様に呼ばれること
- admin/web 全テスト 16 件パス。API ルートは `collectCoverageFrom`（`src/lib/**`）対象外のためカバレッジ閾値に影響なし

## レビューポイント

- infra のエラーイベント書き込み権限は、`grantErrorEventsWrite` ではなく既存の `additionalPolicyStatements` 内の error-events ステートメントに `dynamodb:PutItem` を追記する形にしました（Issue で許容された方式）。問題なければこのまま。
- jsdom 環境では route handler の `Request` が未定義のため、テストファイルに `@jest-environment node` を指定しています。
- `@nagiyu/admin-core` は dist 未ビルド + jest 未マッピングのため、テストでは `{ virtual: true }` でモックしています（本 PR スコープ外の jest 設定変更を避けるため）。

## 動作確認

- dev 反映後、Admin `/errors` に `serviceId=admin` のアプリ層イベントが流入することを確認（人力・別途）


---
_Generated by [Claude Code](https://claude.ai/code/session_014fYDetMDdM2U6sSXf1K1Pn)_