### PR TITLE
#3145: share-together への reportErrorEvent 導入

### DIFF
--- a/infra/share-together/lib/lambda-stack.ts
+++ b/infra/share-together/lib/lambda-stack.ts
@@ -29,7 +29,8 @@ export class LambdaStack extends LambdaStackBase {
           NODE_ENV: environment,
           APP_VERSION: appVersion,
           DYNAMODB_TABLE_NAME: dynamoTable.tableName,
-          AUTH_URL: environment === 'prod' ? 'https://auth.nagiyu.com' : 'https://dev-auth.nagiyu.com',
+          AUTH_URL:
+            environment === 'prod' ? 'https://auth.nagiyu.com' : 'https://dev-auth.nagiyu.com',
           NEXT_PUBLIC_AUTH_URL:
             environment === 'prod' ? 'https://auth.nagiyu.com' : 'https://dev-auth.nagiyu.com',
           APP_URL:

--- a/infra/share-together/lib/lambda-stack.ts
+++ b/infra/share-together/lib/lambda-stack.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
-import { LambdaStackBase, LambdaStackBaseProps } from '@nagiyu/infra-common';
+import { grantErrorEventsWrite, LambdaStackBase, LambdaStackBaseProps } from '@nagiyu/infra-common';
 import { WebRuntimePolicy } from './policies/web-runtime-policy';
 
 export interface LambdaStackProps extends cdk.StackProps {
@@ -37,12 +37,15 @@ export class LambdaStack extends LambdaStackBase {
               ? 'https://share-together.nagiyu.com'
               : 'https://dev-share-together.nagiyu.com',
           AUTH_SECRET: nextAuthSecret,
+          ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
         },
       },
       enableFunctionUrl: true,
     };
 
     super(scope, id, baseProps);
+
+    grantErrorEventsWrite(this, this.executionRole, environment as 'dev' | 'prod');
 
     this.webRuntimePolicy = new WebRuntimePolicy(this, 'WebRuntimePolicy', {
       dynamoTable,

--- a/services/share-together/web/src/app/api/groups/[groupId]/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/route.ts
@@ -6,7 +6,7 @@ import {
 import { NextResponse, type NextRequest } from 'next/server';
 import type { ApiErrorResponse, GroupResponse } from '@/types';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 import { createGroupRepository, createMembershipRepository } from '@nagiyu/share-together-core';
 
@@ -113,7 +113,15 @@ export async function PUT(request: NextRequest, { params }: RouteParams): Promis
       return notFoundResponse;
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('グループ更新 API の実行に失敗しました', { groupId, error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: グループ更新エラー',
+      message: errorMessage,
+      context: { groupId, errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createErrorResponse(500, 'INTERNAL_SERVER_ERROR', ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
   }
 }
@@ -139,7 +147,15 @@ export async function DELETE(
       return notFoundResponse;
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('グループ削除 API の実行に失敗しました', { groupId, error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: グループ削除エラー',
+      message: errorMessage,
+      context: { groupId, errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createErrorResponse(500, 'INTERNAL_SERVER_ERROR', ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
   }
 }

--- a/services/share-together/web/src/app/api/groups/route.ts
+++ b/services/share-together/web/src/app/api/groups/route.ts
@@ -2,7 +2,7 @@ import { createGroup, type Group } from '@nagiyu/share-together-core';
 import { NextResponse } from 'next/server';
 import type { ApiErrorResponse, ApiSuccessResponse } from '@/types';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 import { createGroupRepository, createMembershipRepository } from '@nagiyu/share-together-core';
 
@@ -59,7 +59,15 @@ export async function GET(): Promise<NextResponse> {
     };
     return NextResponse.json(response);
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('グループ一覧取得 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: グループ一覧取得エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createErrorResponse(500, 'INTERNAL_SERVER_ERROR', ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
   }
 }
@@ -101,7 +109,15 @@ export async function POST(request: Request): Promise<NextResponse> {
     const response: ApiSuccessResponse<Group> = { data: group };
     return NextResponse.json(response, { status: 201 });
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('グループ作成 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: グループ作成エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createErrorResponse(500, 'INTERNAL_SERVER_ERROR', ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
   }
 }

--- a/services/share-together/web/src/app/api/invitations/[groupId]/route.ts
+++ b/services/share-together/web/src/app/api/invitations/[groupId]/route.ts
@@ -5,7 +5,7 @@ import {
 import { NextResponse } from 'next/server';
 import type { ApiErrorResponse, ApiSuccessResponse } from '@/types';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 import { createGroupRepository, createMembershipRepository } from '@nagiyu/share-together-core';
 
@@ -115,10 +115,22 @@ export async function PUT(request: Request, { params }: RouteParams): Promise<Ne
       }
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('招待承認・拒否 API の実行に失敗しました', {
       groupId: requestedGroupId,
       action: requestedAction,
       error,
+    });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: 招待承認・拒否エラー',
+      message: errorMessage,
+      context: {
+        groupId: requestedGroupId,
+        action: requestedAction,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
     });
     return createInternalServerErrorResponse();
   }

--- a/services/share-together/web/src/app/api/invitations/route.ts
+++ b/services/share-together/web/src/app/api/invitations/route.ts
@@ -2,7 +2,7 @@ import { BatchGetCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynam
 import { NextResponse } from 'next/server';
 import type { ApiErrorResponse, InvitationSummary, InvitationsResponse } from '@/types';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 import {
   createGroupRepository,
@@ -95,7 +95,15 @@ export async function GET(): Promise<NextResponse> {
 
     return NextResponse.json(response);
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('招待一覧取得 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: 招待一覧取得エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createInternalServerErrorResponse();
   }
 }

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
@@ -242,10 +242,9 @@ describe('/api/groups/[groupId] route handlers', () => {
     } as SessionOrUnauthorized);
     mockGetById.mockRejectedValue(new Error('DynamoDB 接続エラー'));
 
-    const response = await PUT(
-      { json: async () => ({ name: '更新後' }) } as Request,
-      { params: Promise.resolve({ groupId: 'group-1' }) }
-    );
+    const response = await PUT({ json: async () => ({ name: '更新後' }) } as Request, {
+      params: Promise.resolve({ groupId: 'group-1' }),
+    });
 
     expect(response.status).toBe(500);
     expect(mockReportErrorEvent).toHaveBeenCalledWith(

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
@@ -27,6 +27,7 @@ jest.mock('@/lib/auth/session', () => ({
 
 jest.mock('@nagiyu/aws', () => ({
   getDynamoDBDocumentClient: jest.fn(),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@nagiyu/share-together-core', () => ({
@@ -39,7 +40,7 @@ jest.mock('@nagiyu/share-together-core', () => ({
 import { DELETE, PUT } from '@/app/api/groups/[groupId]/route';
 import { DynamoDBGroupRepository, DynamoDBMembershipRepository } from '@nagiyu/share-together-core';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 
 const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunction<
   typeof getSessionOrUnauthorized
@@ -47,6 +48,7 @@ const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunc
 const mockGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
   typeof getDynamoDBDocumentClient
 >;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 const mockDynamoDBGroupRepository = DynamoDBGroupRepository as jest.MockedClass<
   typeof DynamoDBGroupRepository
 >;
@@ -232,5 +234,38 @@ describe('/api/groups/[groupId] route handlers', () => {
       error: 'VALIDATION_ERROR',
       message: '入力内容が不正です',
     });
+  });
+
+  it('PUT: 例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'owner-1' },
+    } as SessionOrUnauthorized);
+    mockGetById.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    const response = await PUT(
+      { json: async () => ({ name: '更新後' }) } as Request,
+      { params: Promise.resolve({ groupId: 'group-1' }) }
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
+  });
+
+  it('DELETE: 例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'owner-1' },
+    } as SessionOrUnauthorized);
+    mockGetById.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    const response = await DELETE({} as Request, {
+      params: Promise.resolve({ groupId: 'group-1' }),
+    });
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
   });
 });

--- a/services/share-together/web/tests/unit/app/api/groups/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/route.test.ts
@@ -13,6 +13,7 @@ jest.mock('@/lib/auth/session', () => ({
 
 jest.mock('@nagiyu/aws', () => ({
   getDynamoDBDocumentClient: jest.fn(),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@nagiyu/share-together-core', () => ({
@@ -30,7 +31,7 @@ import {
 } from '@nagiyu/share-together-core';
 import { GET, POST } from '@/app/api/groups/route';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 
 const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunction<
   typeof getSessionOrUnauthorized
@@ -38,6 +39,7 @@ const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunc
 const mockGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
   typeof getDynamoDBDocumentClient
 >;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 const mockDynamoDBGroupRepository = DynamoDBGroupRepository as jest.MockedClass<
   typeof DynamoDBGroupRepository
 >;
@@ -200,5 +202,35 @@ describe('/api/groups route', () => {
 
     expect(response.status).toBe(400);
     expect(mockCreateGroup).not.toHaveBeenCalled();
+  });
+
+  it('GET: 例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as SessionOrUnauthorized);
+    delete process.env.DYNAMODB_TABLE_NAME;
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
+  });
+
+  it('POST: 例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'owner-1' },
+    } as SessionOrUnauthorized);
+    delete process.env.DYNAMODB_TABLE_NAME;
+
+    const response = await POST({
+      json: async () => ({ name: '新規グループ' }),
+    } as Request);
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
   });
 });

--- a/services/share-together/web/tests/unit/app/api/invitations/[groupId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/invitations/[groupId]/route.test.ts
@@ -16,6 +16,7 @@ jest.mock('@nagiyu/aws', () => {
   return {
     ...actualAws,
     getDynamoDBDocumentClient: jest.fn(),
+    reportErrorEvent: jest.fn().mockResolvedValue(null),
   };
 });
 
@@ -42,7 +43,7 @@ import {
 } from '@nagiyu/share-together-core';
 import { PUT } from '@/app/api/invitations/[groupId]/route';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 
 const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunction<
   typeof getSessionOrUnauthorized
@@ -50,6 +51,7 @@ const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunc
 const mockGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
   typeof getDynamoDBDocumentClient
 >;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 const mockDynamoDBGroupRepository = DynamoDBGroupRepository as jest.MockedClass<
   typeof DynamoDBGroupRepository
 >;
@@ -230,5 +232,22 @@ describe('PUT /api/invitations/[groupId]', () => {
       error: 'ALREADY_RESPONDED',
       message: 'この招待には既に応答済みです',
     });
+  });
+
+  it('予期しない例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as SessionOrUnauthorized);
+    mockRespondToInvitation.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    const request = {
+      json: jest.fn().mockResolvedValue({ action: 'ACCEPT' }),
+    } as unknown as Request;
+    const response = await PUT(request, { params: Promise.resolve({ groupId: 'group-1' }) });
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
   });
 });

--- a/services/share-together/web/tests/unit/app/api/invitations/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/invitations/route.test.ts
@@ -13,6 +13,7 @@ jest.mock('@/lib/auth/session', () => ({
 
 jest.mock('@nagiyu/aws', () => ({
   getDynamoDBDocumentClient: jest.fn(),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@nagiyu/share-together-core', () => ({
@@ -26,7 +27,7 @@ import { BatchGetCommand } from '@aws-sdk/lib-dynamodb';
 import { DynamoDBGroupRepository, DynamoDBMembershipRepository } from '@nagiyu/share-together-core';
 import { GET } from '@/app/api/invitations/route';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 
 const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunction<
   typeof getSessionOrUnauthorized
@@ -34,6 +35,7 @@ const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunc
 const mockGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
   typeof getDynamoDBDocumentClient
 >;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 const mockDynamoDBMembershipRepository = DynamoDBMembershipRepository as jest.MockedClass<
   typeof DynamoDBMembershipRepository
 >;
@@ -151,7 +153,7 @@ describe('GET /api/invitations', () => {
     });
   });
 
-  it('例外発生時は500レスポンスを返す', async () => {
+  it('例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
     mockGetSessionOrUnauthorized.mockResolvedValue({
       user: { id: 'user-1' },
     } as SessionOrUnauthorized);
@@ -164,5 +166,8 @@ describe('GET /api/invitations', () => {
       error: 'INTERNAL_SERVER_ERROR',
       message: 'サーバーエラーが発生しました',
     });
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
   });
 });


### PR DESCRIPTION
## 変更の概要

Issue #3145 の実装。`services/share-together/` の主要な API catch ブロックに `reportErrorEvent` を追加し、Admin `/errors` 画面で share-together 由来のエラーを横断追跡できるようにした。

## 関連 Issue

関連: #3145（integration → develop マージ後にクローズ）

## 変更種別

- [x] 新規機能
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（本対応でドキュメント更新は不要）
- [ ] CI/CD 設定を追加・更新した（既存サービスのため不要）
- [x] ローカルでテストが全て通ることを確認した（214 tests passed）
- [x] ビルドエラーがないことを確認した

## テスト内容

### 追加したテストケース（web/tests/unit/app/api/）

| ファイル | 追加テスト |
|---|---|
| `groups/route.test.ts` | GET/POST 例外時に `reportErrorEvent` が `serviceId: 'share-together', severity: 'error'` で呼ばれることを確認 |
| `groups/[groupId]/route.test.ts` | PUT/DELETE 例外時に `reportErrorEvent` が呼ばれることを確認 |
| `invitations/route.test.ts` | 既存の 500 テストに `reportErrorEvent` 呼び出しアサーションを追加 |
| `invitations/[groupId]/route.test.ts` | 予期しない例外時に `reportErrorEvent` が `severity: 'error'` で呼ばれることを確認 |

全 214 テスト pass。ブランチカバレッジは 70.98%（変更前 70.67%）で、閾値未達は変更前から存在する既存問題。

## レビューポイント

- `infra/share-together/lib/lambda-stack.ts`：`LambdaStackBase` は `grantErrorEventsWrite` を自動付与しないため、`super()` 直後に明示的に呼ぶ実装にした
- `core/src/libs/group.ts` は catch ブロックが存在しないため対象外（Issue の「最低限」要件に準拠）
- `serviceId: 'share-together'` を全レイヤ共通で使用
- 業務エラー（404/409）分岐は `reportErrorEvent` を呼ばず、一般的な 500 エラー catch のみ対象（最小スコープ）

## スクリーンショット（該当する場合）

UI 変更なし。dev 環境でのエラー発生 → `/errors` 確認は人力で実施。

## 補足事項

- `@nagiyu/aws` 依存・jest moduleNameMapper・`@nagiyu/infra-common` 依存はすべて既存のため追加不要
- 既存の `console.error` は Issue 指示通り並行運用で残している

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNZnUdk8AfvmaL31STjGxP)_