### PR TITLE
#3144: deploy ワークフローの shared-workspaces に @nagiyu/aws を追加

### DIFF
--- a/.github/workflows/quick-clip-deploy.yml
+++ b/.github/workflows/quick-clip-deploy.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           workspace: '@nagiyu/quick-clip-web'
           shared-workspaces: >
-            @nagiyu/common,@nagiyu/browser,@nagiyu/react,
+            @nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,
             @nagiyu/nextjs,@nagiyu/ui,@nagiyu/quick-clip-core
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## 変更の概要

`quick-clip-deploy.yml` の「Build and Push Web Docker Image」ジョブが `build-web-app` を呼ぶ際の `shared-workspaces` に `@nagiyu/aws` を追加する（`@nagiyu/common` の直後＝`@nagiyu/quick-clip-core` より前）。

## 背景・原因

#3144（PR #3150、マージ済）で `quick-clip-core` が `@nagiyu/aws` を import するようになった。`build-web-app` アクションはリスト順に `npm run build` するため、`@nagiyu/aws` が未ビルドのまま `@nagiyu/quick-clip-core` の `tsc` が走り、dev デプロイで以下が発生していた：

```
src/libs/quick-clip-batch-runner.ts(1,34): error TS2307: Cannot find module '@nagiyu/aws'
```

### なぜ PR CI で検知できなかったか

ワークスペースのビルド対象リストが `quick-clip-verify.yml`（PR 検証）と `quick-clip-deploy.yml`（dev デプロイ）で**重複定義**されている。PR #3150 では verify 側の全 `shared-workspaces`（build-web-app 含む）に `@nagiyu/aws` を追加したが、deploy ワークフローは **PR では一切走らず**（`integration/**`・`develop` への push 時のみ実行）、別ファイル・別リストのため未反映だった。Docker Build 系（batch/clip/zip）は Dockerfile 内で `@nagiyu/aws` をビルドするため影響なし。web のみ Docker 前に `build-web-app` で Next ビルドする構成のため露見した。

## 関連 Issue

関連: #3144（`Closes` は integration → develop の PR で付与）

## 変更種別

- [x] バグ修正
- [x] CI/CD 更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（ワークフロー変更のため対象外。デプロイ実行で成否判定）
- [x] 関連ドキュメントを更新した（ドキュメント変更なし）
- [x] CI/CD 設定を追加・更新した
- [x] ローカルで YAML 妥当性を確認した
- [x] ビルドエラーがないことを確認した（verify 側で `@nagiyu/aws` ビルド込みの全 green を確認済）

## テスト内容

- `quick-clip-deploy.yml` の YAML 妥当性を `yaml.safe_load` で確認
- マージ後、dev デプロイで `@nagiyu/quick-clip-core` の `tsc` が `@nagiyu/aws` を解決でき、Web Docker イメージのビルド・デプロイが完走することを確認（人力）

## レビューポイント

- 追加位置は `@nagiyu/common` の直後（`build-web-app` は列挙順にビルドするため、`@nagiyu/aws` は依存元の `@nagiyu/common` の後・利用側の `@nagiyu/quick-clip-core` の前である必要がある）
- batch/clip/zip の deploy ジョブは Docker ビルド（Dockerfile 側で `@nagiyu/aws` ビルド済）のため本 PR の対象外

## 補足事項

- マージ済 PR #3150 とは別の後追い修正。同 Issue #3144 のスコープ内のため新規 Issue は起票しない
- 恒久対応としては verify/deploy 間で `shared-workspaces` リストが二重管理になっている点の一元化が望ましいが、本 PR では最小修正に留める

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVW7YtijUDUjABC2JuYXVf)_