### PR TITLE
各サービスへの reportErrorEvent 導入（#3122 統合）

### DIFF
--- a/.github/workflows/quick-clip-deploy.yml
+++ b/.github/workflows/quick-clip-deploy.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           workspace: '@nagiyu/quick-clip-web'
           shared-workspaces: >
-            @nagiyu/common,@nagiyu/browser,@nagiyu/react,
+            @nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,
             @nagiyu/nextjs,@nagiyu/ui,@nagiyu/quick-clip-core
 
       - name: Configure AWS credentials

--- a/.github/workflows/quick-clip-verify.yml
+++ b/.github/workflows/quick-clip-verify.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -149,7 +149,7 @@ jobs:
         uses: ./.github/actions/build-web-app
         with:
           workspace: '@nagiyu/quick-clip-web'
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui,@nagiyu/quick-clip-core'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui,@nagiyu/quick-clip-core'
 
   build-batch:
     name: Build Batch Package
@@ -169,7 +169,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -195,7 +195,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -221,7 +221,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -268,7 +268,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -294,7 +294,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -320,7 +320,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -349,7 +349,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -374,6 +374,11 @@ jobs:
         with:
           node-version: '24'
           cache-dependency-path: './package-lock.json'
+
+      - name: Build shared libraries
+        uses: ./.github/actions/build-shared-workspaces
+        with:
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws'
 
       - name: Build lambda zip package
         run: npm run build --workspace=@nagiyu/quick-clip-lambda-zip
@@ -400,7 +405,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -546,7 +551,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -614,7 +619,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core
@@ -682,7 +687,7 @@ jobs:
       - name: Build shared libraries
         uses: ./.github/actions/build-shared-workspaces
         with:
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
+          shared-workspaces: '@nagiyu/common,@nagiyu/aws,@nagiyu/browser,@nagiyu/react,@nagiyu/nextjs,@nagiyu/ui'
 
       - name: Build core package
         run: npm run build --workspace=@nagiyu/quick-clip-core

--- a/infra/admin/lib/lambda-stack.ts
+++ b/infra/admin/lib/lambda-stack.ts
@@ -58,10 +58,11 @@ export class LambdaStack extends LambdaStackBase {
           `arn:aws:dynamodb:*:*:table/nagiyu-admin-main-${environment}/index/*`,
         ],
       }),
-      // 共通エラーイベントテーブルへの読み取り権限（/errors UI / API 用）
+      // 共通エラーイベントテーブルへの読み取り権限（/errors UI / API 用）+
+      // アプリ層の自己監視（reportErrorEvent）のための書き込み権限
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['dynamodb:GetItem', 'dynamodb:Query'],
+        actions: ['dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:PutItem'],
         resources: [
           `arn:aws:dynamodb:*:*:table/nagiyu-error-events-${environment}`,
           `arn:aws:dynamodb:*:*:table/nagiyu-error-events-${environment}/index/*`,

--- a/infra/auth/lib/lambda-stack.ts
+++ b/infra/auth/lib/lambda-stack.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
-import { LambdaStackBase, LambdaStackBaseProps } from '@nagiyu/infra-common';
+import { LambdaStackBase, LambdaStackBaseProps, grantErrorEventsWrite } from '@nagiyu/infra-common';
 
 export interface LambdaStackProps extends cdk.StackProps {
   environment: string;
@@ -65,6 +65,7 @@ export class LambdaStack extends LambdaStackBase {
           // Google OAuth
           GOOGLE_CLIENT_ID: googleClientId,
           GOOGLE_CLIENT_SECRET: googleClientSecret,
+          ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
         },
       },
       additionalPolicyStatements,
@@ -77,5 +78,7 @@ export class LambdaStack extends LambdaStackBase {
     };
 
     super(scope, id, baseProps);
+
+    grantErrorEventsWrite(this, this.executionRole, environment as 'dev' | 'prod');
   }
 }

--- a/infra/codec-converter/lib/codec-converter-stack.ts
+++ b/infra/codec-converter/lib/codec-converter-stack.ts
@@ -12,7 +12,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
-import { SSM_PARAMETERS } from '@nagiyu/infra-common';
+import { SSM_PARAMETERS, grantErrorEventsWrite } from '@nagiyu/infra-common';
 import { AppRuntimePolicy } from './policies/app-runtime-policy';
 import { LambdaExecutionRole } from './roles/lambda-execution-role';
 import { BatchJobRole } from './roles/batch-job-role';
@@ -141,6 +141,7 @@ export class CodecConverterStack extends cdk.Stack {
         storageBucket,
         jobsTable,
       });
+      grantErrorEventsWrite(this, batchJobRole, envName as 'dev' | 'prod');
 
       const vpcId = ssm.StringParameter.valueForStringParameter(
         this,
@@ -255,6 +256,10 @@ export class CodecConverterStack extends cdk.Stack {
                 name: 'AWS_REGION',
                 value: this.region,
               },
+              {
+                name: 'ERROR_EVENTS_TABLE_NAME',
+                value: `nagiyu-error-events-${envName}`,
+              },
             ],
           },
           retryStrategy: {
@@ -282,6 +287,7 @@ export class CodecConverterStack extends cdk.Stack {
       const lambdaExecutionRole = new LambdaExecutionRole(this, 'LambdaExecutionRole', {
         appRuntimePolicy,
       });
+      grantErrorEventsWrite(this, lambdaExecutionRole, envName as 'dev' | 'prod');
 
       // Development IAM User (shares the same runtime policy as Lambda)
       new DevUser(this, 'DevUser', {
@@ -312,6 +318,7 @@ export class CodecConverterStack extends cdk.Stack {
           S3_BUCKET: storageBucket.bucketName,
           BATCH_JOB_QUEUE: jobQueue.jobQueueName || `nagiyu-codec-converter-${envName}`,
           BATCH_JOB_DEFINITION_PREFIX: `nagiyu-codec-converter-${envName}`, // Prefix for all job definitions (e.g., nagiyu-codec-converter-dev-small)
+          ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${envName}`,
           // AWS_REGION is automatically provided by Lambda runtime
         },
         // Note: Lambda Web Adapter must be included in the Docker image itself

--- a/infra/niconico-mylist-assistant/lib/batch-stack.ts
+++ b/infra/niconico-mylist-assistant/lib/batch-stack.ts
@@ -6,7 +6,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
-import { getEcrRepositoryName, getDynamoDBTableName, SSM_PARAMETERS } from '@nagiyu/infra-common';
+import { getEcrRepositoryName, getDynamoDBTableName, SSM_PARAMETERS, grantErrorEventsWrite } from '@nagiyu/infra-common';
 import { BatchRuntimePolicy } from './policies/batch-runtime-policy';
 
 export interface BatchStackProps extends cdk.StackProps {
@@ -134,6 +134,7 @@ export class BatchStack extends cdk.Stack {
       description: 'Role for Batch job container runtime',
       managedPolicies: [this.batchRuntimePolicy],
     });
+    grantErrorEventsWrite(this, batchJobRole, env);
 
     // Batch Compute Environment (Fargate) - L1 construct for assignPublicIp support
     const computeEnvironment = new batch.CfnComputeEnvironment(this, 'ComputeEnvironment', {
@@ -212,6 +213,10 @@ export class BatchStack extends cdk.Stack {
           {
             name: 'VAPID_PRIVATE_KEY',
             value: vapidPrivateKey,
+          },
+          {
+            name: 'ERROR_EVENTS_TABLE_NAME',
+            value: `nagiyu-error-events-${env}`,
           },
           ...(screenshotBucketName
             ? [

--- a/infra/niconico-mylist-assistant/lib/lambda-stack.ts
+++ b/infra/niconico-mylist-assistant/lib/lambda-stack.ts
@@ -5,6 +5,7 @@ import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
+import { grantErrorEventsWrite } from '@nagiyu/infra-common';
 import { WebRuntimePolicy } from './policies/web-runtime-policy';
 
 export interface LambdaStackProps extends cdk.StackProps {
@@ -87,6 +88,7 @@ export class LambdaStack extends cdk.Stack {
         this.webRuntimePolicy,
       ],
     });
+    grantErrorEventsWrite(this, webExecutionRole, environment as 'dev' | 'prod');
 
     // Web Lambda Function の作成
     this.webFunction = new lambda.Function(this, 'WebFunction', {
@@ -113,6 +115,7 @@ export class LambdaStack extends cdk.Stack {
         AWS_REGION_FOR_SDK: this.region,
         VAPID_PUBLIC_KEY: vapidPublicKey,
         VAPID_PRIVATE_KEY: vapidPrivateKey,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       tracing: lambda.Tracing.ACTIVE, // X-Ray トレーシング有効化
       logRetention: logs.RetentionDays.ONE_MONTH, // CloudWatch Logs 保持期間: 30日

--- a/infra/quick-clip/lib/batch-stack.ts
+++ b/infra/quick-clip/lib/batch-stack.ts
@@ -7,7 +7,7 @@ import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
-import { SSM_PARAMETERS } from '@nagiyu/infra-common';
+import { SSM_PARAMETERS, grantErrorEventsWrite } from '@nagiyu/infra-common';
 import type { QuickClipEnvironment } from './environment';
 
 export interface BatchStackProps extends cdk.StackProps {
@@ -62,6 +62,7 @@ export class BatchStack extends cdk.Stack {
     });
     props.storageBucket.grantReadWrite(jobRole);
     props.jobsTable.grantReadWriteData(jobRole);
+    grantErrorEventsWrite(this, jobRole, props.environment);
 
     const batchLogGroup = new logs.LogGroup(this, 'BatchLogGroup', {
       logGroupName: `/aws/batch/nagiyu-quick-clip-${props.environment}`,
@@ -137,6 +138,10 @@ export class BatchStack extends cdk.Stack {
             name: 'OPENAI_API_KEY',
             value: props.openAiApiKey,
           },
+          {
+            name: 'ERROR_EVENTS_TABLE_NAME',
+            value: `nagiyu-error-events-${props.environment}`,
+          },
         ],
       },
       timeout: { attemptDurationSeconds: 3600 },
@@ -186,6 +191,10 @@ export class BatchStack extends cdk.Stack {
             name: 'OPENAI_API_KEY',
             value: props.openAiApiKey,
           },
+          {
+            name: 'ERROR_EVENTS_TABLE_NAME',
+            value: `nagiyu-error-events-${props.environment}`,
+          },
         ],
       },
       timeout: { attemptDurationSeconds: 3 * 3600 },
@@ -234,6 +243,10 @@ export class BatchStack extends cdk.Stack {
           {
             name: 'OPENAI_API_KEY',
             value: props.openAiApiKey,
+          },
+          {
+            name: 'ERROR_EVENTS_TABLE_NAME',
+            value: `nagiyu-error-events-${props.environment}`,
           },
         ],
       },

--- a/infra/quick-clip/lib/lambda-stack.ts
+++ b/infra/quick-clip/lib/lambda-stack.ts
@@ -3,7 +3,7 @@ import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
-import { LambdaStackBase, LambdaStackBaseProps } from '@nagiyu/infra-common';
+import { LambdaStackBase, LambdaStackBaseProps, grantErrorEventsWrite } from '@nagiyu/infra-common';
 import type { QuickClipEnvironment } from './environment';
 
 const QUICK_CLIP_ALLOWED_ORIGINS: Record<QuickClipEnvironment, string[]> = {
@@ -80,6 +80,7 @@ export class LambdaStack extends LambdaStackBase {
           BATCH_JOB_DEFINITION_PREFIX: batchJobDefinitionPrefix,
           CLIP_REGENERATE_FUNCTION_NAME: `nagiyu-quick-clip-clip-regenerate-${environment}`,
           ZIP_GENERATOR_FUNCTION_NAME: `nagiyu-quick-clip-zip-generator-${environment}`,
+          ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
         },
       },
       additionalPolicyStatements: [
@@ -162,6 +163,7 @@ export class LambdaStack extends LambdaStackBase {
         DEPLOY_ENV: environment,
         DYNAMODB_TABLE_NAME: jobsTableName,
         S3_BUCKET: storageBucketName,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
     });
     this.clipFunction.addToRolePolicy(
@@ -199,6 +201,7 @@ export class LambdaStack extends LambdaStackBase {
         NODE_ENV: environment === 'prod' ? 'production' : 'development',
         DEPLOY_ENV: environment,
         S3_BUCKET: storageBucketName,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
     });
     this.zipFunction.addToRolePolicy(
@@ -215,6 +218,10 @@ export class LambdaStack extends LambdaStackBase {
         resources: [`${storageBucketArn}/*`],
       })
     );
+
+    grantErrorEventsWrite(this, this.webFunction, environment);
+    grantErrorEventsWrite(this, this.clipFunction, environment);
+    grantErrorEventsWrite(this, this.zipFunction, environment);
 
     new cdk.CfnOutput(this, 'ClipRegenerateFunctionArn', {
       value: this.clipFunction.functionArn,

--- a/infra/share-together/lib/lambda-stack.ts
+++ b/infra/share-together/lib/lambda-stack.ts
@@ -29,7 +29,8 @@ export class LambdaStack extends LambdaStackBase {
           NODE_ENV: environment,
           APP_VERSION: appVersion,
           DYNAMODB_TABLE_NAME: dynamoTable.tableName,
-          AUTH_URL: environment === 'prod' ? 'https://auth.nagiyu.com' : 'https://dev-auth.nagiyu.com',
+          AUTH_URL:
+            environment === 'prod' ? 'https://auth.nagiyu.com' : 'https://dev-auth.nagiyu.com',
           NEXT_PUBLIC_AUTH_URL:
             environment === 'prod' ? 'https://auth.nagiyu.com' : 'https://dev-auth.nagiyu.com',
           APP_URL:

--- a/infra/share-together/lib/lambda-stack.ts
+++ b/infra/share-together/lib/lambda-stack.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
-import { LambdaStackBase, LambdaStackBaseProps } from '@nagiyu/infra-common';
+import { grantErrorEventsWrite, LambdaStackBase, LambdaStackBaseProps } from '@nagiyu/infra-common';
 import { WebRuntimePolicy } from './policies/web-runtime-policy';
 
 export interface LambdaStackProps extends cdk.StackProps {
@@ -37,12 +37,15 @@ export class LambdaStack extends LambdaStackBase {
               ? 'https://share-together.nagiyu.com'
               : 'https://dev-share-together.nagiyu.com',
           AUTH_SECRET: nextAuthSecret,
+          ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
         },
       },
       enableFunctionUrl: true,
     };
 
     super(scope, id, baseProps);
+
+    grantErrorEventsWrite(this, this.executionRole, environment as 'dev' | 'prod');
 
     this.webRuntimePolicy = new WebRuntimePolicy(this, 'WebRuntimePolicy', {
       dynamoTable,

--- a/infra/stock-tracker/bin/stock-tracker.ts
+++ b/infra/stock-tracker/bin/stock-tracker.ts
@@ -19,9 +19,7 @@ const env = app.node.tryGetContext('env') || 'dev';
 // 許可された環境値のチェック
 const allowedEnvironments = ['dev', 'prod'];
 if (!allowedEnvironments.includes(env)) {
-  throw new Error(
-    `Invalid environment: ${env}. Allowed values: ${allowedEnvironments.join(', ')}`
-  );
+  throw new Error(`Invalid environment: ${env}. Allowed values: ${allowedEnvironments.join(', ')}`);
 }
 
 // 環境変数からバージョンを取得（デフォルト: '1.0.0'）
@@ -114,57 +112,45 @@ if (!lambdaStack.functionUrl) {
   throw new Error('Lambda function URL is not available');
 }
 
-const cloudFrontStack = new CloudFrontStack(
-  app,
-  `NagiyuStockTrackerCloudFront${envSuffix}`,
-  {
-    environment: env,
-    functionUrl: lambdaStack.functionUrl.url,
-    env: {
-      account: process.env.CDK_DEFAULT_ACCOUNT,
-      region: 'us-east-1', // CloudFront は us-east-1 必須
-    },
-    crossRegionReferences: true,
-    description: `Stock Tracker CloudFront - ${env} environment`,
-  }
-);
+const cloudFrontStack = new CloudFrontStack(app, `NagiyuStockTrackerCloudFront${envSuffix}`, {
+  environment: env,
+  functionUrl: lambdaStack.functionUrl.url,
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: 'us-east-1', // CloudFront は us-east-1 必須
+  },
+  crossRegionReferences: true,
+  description: `Stock Tracker CloudFront - ${env} environment`,
+});
 cloudFrontStack.addDependency(lambdaStack);
 
 // 8. EventBridge スタック（バッチ処理スケジューラ）
-const eventBridgeStack = new EventBridgeStack(
-  app,
-  `NagiyuStockTrackerEventBridge${envSuffix}`,
-  {
-    environment: env,
-    batchMinuteFunction: lambdaStack.batchMinuteFunction,
-    batchHourlyFunction: lambdaStack.batchHourlyFunction,
-    batchSummaryFunction: lambdaStack.batchSummaryFunction,
-    batchDailyFunction: lambdaStack.batchDailyFunction,
-    batchTemporaryAlertExpiryFunction: lambdaStack.batchTemporaryAlertExpiryFunction,
-    batchEvaluationFunction: lambdaStack.batchEvaluationFunction,
-    env: stackEnv,
-    description: `Stock Tracker EventBridge Scheduler - ${env} environment`,
-  }
-);
+const eventBridgeStack = new EventBridgeStack(app, `NagiyuStockTrackerEventBridge${envSuffix}`, {
+  environment: env,
+  batchMinuteFunction: lambdaStack.batchMinuteFunction,
+  batchHourlyFunction: lambdaStack.batchHourlyFunction,
+  batchSummaryFunction: lambdaStack.batchSummaryFunction,
+  batchDailyFunction: lambdaStack.batchDailyFunction,
+  batchTemporaryAlertExpiryFunction: lambdaStack.batchTemporaryAlertExpiryFunction,
+  batchEvaluationFunction: lambdaStack.batchEvaluationFunction,
+  env: stackEnv,
+  description: `Stock Tracker EventBridge Scheduler - ${env} environment`,
+});
 eventBridgeStack.addDependency(lambdaStack);
 
 // 9. CloudWatch Alarms スタック（監視アラーム）
-const alarmsStack = new CloudWatchAlarmsStack(
-  app,
-  `NagiyuStockTrackerAlarms${envSuffix}`,
-  {
-    environment: env,
-    webFunction: lambdaStack.webFunction,
-    batchMinuteFunction: lambdaStack.batchMinuteFunction,
-    batchHourlyFunction: lambdaStack.batchHourlyFunction,
-    batchDailyFunction: lambdaStack.batchDailyFunction,
-    dynamoTable: dynamoStack.table,
-    alarmTopic: snsStack.alarmTopic,
-    adminAlarmTopicArn,
-    env: stackEnv,
-    description: `Stock Tracker CloudWatch Alarms - ${env} environment`,
-  }
-);
+const alarmsStack = new CloudWatchAlarmsStack(app, `NagiyuStockTrackerAlarms${envSuffix}`, {
+  environment: env,
+  webFunction: lambdaStack.webFunction,
+  batchMinuteFunction: lambdaStack.batchMinuteFunction,
+  batchHourlyFunction: lambdaStack.batchHourlyFunction,
+  batchDailyFunction: lambdaStack.batchDailyFunction,
+  dynamoTable: dynamoStack.table,
+  alarmTopic: snsStack.alarmTopic,
+  adminAlarmTopicArn,
+  env: stackEnv,
+  description: `Stock Tracker CloudWatch Alarms - ${env} environment`,
+});
 alarmsStack.addDependency(lambdaStack);
 alarmsStack.addDependency(dynamoStack);
 alarmsStack.addDependency(snsStack);

--- a/infra/stock-tracker/lib/cloudwatch-alarms-stack.ts
+++ b/infra/stock-tracker/lib/cloudwatch-alarms-stack.ts
@@ -39,11 +39,7 @@ export class CloudWatchAlarmsStack extends cdk.Stack {
     } = props;
 
     const alarmAction = new cloudwatch_actions.SnsAction(alarmTopic);
-    const adminAlarmTopic = sns.Topic.fromTopicArn(
-      this,
-      'AdminAlarmTopic',
-      adminAlarmTopicArn
-    );
+    const adminAlarmTopic = sns.Topic.fromTopicArn(this, 'AdminAlarmTopic', adminAlarmTopicArn);
     const adminAlarmAction = new cloudwatch_actions.SnsAction(adminAlarmTopic);
 
     // Lambda Web - エラー率アラーム
@@ -95,224 +91,188 @@ export class CloudWatchAlarmsStack extends cdk.Stack {
     webThrottleAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Minute - エラー率アラーム
-    const batchMinuteErrorAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchMinuteLambdaErrorAlarm',
-      {
-        alarmName: `stock-tracker-batch-minute-error-rate-${environment}`,
-        alarmDescription: 'Batch Minute Lambda error rate exceeds 10%',
-        metric: batchMinuteFunction.metricErrors({
-          statistic: cloudwatch.Stats.AVERAGE,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 0.1, // 10%
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchMinuteErrorAlarm = new cloudwatch.Alarm(this, 'BatchMinuteLambdaErrorAlarm', {
+      alarmName: `stock-tracker-batch-minute-error-rate-${environment}`,
+      alarmDescription: 'Batch Minute Lambda error rate exceeds 10%',
+      metric: batchMinuteFunction.metricErrors({
+        statistic: cloudwatch.Stats.AVERAGE,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 0.1, // 10%
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchMinuteErrorAlarm.addAlarmAction(alarmAction);
     batchMinuteErrorAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Minute - 実行時間アラーム
-    const batchMinuteDurationAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchMinuteLambdaDurationAlarm',
-      {
-        alarmName: `stock-tracker-batch-minute-duration-${environment}`,
-        alarmDescription: 'Batch Minute Lambda duration exceeds 40 seconds',
-        metric: batchMinuteFunction.metricDuration({
-          statistic: cloudwatch.Stats.AVERAGE,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 40000, // 40秒（ミリ秒）
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchMinuteDurationAlarm = new cloudwatch.Alarm(this, 'BatchMinuteLambdaDurationAlarm', {
+      alarmName: `stock-tracker-batch-minute-duration-${environment}`,
+      alarmDescription: 'Batch Minute Lambda duration exceeds 40 seconds',
+      metric: batchMinuteFunction.metricDuration({
+        statistic: cloudwatch.Stats.AVERAGE,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 40000, // 40秒（ミリ秒）
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchMinuteDurationAlarm.addAlarmAction(alarmAction);
     batchMinuteDurationAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Minute - スロットリングアラーム
-    const batchMinuteThrottleAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchMinuteLambdaThrottleAlarm',
-      {
-        alarmName: `stock-tracker-batch-minute-throttle-${environment}`,
-        alarmDescription: 'Batch Minute Lambda throttling detected',
-        metric: batchMinuteFunction.metricThrottles({
-          statistic: cloudwatch.Stats.SUM,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 1,
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchMinuteThrottleAlarm = new cloudwatch.Alarm(this, 'BatchMinuteLambdaThrottleAlarm', {
+      alarmName: `stock-tracker-batch-minute-throttle-${environment}`,
+      alarmDescription: 'Batch Minute Lambda throttling detected',
+      metric: batchMinuteFunction.metricThrottles({
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchMinuteThrottleAlarm.addAlarmAction(alarmAction);
     batchMinuteThrottleAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Hourly - エラー率アラーム
-    const batchHourlyErrorAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchHourlyLambdaErrorAlarm',
-      {
-        alarmName: `stock-tracker-batch-hourly-error-rate-${environment}`,
-        alarmDescription: 'Batch Hourly Lambda error rate exceeds 10%',
-        metric: batchHourlyFunction.metricErrors({
-          statistic: cloudwatch.Stats.AVERAGE,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 0.1, // 10%
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchHourlyErrorAlarm = new cloudwatch.Alarm(this, 'BatchHourlyLambdaErrorAlarm', {
+      alarmName: `stock-tracker-batch-hourly-error-rate-${environment}`,
+      alarmDescription: 'Batch Hourly Lambda error rate exceeds 10%',
+      metric: batchHourlyFunction.metricErrors({
+        statistic: cloudwatch.Stats.AVERAGE,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 0.1, // 10%
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchHourlyErrorAlarm.addAlarmAction(alarmAction);
     batchHourlyErrorAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Hourly - 実行時間アラーム
-    const batchHourlyDurationAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchHourlyLambdaDurationAlarm',
-      {
-        alarmName: `stock-tracker-batch-hourly-duration-${environment}`,
-        alarmDescription: 'Batch Hourly Lambda duration exceeds 4 minutes',
-        metric: batchHourlyFunction.metricDuration({
-          statistic: cloudwatch.Stats.AVERAGE,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 240000, // 4分（ミリ秒）
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchHourlyDurationAlarm = new cloudwatch.Alarm(this, 'BatchHourlyLambdaDurationAlarm', {
+      alarmName: `stock-tracker-batch-hourly-duration-${environment}`,
+      alarmDescription: 'Batch Hourly Lambda duration exceeds 4 minutes',
+      metric: batchHourlyFunction.metricDuration({
+        statistic: cloudwatch.Stats.AVERAGE,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 240000, // 4分（ミリ秒）
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchHourlyDurationAlarm.addAlarmAction(alarmAction);
     batchHourlyDurationAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Hourly - スロットリングアラーム
-    const batchHourlyThrottleAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchHourlyLambdaThrottleAlarm',
-      {
-        alarmName: `stock-tracker-batch-hourly-throttle-${environment}`,
-        alarmDescription: 'Batch Hourly Lambda throttling detected',
-        metric: batchHourlyFunction.metricThrottles({
-          statistic: cloudwatch.Stats.SUM,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 1,
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchHourlyThrottleAlarm = new cloudwatch.Alarm(this, 'BatchHourlyLambdaThrottleAlarm', {
+      alarmName: `stock-tracker-batch-hourly-throttle-${environment}`,
+      alarmDescription: 'Batch Hourly Lambda throttling detected',
+      metric: batchHourlyFunction.metricThrottles({
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchHourlyThrottleAlarm.addAlarmAction(alarmAction);
     batchHourlyThrottleAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Daily - エラー率アラーム
-    const batchDailyErrorAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchDailyLambdaErrorAlarm',
-      {
-        alarmName: `stock-tracker-batch-daily-error-rate-${environment}`,
-        alarmDescription: 'Batch Daily Lambda error rate exceeds 10%',
-        metric: batchDailyFunction.metricErrors({
-          statistic: cloudwatch.Stats.AVERAGE,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 0.1, // 10%
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchDailyErrorAlarm = new cloudwatch.Alarm(this, 'BatchDailyLambdaErrorAlarm', {
+      alarmName: `stock-tracker-batch-daily-error-rate-${environment}`,
+      alarmDescription: 'Batch Daily Lambda error rate exceeds 10%',
+      metric: batchDailyFunction.metricErrors({
+        statistic: cloudwatch.Stats.AVERAGE,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 0.1, // 10%
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchDailyErrorAlarm.addAlarmAction(alarmAction);
     batchDailyErrorAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Daily - 実行時間アラーム
-    const batchDailyDurationAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchDailyLambdaDurationAlarm',
-      {
-        alarmName: `stock-tracker-batch-daily-duration-${environment}`,
-        alarmDescription: 'Batch Daily Lambda duration exceeds 8 minutes',
-        metric: batchDailyFunction.metricDuration({
-          statistic: cloudwatch.Stats.AVERAGE,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 480000, // 8分（ミリ秒）
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchDailyDurationAlarm = new cloudwatch.Alarm(this, 'BatchDailyLambdaDurationAlarm', {
+      alarmName: `stock-tracker-batch-daily-duration-${environment}`,
+      alarmDescription: 'Batch Daily Lambda duration exceeds 8 minutes',
+      metric: batchDailyFunction.metricDuration({
+        statistic: cloudwatch.Stats.AVERAGE,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 480000, // 8分（ミリ秒）
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchDailyDurationAlarm.addAlarmAction(alarmAction);
     batchDailyDurationAlarm.addAlarmAction(adminAlarmAction);
 
     // Lambda Batch Daily - スロットリングアラーム
-    const batchDailyThrottleAlarm = new cloudwatch.Alarm(
-      this,
-      'BatchDailyLambdaThrottleAlarm',
-      {
-        alarmName: `stock-tracker-batch-daily-throttle-${environment}`,
-        alarmDescription: 'Batch Daily Lambda throttling detected',
-        metric: batchDailyFunction.metricThrottles({
-          statistic: cloudwatch.Stats.SUM,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 1,
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const batchDailyThrottleAlarm = new cloudwatch.Alarm(this, 'BatchDailyLambdaThrottleAlarm', {
+      alarmName: `stock-tracker-batch-daily-throttle-${environment}`,
+      alarmDescription: 'Batch Daily Lambda throttling detected',
+      metric: batchDailyFunction.metricThrottles({
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     batchDailyThrottleAlarm.addAlarmAction(alarmAction);
     batchDailyThrottleAlarm.addAlarmAction(adminAlarmAction);
 
     // DynamoDB - Read Throttle Events アラーム
-    const dynamoReadThrottleAlarm = new cloudwatch.Alarm(
-      this,
-      'DynamoDBReadThrottleAlarm',
-      {
-        alarmName: `stock-tracker-dynamodb-read-throttle-${environment}`,
-        alarmDescription: 'DynamoDB read throttle events detected',
-        metric: dynamoTable.metricSystemErrorsForOperations({
-          operations: [dynamodb.Operation.GET_ITEM, dynamodb.Operation.QUERY, dynamodb.Operation.SCAN],
-          statistic: cloudwatch.Stats.SUM,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 1,
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const dynamoReadThrottleAlarm = new cloudwatch.Alarm(this, 'DynamoDBReadThrottleAlarm', {
+      alarmName: `stock-tracker-dynamodb-read-throttle-${environment}`,
+      alarmDescription: 'DynamoDB read throttle events detected',
+      metric: dynamoTable.metricSystemErrorsForOperations({
+        operations: [
+          dynamodb.Operation.GET_ITEM,
+          dynamodb.Operation.QUERY,
+          dynamodb.Operation.SCAN,
+        ],
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     dynamoReadThrottleAlarm.addAlarmAction(alarmAction);
     dynamoReadThrottleAlarm.addAlarmAction(adminAlarmAction);
 
     // DynamoDB - Write Throttle Events アラーム
-    const dynamoWriteThrottleAlarm = new cloudwatch.Alarm(
-      this,
-      'DynamoDBWriteThrottleAlarm',
-      {
-        alarmName: `stock-tracker-dynamodb-write-throttle-${environment}`,
-        alarmDescription: 'DynamoDB write throttle events detected',
-        metric: dynamoTable.metricSystemErrorsForOperations({
-          operations: [dynamodb.Operation.PUT_ITEM, dynamodb.Operation.UPDATE_ITEM, dynamodb.Operation.DELETE_ITEM],
-          statistic: cloudwatch.Stats.SUM,
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 1,
-        evaluationPeriods: 1,
-        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      }
-    );
+    const dynamoWriteThrottleAlarm = new cloudwatch.Alarm(this, 'DynamoDBWriteThrottleAlarm', {
+      alarmName: `stock-tracker-dynamodb-write-throttle-${environment}`,
+      alarmDescription: 'DynamoDB write throttle events detected',
+      metric: dynamoTable.metricSystemErrorsForOperations({
+        operations: [
+          dynamodb.Operation.PUT_ITEM,
+          dynamodb.Operation.UPDATE_ITEM,
+          dynamodb.Operation.DELETE_ITEM,
+        ],
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
     dynamoWriteThrottleAlarm.addAlarmAction(alarmAction);
     dynamoWriteThrottleAlarm.addAlarmAction(adminAlarmAction);
 

--- a/infra/stock-tracker/lib/dynamodb-stack.ts
+++ b/infra/stock-tracker/lib/dynamodb-stack.ts
@@ -37,8 +37,7 @@ export class DynamoDBStack extends cdk.Stack {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // オンデマンドキャパシティ
       pointInTimeRecovery: true, // PITR 有効（35日間保持）
       timeToLiveAttribute: 'TTL', // TTL 属性
-      removalPolicy:
-        environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
       encryption: dynamodb.TableEncryption.AWS_MANAGED, // AWS マネージドキーで暗号化
     });
 

--- a/infra/stock-tracker/lib/eventbridge-stack.ts
+++ b/infra/stock-tracker/lib/eventbridge-stack.ts
@@ -69,7 +69,9 @@ export class EventBridgeStack extends cdk.Stack {
       description: 'Trigger Stock Tracker Temporary Alert Expiry Batch every 1 hour',
       schedule: events.Schedule.rate(cdk.Duration.hours(1)),
     });
-    temporaryAlertExpiryRule.addTarget(new targets.LambdaFunction(batchTemporaryAlertExpiryFunction));
+    temporaryAlertExpiryRule.addTarget(
+      new targets.LambdaFunction(batchTemporaryAlertExpiryFunction)
+    );
 
     // EventBridge Rule - Evaluation（1時間間隔、予測精度の採点）
     const evaluationRule = new events.Rule(this, 'BatchEvaluationRule', {

--- a/infra/stock-tracker/lib/lambda-stack.ts
+++ b/infra/stock-tracker/lib/lambda-stack.ts
@@ -8,6 +8,7 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { WebRuntimePolicy } from './policies/web-runtime-policy';
 import { BatchRuntimePolicy } from './policies/batch-runtime-policy';
+import { grantErrorEventsWrite } from '@nagiyu/infra-common';
 
 export interface LambdaStackProps extends cdk.StackProps {
   environment: string;
@@ -95,6 +96,8 @@ export class LambdaStack extends cdk.Stack {
       ],
     });
 
+    grantErrorEventsWrite(this, webExecutionRole, environment as 'dev' | 'prod');
+
     // Web Lambda Function の作成
     this.webFunction = new lambda.Function(this, 'WebFunction', {
       functionName: `nagiyu-stock-tracker-web-${environment}`,
@@ -122,6 +125,7 @@ export class LambdaStack extends cdk.Stack {
             : 'https://dev-stock-tracker.nagiyu.com',
         AUTH_SECRET: nextAuthSecret,
         STOCK_TRACKER_SUMMARY_BATCH_FUNCTION_NAME: `nagiyu-stock-tracker-batch-summary-${environment}`,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       tracing: lambda.Tracing.ACTIVE, // X-Ray トレーシング有効化
       logRetention: logs.RetentionDays.ONE_MONTH, // CloudWatch Logs 保持期間: 30日
@@ -148,6 +152,8 @@ export class LambdaStack extends cdk.Stack {
       ],
     });
 
+    grantErrorEventsWrite(this, batchExecutionRole, environment as 'dev' | 'prod');
+
     // Batch Lambda - Minute（1分間隔、MINUTE_LEVEL アラート処理）
     this.batchMinuteFunction = new lambda.Function(this, 'BatchMinuteFunction', {
       functionName: `nagiyu-stock-tracker-batch-minute-${environment}`,
@@ -170,6 +176,7 @@ export class LambdaStack extends cdk.Stack {
         OPENAI_API_KEY: openAiApiKey,
         MINUTE_BATCH_CONCURRENCY: '10',
         MINUTE_BATCH_TIME_BUDGET_MS: '38000',
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       tracing: lambda.Tracing.ACTIVE,
       logRetention: logs.RetentionDays.ONE_MONTH,
@@ -194,6 +201,7 @@ export class LambdaStack extends cdk.Stack {
         VAPID_PUBLIC_KEY: vapidPublicKey,
         VAPID_PRIVATE_KEY: vapidPrivateKey,
         OPENAI_API_KEY: openAiApiKey,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       tracing: lambda.Tracing.ACTIVE,
       logRetention: logs.RetentionDays.ONE_MONTH,
@@ -216,6 +224,7 @@ export class LambdaStack extends cdk.Stack {
         DYNAMODB_TABLE_NAME: dynamoTable.tableName,
         BATCH_TYPE: 'SUMMARY',
         OPENAI_API_KEY: openAiApiKey,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       tracing: lambda.Tracing.ACTIVE,
       logRetention: logs.RetentionDays.ONE_MONTH,
@@ -238,6 +247,7 @@ export class LambdaStack extends cdk.Stack {
         DYNAMODB_TABLE_NAME: dynamoTable.tableName,
         BATCH_TYPE: 'DAILY',
         OPENAI_API_KEY: openAiApiKey,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       tracing: lambda.Tracing.ACTIVE,
       logRetention: logs.RetentionDays.ONE_MONTH,
@@ -259,6 +269,7 @@ export class LambdaStack extends cdk.Stack {
         NODE_ENV: environment,
         DYNAMODB_TABLE_NAME: dynamoTable.tableName,
         BATCH_TYPE: 'EVALUATION',
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       tracing: lambda.Tracing.ACTIVE,
       logRetention: logs.RetentionDays.ONE_MONTH,
@@ -284,6 +295,7 @@ export class LambdaStack extends cdk.Stack {
           DYNAMODB_TABLE_NAME: dynamoTable.tableName,
           BATCH_TYPE: 'TEMPORARY_ALERT_EXPIRY',
           OPENAI_API_KEY: openAiApiKey,
+          ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
         },
         tracing: lambda.Tracing.ACTIVE,
         logRetention: logs.RetentionDays.ONE_MONTH,

--- a/infra/stock-tracker/lib/policies/web-runtime-policy.ts
+++ b/infra/stock-tracker/lib/policies/web-runtime-policy.ts
@@ -43,8 +43,7 @@ export class WebRuntimePolicy extends iam.ManagedPolicy {
   constructor(scope: Construct, id: string, props: WebRuntimePolicyProps) {
     super(scope, id, {
       managedPolicyName: `stock-tracker-web-runtime-${props.envName}`,
-      description:
-        'Stock Tracker Web runtime permissions (shared by Lambda and developers)',
+      description: 'Stock Tracker Web runtime permissions (shared by Lambda and developers)',
     });
 
     // DynamoDB 権限: Query, GetItem, PutItem, UpdateItem, DeleteItem

--- a/package-lock.json
+++ b/package-lock.json
@@ -14469,6 +14469,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14490,6 +14491,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14511,6 +14513,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14532,6 +14535,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14553,6 +14557,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14574,6 +14579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14595,6 +14601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14616,6 +14623,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14637,6 +14645,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14658,6 +14667,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14679,6 +14689,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -16650,6 +16661,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -19877,6 +19889,7 @@
         "@aws-sdk/client-dynamodb": "^3.1024.0",
         "@aws-sdk/client-s3": "^3.1024.0",
         "@aws-sdk/lib-dynamodb": "^3.1024.0",
+        "@nagiyu/aws": "*",
         "@nagiyu/codec-converter-core": "*"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1652,7 +1652,6 @@
       "version": "7.29.3",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
       "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1662,7 +1661,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -1693,7 +1691,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/generator": {
@@ -1716,7 +1713,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -1755,7 +1751,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -1773,7 +1768,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1801,7 +1795,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1811,7 +1804,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -1840,7 +1832,6 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1853,7 +1844,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1866,7 +1856,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -1879,7 +1868,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1895,7 +1883,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
       "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1911,7 +1898,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1924,7 +1910,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1937,7 +1922,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
       "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -1953,7 +1937,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1966,7 +1949,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1979,7 +1961,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1992,7 +1973,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2005,7 +1985,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2018,7 +1997,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2031,7 +2009,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -2047,7 +2024,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -2063,7 +2039,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
       "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -2133,7 +2108,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
@@ -2152,7 +2126,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2165,7 +2139,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2330,7 +2304,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2352,7 +2325,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3649,7 +3621,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -3667,7 +3638,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3680,7 +3650,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3693,14 +3662,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -3718,7 +3685,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -3734,7 +3700,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -3752,7 +3717,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -3769,7 +3733,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -3783,7 +3746,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -3796,7 +3758,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -3812,7 +3773,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -3825,7 +3785,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3835,7 +3794,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
       "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3845,7 +3803,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
       "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.4.1",
@@ -3863,7 +3820,6 @@
       "version": "30.4.2",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
       "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "30.4.1",
@@ -3911,7 +3867,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3924,7 +3879,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -3940,7 +3894,6 @@
       "version": "30.4.0",
       "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
       "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3950,7 +3903,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
       "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "30.4.1",
@@ -3994,7 +3946,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
       "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "expect": "30.4.1",
@@ -4008,7 +3959,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
       "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0"
@@ -4021,7 +3971,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
       "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.4.1",
@@ -4039,7 +3988,6 @@
       "version": "30.1.0",
       "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
       "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4049,7 +3997,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
       "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.4.1",
@@ -4065,7 +4012,6 @@
       "version": "30.4.0",
       "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
       "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4079,7 +4025,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
       "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -4122,14 +4067,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4140,7 +4083,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4161,14 +4103,12 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@jest/reporters/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -4184,7 +4124,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -4201,7 +4140,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
       "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
@@ -4214,7 +4152,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
       "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.4.1",
@@ -4230,7 +4167,6 @@
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
       "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -4245,7 +4181,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
       "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "30.4.1",
@@ -4261,7 +4196,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
       "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "30.4.1",
@@ -4277,7 +4211,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
       "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
@@ -4303,14 +4236,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/types": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
       "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/pattern": "30.4.0",
@@ -4359,7 +4290,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -4862,7 +4792,6 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5088,7 +5017,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5099,7 +5027,6 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
       "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -5766,14 +5693,12 @@
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -5783,7 +5708,6 @@
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
       "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
@@ -6928,35 +6852,34 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6974,7 +6897,6 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -6988,7 +6910,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -6998,7 +6919,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -7009,7 +6929,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -7084,14 +7003,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -7101,7 +7018,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -7220,7 +7136,6 @@
       "version": "24.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -7301,7 +7216,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
@@ -7355,7 +7269,6 @@
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -7365,7 +7278,6 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7624,7 +7536,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7638,7 +7549,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7652,7 +7562,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7666,7 +7575,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7680,7 +7588,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7694,7 +7601,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7708,7 +7614,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7722,7 +7627,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7736,7 +7640,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7750,7 +7653,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7764,7 +7666,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7778,7 +7679,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7792,7 +7692,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7806,7 +7705,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7820,7 +7718,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7834,7 +7731,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7851,7 +7747,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7865,7 +7760,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7879,7 +7773,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7955,7 +7848,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -7978,7 +7871,7 @@
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
       "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -8017,7 +7910,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -8033,7 +7925,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8043,7 +7934,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -8059,7 +7949,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -8073,7 +7962,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -8784,7 +8673,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
       "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "30.4.1",
@@ -8806,7 +8694,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
       "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "workspaces": [
         "test/babel-8"
@@ -8826,7 +8713,6 @@
       "version": "30.4.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
       "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/babel__core": "^7.20.5"
@@ -8854,7 +8740,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -8881,7 +8766,6 @@
       "version": "30.4.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
       "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "30.4.0",
@@ -8977,7 +8861,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9011,7 +8894,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-json-stable-stringify": "2.x"
@@ -9024,7 +8906,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -9133,7 +9014,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9196,7 +9076,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -9213,7 +9092,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9273,7 +9151,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9289,7 +9166,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/client-only": {
@@ -9302,7 +9178,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -9326,7 +9201,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -9337,14 +9211,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -9357,7 +9229,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -9386,7 +9257,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -9451,14 +9321,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -9643,7 +9512,6 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -9675,7 +9543,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9792,7 +9659,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9900,7 +9766,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -9946,14 +9811,12 @@
       "version": "1.5.354",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.354.tgz",
       "integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9966,7 +9829,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/empathic": {
@@ -10243,7 +10105,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10831,7 +10692,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -10855,7 +10715,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
       "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -10865,7 +10724,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
       "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "30.4.1",
@@ -10937,7 +10795,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -10998,7 +10855,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -11173,7 +11029,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -11190,7 +11045,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -11219,14 +11073,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11291,7 +11143,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -11301,7 +11152,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -11335,7 +11185,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -11358,7 +11207,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11475,7 +11323,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/gray-matter": {
@@ -11497,7 +11344,6 @@
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -11519,7 +11365,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11549,7 +11394,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11735,7 +11579,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-url-attributes": {
@@ -11813,7 +11656,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -11881,7 +11723,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -11901,7 +11742,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -11922,7 +11762,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -12208,7 +12047,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12218,7 +12056,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12409,7 +12246,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12542,7 +12378,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isomorphic-dompurify": {
@@ -12860,7 +12695,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -12870,7 +12704,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.23.9",
@@ -12887,7 +12720,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12900,7 +12732,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -12915,7 +12746,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
       "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.23",
@@ -12930,7 +12760,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -12962,7 +12791,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -12978,7 +12806,6 @@
       "version": "30.4.2",
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "30.4.2",
@@ -13118,7 +12945,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
       "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
@@ -13133,7 +12959,6 @@
       "version": "30.4.2",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
       "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.4.1",
@@ -13165,7 +12990,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13178,7 +13002,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -13194,7 +13017,6 @@
       "version": "30.4.2",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
       "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "30.4.2",
@@ -13227,7 +13049,6 @@
       "version": "30.4.2",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
       "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
@@ -13278,7 +13099,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13291,14 +13111,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13309,7 +13127,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -13330,14 +13147,12 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jest-config/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -13353,7 +13168,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -13370,7 +13184,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -13386,7 +13199,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
       "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/diff-sequences": "30.4.0",
@@ -13402,7 +13214,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13415,7 +13226,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -13431,7 +13241,6 @@
       "version": "30.4.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
       "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.1.0"
@@ -13444,7 +13253,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
       "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
@@ -13461,7 +13269,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13474,7 +13281,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -13513,7 +13319,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
       "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.4.1",
@@ -13542,7 +13347,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
       "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.4.1",
@@ -13567,7 +13371,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
       "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
@@ -13581,7 +13384,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13594,7 +13396,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -13610,7 +13411,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
       "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
@@ -13626,7 +13426,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13639,7 +13438,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -13655,7 +13453,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
       "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -13677,7 +13474,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13690,7 +13486,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -13706,7 +13501,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
       "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.4.1",
@@ -13721,7 +13515,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13739,7 +13532,6 @@
       "version": "30.4.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
       "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -13749,7 +13541,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
       "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -13769,7 +13560,6 @@
       "version": "30.4.2",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
       "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "30.4.0",
@@ -13783,7 +13573,6 @@
       "version": "30.4.2",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
       "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "30.4.1",
@@ -13817,7 +13606,6 @@
       "version": "30.4.2",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
       "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.4.1",
@@ -13851,14 +13639,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13869,7 +13655,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -13890,14 +13675,12 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jest-runtime/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -13913,7 +13696,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -13930,7 +13712,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
       "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
@@ -13963,7 +13744,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13976,7 +13756,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -13992,7 +13771,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14005,7 +13783,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
       "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.4.1",
@@ -14023,7 +13800,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
       "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
@@ -14041,7 +13817,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14054,7 +13829,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14067,7 +13841,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
       "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "30.4.1",
@@ -14083,7 +13856,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
       "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "30.4.1",
@@ -14103,7 +13875,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
       "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -14120,7 +13891,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14253,7 +14023,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -14397,7 +14166,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14469,6 +14237,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14490,6 +14259,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14511,6 +14281,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14532,6 +14303,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14553,6 +14325,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14574,6 +14347,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14595,6 +14369,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14616,6 +14391,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14637,6 +14413,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14658,6 +14435,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14679,6 +14457,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14713,7 +14492,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -14756,7 +14534,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -14786,7 +14563,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -14802,7 +14578,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14815,14 +14590,12 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -15139,7 +14912,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -15754,7 +15526,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15805,7 +15576,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -15848,7 +15618,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
       "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "napi-postinstall": "lib/cli.js"
@@ -15864,14 +15633,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/next": {
@@ -16001,21 +15768,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
       "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16025,7 +15789,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -16182,7 +15945,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -16192,7 +15954,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -16284,7 +16045,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -16316,7 +16076,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16326,7 +16085,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
@@ -16412,7 +16170,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16437,7 +16194,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16447,7 +16203,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16526,7 +16281,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16539,7 +16293,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -16549,7 +16302,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -16562,7 +16314,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -16576,7 +16327,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -16589,7 +16339,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -16605,7 +16354,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -16650,6 +16398,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16842,7 +16591,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
       "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -16940,7 +16688,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-is-19": {
@@ -16948,7 +16695,6 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -17207,7 +16953,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17247,7 +16992,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -17260,7 +17004,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17517,7 +17260,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17640,7 +17382,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -17653,7 +17394,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17739,7 +17479,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/sinon": {
@@ -17781,7 +17520,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17815,7 +17553,6 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -17826,7 +17563,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -17859,7 +17595,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -17872,7 +17607,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17959,7 +17693,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -17973,7 +17706,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -17989,7 +17721,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -18131,7 +17862,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18145,7 +17875,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18158,7 +17887,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18177,7 +17905,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18200,7 +17927,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18272,7 +17998,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -18303,7 +18028,6 @@
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
       "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@pkgr/core": "^0.2.9"
@@ -18340,7 +18064,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -18355,14 +18078,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -18374,7 +18095,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -18395,7 +18115,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -18472,7 +18191,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
@@ -18561,7 +18279,6 @@
       "version": "29.4.9",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
       "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
@@ -18614,7 +18331,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -18627,7 +18343,6 @@
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -18640,7 +18355,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -18684,7 +18399,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -18738,7 +18453,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18748,7 +18462,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -18845,7 +18558,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -18883,7 +18595,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -18925,7 +18636,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -19035,7 +18745,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
       "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19070,7 +18779,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -19153,14 +18861,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -19175,7 +18882,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vfile": {
@@ -19326,7 +19032,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -19410,7 +19115,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -19525,14 +19229,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -19551,7 +19253,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -19569,14 +19270,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -19590,7 +19289,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -19693,7 +19391,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -19703,14 +19400,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -19729,7 +19424,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -19739,7 +19433,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19749,7 +19443,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20103,6 +19796,7 @@
         "@resvg/resvg-js": "^2.6.2",
         "echarts": "^6.0.0",
         "openai": "^6.33.0",
+        "ts-jest": "^29.4.9",
         "web-push": "^3.6.7",
         "zod": "^4.3.6"
       }
@@ -20133,6 +19827,7 @@
         "@aws-sdk/client-dynamodb": "^3.1024.0",
         "@aws-sdk/client-lambda": "^3.1024.0",
         "@aws-sdk/lib-dynamodb": "^3.1024.0",
+        "@nagiyu/aws": "*",
         "@nagiyu/browser": "*",
         "@nagiyu/common": "*",
         "@nagiyu/nextjs": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19713,6 +19713,7 @@
       "name": "@nagiyu/quick-clip-batch",
       "version": "0.1.0",
       "dependencies": {
+        "@nagiyu/aws": "*",
         "@nagiyu/quick-clip-core": "*"
       }
     },
@@ -19723,6 +19724,7 @@
         "@aws-sdk/client-dynamodb": "^3.1024.0",
         "@aws-sdk/client-s3": "^3.1024.0",
         "@aws-sdk/lib-dynamodb": "^3.1024.0",
+        "@nagiyu/aws": "*",
         "@nagiyu/common": "*",
         "jszip": "^3.10.1",
         "openai": "^6.33.0",
@@ -19737,6 +19739,7 @@
         "@aws-sdk/client-s3": "^3.1024.0",
         "@aws-sdk/lib-dynamodb": "^3.1024.0",
         "@aws-sdk/s3-request-presigner": "^3.1024.0",
+        "@nagiyu/aws": "*",
         "@nagiyu/quick-clip-core": "*",
         "ffmpeg-static": "^5.2.0"
       }
@@ -19747,6 +19750,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1024.0",
         "@aws-sdk/s3-request-presigner": "^3.1024.0",
+        "@nagiyu/aws": "*",
         "jszip": "^3.10.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19529,6 +19529,7 @@
       "version": "1.2.1",
       "dependencies": {
         "@nagiyu/admin-core": "*",
+        "@nagiyu/aws": "*",
         "@nagiyu/browser": "*",
         "@nagiyu/common": "*",
         "@nagiyu/nextjs": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14469,6 +14469,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14490,6 +14491,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14511,6 +14513,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14532,6 +14535,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14553,6 +14557,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14574,6 +14579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14595,6 +14601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14616,6 +14623,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14637,6 +14645,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14658,6 +14667,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14679,6 +14689,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -16650,6 +16661,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/services/admin/web/jest.config.ts
+++ b/services/admin/web/jest.config.ts
@@ -18,6 +18,7 @@ const config: Config = {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/ui$': '<rootDir>/../../../libs/ui/src/index.ts',
     '^@nagiyu/browser$': '<rootDir>/../../../libs/browser/src/index.ts',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/nextjs$': '<rootDir>/../../../libs/nextjs/src/index.ts',
     '^@nagiyu/nextjs/(.*)$': '<rootDir>/../../../libs/nextjs/src/$1.ts',

--- a/services/admin/web/package.json
+++ b/services/admin/web/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@nagiyu/admin-core": "*",
+    "@nagiyu/aws": "*",
     "@nagiyu/browser": "*",
     "@nagiyu/common": "*",
     "@nagiyu/nextjs": "*",

--- a/services/admin/web/src/app/api/errors/[eventId]/route.ts
+++ b/services/admin/web/src/app/api/errors/[eventId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { COMMON_ERROR_MESSAGES, hasPermission } from '@nagiyu/common';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { createErrorEventReader } from '@nagiyu/admin-core';
 import { createErrorResponse } from '@nagiyu/nextjs';
 import { getSession } from '@/lib/auth/session';
@@ -62,6 +62,16 @@ export async function GET(
     return NextResponse.json(event, { status: 200 });
   } catch (error) {
     console.error('エラー詳細取得 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'admin',
+      severity: 'error',
+      title: 'エラー詳細取得 API の実行に失敗しました',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        endpoint: 'GET /api/errors/[eventId]',
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     return createErrorResponse(500, 'INTERNAL_ERROR', ERROR_MESSAGES.INTERNAL_ERROR);
   }
 }

--- a/services/admin/web/src/app/api/errors/route.ts
+++ b/services/admin/web/src/app/api/errors/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { COMMON_ERROR_MESSAGES, hasPermission } from '@nagiyu/common';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { createErrorEventReader, type ListErrorEventsQuery } from '@nagiyu/admin-core';
 import { createErrorResponse } from '@nagiyu/nextjs';
 import { getSession } from '@/lib/auth/session';
@@ -98,6 +98,16 @@ export async function GET(request: Request): Promise<NextResponse> {
     }
 
     console.error('エラー一覧取得 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'admin',
+      severity: 'error',
+      title: 'エラー一覧取得 API の実行に失敗しました',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        endpoint: 'GET /api/errors',
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     return createErrorResponse(500, 'INTERNAL_ERROR', ERROR_MESSAGES.INTERNAL_ERROR);
   }
 }

--- a/services/admin/web/tests/unit/app/api/errors-report.test.ts
+++ b/services/admin/web/tests/unit/app/api/errors-report.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ */
+import { GET as listErrors } from '@/app/api/errors/route';
+import { GET as getErrorDetail } from '@/app/api/errors/[eventId]/route';
+import { reportErrorEvent } from '@nagiyu/aws';
+import { createErrorEventReader } from '@nagiyu/admin-core';
+import { getSession } from '@/lib/auth/session';
+
+jest.mock('@nagiyu/aws', () => ({
+  getDynamoDBDocumentClient: jest.fn(),
+  reportErrorEvent: jest.fn(async () => null),
+}));
+
+jest.mock(
+  '@nagiyu/admin-core',
+  () => ({
+    createErrorEventReader: jest.fn(),
+  }),
+  { virtual: true }
+);
+
+jest.mock('@/lib/auth/session', () => ({
+  getSession: jest.fn(),
+}));
+
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
+const mockCreateErrorEventReader = createErrorEventReader as jest.MockedFunction<
+  typeof createErrorEventReader
+>;
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+
+describe('admin /api/errors の reportErrorEvent 連携', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.USE_IN_MEMORY_DB = 'true';
+    mockGetSession.mockResolvedValue({
+      user: {
+        id: 'test-user-id',
+        email: 'admin@example.com',
+        name: 'Admin',
+        roles: ['admin'],
+      },
+      expires: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    } as Awaited<ReturnType<typeof getSession>>);
+  });
+
+  it('一覧取得 API の内部エラー時に reportErrorEvent を呼ぶ', async () => {
+    mockCreateErrorEventReader.mockReturnValue({
+      list: jest.fn().mockRejectedValue(new Error('DynamoDB 接続失敗')),
+    } as unknown as ReturnType<typeof createErrorEventReader>);
+
+    const response = await listErrors(new Request('http://localhost/api/errors'));
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledTimes(1);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'admin',
+        severity: 'error',
+        title: 'エラー一覧取得 API の実行に失敗しました',
+        message: 'DynamoDB 接続失敗',
+        context: expect.objectContaining({ endpoint: 'GET /api/errors' }),
+      })
+    );
+  });
+
+  it('詳細取得 API の内部エラー時に reportErrorEvent を呼ぶ', async () => {
+    mockCreateErrorEventReader.mockReturnValue({
+      findById: jest.fn().mockRejectedValue(new Error('DynamoDB 読み取り失敗')),
+    } as unknown as ReturnType<typeof createErrorEventReader>);
+
+    const response = await getErrorDetail(
+      new Request('http://localhost/api/errors/evt-1?at=2026-05-16T00:00:00Z&serviceId=admin'),
+      { params: Promise.resolve({ eventId: 'evt-1' }) }
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledTimes(1);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'admin',
+        severity: 'error',
+        title: 'エラー詳細取得 API の実行に失敗しました',
+        message: 'DynamoDB 読み取り失敗',
+        context: expect.objectContaining({ endpoint: 'GET /api/errors/[eventId]' }),
+      })
+    );
+  });
+});

--- a/services/auth/core/jest.config.ts
+++ b/services/auth/core/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
   moduleNameMapper: {
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
+    '^@nagiyu/nextjs$': '<rootDir>/../../../libs/nextjs/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   // next-auth などの ES モジュールをトランスフォームする

--- a/services/auth/core/src/auth/auth.ts
+++ b/services/auth/core/src/auth/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth, { type NextAuthConfig } from 'next-auth';
 import Google from 'next-auth/providers/google';
 import { createAuthConfig } from '@nagiyu/nextjs';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { createUserRepository } from '../repositories/factory';
 
 // エラーメッセージ定数
@@ -89,20 +90,49 @@ export const authConfig: NextAuthConfig = {
       // email と name の null チェック
       if (!user.email) {
         console.error(ERROR_MESSAGES.MISSING_USER_EMAIL);
+        await reportErrorEvent({
+          serviceId: 'auth',
+          severity: 'error',
+          title: 'signIn: OAuth ユーザー情報に email がありません',
+          message: ERROR_MESSAGES.MISSING_USER_EMAIL,
+          context: { step: 'signIn' },
+        });
         return false;
       }
       if (!user.name) {
         console.error(ERROR_MESSAGES.MISSING_USER_NAME);
+        await reportErrorEvent({
+          serviceId: 'auth',
+          severity: 'error',
+          title: 'signIn: OAuth ユーザー情報に name がありません',
+          message: ERROR_MESSAGES.MISSING_USER_NAME,
+          context: { step: 'signIn' },
+        });
         return false;
       }
 
       const userRepository = createUserRepository();
-      await userRepository.upsertUser({
-        googleId: account.providerAccountId,
-        email: user.email,
-        name: user.name,
-        picture: user.image || undefined,
-      });
+      try {
+        await userRepository.upsertUser({
+          googleId: account.providerAccountId,
+          email: user.email,
+          name: user.name,
+          picture: user.image || undefined,
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await reportErrorEvent({
+          serviceId: 'auth',
+          severity: 'error',
+          title: 'signIn: ユーザー upsert エラー',
+          message: errorMessage,
+          context: {
+            step: 'upsertUser',
+            errorStack: error instanceof Error ? error.stack : undefined,
+          },
+        });
+        return false;
+      }
 
       return true;
     },

--- a/services/auth/core/src/repositories/dynamodb-user-repository.ts
+++ b/services/auth/core/src/repositories/dynamodb-user-repository.ts
@@ -6,7 +6,7 @@ import {
   ScanCommand,
 } from '@aws-sdk/lib-dynamodb';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 import type { User } from '@nagiyu/common';
 import { randomUUID } from 'node:crypto';
 import {
@@ -27,18 +27,32 @@ export class DynamoDBUserRepository implements UserRepository {
   }
 
   public async getUserByGoogleId(googleId: string): Promise<User | null> {
-    const result = await this.dynamoDb.send(
-      new QueryCommand({
-        TableName: this.tableName,
-        IndexName: 'googleId-index',
-        KeyConditionExpression: 'googleId = :googleId',
-        ExpressionAttributeValues: {
-          ':googleId': googleId,
+    try {
+      const result = await this.dynamoDb.send(
+        new QueryCommand({
+          TableName: this.tableName,
+          IndexName: 'googleId-index',
+          KeyConditionExpression: 'googleId = :googleId',
+          ExpressionAttributeValues: {
+            ':googleId': googleId,
+          },
+        })
+      );
+      return (result.Items?.[0] as User) || null;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await reportErrorEvent({
+        serviceId: 'auth',
+        severity: 'error',
+        title: 'DB: getUserByGoogleId エラー',
+        message: errorMessage,
+        context: {
+          step: 'getUserByGoogleId',
+          errorStack: error instanceof Error ? error.stack : undefined,
         },
-      })
-    );
-
-    return (result.Items?.[0] as User) || null;
+      });
+      throw error;
+    }
   }
 
   public async getUserById(userId: string): Promise<User | null> {
@@ -81,12 +95,28 @@ export class DynamoDBUserRepository implements UserRepository {
         updatedAt: new Date().toISOString(),
       };
 
-      await this.dynamoDb.send(
-        new PutCommand({
-          TableName: this.tableName,
-          Item: updatedUser,
-        })
-      );
+      try {
+        await this.dynamoDb.send(
+          new PutCommand({
+            TableName: this.tableName,
+            Item: updatedUser,
+          })
+        );
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await reportErrorEvent({
+          serviceId: 'auth',
+          severity: 'error',
+          title: 'DB: upsertUser (既存ユーザー更新) エラー',
+          message: errorMessage,
+          context: {
+            step: 'upsertUser',
+            userId: existingUser.userId,
+            errorStack: error instanceof Error ? error.stack : undefined,
+          },
+        });
+        throw error;
+      }
 
       return updatedUser;
     }
@@ -102,12 +132,27 @@ export class DynamoDBUserRepository implements UserRepository {
       updatedAt: new Date().toISOString(),
     };
 
-    await this.dynamoDb.send(
-      new PutCommand({
-        TableName: this.tableName,
-        Item: newUser,
-      })
-    );
+    try {
+      await this.dynamoDb.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: newUser,
+        })
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await reportErrorEvent({
+        serviceId: 'auth',
+        severity: 'error',
+        title: 'DB: upsertUser (新規ユーザー作成) エラー',
+        message: errorMessage,
+        context: {
+          step: 'upsertUser',
+          errorStack: error instanceof Error ? error.stack : undefined,
+        },
+      });
+      throw error;
+    }
 
     return newUser;
   }

--- a/services/auth/core/tests/unit/auth/sign-in-callback.test.ts
+++ b/services/auth/core/tests/unit/auth/sign-in-callback.test.ts
@@ -2,7 +2,9 @@ import { reportErrorEvent } from '@nagiyu/aws';
 
 const mockUpsertUser = jest.fn();
 
-const capturedCallbacks: { jwt?: Function } = {};
+type AnyAsyncFn = (...args: unknown[]) => Promise<unknown>;
+
+const capturedCallbacks: { jwt?: AnyAsyncFn } = {};
 
 jest.mock('@nagiyu/aws', () => ({
   reportErrorEvent: jest.fn().mockResolvedValue(null),
@@ -100,11 +102,11 @@ describe('jwt コールバック', () => {
 });
 
 describe('redirect コールバック', () => {
-  let redirect: Function;
+  let redirect: AnyAsyncFn;
 
   beforeAll(async () => {
     const { authConfig } = await import('../../../src/auth/auth');
-    redirect = authConfig.callbacks!.redirect as Function;
+    redirect = authConfig.callbacks!.redirect as AnyAsyncFn;
   });
 
   it('baseUrl と同じ URL は許可する', async () => {
@@ -133,11 +135,11 @@ describe('redirect コールバック', () => {
 });
 
 describe('signIn コールバック', () => {
-  let signIn: Function;
+  let signIn: AnyAsyncFn;
 
   beforeAll(async () => {
     const { authConfig } = await import('../../../src/auth/auth');
-    signIn = authConfig.callbacks!.signIn as Function;
+    signIn = authConfig.callbacks!.signIn as AnyAsyncFn;
   });
 
   beforeEach(() => {

--- a/services/auth/core/tests/unit/auth/sign-in-callback.test.ts
+++ b/services/auth/core/tests/unit/auth/sign-in-callback.test.ts
@@ -108,17 +108,26 @@ describe('redirect コールバック', () => {
   });
 
   it('baseUrl と同じ URL は許可する', async () => {
-    const result = await redirect({ url: 'https://auth.nagiyu.com/signin', baseUrl: 'https://auth.nagiyu.com' });
+    const result = await redirect({
+      url: 'https://auth.nagiyu.com/signin',
+      baseUrl: 'https://auth.nagiyu.com',
+    });
     expect(result).toBe('https://auth.nagiyu.com/signin');
   });
 
   it('*.nagiyu.com へのリダイレクトは許可する', async () => {
-    const result = await redirect({ url: 'https://admin.nagiyu.com/', baseUrl: 'https://auth.nagiyu.com' });
+    const result = await redirect({
+      url: 'https://admin.nagiyu.com/',
+      baseUrl: 'https://auth.nagiyu.com',
+    });
     expect(result).toBe('https://admin.nagiyu.com/');
   });
 
   it('外部 URL は baseUrl にフォールバックする', async () => {
-    const result = await redirect({ url: 'https://evil.example.com/', baseUrl: 'https://auth.nagiyu.com' });
+    const result = await redirect({
+      url: 'https://evil.example.com/',
+      baseUrl: 'https://auth.nagiyu.com',
+    });
     expect(result).toBe('https://auth.nagiyu.com');
   });
 });

--- a/services/auth/core/tests/unit/auth/sign-in-callback.test.ts
+++ b/services/auth/core/tests/unit/auth/sign-in-callback.test.ts
@@ -1,0 +1,236 @@
+import { reportErrorEvent } from '@nagiyu/aws';
+
+const mockUpsertUser = jest.fn();
+
+const capturedCallbacks: { jwt?: Function } = {};
+
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@nagiyu/nextjs', () => ({
+  createAuthConfig: jest.fn().mockImplementation(({ jwt }) => {
+    capturedCallbacks.jwt = jwt;
+    return { callbacks: {} };
+  }),
+}));
+
+jest.mock('next-auth', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({
+    handlers: {},
+    auth: jest.fn(),
+    signIn: jest.fn(),
+    signOut: jest.fn(),
+  }),
+}));
+
+jest.mock('next-auth/providers/google', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../../src/repositories/factory', () => ({
+  createUserRepository: jest.fn().mockReturnValue({ upsertUser: mockUpsertUser }),
+}));
+
+describe('jwt コールバック', () => {
+  let mockGetUserByGoogleId: jest.Mock;
+  let mockUpdateLastLogin: jest.Mock;
+
+  beforeAll(async () => {
+    await import('../../../src/auth/auth');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (reportErrorEvent as jest.Mock).mockResolvedValue(null);
+    mockGetUserByGoogleId = jest.fn();
+    mockUpdateLastLogin = jest.fn();
+    mockUpsertUser.mockResolvedValue({ userId: 'user-123' });
+  });
+
+  it('account と user がある場合はトークンにユーザー情報を設定する', async () => {
+    const mockDbUser = { userId: 'db-user-123', roles: ['admin'] };
+    mockGetUserByGoogleId.mockResolvedValueOnce(mockDbUser);
+    mockUpdateLastLogin.mockResolvedValueOnce(undefined);
+
+    const { createUserRepository } = await import('../../../src/repositories/factory');
+    (createUserRepository as jest.Mock).mockReturnValueOnce({
+      getUserByGoogleId: mockGetUserByGoogleId,
+      updateLastLogin: mockUpdateLastLogin,
+    });
+
+    const token = {};
+    const result = await capturedCallbacks.jwt!({
+      token,
+      user: { email: 'test@example.com', name: 'Test', image: null },
+      account: { providerAccountId: 'google-123' },
+    });
+
+    expect(result.userId).toBe('db-user-123');
+    expect(result.roles).toEqual(['admin']);
+  });
+
+  it('account がない場合はトークンをそのまま返す', async () => {
+    const token = { existing: 'value' };
+    const result = await capturedCallbacks.jwt!({ token, user: {}, account: null });
+    expect(result).toEqual({ existing: 'value' });
+  });
+
+  it('dbUser が見つからない場合は roles を空配列に設定する', async () => {
+    mockGetUserByGoogleId.mockResolvedValueOnce(null);
+
+    const { createUserRepository } = await import('../../../src/repositories/factory');
+    (createUserRepository as jest.Mock).mockReturnValueOnce({
+      getUserByGoogleId: mockGetUserByGoogleId,
+      updateLastLogin: mockUpdateLastLogin,
+    });
+
+    const token = {};
+    const result = await capturedCallbacks.jwt!({
+      token,
+      user: {},
+      account: { providerAccountId: 'google-123' },
+    });
+
+    expect(result.roles).toEqual([]);
+    expect(mockUpdateLastLogin).not.toHaveBeenCalled();
+  });
+});
+
+describe('redirect コールバック', () => {
+  let redirect: Function;
+
+  beforeAll(async () => {
+    const { authConfig } = await import('../../../src/auth/auth');
+    redirect = authConfig.callbacks!.redirect as Function;
+  });
+
+  it('baseUrl と同じ URL は許可する', async () => {
+    const result = await redirect({ url: 'https://auth.nagiyu.com/signin', baseUrl: 'https://auth.nagiyu.com' });
+    expect(result).toBe('https://auth.nagiyu.com/signin');
+  });
+
+  it('*.nagiyu.com へのリダイレクトは許可する', async () => {
+    const result = await redirect({ url: 'https://admin.nagiyu.com/', baseUrl: 'https://auth.nagiyu.com' });
+    expect(result).toBe('https://admin.nagiyu.com/');
+  });
+
+  it('外部 URL は baseUrl にフォールバックする', async () => {
+    const result = await redirect({ url: 'https://evil.example.com/', baseUrl: 'https://auth.nagiyu.com' });
+    expect(result).toBe('https://auth.nagiyu.com');
+  });
+});
+
+describe('signIn コールバック', () => {
+  let signIn: Function;
+
+  beforeAll(async () => {
+    const { authConfig } = await import('../../../src/auth/auth');
+    signIn = authConfig.callbacks!.signIn as Function;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (reportErrorEvent as jest.Mock).mockResolvedValue(null);
+    mockUpsertUser.mockResolvedValue({ userId: 'user-123' });
+  });
+
+  it('account が null の場合は false を返し reportErrorEvent は呼ばない', async () => {
+    const result = await signIn({
+      user: { email: 'test@example.com', name: 'Test' },
+      account: null,
+    });
+
+    expect(result).toBe(false);
+    expect(reportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('email が欠落している場合は reportErrorEvent を呼び false を返す', async () => {
+    const result = await signIn({
+      user: { email: null, name: 'Test' },
+      account: { providerAccountId: 'google-secret-id' },
+    });
+
+    expect(result).toBe(false);
+    expect(reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'auth',
+        severity: 'error',
+        title: 'signIn: OAuth ユーザー情報に email がありません',
+      })
+    );
+    const call = (reportErrorEvent as jest.Mock).mock.calls[0][0];
+    expect(JSON.stringify(call.context)).not.toContain('google-secret-id');
+    expect(JSON.stringify(call.context)).not.toContain('@');
+  });
+
+  it('name が欠落している場合は reportErrorEvent を呼び false を返す', async () => {
+    const result = await signIn({
+      user: { email: 'test@example.com', name: null },
+      account: { providerAccountId: 'google-secret-id' },
+    });
+
+    expect(result).toBe(false);
+    expect(reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'auth',
+        severity: 'error',
+        title: 'signIn: OAuth ユーザー情報に name がありません',
+      })
+    );
+    const call = (reportErrorEvent as jest.Mock).mock.calls[0][0];
+    expect(JSON.stringify(call.context)).not.toContain('google-secret-id');
+    expect(JSON.stringify(call.context)).not.toContain('@example.com');
+  });
+
+  it('upsertUser エラー時は reportErrorEvent を呼び false を返す', async () => {
+    mockUpsertUser.mockRejectedValueOnce(new Error('DynamoDB error'));
+
+    const result = await signIn({
+      user: { email: 'test@example.com', name: 'Test' },
+      account: { providerAccountId: 'google-secret-id' },
+    });
+
+    expect(result).toBe(false);
+    expect(reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'auth',
+        severity: 'error',
+        title: 'signIn: ユーザー upsert エラー',
+        message: 'DynamoDB error',
+      })
+    );
+    const call = (reportErrorEvent as jest.Mock).mock.calls[0][0];
+    expect(JSON.stringify(call.context)).not.toContain('google-secret-id');
+    expect(JSON.stringify(call.context)).not.toContain('@example.com');
+  });
+
+  it('upsertUser が Error 以外をスローした場合も false を返す', async () => {
+    mockUpsertUser.mockRejectedValueOnce('string error from db');
+
+    const result = await signIn({
+      user: { email: 'test@example.com', name: 'Test' },
+      account: { providerAccountId: 'google-secret-id' },
+    });
+
+    expect(result).toBe(false);
+    expect(reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'string error from db',
+        context: expect.objectContaining({ errorStack: undefined }),
+      })
+    );
+  });
+
+  it('正常時は true を返し reportErrorEvent は呼ばない', async () => {
+    const result = await signIn({
+      user: { email: 'test@example.com', name: 'Test' },
+      account: { providerAccountId: 'google-secret-id' },
+    });
+
+    expect(result).toBe(true);
+    expect(reportErrorEvent).not.toHaveBeenCalled();
+  });
+});

--- a/services/auth/core/tests/unit/repositories/dynamodb-user-repository.test.ts
+++ b/services/auth/core/tests/unit/repositories/dynamodb-user-repository.test.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../src/repositories/dynamodb-user-repository';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import type { User } from '@nagiyu/common';
-import { getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 
 const USERS_TABLE_NAME = 'test-users-table';
 
@@ -12,6 +12,7 @@ const USERS_TABLE_NAME = 'test-users-table';
 jest.mock('@nagiyu/aws', () => ({
   getDynamoDBDocumentClient: jest.fn(),
   getTableName: jest.fn(),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
 }));
 
 // Mock crypto.randomUUID
@@ -82,6 +83,40 @@ describe('DynamoDBUserRepository', () => {
       const result = await repository.getUserByGoogleId('google-123');
 
       expect(result).toBeNull();
+    });
+
+    it('DynamoDB エラー時は reportErrorEvent を呼び再スローする', async () => {
+      const dbError = new Error('DynamoDB connection failed');
+      mockSend.mockRejectedValueOnce(dbError);
+
+      await expect(repository.getUserByGoogleId('google-123')).rejects.toThrow(dbError);
+
+      expect(reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'auth',
+          severity: 'error',
+          title: 'DB: getUserByGoogleId エラー',
+          message: 'DynamoDB connection failed',
+        })
+      );
+      const call = (reportErrorEvent as jest.Mock).mock.calls[0][0];
+      expect(JSON.stringify(call.context)).not.toContain('google-123');
+    });
+
+    it('Error インスタンス以外の例外でも reportErrorEvent を呼び再スローする', async () => {
+      const stringError = 'unexpected string error';
+      mockSend.mockRejectedValueOnce(stringError);
+
+      await expect(repository.getUserByGoogleId('google-123')).rejects.toBe(stringError);
+
+      expect(reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'auth',
+          severity: 'error',
+          message: 'unexpected string error',
+          context: expect.objectContaining({ errorStack: undefined }),
+        })
+      );
     });
   });
 
@@ -302,6 +337,109 @@ describe('DynamoDBUserRepository', () => {
       });
 
       expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('新規ユーザー作成時に DynamoDB エラーが発生した場合は reportErrorEvent を呼び再スローする', async () => {
+      const dbError = new Error('DynamoDB put failed');
+
+      // getUserByGoogleId returns null (new user)
+      mockSend.mockResolvedValueOnce({ Items: [], $metadata: {} });
+      // PutCommand fails
+      mockSend.mockRejectedValueOnce(dbError);
+
+      await expect(
+        repository.upsertUser({ googleId: 'google-new', email: 'new@example.com', name: '新規' })
+      ).rejects.toThrow(dbError);
+
+      expect(reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'auth',
+          severity: 'error',
+          title: 'DB: upsertUser (新規ユーザー作成) エラー',
+          message: 'DynamoDB put failed',
+        })
+      );
+      const call = (reportErrorEvent as jest.Mock).mock.calls[0][0];
+      expect(JSON.stringify(call.context)).not.toContain('google-new');
+      expect(JSON.stringify(call.context)).not.toContain('@example.com');
+    });
+
+    it('新規ユーザー作成時に Error 以外の例外でも reportErrorEvent を呼ぶ', async () => {
+      mockSend.mockResolvedValueOnce({ Items: [], $metadata: {} });
+      mockSend.mockRejectedValueOnce('db string error');
+
+      await expect(
+        repository.upsertUser({ googleId: 'g', email: 'e@example.com', name: 'N' })
+      ).rejects.toBe('db string error');
+
+      expect(reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'db string error',
+          context: expect.objectContaining({ errorStack: undefined }),
+        })
+      );
+    });
+
+    it('既存ユーザー更新時に DynamoDB エラーが発生した場合は reportErrorEvent を userId 付きで呼ぶ', async () => {
+      const existingUser: User = {
+        userId: 'user-existing',
+        googleId: 'google-existing',
+        email: 'old@example.com',
+        name: '古い名前',
+        roles: ['admin'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+      const dbError = new Error('DynamoDB put failed');
+
+      // getUserByGoogleId returns existing user
+      mockSend.mockResolvedValueOnce({ Items: [existingUser], $metadata: {} });
+      // PutCommand fails
+      mockSend.mockRejectedValueOnce(dbError);
+
+      await expect(
+        repository.upsertUser({
+          googleId: 'google-existing',
+          email: 'old@example.com',
+          name: '新しい名前',
+        })
+      ).rejects.toThrow(dbError);
+
+      expect(reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'auth',
+          severity: 'error',
+          title: 'DB: upsertUser (既存ユーザー更新) エラー',
+          context: expect.objectContaining({ userId: 'user-existing' }),
+        })
+      );
+      const call = (reportErrorEvent as jest.Mock).mock.calls[0][0];
+      expect(JSON.stringify(call.context)).not.toContain('google-existing');
+      expect(JSON.stringify(call.context)).not.toContain('@example.com');
+    });
+
+    it('既存ユーザー更新時に Error 以外の例外でも reportErrorEvent を呼ぶ', async () => {
+      const existingUser: User = {
+        userId: 'user-existing',
+        googleId: 'google-existing',
+        email: 'old@example.com',
+        name: '古い名前',
+        roles: [],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      };
+      mockSend.mockResolvedValueOnce({ Items: [existingUser], $metadata: {} });
+      mockSend.mockRejectedValueOnce('db string error');
+
+      await expect(
+        repository.upsertUser({ googleId: 'google-existing', email: 'old@example.com', name: '名前' })
+      ).rejects.toBe('db string error');
+
+      expect(reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.objectContaining({ errorStack: undefined, userId: 'user-existing' }),
+        })
+      );
     });
   });
 

--- a/services/auth/core/tests/unit/repositories/dynamodb-user-repository.test.ts
+++ b/services/auth/core/tests/unit/repositories/dynamodb-user-repository.test.ts
@@ -432,7 +432,11 @@ describe('DynamoDBUserRepository', () => {
       mockSend.mockRejectedValueOnce('db string error');
 
       await expect(
-        repository.upsertUser({ googleId: 'google-existing', email: 'old@example.com', name: '名前' })
+        repository.upsertUser({
+          googleId: 'google-existing',
+          email: 'old@example.com',
+          name: '名前',
+        })
       ).rejects.toBe('db string error');
 
       expect(reportErrorEvent).toHaveBeenCalledWith(

--- a/services/auth/core/tests/unit/repositories/factory.test.ts
+++ b/services/auth/core/tests/unit/repositories/factory.test.ts
@@ -2,19 +2,21 @@ jest.mock('@nagiyu/aws', () => ({
   getDynamoDBDocumentClient: jest.fn().mockReturnValue({}),
   getTableName: jest.fn().mockReturnValue('test-table'),
   reportErrorEvent: jest.fn().mockResolvedValue(null),
-  registerDynamoRepositories: jest.fn().mockImplementation((config: {
-    user: {
-      createInMemoryRepository: () => unknown;
-      createDynamoDBRepository: (opts: { docClient: unknown; tableName: string }) => unknown;
-    };
-  }) => {
-    config.user.createInMemoryRepository();
-    config.user.createDynamoDBRepository({ docClient: {}, tableName: 'test-table' });
-    return {
-      user: { createRepository: jest.fn().mockReturnValue({}) },
-      resetAll: jest.fn(),
-    };
-  }),
+  registerDynamoRepositories: jest.fn().mockImplementation(
+    (config: {
+      user: {
+        createInMemoryRepository: () => unknown;
+        createDynamoDBRepository: (opts: { docClient: unknown; tableName: string }) => unknown;
+      };
+    }) => {
+      config.user.createInMemoryRepository();
+      config.user.createDynamoDBRepository({ docClient: {}, tableName: 'test-table' });
+      return {
+        user: { createRepository: jest.fn().mockReturnValue({}) },
+        resetAll: jest.fn(),
+      };
+    }
+  ),
 }));
 
 import { registerDynamoRepositories } from '@nagiyu/aws';

--- a/services/auth/core/tests/unit/repositories/factory.test.ts
+++ b/services/auth/core/tests/unit/repositories/factory.test.ts
@@ -1,0 +1,46 @@
+jest.mock('@nagiyu/aws', () => ({
+  getDynamoDBDocumentClient: jest.fn().mockReturnValue({}),
+  getTableName: jest.fn().mockReturnValue('test-table'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+  registerDynamoRepositories: jest.fn().mockImplementation((config: {
+    user: {
+      createInMemoryRepository: () => unknown;
+      createDynamoDBRepository: (opts: { docClient: unknown; tableName: string }) => unknown;
+    };
+  }) => {
+    config.user.createInMemoryRepository();
+    config.user.createDynamoDBRepository({ docClient: {}, tableName: 'test-table' });
+    return {
+      user: { createRepository: jest.fn().mockReturnValue({}) },
+      resetAll: jest.fn(),
+    };
+  }),
+}));
+
+import { registerDynamoRepositories } from '@nagiyu/aws';
+import { createUserRepository, resetUserRepository } from '../../../src/repositories/factory';
+
+describe('createUserRepository', () => {
+  it('UserRepository を返す', () => {
+    const repo = createUserRepository();
+    expect(repo).toBeDefined();
+  });
+
+  it('引数で docClient と tableName を渡せる', () => {
+    const mockDocClient = {} as never;
+    const repo = createUserRepository(mockDocClient, 'my-table');
+    expect(repo).toBeDefined();
+
+    const registry = (registerDynamoRepositories as jest.Mock).mock.results[0].value;
+    expect(registry.user.createRepository).toHaveBeenCalledWith(mockDocClient, 'my-table');
+  });
+});
+
+describe('resetUserRepository', () => {
+  it('例外なく呼び出せる', () => {
+    expect(() => resetUserRepository()).not.toThrow();
+
+    const registry = (registerDynamoRepositories as jest.Mock).mock.results[0].value;
+    expect(registry.resetAll).toHaveBeenCalled();
+  });
+});

--- a/services/auth/web/jest.config.ts
+++ b/services/auth/web/jest.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
     '\\.module\\.css$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@nagiyu/auth-core$': '<rootDir>/../core/src/index.ts',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/browser$': '<rootDir>/../../../libs/browser/src/index.ts',
     '^@nagiyu/nextjs$': '<rootDir>/../../../libs/nextjs/src/index.ts',

--- a/services/auth/web/package.json
+++ b/services/auth/web/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@nagiyu/auth-core": "*",
+    "@nagiyu/aws": "*",
     "@nagiyu/browser": "*",
     "@nagiyu/common": "*",
     "@nagiyu/nextjs": "*",

--- a/services/auth/web/src/app/api/users/[userId]/roles/route.ts
+++ b/services/auth/web/src/app/api/users/[userId]/roles/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createUserRepository, UserNotFoundError } from '@nagiyu/auth-core';
 import { COMMON_ERROR_MESSAGES, VALID_ROLES, hasPermission } from '@nagiyu/common';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { z } from 'zod';
 import { getSession } from '@/lib/auth/session';
 
@@ -89,6 +90,14 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ use
       return NextResponse.json({ error: ERROR_MESSAGES.USER_NOT_FOUND }, { status: 404 });
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await reportErrorEvent({
+      serviceId: 'auth',
+      severity: 'error',
+      title: 'Web API: ロール割り当てエラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     console.error('Error assigning roles:', error);
     return NextResponse.json({ error: 'ロールの割り当てに失敗しました' }, { status: 500 });
   }

--- a/services/auth/web/src/app/api/users/[userId]/route.ts
+++ b/services/auth/web/src/app/api/users/[userId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createUserRepository, UserNotFoundError } from '@nagiyu/auth-core';
 import { getSession } from '@/lib/auth/session';
 import { COMMON_ERROR_MESSAGES, hasPermission } from '@nagiyu/common';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { UpdateUserSchema } from '../schemas';
 import { ZodError } from 'zod';
 
@@ -48,6 +49,14 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ user
 
     return NextResponse.json(user);
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await reportErrorEvent({
+      serviceId: 'auth',
+      severity: 'error',
+      title: 'Web API: ユーザー詳細取得エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     console.error('Error fetching user:', error);
     return NextResponse.json({ error: 'ユーザー情報の取得に失敗しました' }, { status: 500 });
   }
@@ -126,6 +135,14 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ us
       return NextResponse.json({ error: ERROR_MESSAGES.USER_NOT_FOUND }, { status: 404 });
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await reportErrorEvent({
+      serviceId: 'auth',
+      severity: 'error',
+      title: 'Web API: ユーザー情報更新エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     console.error('Error updating user:', error);
     return NextResponse.json({ error: 'ユーザー情報の更新に失敗しました' }, { status: 500 });
   }
@@ -173,6 +190,14 @@ export async function DELETE(
 
     return NextResponse.json({ message: 'ユーザーが正常に削除されました' });
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await reportErrorEvent({
+      serviceId: 'auth',
+      severity: 'error',
+      title: 'Web API: ユーザー削除エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     console.error('Error deleting user:', error);
     return NextResponse.json({ error: 'ユーザーの削除に失敗しました' }, { status: 500 });
   }

--- a/services/auth/web/src/app/api/users/me/route.ts
+++ b/services/auth/web/src/app/api/users/me/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createUserRepository } from '@nagiyu/auth-core';
 import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { getSession } from '@/lib/auth/session';
 
 // エラーメッセージ定数
@@ -33,6 +34,17 @@ export async function GET() {
 
     return NextResponse.json(user);
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await reportErrorEvent({
+      serviceId: 'auth',
+      severity: 'error',
+      title: 'Web API: 自分のユーザー情報取得エラー',
+      message: errorMessage,
+      context: {
+        userId: session.user.id,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     console.error('Error fetching current user:', error);
     return NextResponse.json({ error: 'ユーザー情報の取得に失敗しました' }, { status: 500 });
   }

--- a/services/auth/web/src/app/api/users/route.ts
+++ b/services/auth/web/src/app/api/users/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createUserRepository } from '@nagiyu/auth-core';
 import { COMMON_ERROR_MESSAGES, hasPermission } from '@nagiyu/common';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { ListUsersQuerySchema } from './schemas';
 import { ZodError } from 'zod';
 import { getSession } from '@/lib/auth/session';
@@ -84,6 +85,14 @@ export async function GET(req: NextRequest) {
       );
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await reportErrorEvent({
+      serviceId: 'auth',
+      severity: 'error',
+      title: 'Web API: ユーザー一覧取得エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     console.error('Error fetching users:', error);
     return NextResponse.json({ error: 'ユーザー一覧の取得に失敗しました' }, { status: 500 });
   }

--- a/services/auth/web/tests/unit/app/api/users/route.test.ts
+++ b/services/auth/web/tests/unit/app/api/users/route.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for GET /api/users endpoint
+ *
+ * NOTE: このテストは jest.config.ts の testPathIgnorePatterns により
+ * 自動テストランナーから除外されています（既存の規約に従い）。
+ */
+
+import { GET } from '../../../../../src/app/api/users/route';
+
+const mockListUsers = jest.fn();
+const mockReportErrorEvent = jest.fn().mockResolvedValue(null);
+const mockHasPermission = jest.fn();
+const mockGetSession = jest.fn();
+
+jest.mock('@nagiyu/auth-core', () => ({
+  createUserRepository: jest.fn().mockReturnValue({ listUsers: mockListUsers }),
+}));
+
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: mockReportErrorEvent,
+}));
+
+jest.mock('@nagiyu/common', () => ({
+  COMMON_ERROR_MESSAGES: {
+    UNAUTHORIZED: '認証が必要です',
+    FORBIDDEN: 'この操作を実行する権限がありません',
+    INVALID_REQUEST_PARAMS: 'クエリパラメータが不正です',
+  },
+  hasPermission: mockHasPermission,
+}));
+
+jest.mock('../../../../../src/lib/auth/session', () => ({
+  getSession: mockGetSession,
+}));
+
+describe('GET /api/users', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReportErrorEvent.mockResolvedValue(null);
+  });
+
+  describe('エラーパス', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ user: { id: 'admin', roles: ['admin'] } });
+      mockHasPermission.mockReturnValue(true);
+    });
+
+    it('DB エラー時は reportErrorEvent を呼び 500 を返す', async () => {
+      mockListUsers.mockRejectedValueOnce(new Error('DynamoDB scan failed'));
+
+      const req = new Request('http://localhost/api/users') as unknown as Parameters<typeof GET>[0];
+      const response = await GET(req);
+
+      expect(response.status).toBe(500);
+      expect(mockReportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'auth',
+          severity: 'error',
+          title: 'Web API: ユーザー一覧取得エラー',
+          message: 'DynamoDB scan failed',
+        })
+      );
+      const call = mockReportErrorEvent.mock.calls[0][0];
+      expect(JSON.stringify(call.context)).not.toContain('email');
+      expect(JSON.stringify(call.context)).not.toContain('googleId');
+    });
+  });
+});

--- a/services/codec-converter/batch/Dockerfile
+++ b/services/codec-converter/batch/Dockerfile
@@ -23,6 +23,8 @@ COPY services/codec-converter ./services/codec-converter/
 RUN npm install --prefer-offline --no-audit
 
 # モノレポのルートからビルド（共通ライブラリも含めて）
+RUN npm run build --workspace=@nagiyu/common
+RUN npm run build --workspace=@nagiyu/aws
 RUN npm run build --workspace=@nagiyu/codec-converter-core
 RUN npm run build --workspace=@nagiyu/codec-converter-batch
 

--- a/services/codec-converter/batch/Dockerfile
+++ b/services/codec-converter/batch/Dockerfile
@@ -39,6 +39,10 @@ COPY --from=builder /app/node_modules ./node_modules
 
 # 必要なビルド成果物とpackage.jsonをコピー
 COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/libs/common/package*.json ./libs/common/
+COPY --from=builder /app/libs/common/dist ./libs/common/dist
+COPY --from=builder /app/libs/aws/package*.json ./libs/aws/
+COPY --from=builder /app/libs/aws/dist ./libs/aws/dist
 COPY --from=builder /app/services/codec-converter/core/package*.json ./services/codec-converter/core/
 COPY --from=builder /app/services/codec-converter/core/dist ./services/codec-converter/core/dist
 COPY --from=builder /app/services/codec-converter/batch/package*.json ./services/codec-converter/batch/

--- a/services/codec-converter/batch/jest.config.ts
+++ b/services/codec-converter/batch/jest.config.ts
@@ -11,6 +11,8 @@ const config: Config.InitialOptions = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
+    '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
   },
   transform: {
     '^.+\\.ts$': [

--- a/services/codec-converter/batch/package.json
+++ b/services/codec-converter/batch/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/client-dynamodb": "^3.1024.0",
     "@aws-sdk/client-s3": "^3.1024.0",
     "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@nagiyu/aws": "*",
     "@nagiyu/codec-converter-core": "*"
   },
   "devDependencies": {

--- a/services/codec-converter/batch/src/index.ts
+++ b/services/codec-converter/batch/src/index.ts
@@ -350,7 +350,8 @@ export async function processJob(
         errorMessage
       );
     } catch (updateError) {
-      const updateErrorMessage = updateError instanceof Error ? updateError.message : String(updateError);
+      const updateErrorMessage =
+        updateError instanceof Error ? updateError.message : String(updateError);
       console.error('Failed to update job status to FAILED:', updateError);
       await reportErrorEvent({
         serviceId: 'codec-converter',
@@ -365,7 +366,8 @@ export async function processJob(
     try {
       await cleanup([inputPath, outputPath]);
     } catch (cleanupError) {
-      const cleanupErrorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      const cleanupErrorMessage =
+        cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
       console.error('Cleanup failed:', cleanupError);
       await reportErrorEvent({
         serviceId: 'codec-converter',

--- a/services/codec-converter/batch/src/index.ts
+++ b/services/codec-converter/batch/src/index.ts
@@ -6,6 +6,7 @@ import { createWriteStream, createReadStream, promises as fs } from 'fs';
 import { pipeline } from 'stream/promises';
 import { Readable } from 'stream';
 import type { CodecType } from '@nagiyu/codec-converter-core';
+import { reportErrorEvent } from '@nagiyu/aws';
 
 // エラーメッセージ定数
 const ERROR_MESSAGES = {
@@ -326,6 +327,17 @@ export async function processJob(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`Job ${env.JOB_ID} failed:`, errorMessage);
+    await reportErrorEvent({
+      serviceId: 'codec-converter',
+      severity: 'critical',
+      title: 'Batchジョブが失敗しました',
+      message: errorMessage,
+      context: {
+        jobId: env.JOB_ID,
+        outputCodec: env.OUTPUT_CODEC,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
 
     // ステータスをFAILEDに更新
     try {
@@ -338,14 +350,30 @@ export async function processJob(
         errorMessage
       );
     } catch (updateError) {
+      const updateErrorMessage = updateError instanceof Error ? updateError.message : String(updateError);
       console.error('Failed to update job status to FAILED:', updateError);
+      await reportErrorEvent({
+        serviceId: 'codec-converter',
+        severity: 'error',
+        title: 'ジョブステータスのFAILD更新に失敗しました',
+        message: updateErrorMessage,
+        context: { jobId: env.JOB_ID, originalError: errorMessage },
+      });
     }
 
     // クリーンアップを試みる（エラーは無視）
     try {
       await cleanup([inputPath, outputPath]);
     } catch (cleanupError) {
+      const cleanupErrorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
       console.error('Cleanup failed:', cleanupError);
+      await reportErrorEvent({
+        serviceId: 'codec-converter',
+        severity: 'warning',
+        title: '一時ファイルのクリーンアップに失敗しました',
+        message: cleanupErrorMessage,
+        context: { jobId: env.JOB_ID },
+      });
     }
 
     throw error;

--- a/services/codec-converter/batch/tests/integration/index.test.ts
+++ b/services/codec-converter/batch/tests/integration/index.test.ts
@@ -19,6 +19,13 @@ import type { ChildProcess } from 'child_process';
 import type { CodecType } from '@nagiyu/codec-converter-core';
 import type { SdkStream } from '@smithy/types';
 
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+import { reportErrorEvent } from '@nagiyu/aws';
+const reportErrorEventMock = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
+
 // AWS SDK モック
 const s3Mock = mockClient(S3Client);
 const dynamodbMock = mockClient(DynamoDBDocumentClient);
@@ -402,6 +409,41 @@ describe('convertWithFFmpeg', () => {
     );
   });
 
+  it('FFmpeg stderr に time= が含まれる場合は進捗ログを出力する', async () => {
+    const mockFFmpeg = {
+      stdout: { on: jest.fn() },
+      stderr: {
+        on: jest.fn((event, callback) => {
+          if (event === 'data') {
+            callback(Buffer.from('frame=10 time=00:00:05.00 bitrate=100'));
+          }
+        }),
+      },
+      on: jest.fn((event, callback) => {
+        if (event === 'close') callback(0);
+      }),
+    } as unknown as ChildProcess;
+    spawnMock.mockReturnValue(mockFFmpeg);
+
+    await convertWithFFmpeg('/tmp/input.mp4', '/tmp/output.mp4', 'h264');
+    expect(spawnMock).toHaveBeenCalled();
+  });
+
+  it('FFmpeg プロセス自体がエラーを発生させた場合はエラー', async () => {
+    const mockFFmpeg = {
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: jest.fn((event, callback) => {
+        if (event === 'error') callback(new Error('spawn error'));
+      }),
+    } as unknown as ChildProcess;
+    spawnMock.mockReturnValue(mockFFmpeg);
+
+    await expect(convertWithFFmpeg('/tmp/input.mp4', '/tmp/output.mp4', 'h264')).rejects.toThrow(
+      'FFmpegの実行に失敗しました'
+    );
+  });
+
   it('FFmpegが失敗した場合はエラー', async () => {
     const mockFFmpeg = {
       stdout: { on: jest.fn() },
@@ -464,6 +506,132 @@ describe('processJob', () => {
     spawnMock.mockClear();
     unlinkMock.mockClear();
     unlinkMock.mockResolvedValue(undefined);
+    reportErrorEventMock.mockClear();
+  });
+
+  it('S3ダウンロード失敗時に reportErrorEvent が critical で呼ばれる', async () => {
+    s3Mock.on(GetObjectCommand).rejects(new Error('S3 download error'));
+    dynamodbMock.on(UpdateCommand).resolves({});
+
+    const env = {
+      S3_BUCKET: 'test-bucket',
+      DYNAMODB_TABLE: 'test-table',
+      AWS_REGION: 'ap-northeast-1',
+      JOB_ID: 'test-job-id',
+      OUTPUT_CODEC: 'h264' as CodecType,
+    };
+
+    const s3Client = new S3Client({ region: 'us-east-1' });
+    const dynamodbClient = createMockDynamoDBClient();
+
+    await expect(processJob(env, s3Client, dynamodbClient)).rejects.toThrow();
+
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'codec-converter',
+        severity: 'critical',
+        context: expect.objectContaining({ jobId: 'test-job-id' }),
+      })
+    );
+  });
+
+  it('FFmpeg失敗時に reportErrorEvent が critical で呼ばれる', async () => {
+    const mockBody = Readable.from(['test content']);
+    s3Mock.on(GetObjectCommand).resolves({ Body: mockBody as SdkStream<Readable> });
+    dynamodbMock.on(UpdateCommand).resolves({});
+
+    const mockFFmpeg = {
+      stdout: { on: jest.fn() },
+      stderr: {
+        on: jest.fn((event, callback) => {
+          if (event === 'data') callback(Buffer.from('ffmpeg error output'));
+        }),
+      },
+      on: jest.fn((event, callback) => {
+        if (event === 'close') callback(1); // 異常終了
+      }),
+    } as unknown as ChildProcess;
+    spawnMock.mockReturnValue(mockFFmpeg);
+
+    const env = {
+      S3_BUCKET: 'test-bucket',
+      DYNAMODB_TABLE: 'test-table',
+      AWS_REGION: 'ap-northeast-1',
+      JOB_ID: 'test-job-ffmpeg',
+      OUTPUT_CODEC: 'h264' as CodecType,
+    };
+
+    const s3Client = new S3Client({ region: 'us-east-1' });
+    const dynamodbClient = createMockDynamoDBClient();
+
+    await expect(processJob(env, s3Client, dynamodbClient)).rejects.toThrow();
+
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'codec-converter',
+        severity: 'critical',
+        context: expect.objectContaining({ jobId: 'test-job-ffmpeg', outputCodec: 'h264' }),
+      })
+    );
+  });
+
+  it('ジョブステータス更新失敗時に reportErrorEvent が error で呼ばれる', async () => {
+    s3Mock.on(GetObjectCommand).rejects(new Error('S3 error'));
+    // 1回目（PROCESSING更新）は成功、2回目（FAILED更新）は失敗
+    let callCount = 0;
+    dynamodbMock.on(UpdateCommand).callsFake(() => {
+      callCount++;
+      if (callCount === 2) throw new Error('DynamoDB update failed');
+      return {};
+    });
+
+    const env = {
+      S3_BUCKET: 'test-bucket',
+      DYNAMODB_TABLE: 'test-table',
+      AWS_REGION: 'ap-northeast-1',
+      JOB_ID: 'test-job-status',
+      OUTPUT_CODEC: 'vp9' as CodecType,
+    };
+
+    const s3Client = new S3Client({ region: 'us-east-1' });
+    const dynamodbClient = createMockDynamoDBClient();
+
+    await expect(processJob(env, s3Client, dynamodbClient)).rejects.toThrow();
+
+    // critical（ジョブ失敗）と error（ステータス更新失敗）の2回呼ばれる
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'codec-converter', severity: 'critical' })
+    );
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'codec-converter', severity: 'error' })
+    );
+  });
+
+  it('エラー後のクリーンアップ失敗時に reportErrorEvent が warning で呼ばれる', async () => {
+    s3Mock.on(GetObjectCommand).rejects(new Error('S3 error'));
+    dynamodbMock.on(UpdateCommand).resolves({});
+    // FAILED ステータス更新後にクリーンアップが失敗するようにモックを設定
+    const permissionError = new Error('Permission denied');
+    (permissionError as NodeJS.ErrnoException).code = 'EACCES';
+    const unlinkMock = fs.unlink as jest.MockedFunction<typeof fs.unlink>;
+    unlinkMock.mockRejectedValue(permissionError);
+
+    const env = {
+      S3_BUCKET: 'test-bucket',
+      DYNAMODB_TABLE: 'test-table',
+      AWS_REGION: 'ap-northeast-1',
+      JOB_ID: 'test-job-cleanup',
+      OUTPUT_CODEC: 'h264' as CodecType,
+    };
+
+    const s3Client = new S3Client({ region: 'us-east-1' });
+    const dynamodbClient = createMockDynamoDBClient();
+
+    await expect(processJob(env, s3Client, dynamodbClient)).rejects.toThrow();
+
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'codec-converter', severity: 'warning' })
+    );
   });
 
   it.skip('ジョブ処理が成功する', async () => {

--- a/services/codec-converter/web/src/app/api/jobs/[jobId]/submit/route.ts
+++ b/services/codec-converter/web/src/app/api/jobs/[jobId]/submit/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { GetCommand } from '@aws-sdk/lib-dynamodb';
 import { HeadObjectCommand } from '@aws-sdk/client-s3';
 import { SubmitJobCommand } from '@aws-sdk/client-batch';
-import { getAwsClients } from '@nagiyu/aws';
+import { getAwsClients, reportErrorEvent } from '@nagiyu/aws';
 import { type Job, type JobStatus, selectJobDefinition } from '@nagiyu/codec-converter-core';
 import type { ErrorResponse } from '@nagiyu/common';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
@@ -36,9 +36,10 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ jobId: string }> }
 ): Promise<NextResponse<SubmitJobResponse | ErrorResponse>> {
+  let jobId: string | undefined;
   try {
     // パスパラメータの取得
-    const { jobId } = await params;
+    ({ jobId } = await params);
 
     // AWS クライアントと環境変数の取得
     const { DYNAMODB_TABLE, S3_BUCKET, BATCH_JOB_QUEUE, BATCH_JOB_DEFINITION_PREFIX, AWS_REGION } =
@@ -85,7 +86,19 @@ export async function POST(
         })
       );
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Input file not found in S3:', error);
+      await reportErrorEvent({
+        serviceId: 'codec-converter',
+        severity: 'error',
+        title: '入力ファイルがS3に存在しません',
+        message: errorMessage,
+        context: {
+          jobId,
+          s3Key: job.inputFile,
+          errorStack: error instanceof Error ? error.stack : undefined,
+        },
+      });
       return NextResponse.json(
         {
           error: 'FILE_NOT_FOUND',
@@ -169,7 +182,18 @@ export async function POST(
       { status: 200 }
     );
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('Error submitting job:', error);
+    await reportErrorEvent({
+      serviceId: 'codec-converter',
+      severity: 'error',
+      title: 'Batchジョブの投入に失敗しました',
+      message: errorMessage,
+      context: {
+        jobId,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     return NextResponse.json(
       {
         error: 'INTERNAL_SERVER_ERROR',

--- a/services/codec-converter/web/src/app/api/jobs/route.ts
+++ b/services/codec-converter/web/src/app/api/jobs/route.ts
@@ -10,7 +10,7 @@ import {
   type CodecType,
 } from '@nagiyu/codec-converter-core';
 import type { ErrorResponse } from '@nagiyu/common';
-import { getAwsClients } from '@nagiyu/aws';
+import { getAwsClients, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 
 // Presigned URLの有効期限（1時間 = 3600秒）
@@ -149,7 +149,15 @@ export async function POST(
       { status: 201 }
     );
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('Error creating job:', error);
+    await reportErrorEvent({
+      serviceId: 'codec-converter',
+      severity: 'error',
+      title: 'ジョブ作成に失敗しました',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return NextResponse.json(
       {
         error: 'INTERNAL_SERVER_ERROR',

--- a/services/niconico-mylist-assistant/batch/jest.config.ts
+++ b/services/niconico-mylist-assistant/batch/jest.config.ts
@@ -13,6 +13,7 @@ const config: Config.InitialOptions = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/common/push$': '<rootDir>/../../../libs/common/src/push/index.ts',
   },

--- a/services/niconico-mylist-assistant/batch/src/index.ts
+++ b/services/niconico-mylist-assistant/batch/src/index.ts
@@ -6,6 +6,7 @@
 
 import { decrypt, updateBatchJob, getBatchJob } from '@nagiyu/niconico-mylist-assistant-core';
 import type { CryptoConfig } from '@nagiyu/niconico-mylist-assistant-core';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { sendWebPushNotification, getVapidConfig } from '@nagiyu/common/push';
 import { executeMylistRegistration } from './playwright-automation.js';
 import {
@@ -123,6 +124,16 @@ async function decryptPassword(encryptedData: string, config: CryptoConfig): Pro
     return password;
   } catch (error) {
     console.error('パスワードの復号化に失敗しました:', error);
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'critical',
+      title: 'パスワード復号化失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     throw new Error(
       `${ERROR_MESSAGES.DECRYPTION_FAILED}: ${error instanceof Error ? error.message : String(error)}`
     );
@@ -363,6 +374,19 @@ async function main() {
     console.error(`エラー時刻: ${getTimestamp()}`);
     console.error('エラー詳細:', error);
     console.error('========================================');
+
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'critical',
+      title: 'バッチジョブ全体の失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        jobId: params?.jobId,
+        userId: params?.userId,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    });
 
     // ジョブステータスを FAILED に更新
     if (params?.jobId && params?.userId) {

--- a/services/niconico-mylist-assistant/batch/src/index.ts
+++ b/services/niconico-mylist-assistant/batch/src/index.ts
@@ -365,6 +365,18 @@ async function main() {
     // （全失敗の場合のみエラー終了）
     if (result.successVideoIds.length === 0 && result.failedVideoIds.length > 0) {
       console.error('全ての動画の登録に失敗しました');
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'critical',
+        title: 'バッチジョブ全失敗',
+        message: result.errorMessage ?? '全ての動画の登録に失敗しました',
+        context: {
+          jobId: params?.jobId,
+          userId: params?.userId,
+          failedCount: result.failedVideoIds.length,
+          errorMessage: result.errorMessage,
+        },
+      });
       process.exit(1);
     }
   } catch (error) {

--- a/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
+++ b/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
@@ -723,6 +723,18 @@ export async function executeMylistRegistration(
 
     console.error('マイリスト登録処理でエラーが発生しました:', errorMessage);
 
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'Playwright 自動化処理失敗',
+      message: errorMessage,
+      context: {
+        step: 'executeMylistRegistration',
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    });
+
     return {
       successVideoIds: [],
       failedVideoIds: videoIds,

--- a/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
+++ b/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
@@ -13,7 +13,7 @@ import {
   VIDEO_REGISTRATION_WAIT,
 } from './constants.js';
 import { MylistRegistrationResult, LoginResult } from './types.js';
-import { createS3Client, uploadFile, getS3ObjectUrl } from '@nagiyu/aws';
+import { createS3Client, uploadFile, getS3ObjectUrl, reportErrorEvent } from '@nagiyu/aws';
 import { readFile } from 'fs/promises';
 
 const VIDEO_RETRY_OPTIONS: Pick<
@@ -71,6 +71,16 @@ export async function login(page: Page, email: string, password: string): Promis
     return { requires2FA: false };
   } catch (error) {
     console.error('ログイン失敗:', error);
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'ニコニコログイン失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        step: 'login',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
     throw new Error(ERROR_MESSAGES.LOGIN_FAILED);
   }
 }

--- a/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
+++ b/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
@@ -1,3 +1,5 @@
+const mockChromiumLaunch = jest.fn();
+
 jest.mock('@nagiyu/aws', () => ({
   ...jest.requireActual('@nagiyu/aws'),
   reportErrorEvent: jest.fn().mockResolvedValue(null),
@@ -8,14 +10,11 @@ jest.mock('@nagiyu/aws', () => ({
 
 jest.mock('playwright', () => ({
   chromium: {
-    launch: jest.fn().mockResolvedValue({
-      newPage: jest.fn(),
-      close: jest.fn(),
-    }),
+    launch: (...args: unknown[]) => mockChromiumLaunch(...args),
   },
 }));
 
-import { login } from '../../src/playwright-automation';
+import { login, executeMylistRegistration } from '../../src/playwright-automation';
 import { reportErrorEvent } from '@nagiyu/aws';
 import type { Page } from 'playwright';
 
@@ -52,6 +51,30 @@ describe('playwright-automation', () => {
           severity: 'error',
           title: 'ニコニコログイン失敗',
           context: expect.objectContaining({ step: 'login' }),
+        })
+      );
+    });
+  });
+
+  describe('executeMylistRegistration', () => {
+    it('ブラウザ起動失敗時に reportErrorEvent を呼ぶ', async () => {
+      mockChromiumLaunch.mockRejectedValue(new Error('Executable does not exist'));
+
+      const result = await executeMylistRegistration(
+        'test@example.com',
+        'password',
+        'test-mylist',
+        ['sm1', 'sm2']
+      );
+
+      expect(result.successVideoIds).toHaveLength(0);
+      expect(result.failedVideoIds).toEqual(['sm1', 'sm2']);
+      expect(jest.mocked(reportErrorEvent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'niconico-mylist-assistant',
+          severity: 'error',
+          title: 'Playwright 自動化処理失敗',
+          context: expect.objectContaining({ step: 'executeMylistRegistration' }),
         })
       );
     });

--- a/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
+++ b/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
@@ -1,0 +1,59 @@
+jest.mock('@nagiyu/aws', () => ({
+  ...jest.requireActual('@nagiyu/aws'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+  createS3Client: jest.fn().mockReturnValue(null),
+  uploadFile: jest.fn().mockResolvedValue(undefined),
+  getS3ObjectUrl: jest.fn().mockReturnValue(''),
+}));
+
+jest.mock('playwright', () => ({
+  chromium: {
+    launch: jest.fn().mockResolvedValue({
+      newPage: jest.fn(),
+      close: jest.fn(),
+    }),
+  },
+}));
+
+import { login } from '../../src/playwright-automation';
+import { reportErrorEvent } from '@nagiyu/aws';
+import type { Page } from 'playwright';
+
+function createMockPage(overrides: Partial<Record<string, jest.Mock>> = {}): Page {
+  return {
+    goto: jest.fn().mockRejectedValue(new Error('Navigation timeout')),
+    fill: jest.fn(),
+    getByRole: jest.fn().mockReturnValue({ click: jest.fn() }),
+    waitForURL: jest.fn(),
+    url: jest.fn().mockReturnValue('https://example.com'),
+    screenshot: jest.fn().mockResolvedValue(Buffer.from('')),
+    locator: jest.fn().mockReturnValue({ all: jest.fn().mockResolvedValue([]) }),
+    on: jest.fn(),
+    ...overrides,
+  } as unknown as Page;
+}
+
+describe('playwright-automation', () => {
+  beforeEach(() => {
+    jest.mocked(reportErrorEvent).mockClear();
+  });
+
+  describe('login', () => {
+    it('ログイン失敗時に reportErrorEvent を呼ぶ', async () => {
+      const mockPage = createMockPage({
+        goto: jest.fn().mockRejectedValue(new Error('Navigation timeout')),
+      });
+
+      await expect(login(mockPage, 'test@example.com', 'password')).rejects.toThrow();
+
+      expect(jest.mocked(reportErrorEvent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'niconico-mylist-assistant',
+          severity: 'error',
+          title: 'ニコニコログイン失敗',
+          context: expect.objectContaining({ step: 'login' }),
+        })
+      );
+    });
+  });
+});

--- a/services/niconico-mylist-assistant/core/src/db/videos.ts
+++ b/services/niconico-mylist-assistant/core/src/db/videos.ts
@@ -1,4 +1,4 @@
-import { getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 import { createVideoRepository, createUserSettingRepository } from '../repositories/factory.js';
 import type { VideoRepository } from '../repositories/video.repository.interface.js';
 import type { UserSettingRepository } from '../repositories/user-setting.repository.interface.js';
@@ -43,8 +43,23 @@ function getUserSettingRepository(): UserSettingRepository {
 export async function createVideoBasicInfo(
   input: CreateVideoBasicInfoInput
 ): Promise<VideoBasicInfo> {
-  const entity = await getVideoRepository().create(input);
-  return entity as VideoBasicInfo;
+  try {
+    const entity = await getVideoRepository().create(input);
+    return entity as VideoBasicInfo;
+  } catch (error) {
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'DynamoDB 動画基本情報書き込み失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        videoId: input.videoId,
+        operation: 'createVideoBasicInfo',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    throw error;
+  }
 }
 
 /**
@@ -96,8 +111,24 @@ export async function createUserVideoSetting(
 export async function upsertUserVideoSetting(
   input: CreateUserSettingInput
 ): Promise<UserVideoSetting> {
-  const entity = await getUserSettingRepository().upsert(input);
-  return entity as UserVideoSetting;
+  try {
+    const entity = await getUserSettingRepository().upsert(input);
+    return entity as UserVideoSetting;
+  } catch (error) {
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'DynamoDB ユーザー設定書き込み失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        userId: input.userId,
+        videoId: input.videoId,
+        operation: 'upsertUserVideoSetting',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    throw error;
+  }
 }
 
 /**
@@ -122,8 +153,24 @@ export async function updateUserVideoSetting(
   videoId: string,
   update: VideoSettingUpdate
 ): Promise<UserVideoSetting> {
-  const entity = await getUserSettingRepository().update(userId, videoId, update);
-  return entity as UserVideoSetting;
+  try {
+    const entity = await getUserSettingRepository().update(userId, videoId, update);
+    return entity as UserVideoSetting;
+  } catch (error) {
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'DynamoDB ユーザー設定更新失敗',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        userId,
+        videoId,
+        operation: 'updateUserVideoSetting',
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    throw error;
+  }
 }
 
 /**

--- a/services/niconico-mylist-assistant/core/src/niconico/client.ts
+++ b/services/niconico-mylist-assistant/core/src/niconico/client.ts
@@ -1,4 +1,5 @@
 import { parseStringPromise } from 'xml2js';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { NICONICO_ERROR_MESSAGES } from './constants.js';
 
 export interface NiconicoVideoInfo {
@@ -81,6 +82,16 @@ export async function getVideoInfo(videoId: string): Promise<NiconicoVideoInfo> 
     };
   } catch (error) {
     if (error instanceof NiconicoAPIError) {
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'error',
+        title: 'Niconico API エラー',
+        message: error.message,
+        context: {
+          videoId: error.videoId,
+          errorCode: error.code,
+        },
+      });
       throw error;
     }
 

--- a/services/niconico-mylist-assistant/core/tests/unit/videos.test.ts
+++ b/services/niconico-mylist-assistant/core/tests/unit/videos.test.ts
@@ -1,6 +1,11 @@
 // テスト実行前にDYNAMODB_TABLE_NAMEを設定
 process.env.DYNAMODB_TABLE_NAME = 'test-table';
 
+jest.mock('@nagiyu/aws', () => ({
+  ...jest.requireActual('@nagiyu/aws'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
 import { mockClient } from 'aws-sdk-client-mock';
 import {
   DynamoDBDocumentClient,
@@ -22,6 +27,7 @@ import {
   listUserVideoSettings,
   deleteUserVideoSetting,
 } from '../../src/db/videos';
+import { reportErrorEvent } from '@nagiyu/aws';
 import type {
   CreateVideoBasicInfoInput,
   CreateUserSettingInput,
@@ -33,6 +39,7 @@ const ddbMock = mockClient(DynamoDBDocumentClient);
 describe('videos', () => {
   beforeEach(() => {
     ddbMock.reset();
+    jest.mocked(reportErrorEvent).mockClear();
   });
 
   describe('VIDEO エンティティ', () => {
@@ -81,6 +88,15 @@ describe('videos', () => {
         };
 
         await expect(createVideoBasicInfo(input)).rejects.toThrow('エンティティは既に存在します');
+
+        expect(jest.mocked(reportErrorEvent)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            serviceId: 'niconico-mylist-assistant',
+            severity: 'error',
+            title: 'DynamoDB 動画基本情報書き込み失敗',
+            context: expect.objectContaining({ videoId: 'sm12345678' }),
+          })
+        );
       });
     });
 
@@ -448,6 +464,15 @@ describe('videos', () => {
 
         await expect(updateUserVideoSetting('user123', 'sm99999999', update)).rejects.toThrow(
           'エンティティが見つかりません'
+        );
+
+        expect(jest.mocked(reportErrorEvent)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            serviceId: 'niconico-mylist-assistant',
+            severity: 'error',
+            title: 'DynamoDB ユーザー設定更新失敗',
+            context: expect.objectContaining({ userId: 'user123', videoId: 'sm99999999' }),
+          })
         );
       });
     });

--- a/services/niconico-mylist-assistant/web/src/app/api/mylist/register/route.ts
+++ b/services/niconico-mylist-assistant/web/src/app/api/mylist/register/route.ts
@@ -5,7 +5,7 @@ import {
   encrypt,
   createBatchJob,
 } from '@nagiyu/niconico-mylist-assistant-core';
-import { getBatchClient } from '@nagiyu/aws';
+import { getBatchClient, reportErrorEvent } from '@nagiyu/aws';
 import type { CryptoConfig } from '@nagiyu/niconico-mylist-assistant-core';
 import { getSession } from '@/lib/auth/session';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
@@ -254,6 +254,16 @@ export async function POST(
       encryptedPasswordJson = JSON.stringify(encryptedData);
     } catch (error) {
       console.error('パスワード暗号化エラー:', error);
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'error',
+        title: 'パスワード暗号化エラー',
+        message: error instanceof Error ? error.message : String(error),
+        context: {
+          userId: session.user.userId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
       return NextResponse.json(
         {
           error: 'ENCRYPTION_ERROR',
@@ -287,6 +297,16 @@ export async function POST(
     // ジョブIDの確認
     if (!submitResult.jobId) {
       console.error('Batch job submission returned no jobId:', submitResult.jobId);
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'error',
+        title: 'Batch ジョブ ID 未取得',
+        message: 'SubmitJob のレスポンスにジョブ ID が含まれていませんでした',
+        context: {
+          userId: session.user.userId,
+          jobName,
+        },
+      });
       return NextResponse.json(
         {
           error: 'BATCH_ERROR',
@@ -309,6 +329,17 @@ export async function POST(
       console.log(`バッチジョブレコードを作成しました: ${submitResult.jobId}`);
     } catch (error) {
       console.error('バッチジョブレコード作成エラー:', error);
+      await reportErrorEvent({
+        serviceId: 'niconico-mylist-assistant',
+        severity: 'error',
+        title: 'DynamoDB バッチジョブレコード作成失敗',
+        message: error instanceof Error ? error.message : String(error),
+        context: {
+          userId: session.user.userId,
+          jobId: submitResult.jobId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
       // DynamoDB への保存に失敗した場合はエラーを返す
       // ジョブステータスが照会できないため
       return NextResponse.json(
@@ -334,6 +365,16 @@ export async function POST(
     );
   } catch (error) {
     console.error('バッチジョブ投入エラー:', error);
+    await reportErrorEvent({
+      serviceId: 'niconico-mylist-assistant',
+      severity: 'error',
+      title: 'Batch ジョブ投入エラー',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+    });
 
     // AWS Batch エラー
     return NextResponse.json(

--- a/services/quick-clip/batch/Dockerfile
+++ b/services/quick-clip/batch/Dockerfile
@@ -10,6 +10,7 @@ COPY services/quick-clip ./services/quick-clip/
 
 RUN npm install --prefer-offline --no-audit
 RUN npm run build --workspace=@nagiyu/common
+RUN npm run build --workspace=@nagiyu/aws
 RUN npm run build --workspace=@nagiyu/quick-clip-core
 RUN npm run build --workspace=@nagiyu/quick-clip-batch
 
@@ -25,6 +26,8 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/libs/common/package*.json ./libs/common/
 COPY --from=builder /app/libs/common/dist ./libs/common/dist
+COPY --from=builder /app/libs/aws/package*.json ./libs/aws/
+COPY --from=builder /app/libs/aws/dist ./libs/aws/dist
 COPY --from=builder /app/services/quick-clip/core/package*.json ./services/quick-clip/core/
 COPY --from=builder /app/services/quick-clip/core/dist ./services/quick-clip/core/dist
 COPY --from=builder /app/services/quick-clip/batch/package*.json ./services/quick-clip/batch/

--- a/services/quick-clip/batch/jest.config.ts
+++ b/services/quick-clip/batch/jest.config.ts
@@ -9,6 +9,8 @@ const config: Config = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
+    '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/services/quick-clip/batch/package.json
+++ b/services/quick-clip/batch/package.json
@@ -14,6 +14,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@nagiyu/aws": "*",
     "@nagiyu/quick-clip-core": "*"
   }
 }

--- a/services/quick-clip/batch/src/entrypoint.ts
+++ b/services/quick-clip/batch/src/entrypoint.ts
@@ -1,12 +1,33 @@
+import { reportErrorEvent } from '@nagiyu/aws';
 import { runQuickClipBatch } from '@nagiyu/quick-clip-core';
 import { validateEnvironment } from './lib/environment.js';
 
+const SERVICE_ID = 'quick-clip';
+
 export const main = async (): Promise<void> => {
-  const env = validateEnvironment();
-  console.info(
-    `[QuickClipBatch] ジョブ開始: jobId=${env.jobId} command=${env.command} region=${env.awsRegion}`
-  );
-  await runQuickClipBatch(env);
+  let jobId: string | undefined;
+  try {
+    const env = validateEnvironment();
+    jobId = env.jobId;
+    console.info(
+      `[QuickClipBatch] ジョブ開始: jobId=${env.jobId} command=${env.command} region=${env.awsRegion}`
+    );
+    await runQuickClipBatch(env);
+  } catch (error) {
+    // catch を経由しない process.exit(1) 分岐でも必ずイベントを記録するため、
+    // main() 内で報告してから再スローする（fire-and-forget 禁止）。
+    await reportErrorEvent({
+      serviceId: SERVICE_ID,
+      severity: 'critical',
+      title: 'QuickClip バッチ処理が失敗しました',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        jobId,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
+    throw error;
+  }
 };
 
 if (process.env.NODE_ENV !== 'test') {

--- a/services/quick-clip/batch/tests/unit/index.test.ts
+++ b/services/quick-clip/batch/tests/unit/index.test.ts
@@ -1,7 +1,11 @@
 import { main } from '../../src/index.js';
 import * as quickClipCore from '@nagiyu/quick-clip-core';
+import { reportErrorEvent } from '@nagiyu/aws';
 import * as batchEnvironment from '../../src/lib/environment.js';
 
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
 jest.mock('@nagiyu/quick-clip-core', () => ({
   runQuickClipBatch: jest.fn().mockResolvedValue(undefined),
 }));
@@ -21,11 +25,13 @@ const coreMocks = quickClipCore as unknown as {
 const envMocks = batchEnvironment as unknown as {
   validateEnvironment: jest.Mock;
 };
+const reportErrorEventMock = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 
 describe('quick-clip batch', () => {
   beforeEach(() => {
     envMocks.validateEnvironment.mockClear();
     coreMocks.runQuickClipBatch.mockClear();
+    reportErrorEventMock.mockClear();
   });
 
   it('main: batch の validateEnvironment と core の runQuickClipBatch を呼び出す', async () => {
@@ -63,5 +69,40 @@ describe('quick-clip batch', () => {
     coreMocks.runQuickClipBatch.mockRejectedValueOnce(new Error('core error'));
 
     await expect(main()).rejects.toThrow('core error');
+  });
+
+  it('main: 正常終了時は reportErrorEvent を呼ばない', async () => {
+    await main();
+
+    expect(reportErrorEventMock).not.toHaveBeenCalled();
+  });
+
+  it('main: core のエラー時に reportErrorEvent を critical で呼ぶ', async () => {
+    coreMocks.runQuickClipBatch.mockRejectedValueOnce(new Error('core error'));
+
+    await expect(main()).rejects.toThrow('core error');
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'quick-clip',
+        severity: 'critical',
+        message: 'core error',
+        context: expect.objectContaining({ jobId: 'job-1' }),
+      })
+    );
+  });
+
+  it('main: validateEnvironment 失敗時も reportErrorEvent を critical で呼ぶ', async () => {
+    envMocks.validateEnvironment.mockImplementationOnce(() => {
+      throw new Error('env error');
+    });
+
+    await expect(main()).rejects.toThrow('env error');
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'quick-clip',
+        severity: 'critical',
+        message: 'env error',
+      })
+    );
   });
 });

--- a/services/quick-clip/core/jest.config.ts
+++ b/services/quick-clip/core/jest.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
   },
   transform: {

--- a/services/quick-clip/core/package.json
+++ b/services/quick-clip/core/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/client-dynamodb": "^3.1024.0",
     "@aws-sdk/client-s3": "^3.1024.0",
     "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@nagiyu/aws": "*",
     "@nagiyu/common": "*",
     "jszip": "^3.10.1",
     "openai": "^6.33.0",

--- a/services/quick-clip/core/src/libs/quick-clip-batch-runner.ts
+++ b/services/quick-clip/core/src/libs/quick-clip-batch-runner.ts
@@ -1,3 +1,4 @@
+import { reportErrorEvent } from '@nagiyu/aws';
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
@@ -317,6 +318,17 @@ const buildHighlights = async (
       console.warn('[buildHighlights] 感情分析をスキップします:', error);
       progress.emotionScoring = { status: 'failed' };
       await updateAnalysisProgress(jobId, { ...progress }, tableName, awsRegion);
+      await reportErrorEvent({
+        serviceId: 'quick-clip',
+        severity: 'warning',
+        title: 'QuickClip 感情分析に失敗しスキップしました',
+        message: error instanceof Error ? error.message : String(error),
+        context: {
+          jobId,
+          stage: 'emotionScoring',
+          errorStack: error instanceof Error ? error.stack : undefined,
+        },
+      });
     }
   }
 
@@ -426,6 +438,17 @@ export const runQuickClipBatch = async (env: QuickClipBatchRunInput): Promise<vo
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await updateErrorMessage(env.jobId, message, env.tableName, env.awsRegion);
+    await reportErrorEvent({
+      serviceId: 'quick-clip',
+      severity: 'error',
+      title: 'QuickClip 抽出処理が失敗しました',
+      message,
+      context: {
+        jobId: env.jobId,
+        command: env.command,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     throw error;
   }
 };

--- a/services/quick-clip/core/tests/unit/libs/quick-clip-batch-runner.test.ts
+++ b/services/quick-clip/core/tests/unit/libs/quick-clip-batch-runner.test.ts
@@ -124,10 +124,17 @@ jest.mock('../../../src/libs/emotion-highlight.service.js', () => ({
   })),
 }));
 
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+import { reportErrorEvent } from '@nagiyu/aws';
 import {
   runQuickClipBatch,
   type QuickClipBatchRunInput,
 } from '../../../src/libs/quick-clip-batch-runner.js';
+
+const reportErrorEventMock = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 
 const input: QuickClipBatchRunInput = {
   command: 'extract',
@@ -217,6 +224,14 @@ describe('runQuickClipBatch', () => {
     expect(mockUpdateErrorMessage).toHaveBeenCalledWith(
       'job-1',
       'アップロード済みの動画ファイルが見つかりません: uploads/job-1/input.mp4'
+    );
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'quick-clip',
+        severity: 'error',
+        message: 'アップロード済みの動画ファイルが見つかりません: uploads/job-1/input.mp4',
+        context: expect.objectContaining({ jobId: 'job-1', command: 'extract' }),
+      })
     );
   });
 
@@ -378,6 +393,25 @@ describe('runQuickClipBatch', () => {
     expect(mockAggregate).toHaveBeenCalledWith([], [], 120);
     expect(mockUpdateBatchStage).toHaveBeenCalledWith('job-1', 'clipping');
     expect(mockUpdateBatchStage).toHaveBeenCalledWith('job-1', 'aggregating');
+    expect(mockUpdateErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('感情分析の getScores が失敗した場合は reportErrorEvent を warning で呼びつつ処理を継続する', async () => {
+    mockS3Send.mockResolvedValue({ Body: { pipe: jest.fn() } });
+    mockTranscribe.mockResolvedValue([{ start: 1.0, end: 3.0, text: 'やばい！' }]);
+    mockGetScores.mockRejectedValue(new Error('emotion api failed'));
+
+    const inputWithKey: QuickClipBatchRunInput = { ...input, openAiApiKey: 'sk-test-key' };
+    await expect(runQuickClipBatch(inputWithKey)).resolves.toBeUndefined();
+
+    expect(reportErrorEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'quick-clip',
+        severity: 'warning',
+        message: 'emotion api failed',
+        context: expect.objectContaining({ jobId: 'job-1', stage: 'emotionScoring' }),
+      })
+    );
     expect(mockUpdateErrorMessage).not.toHaveBeenCalled();
   });
 

--- a/services/quick-clip/lambda/clip/Dockerfile
+++ b/services/quick-clip/lambda/clip/Dockerfile
@@ -10,6 +10,7 @@ COPY services/quick-clip ./services/quick-clip/
 
 RUN npm ci
 RUN npm run build --workspace=@nagiyu/common
+RUN npm run build --workspace=@nagiyu/aws
 RUN npm run build --workspace=@nagiyu/quick-clip-core
 RUN npm run build --workspace=@nagiyu/quick-clip-lambda-clip
 
@@ -25,6 +26,8 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/libs/common/package*.json ./libs/common/
 COPY --from=builder /app/libs/common/dist ./libs/common/dist
+COPY --from=builder /app/libs/aws/package*.json ./libs/aws/
+COPY --from=builder /app/libs/aws/dist ./libs/aws/dist
 COPY --from=builder /app/services/quick-clip/core/package*.json ./services/quick-clip/core/
 COPY --from=builder /app/services/quick-clip/core/dist ./services/quick-clip/core/dist
 COPY --from=builder /app/services/quick-clip/lambda/clip/package*.json ./services/quick-clip/lambda/clip/

--- a/services/quick-clip/lambda/clip/jest.config.ts
+++ b/services/quick-clip/lambda/clip/jest.config.ts
@@ -9,6 +9,8 @@ const config: Config = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/aws$': '<rootDir>/../../../../libs/aws/src/index.ts',
+    '^@nagiyu/common$': '<rootDir>/../../../../libs/common/src/index.ts',
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/services/quick-clip/lambda/clip/package.json
+++ b/services/quick-clip/lambda/clip/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/client-s3": "^3.1024.0",
     "@aws-sdk/lib-dynamodb": "^3.1024.0",
     "@aws-sdk/s3-request-presigner": "^3.1024.0",
+    "@nagiyu/aws": "*",
     "@nagiyu/quick-clip-core": "*",
     "ffmpeg-static": "^5.2.0"
   }

--- a/services/quick-clip/lambda/clip/src/handler.ts
+++ b/services/quick-clip/lambda/clip/src/handler.ts
@@ -7,6 +7,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { DynamoDBHighlightRepository } from '@nagiyu/quick-clip-core';
 
 const ERROR_MESSAGES = {
@@ -170,6 +171,18 @@ export const handler = async (event: ClipRegenerateEvent): Promise<ClipRegenerat
     return { clipStatus: 'GENERATED' };
   } catch (error) {
     await updateClipStatus(docClient, tableName, event, 'FAILED');
+    await reportErrorEvent({
+      serviceId: 'quick-clip',
+      severity: 'error',
+      title: 'QuickClip クリップ再生成に失敗しました',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        jobId: event.jobId,
+        highlightId: event.highlightId,
+        s3Key: CLIP_OUTPUT_KEY(event.jobId, event.highlightId),
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     throw error;
   } finally {
     await rm(dirname(localOutputPath), { recursive: true, force: true });

--- a/services/quick-clip/lambda/clip/tests/unit/handler.test.ts
+++ b/services/quick-clip/lambda/clip/tests/unit/handler.test.ts
@@ -41,6 +41,11 @@ jest.mock('@nagiyu/quick-clip-core', () => ({
   },
 }));
 
+const mockReportErrorEvent = jest.fn().mockResolvedValue(null);
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: (...args: unknown[]) => mockReportErrorEvent(...args),
+}));
+
 jest.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
 }));
@@ -116,5 +121,18 @@ describe('clip lambda handler', () => {
     const { handler } = await import('../../src/handler.js');
     await expect(handler(baseEvent)).rejects.toThrow('クリップ分割に失敗しました');
     expect(mockUpdate).toHaveBeenCalledWith('job-1', 'h-1', { clipStatus: 'FAILED' });
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'quick-clip',
+        severity: 'error',
+        context: expect.objectContaining({ jobId: 'job-1', highlightId: 'h-1' }),
+      })
+    );
+  });
+
+  it('正常系では reportErrorEvent を呼ばない', async () => {
+    const { handler } = await import('../../src/handler.js');
+    await handler(baseEvent);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
   });
 });

--- a/services/quick-clip/lambda/zip/Dockerfile
+++ b/services/quick-clip/lambda/zip/Dockerfile
@@ -5,9 +5,12 @@ WORKDIR /app
 
 COPY package*.json ./
 COPY configs ./configs/
+COPY libs ./libs/
 COPY services/quick-clip ./services/quick-clip/
 
 RUN npm ci
+RUN npm run build --workspace=@nagiyu/common
+RUN npm run build --workspace=@nagiyu/aws
 RUN npm run build --workspace=@nagiyu/quick-clip-lambda-zip
 
 FROM public.ecr.aws/lambda/nodejs:24 AS runner
@@ -17,6 +20,10 @@ ENV NODE_ENV=production
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/libs/common/package*.json ./libs/common/
+COPY --from=builder /app/libs/common/dist ./libs/common/dist
+COPY --from=builder /app/libs/aws/package*.json ./libs/aws/
+COPY --from=builder /app/libs/aws/dist ./libs/aws/dist
 COPY --from=builder /app/services/quick-clip/lambda/zip/package*.json ./services/quick-clip/lambda/zip/
 COPY --from=builder /app/services/quick-clip/lambda/zip/dist ./services/quick-clip/lambda/zip/dist
 

--- a/services/quick-clip/lambda/zip/jest.config.ts
+++ b/services/quick-clip/lambda/zip/jest.config.ts
@@ -9,6 +9,8 @@ const config: Config = {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/aws$': '<rootDir>/../../../../libs/aws/src/index.ts',
+    '^@nagiyu/common$': '<rootDir>/../../../../libs/common/src/index.ts',
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/services/quick-clip/lambda/zip/package.json
+++ b/services/quick-clip/lambda/zip/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1024.0",
     "@aws-sdk/s3-request-presigner": "^3.1024.0",
+    "@nagiyu/aws": "*",
     "jszip": "^3.10.1"
   }
 }

--- a/services/quick-clip/lambda/zip/src/handler.ts
+++ b/services/quick-clip/lambda/zip/src/handler.ts
@@ -1,3 +1,4 @@
+import { reportErrorEvent } from '@nagiyu/aws';
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import JSZip from 'jszip';
@@ -120,8 +121,24 @@ export const handler = async (event: ZipGeneratorEvent): Promise<ZipGeneratorRes
   validateEvent(event);
   const { bucketName, awsRegion } = validateEnvironment();
   const s3Client = new S3Client({ region: awsRegion });
-  const zipBuffer = await buildZipBuffer(s3Client, bucketName, event);
-  await uploadZip(s3Client, bucketName, event, zipBuffer);
-  const downloadUrl = await createDownloadUrl(s3Client, bucketName, event);
-  return { downloadUrl };
+  try {
+    const zipBuffer = await buildZipBuffer(s3Client, bucketName, event);
+    await uploadZip(s3Client, bucketName, event, zipBuffer);
+    const downloadUrl = await createDownloadUrl(s3Client, bucketName, event);
+    return { downloadUrl };
+  } catch (error) {
+    await reportErrorEvent({
+      serviceId: 'quick-clip',
+      severity: 'error',
+      title: 'QuickClip ZIP 生成に失敗しました',
+      message: error instanceof Error ? error.message : String(error),
+      context: {
+        jobId: event.jobId,
+        highlightIds: event.highlightIds,
+        s3Key: ZIP_KEY(event.jobId),
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
+    throw error;
+  }
 };

--- a/services/quick-clip/lambda/zip/tests/unit/handler.test.ts
+++ b/services/quick-clip/lambda/zip/tests/unit/handler.test.ts
@@ -24,6 +24,11 @@ jest.mock('@aws-sdk/s3-request-presigner', () => ({
   getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
 }));
 
+const mockReportErrorEvent = jest.fn().mockResolvedValue(null);
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: (...args: unknown[]) => mockReportErrorEvent(...args),
+}));
+
 describe('zip lambda handler', () => {
   beforeEach(() => {
     process.env.S3_BUCKET = 'bucket';
@@ -77,5 +82,29 @@ describe('zip lambda handler', () => {
         highlightIds: [],
       })
     ).rejects.toThrow('入力値が不正です');
+  });
+
+  it('クリップ取得に失敗した場合は reportErrorEvent を error で呼んで再スローする', async () => {
+    mockSend.mockImplementation((command: { constructor: { name: string } }) => {
+      if (command.constructor.name === 'GetObjectCommand') {
+        return Promise.reject(new Error('S3 get failed'));
+      }
+      return Promise.resolve({});
+    });
+
+    const { handler } = await import('../../src/handler.js');
+    await expect(
+      handler({
+        jobId: 'job-1',
+        highlightIds: ['h1'],
+      })
+    ).rejects.toThrow('S3 get failed');
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'quick-clip',
+        severity: 'error',
+        context: expect.objectContaining({ jobId: 'job-1', highlightIds: ['h1'] }),
+      })
+    );
   });
 });

--- a/services/quick-clip/web/Dockerfile
+++ b/services/quick-clip/web/Dockerfile
@@ -19,6 +19,7 @@ RUN npm install --save-optional @next/swc-linux-x64-musl
 
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build --workspace=@nagiyu/common
+RUN npm run build --workspace=@nagiyu/aws
 RUN npm run build --workspace=@nagiyu/browser
 RUN npm run build --workspace=@nagiyu/react
 RUN npm run build --workspace=@nagiyu/nextjs

--- a/services/quick-clip/web/jest.config.ts
+++ b/services/quick-clip/web/jest.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
     '^@nagiyu/nextjs/(.*)$': '<rootDir>/../../../libs/nextjs/src/$1.ts',
     '^@nagiyu/ui$': '<rootDir>/../../../libs/ui/src/index.ts',
     '^@nagiyu/browser$': '<rootDir>/../../../libs/browser/src/index.ts',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/quick-clip-core$': '<rootDir>/../core/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/services/share-together/web/src/app/api/groups/[groupId]/route.ts
+++ b/services/share-together/web/src/app/api/groups/[groupId]/route.ts
@@ -6,7 +6,7 @@ import {
 import { NextResponse, type NextRequest } from 'next/server';
 import type { ApiErrorResponse, GroupResponse } from '@/types';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 import { createGroupRepository, createMembershipRepository } from '@nagiyu/share-together-core';
 
@@ -113,7 +113,15 @@ export async function PUT(request: NextRequest, { params }: RouteParams): Promis
       return notFoundResponse;
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('グループ更新 API の実行に失敗しました', { groupId, error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: グループ更新エラー',
+      message: errorMessage,
+      context: { groupId, errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createErrorResponse(500, 'INTERNAL_SERVER_ERROR', ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
   }
 }
@@ -139,7 +147,15 @@ export async function DELETE(
       return notFoundResponse;
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('グループ削除 API の実行に失敗しました', { groupId, error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: グループ削除エラー',
+      message: errorMessage,
+      context: { groupId, errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createErrorResponse(500, 'INTERNAL_SERVER_ERROR', ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
   }
 }

--- a/services/share-together/web/src/app/api/groups/route.ts
+++ b/services/share-together/web/src/app/api/groups/route.ts
@@ -2,7 +2,7 @@ import { createGroup, type Group } from '@nagiyu/share-together-core';
 import { NextResponse } from 'next/server';
 import type { ApiErrorResponse, ApiSuccessResponse } from '@/types';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 import { createGroupRepository, createMembershipRepository } from '@nagiyu/share-together-core';
 
@@ -59,7 +59,15 @@ export async function GET(): Promise<NextResponse> {
     };
     return NextResponse.json(response);
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('グループ一覧取得 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: グループ一覧取得エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createErrorResponse(500, 'INTERNAL_SERVER_ERROR', ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
   }
 }
@@ -101,7 +109,15 @@ export async function POST(request: Request): Promise<NextResponse> {
     const response: ApiSuccessResponse<Group> = { data: group };
     return NextResponse.json(response, { status: 201 });
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('グループ作成 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: グループ作成エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createErrorResponse(500, 'INTERNAL_SERVER_ERROR', ERROR_MESSAGES.INTERNAL_SERVER_ERROR);
   }
 }

--- a/services/share-together/web/src/app/api/invitations/[groupId]/route.ts
+++ b/services/share-together/web/src/app/api/invitations/[groupId]/route.ts
@@ -5,7 +5,7 @@ import {
 import { NextResponse } from 'next/server';
 import type { ApiErrorResponse, ApiSuccessResponse } from '@/types';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 import { createGroupRepository, createMembershipRepository } from '@nagiyu/share-together-core';
 
@@ -115,10 +115,22 @@ export async function PUT(request: Request, { params }: RouteParams): Promise<Ne
       }
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('招待承認・拒否 API の実行に失敗しました', {
       groupId: requestedGroupId,
       action: requestedAction,
       error,
+    });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: 招待承認・拒否エラー',
+      message: errorMessage,
+      context: {
+        groupId: requestedGroupId,
+        action: requestedAction,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
     });
     return createInternalServerErrorResponse();
   }

--- a/services/share-together/web/src/app/api/invitations/route.ts
+++ b/services/share-together/web/src/app/api/invitations/route.ts
@@ -2,7 +2,7 @@ import { BatchGetCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynam
 import { NextResponse } from 'next/server';
 import type { ApiErrorResponse, InvitationSummary, InvitationsResponse } from '@/types';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 import {
   createGroupRepository,
@@ -95,7 +95,15 @@ export async function GET(): Promise<NextResponse> {
 
     return NextResponse.json(response);
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('招待一覧取得 API の実行に失敗しました', { error });
+    await reportErrorEvent({
+      serviceId: 'share-together',
+      severity: 'error',
+      title: 'Web API: 招待一覧取得エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return createInternalServerErrorResponse();
   }
 }

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
@@ -242,10 +242,9 @@ describe('/api/groups/[groupId] route handlers', () => {
     } as SessionOrUnauthorized);
     mockGetById.mockRejectedValue(new Error('DynamoDB 接続エラー'));
 
-    const response = await PUT(
-      { json: async () => ({ name: '更新後' }) } as Request,
-      { params: Promise.resolve({ groupId: 'group-1' }) }
-    );
+    const response = await PUT({ json: async () => ({ name: '更新後' }) } as Request, {
+      params: Promise.resolve({ groupId: 'group-1' }),
+    });
 
     expect(response.status).toBe(500);
     expect(mockReportErrorEvent).toHaveBeenCalledWith(

--- a/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/[groupId]/route.test.ts
@@ -27,6 +27,7 @@ jest.mock('@/lib/auth/session', () => ({
 
 jest.mock('@nagiyu/aws', () => ({
   getDynamoDBDocumentClient: jest.fn(),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@nagiyu/share-together-core', () => ({
@@ -39,7 +40,7 @@ jest.mock('@nagiyu/share-together-core', () => ({
 import { DELETE, PUT } from '@/app/api/groups/[groupId]/route';
 import { DynamoDBGroupRepository, DynamoDBMembershipRepository } from '@nagiyu/share-together-core';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 
 const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunction<
   typeof getSessionOrUnauthorized
@@ -47,6 +48,7 @@ const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunc
 const mockGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
   typeof getDynamoDBDocumentClient
 >;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 const mockDynamoDBGroupRepository = DynamoDBGroupRepository as jest.MockedClass<
   typeof DynamoDBGroupRepository
 >;
@@ -232,5 +234,38 @@ describe('/api/groups/[groupId] route handlers', () => {
       error: 'VALIDATION_ERROR',
       message: '入力内容が不正です',
     });
+  });
+
+  it('PUT: 例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'owner-1' },
+    } as SessionOrUnauthorized);
+    mockGetById.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    const response = await PUT(
+      { json: async () => ({ name: '更新後' }) } as Request,
+      { params: Promise.resolve({ groupId: 'group-1' }) }
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
+  });
+
+  it('DELETE: 例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'owner-1' },
+    } as SessionOrUnauthorized);
+    mockGetById.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    const response = await DELETE({} as Request, {
+      params: Promise.resolve({ groupId: 'group-1' }),
+    });
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
   });
 });

--- a/services/share-together/web/tests/unit/app/api/groups/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/groups/route.test.ts
@@ -13,6 +13,7 @@ jest.mock('@/lib/auth/session', () => ({
 
 jest.mock('@nagiyu/aws', () => ({
   getDynamoDBDocumentClient: jest.fn(),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@nagiyu/share-together-core', () => ({
@@ -30,7 +31,7 @@ import {
 } from '@nagiyu/share-together-core';
 import { GET, POST } from '@/app/api/groups/route';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 
 const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunction<
   typeof getSessionOrUnauthorized
@@ -38,6 +39,7 @@ const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunc
 const mockGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
   typeof getDynamoDBDocumentClient
 >;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 const mockDynamoDBGroupRepository = DynamoDBGroupRepository as jest.MockedClass<
   typeof DynamoDBGroupRepository
 >;
@@ -200,5 +202,35 @@ describe('/api/groups route', () => {
 
     expect(response.status).toBe(400);
     expect(mockCreateGroup).not.toHaveBeenCalled();
+  });
+
+  it('GET: 例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as SessionOrUnauthorized);
+    delete process.env.DYNAMODB_TABLE_NAME;
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
+  });
+
+  it('POST: 例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'owner-1' },
+    } as SessionOrUnauthorized);
+    delete process.env.DYNAMODB_TABLE_NAME;
+
+    const response = await POST({
+      json: async () => ({ name: '新規グループ' }),
+    } as Request);
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
   });
 });

--- a/services/share-together/web/tests/unit/app/api/invitations/[groupId]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/invitations/[groupId]/route.test.ts
@@ -16,6 +16,7 @@ jest.mock('@nagiyu/aws', () => {
   return {
     ...actualAws,
     getDynamoDBDocumentClient: jest.fn(),
+    reportErrorEvent: jest.fn().mockResolvedValue(null),
   };
 });
 
@@ -42,7 +43,7 @@ import {
 } from '@nagiyu/share-together-core';
 import { PUT } from '@/app/api/invitations/[groupId]/route';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 
 const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunction<
   typeof getSessionOrUnauthorized
@@ -50,6 +51,7 @@ const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunc
 const mockGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
   typeof getDynamoDBDocumentClient
 >;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 const mockDynamoDBGroupRepository = DynamoDBGroupRepository as jest.MockedClass<
   typeof DynamoDBGroupRepository
 >;
@@ -230,5 +232,22 @@ describe('PUT /api/invitations/[groupId]', () => {
       error: 'ALREADY_RESPONDED',
       message: 'この招待には既に応答済みです',
     });
+  });
+
+  it('予期しない例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSessionOrUnauthorized.mockResolvedValue({
+      user: { id: 'user-1' },
+    } as SessionOrUnauthorized);
+    mockRespondToInvitation.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    const request = {
+      json: jest.fn().mockResolvedValue({ action: 'ACCEPT' }),
+    } as unknown as Request;
+    const response = await PUT(request, { params: Promise.resolve({ groupId: 'group-1' }) });
+
+    expect(response.status).toBe(500);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
   });
 });

--- a/services/share-together/web/tests/unit/app/api/invitations/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/invitations/route.test.ts
@@ -13,6 +13,7 @@ jest.mock('@/lib/auth/session', () => ({
 
 jest.mock('@nagiyu/aws', () => ({
   getDynamoDBDocumentClient: jest.fn(),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@nagiyu/share-together-core', () => ({
@@ -26,7 +27,7 @@ import { BatchGetCommand } from '@aws-sdk/lib-dynamodb';
 import { DynamoDBGroupRepository, DynamoDBMembershipRepository } from '@nagiyu/share-together-core';
 import { GET } from '@/app/api/invitations/route';
 import { getSessionOrUnauthorized } from '@/lib/auth/session';
-import { getDynamoDBDocumentClient } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, reportErrorEvent } from '@nagiyu/aws';
 
 const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunction<
   typeof getSessionOrUnauthorized
@@ -34,6 +35,7 @@ const mockGetSessionOrUnauthorized = getSessionOrUnauthorized as jest.MockedFunc
 const mockGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
   typeof getDynamoDBDocumentClient
 >;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
 const mockDynamoDBMembershipRepository = DynamoDBMembershipRepository as jest.MockedClass<
   typeof DynamoDBMembershipRepository
 >;
@@ -151,7 +153,7 @@ describe('GET /api/invitations', () => {
     });
   });
 
-  it('例外発生時は500レスポンスを返す', async () => {
+  it('例外発生時は500レスポンスを返し reportErrorEvent を呼ぶ', async () => {
     mockGetSessionOrUnauthorized.mockResolvedValue({
       user: { id: 'user-1' },
     } as SessionOrUnauthorized);
@@ -164,5 +166,8 @@ describe('GET /api/invitations', () => {
       error: 'INTERNAL_SERVER_ERROR',
       message: 'サーバーエラーが発生しました',
     });
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'share-together', severity: 'error' })
+    );
   });
 });

--- a/services/stock-tracker/batch/package.json
+++ b/services/stock-tracker/batch/package.json
@@ -22,6 +22,7 @@
     "@resvg/resvg-js": "^2.6.2",
     "echarts": "^6.0.0",
     "openai": "^6.33.0",
+    "ts-jest": "^29.4.9",
     "web-push": "^3.6.7",
     "zod": "^4.3.6"
   }

--- a/services/stock-tracker/batch/src/daily.ts
+++ b/services/stock-tracker/batch/src/daily.ts
@@ -5,7 +5,7 @@
  */
 
 import { logger } from '@nagiyu/common';
-import { getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 import { ScanCommand } from '@aws-sdk/lib-dynamodb';
 import type { Alert } from '@nagiyu/stock-tracker-core';
 
@@ -173,6 +173,18 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       eventId: event.id,
       error: errorMessage,
       statistics: {
+        totalAlerts: stats.totalAlerts,
+        validSubscriptions: stats.validSubscriptions,
+        invalidSubscriptions: stats.invalidSubscriptions,
+      },
+    });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'error',
+      title: '日次バッチ: 致命的エラー',
+      message: errorMessage,
+      context: {
+        eventId: event.id,
         totalAlerts: stats.totalAlerts,
         validSubscriptions: stats.validSubscriptions,
         invalidSubscriptions: stats.invalidSubscriptions,

--- a/services/stock-tracker/batch/src/evaluation.ts
+++ b/services/stock-tracker/batch/src/evaluation.ts
@@ -14,7 +14,12 @@
  */
 
 import { logger } from '@nagiyu/common';
-import { EntityAlreadyExistsError, getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import {
+  EntityAlreadyExistsError,
+  getDynamoDBDocumentClient,
+  getTableName,
+  reportErrorEvent,
+} from '@nagiyu/aws';
 import {
   DynamoDBDailySummaryRepository,
   DynamoDBExchangeRepository,
@@ -143,6 +148,18 @@ async function evaluateOne(
       evaluationDate,
       reason: errorMessage,
     });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'warning',
+      title: '採点バッチ: 翌営業日終値取得失敗',
+      message: errorMessage,
+      context: {
+        tickerId: summary.TickerID,
+        date: summary.Date,
+        evaluationDate,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     stats.failed++;
     return;
   }
@@ -206,6 +223,18 @@ async function evaluateOne(
       date: summary.Date,
       evaluationDate,
       reason: errorMessage,
+    });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'warning',
+      title: '採点バッチ: 採点結果書き込み失敗',
+      message: errorMessage,
+      context: {
+        tickerId: summary.TickerID,
+        date: summary.Date,
+        evaluationDate,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
     });
     stats.failed++;
   }
@@ -283,6 +312,13 @@ export async function handler(
       eventId: event.id,
       error: errorMessage,
       statistics: stats,
+    });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'error',
+      title: '採点バッチ: 致命的エラー',
+      message: errorMessage,
+      context: { eventId: event.id, statistics: stats },
     });
 
     return {

--- a/services/stock-tracker/batch/src/hourly.ts
+++ b/services/stock-tracker/batch/src/hourly.ts
@@ -5,7 +5,7 @@
  */
 
 import { logger, withRetry } from '@nagiyu/common';
-import { getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 import { sendWebPushNotification, getVapidConfig } from '@nagiyu/common/push';
 import { createAlertNotificationPayload } from './lib/web-push-client.js';
 import type { AlertRepository, ExchangeRepository } from '@nagiyu/stock-tracker-core';
@@ -154,6 +154,17 @@ async function processAlert(
       userId: alert.UserID,
       error: errorMessage,
     });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'warning',
+      title: '時間次バッチ: アラート処理エラー',
+      message: errorMessage,
+      context: {
+        alertId: alert.AlertID,
+        userId: alert.UserID,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     stats.errors++;
     return false;
   }
@@ -221,6 +232,13 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       eventId: event.id,
       error: errorMessage,
       statistics: stats,
+    });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'error',
+      title: '時間次バッチ: 致命的エラー',
+      message: errorMessage,
+      context: { eventId: event.id, statistics: stats },
     });
 
     return {

--- a/services/stock-tracker/batch/src/minute.ts
+++ b/services/stock-tracker/batch/src/minute.ts
@@ -5,7 +5,7 @@
  */
 
 import { logger, withRetry } from '@nagiyu/common';
-import { getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 import { sendWebPushNotification, getVapidConfig } from '@nagiyu/common/push';
 import { createAlertNotificationPayload } from './lib/web-push-client.js';
 import { runConcurrent } from './lib/concurrent-queue.js';
@@ -160,6 +160,17 @@ async function processAlert(
       userId: alert.UserID,
       error: errorMessage,
     });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'warning',
+      title: '分次バッチ: アラート処理エラー',
+      message: errorMessage,
+      context: {
+        alertId: alert.AlertID,
+        userId: alert.UserID,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
+    });
     stats.errors++;
     return false;
   }
@@ -248,6 +259,13 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       eventId: event.id,
       error: errorMessage,
       statistics: stats,
+    });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'error',
+      title: '分次バッチ: 致命的エラー',
+      message: errorMessage,
+      context: { eventId: event.id, statistics: stats },
     });
 
     return {

--- a/services/stock-tracker/batch/src/summary.ts
+++ b/services/stock-tracker/batch/src/summary.ts
@@ -4,7 +4,7 @@
  */
 
 import { logger } from '@nagiyu/common';
-import { getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 import {
   DynamoDBDailySummaryRepository,
   DynamoDBExchangeRepository,
@@ -253,6 +253,17 @@ async function processExchange(
                   reason: errorMessage,
                 }
               );
+              await reportErrorEvent({
+                serviceId: 'stock-tracker',
+                severity: 'warning',
+                title: 'サマリーバッチ: AI解析用チャートデータ取得失敗',
+                message: errorMessage,
+                context: {
+                  exchangeId: exchange.ExchangeID,
+                  tickerId: ticker.TickerID,
+                  errorStack: error instanceof Error ? error.stack : undefined,
+                },
+              });
               stats.aiAnalysisSkipped++;
               continue;
             }
@@ -299,6 +310,17 @@ async function processExchange(
             tickerId: ticker.TickerID,
             reason: errorMessage,
           });
+          await reportErrorEvent({
+            serviceId: 'stock-tracker',
+            severity: 'warning',
+            title: 'サマリーバッチ: AI解析生成失敗',
+            message: errorMessage,
+            context: {
+              exchangeId: exchange.ExchangeID,
+              tickerId: ticker.TickerID,
+              errorStack: error instanceof Error ? error.stack : undefined,
+            },
+          });
           await dependencies.dailySummaryRepository.upsert({
             ...currentSummaryInput,
             AiAnalysisResult: undefined,
@@ -314,6 +336,17 @@ async function processExchange(
           executionTime: new Date(now).toISOString(),
           reason: errorMessage,
         });
+        await reportErrorEvent({
+          serviceId: 'stock-tracker',
+          severity: 'warning',
+          title: 'サマリーバッチ: ティッカー日足データ取得失敗',
+          message: errorMessage,
+          context: {
+            exchangeId: exchange.ExchangeID,
+            tickerId: ticker.TickerID,
+            errorStack: error instanceof Error ? error.stack : undefined,
+          },
+        });
         stats.errors++;
       } finally {
         stats.processedTickers++;
@@ -324,6 +357,16 @@ async function processExchange(
     logger.error('取引所の日次サマリー処理に失敗しました', {
       exchangeId: exchange.ExchangeID,
       error: errorMessage,
+    });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'error',
+      title: 'サマリーバッチ: 取引所サマリー処理失敗',
+      message: errorMessage,
+      context: {
+        exchangeId: exchange.ExchangeID,
+        errorStack: error instanceof Error ? error.stack : undefined,
+      },
     });
     stats.errors++;
   } finally {
@@ -410,6 +453,13 @@ export async function handler(
       eventId: event.id,
       error: errorMessage,
       statistics: stats,
+    });
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'error',
+      title: 'サマリーバッチ: 致命的エラー',
+      message: errorMessage,
+      context: { eventId: event.id, statistics: stats },
     });
 
     return {

--- a/services/stock-tracker/batch/tests/unit/daily.test.ts
+++ b/services/stock-tracker/batch/tests/unit/daily.test.ts
@@ -212,12 +212,19 @@ describe('daily batch handler', () => {
       // Arrange
       const dbError = new Error('DynamoDB Error');
       mockDocClient.send.mockRejectedValue(dbError);
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
 
       // Act
       const response = await handler(mockEvent);
 
       // Assert
       expect(response.statusCode).toBe(500);
+      expect(awsClients.reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'stock-tracker',
+          severity: 'error',
+        })
+      );
       const body = JSON.parse(response.body);
       expect(body.message).toBe('日次バッチ処理でエラーが発生しました');
       expect(body.error).toBe('DynamoDB Error');

--- a/services/stock-tracker/batch/tests/unit/evaluation.test.ts
+++ b/services/stock-tracker/batch/tests/unit/evaluation.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { EntityAlreadyExistsError, InMemorySingleTableStore } from '@nagiyu/aws';
+import * as awsModule from '@nagiyu/aws';
 import {
   InMemoryDailySummaryRepository,
   InMemoryExchangeRepository,
@@ -79,6 +80,10 @@ describe('evaluation batch handler', () => {
       Start: '09:00',
       End: '17:00',
     });
+  });
+
+  beforeEach(() => {
+    jest.spyOn(awsModule, 'reportErrorEvent').mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -263,6 +268,9 @@ describe('evaluation batch handler', () => {
       expect(body.statistics.totalCandidates).toBe(2);
       expect(body.statistics.failed).toBe(1);
       expect(body.statistics.evaluated).toBe(1);
+      expect(awsModule.reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ serviceId: 'stock-tracker', severity: 'warning' })
+      );
     });
 
     it('ConditionalCheck 違反（並列実行による既採点）は alreadyEvaluatedSkipped にカウント', async () => {
@@ -459,6 +467,22 @@ describe('evaluation batch handler', () => {
       expect(response.statusCode).toBe(500);
       const body = JSON.parse(response.body);
       expect(body.message).toContain('採点バッチでエラー');
+    });
+  });
+
+  describe('DynamoDB 初期化分岐', () => {
+    it('exchangeRepository / dailySummaryRepository を省略した場合、DynamoDB から初期化する', async () => {
+      jest.spyOn(awsModule, 'getDynamoDBDocumentClient').mockReturnValue({} as never);
+      jest.spyOn(awsModule, 'getTableName').mockReturnValue('test-table');
+
+      const response = await handler(buildEvent(), {
+        nowFn: () => NOW,
+        findPendingEvaluationsFn: jest.fn().mockResolvedValue([]),
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(awsModule.getDynamoDBDocumentClient).toHaveBeenCalled();
+      expect(awsModule.getTableName).toHaveBeenCalled();
     });
   });
 });

--- a/services/stock-tracker/batch/tests/unit/hourly.test.ts
+++ b/services/stock-tracker/batch/tests/unit/hourly.test.ts
@@ -380,6 +380,7 @@ describe('hourly batch handler', () => {
       (tradingviewClient.getCurrentPrice as jest.Mock).mockRejectedValue(
         new Error('TradingView API タイムアウト')
       );
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
 
       // Act
       const response = await handler(mockEvent);
@@ -387,6 +388,12 @@ describe('hourly batch handler', () => {
       // Assert
       expect(response.statusCode).toBe(200); // バッチ全体は成功
       expect(sendWebPushNotification).not.toHaveBeenCalled();
+      expect(awsClients.reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'stock-tracker',
+          severity: 'warning',
+        })
+      );
 
       const body = JSON.parse(response.body);
       expect(body.statistics.errors).toBe(1);
@@ -437,12 +444,19 @@ describe('hourly batch handler', () => {
     it('DynamoDB 接続エラーが発生した場合、500 エラーを返す', async () => {
       // Arrange
       mockAlertRepo.getByFrequency.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
 
       // Act
       const response = await handler(mockEvent);
 
       // Assert
       expect(response.statusCode).toBe(500);
+      expect(awsClients.reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'stock-tracker',
+          severity: 'error',
+        })
+      );
       const body = JSON.parse(response.body);
       expect(body.message).toContain('エラーが発生しました');
       expect(body.error).toContain('DynamoDB 接続エラー');
@@ -756,6 +770,62 @@ describe('hourly batch handler', () => {
       const body = JSON.parse(response.body);
       expect(body.statistics.conditionsMet).toBe(1);
       expect(body.statistics.notificationsSent).toBe(1);
+    });
+  });
+
+  describe('異常系: 通知送信失敗', () => {
+    it('sendWebPushNotification が false を返した場合、errors カウンターが増加する', async () => {
+      const mockAlert: Alert = {
+        AlertID: 'alert-1',
+        UserID: 'user-1',
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Mode: 'Sell',
+        Frequency: 'HOURLY_LEVEL',
+        Enabled: true,
+        ConditionList: [{ field: 'price', operator: 'gte', value: 200.0 }],
+        subscription: {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/test',
+          keys: { p256dh: 'test-p256dh', auth: 'test-auth' },
+        },
+        CreatedAt: Date.now(),
+        UpdatedAt: Date.now(),
+      };
+
+      const mockExchange: Exchange = {
+        ExchangeID: 'NASDAQ',
+        Name: 'NASDAQ',
+        Key: 'NSDQ',
+        Timezone: 'America/New_York',
+        Start: '04:00',
+        End: '20:00',
+        CreatedAt: Date.now(),
+        UpdatedAt: Date.now(),
+      };
+
+      mockAlertRepo.getByFrequency.mockResolvedValue({ items: [mockAlert] });
+      mockExchangeRepo.getById.mockResolvedValue(mockExchange);
+      (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
+      (tradingviewClient.getCurrentPrice as jest.Mock).mockResolvedValue(205.0);
+      (alertEvaluator.evaluateAlert as jest.Mock).mockReturnValue(true);
+      (sendWebPushNotification as jest.Mock).mockResolvedValue(false);
+      (webPushClient.createAlertNotificationPayload as jest.Mock).mockReturnValue({
+        title: 'Test Alert',
+        body: 'Test body',
+      });
+      (getVapidConfig as jest.Mock).mockReturnValue({
+        publicKey: 'test-public-key',
+        privateKey: 'test-private-key',
+        subject: 'mailto:support@nagiyu.com',
+      });
+
+      const response = await handler(mockEvent);
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.statistics.conditionsMet).toBe(1);
+      expect(body.statistics.notificationsSent).toBe(0);
+      expect(body.statistics.errors).toBe(1);
     });
   });
 });

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -414,6 +414,7 @@ describe('minute batch handler', () => {
       (tradingviewClient.getCurrentPrice as jest.Mock).mockRejectedValue(
         new Error('TradingView API タイムアウト')
       );
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
 
       // Act
       const response = await handler(mockEvent);
@@ -421,6 +422,12 @@ describe('minute batch handler', () => {
       // Assert
       expect(response.statusCode).toBe(200); // バッチ全体は成功
       expect(sendWebPushNotification).not.toHaveBeenCalled();
+      expect(awsClients.reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'stock-tracker',
+          severity: 'warning',
+        })
+      );
 
       const body = JSON.parse(response.body);
       expect(body.statistics.errors).toBe(1);
@@ -471,12 +478,19 @@ describe('minute batch handler', () => {
     it('DynamoDB 接続エラーが発生した場合、500 エラーを返す', async () => {
       // Arrange
       mockAlertRepo.getByFrequency.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
 
       // Act
       const response = await handler(mockEvent);
 
       // Assert
       expect(response.statusCode).toBe(500);
+      expect(awsClients.reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'stock-tracker',
+          severity: 'error',
+        })
+      );
       const body = JSON.parse(response.body);
       expect(body.message).toContain('エラーが発生しました');
       expect(body.error).toContain('DynamoDB 接続エラー');

--- a/services/stock-tracker/batch/tests/unit/summary.test.ts
+++ b/services/stock-tracker/batch/tests/unit/summary.test.ts
@@ -3,7 +3,9 @@
  */
 
 import { InMemorySingleTableStore } from '@nagiyu/aws';
+import * as awsModule from '@nagiyu/aws';
 import {
+  DynamoDBExchangeRepository,
   InMemoryDailySummaryRepository,
   InMemoryExchangeRepository,
   InMemoryTickerRepository,
@@ -22,6 +24,8 @@ describe('summary batch handler', () => {
   let mockEvent: ScheduledEvent;
 
   beforeEach(() => {
+    jest.spyOn(awsModule, 'reportErrorEvent').mockResolvedValue(null);
+
     const store = new InMemorySingleTableStore();
     exchangeRepository = new InMemoryExchangeRepository(store);
     tickerRepository = new InMemoryTickerRepository(store);
@@ -231,6 +235,9 @@ describe('summary batch handler', () => {
           executionTime: '2026-02-28T23:00:00.000Z',
           reason: 'TradingView API Error',
         })
+      );
+      expect(awsModule.reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ serviceId: 'stock-tracker', severity: 'warning' })
       );
 
       const summary = await dailySummaryRepository.getByTickerAndDate('NSDQ:AAPL', '2026-02-26');
@@ -898,6 +905,54 @@ describe('summary batch handler', () => {
       });
     });
 
+    it('AI解析用chartData が空の場合でも historicalData を空配列にして AI 解析を実行する', async () => {
+      process.env.OPENAI_API_KEY = 'test-api-key';
+
+      const matchedPatternId = PATTERN_REGISTRY[0].definition.patternId;
+      const matchedPatternName = PATTERN_REGISTRY[0].definition.name;
+
+      await dailySummaryRepository.upsert({
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 90,
+        High: 95,
+        Low: 88,
+        Close: 92,
+        PatternResults: Object.fromEntries(
+          PATTERN_REGISTRY.map((pattern) => [
+            pattern.definition.patternId,
+            pattern.definition.patternId === matchedPatternId ? 'MATCHED' : 'NOT_MATCHED',
+          ])
+        ),
+        BuyPatternCount: 1,
+        SellPatternCount: 0,
+      });
+
+      const generateAiAnalysisFn = jest.fn().mockResolvedValue(mockAiAnalysisResult);
+      // needsStaticAnalysis が false のため、AI解析用の chartData 取得が走る（count: 50）
+      const getChartDataFn: jest.MockedFunction<typeof getChartData> = jest
+        .fn()
+        .mockResolvedValue([]);
+
+      await handler(mockEvent, {
+        exchangeRepository,
+        tickerRepository,
+        dailySummaryRepository,
+        getChartDataFn,
+        nowFn: jest.fn(() => Date.UTC(2026, 1, 27, 23, 0, 0)),
+        generateAiAnalysisFn,
+      });
+
+      expect(generateAiAnalysisFn).toHaveBeenCalledWith(
+        'test-api-key',
+        expect.objectContaining({
+          historicalData: [],
+          patternSummary: expect.stringContaining(matchedPatternName),
+        })
+      );
+    });
+
     it('チャート画像生成失敗時は画像なしで AI 解析を継続する', async () => {
       process.env.OPENAI_API_KEY = 'test-api-key';
 
@@ -1153,6 +1208,20 @@ describe('summary batch handler', () => {
         message: '日次サマリー生成バッチでエラーが発生しました',
         error: 'exchange fetch failed',
       });
+    });
+  });
+
+  describe('DynamoDB 初期化分岐', () => {
+    it('dependencies を省略した場合、DynamoDB から初期化する', async () => {
+      jest.spyOn(awsModule, 'getDynamoDBDocumentClient').mockReturnValue({} as never);
+      jest.spyOn(awsModule, 'getTableName').mockReturnValue('test-table');
+      jest.spyOn(DynamoDBExchangeRepository.prototype, 'getAll').mockResolvedValue([]);
+
+      const response = await handler(mockEvent);
+
+      expect(response.statusCode).toBe(200);
+      expect(awsModule.getDynamoDBDocumentClient).toHaveBeenCalled();
+      expect(awsModule.getTableName).toHaveBeenCalled();
     });
   });
 });

--- a/services/stock-tracker/web/app/api/alerts/route.ts
+++ b/services/stock-tracker/web/app/api/alerts/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAlert, calculateTemporaryExpireDate } from '@nagiyu/stock-tracker-core';
 import { withAuth, parsePagination, handleApiError } from '@nagiyu/nextjs';
+import { reportErrorEvent } from '@nagiyu/aws';
 import {
   createAlertRepository,
   createTickerRepository,
@@ -164,6 +165,14 @@ export const GET = withAuth(
         { status: 200 }
       );
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'Web API: アラート一覧取得エラー',
+        message: errorMessage,
+        context: { errorStack: error instanceof Error ? error.stack : undefined },
+      });
       return handleApiError(error);
     }
   }
@@ -323,6 +332,14 @@ export const POST = withAuth(
 
       return NextResponse.json(response, { status: 201 });
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'Web API: アラート作成エラー',
+        message: errorMessage,
+        context: { errorStack: error instanceof Error ? error.stack : undefined },
+      });
       return handleApiError(error);
     }
   }

--- a/services/stock-tracker/web/app/api/exchanges/route.ts
+++ b/services/stock-tracker/web/app/api/exchanges/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
 import { validateExchange, type ExchangeEntity } from '@nagiyu/stock-tracker-core';
 import { withAuth, handleApiError } from '@nagiyu/nextjs';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { getSession } from '../../../lib/auth';
 import { createExchangeRepository } from '../../../lib/repository-factory';
 
@@ -47,6 +48,14 @@ export const GET = withAuth(getSession, 'stocks:read', async () => {
       })),
     });
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await reportErrorEvent({
+      serviceId: 'stock-tracker',
+      severity: 'error',
+      title: 'Web API: 取引所一覧取得エラー',
+      message: errorMessage,
+      context: { errorStack: error instanceof Error ? error.stack : undefined },
+    });
     return handleApiError(error);
   }
 });
@@ -129,6 +138,14 @@ export const POST = withAuth(
         { status: 201 }
       );
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'Web API: 取引所作成エラー',
+        message: errorMessage,
+        context: { errorStack: error instanceof Error ? error.stack : undefined },
+      });
       return handleApiError(error);
     }
   }

--- a/services/stock-tracker/web/app/api/tickers/[id]/route.ts
+++ b/services/stock-tracker/web/app/api/tickers/[id]/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
 import { TickerNotFoundError, validateTickerUpdateData } from '@nagiyu/stock-tracker-core';
 import { withAuth, handleApiError } from '@nagiyu/nextjs';
+import { reportErrorEvent } from '@nagiyu/aws';
 import { getSession } from '../../../../lib/auth';
 import { createTickerRepository } from '../../../../lib/repository-factory';
 
@@ -122,6 +123,14 @@ export const PUT = withAuth(
         throw error;
       }
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'Web API: ティッカー更新エラー',
+        message: errorMessage,
+        context: { errorStack: error instanceof Error ? error.stack : undefined },
+      });
       return handleApiError(error);
     }
   }
@@ -167,6 +176,14 @@ export const DELETE = withAuth(
         throw error;
       }
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await reportErrorEvent({
+        serviceId: 'stock-tracker',
+        severity: 'error',
+        title: 'Web API: ティッカー削除エラー',
+        message: errorMessage,
+        context: { errorStack: error instanceof Error ? error.stack : undefined },
+      });
       return handleApiError(error);
     }
   }

--- a/services/stock-tracker/web/package.json
+++ b/services/stock-tracker/web/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/client-dynamodb": "^3.1024.0",
     "@aws-sdk/client-lambda": "^3.1024.0",
     "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@nagiyu/aws": "*",
     "@nagiyu/browser": "*",
     "@nagiyu/common": "*",
     "@nagiyu/nextjs": "*",

--- a/services/stock-tracker/web/tests/unit/app/api/alerts-create-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/alerts-create-route.test.ts
@@ -65,5 +65,4 @@ describe('POST /api/alerts', () => {
     expect(response.status).toBe(400);
     expect(body.message).toBe('通知本文は必須です');
   });
-
 });

--- a/services/stock-tracker/web/tests/unit/app/api/alerts-create-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/alerts-create-route.test.ts
@@ -21,6 +21,11 @@ jest.mock('@nagiyu/nextjs', () => ({
   }),
 }));
 
+jest.mock('@nagiyu/aws', () => ({
+  ...jest.requireActual('@nagiyu/aws'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
 describe('POST /api/alerts', () => {
   const createRequest = (body: Record<string, unknown>) =>
     new NextRequest('http://localhost/api/alerts', {
@@ -60,4 +65,5 @@ describe('POST /api/alerts', () => {
     expect(response.status).toBe(400);
     expect(body.message).toBe('通知本文は必須です');
   });
+
 });

--- a/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/alerts-get-route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { GET } from '../../../../app/api/alerts/route';
 import { createAlertRepository, createTickerRepository } from '../../../../lib/repository-factory';
+import * as awsModule from '@nagiyu/aws';
 
 jest.mock('../../../../lib/repository-factory', () => ({
   createAlertRepository: jest.fn(),
@@ -20,6 +21,11 @@ jest.mock('@nagiyu/nextjs', () => ({
   handleApiError: jest.fn((error) => {
     throw error;
   }),
+}));
+
+jest.mock('@nagiyu/aws', () => ({
+  ...jest.requireActual('@nagiyu/aws'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
 }));
 
 describe('GET /api/alerts', () => {
@@ -79,5 +85,16 @@ describe('GET /api/alerts', () => {
       true,
       false,
     ]);
+  });
+
+  it('DynamoDB エラー時に reportErrorEvent が呼ばれる', async () => {
+    mockGetByUserId.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    await expect(GET(new NextRequest('http://localhost/api/alerts'))).rejects.toThrow(
+      'DynamoDB 接続エラー'
+    );
+    expect(awsModule.reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'stock-tracker', severity: 'error' })
+    );
   });
 });

--- a/services/stock-tracker/web/tests/unit/app/api/exchanges-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/exchanges-route.test.ts
@@ -1,0 +1,98 @@
+import { GET, POST } from '../../../../app/api/exchanges/route';
+import { createExchangeRepository } from '../../../../lib/repository-factory';
+import * as awsModule from '@nagiyu/aws';
+
+jest.mock('../../../../lib/repository-factory', () => ({
+  createExchangeRepository: jest.fn(),
+}));
+
+jest.mock('../../../../lib/auth', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@nagiyu/nextjs', () => ({
+  withAuth: jest.fn((_auth, _permission, handler) => {
+    return async (...args: unknown[]) => handler({ user: { userId: 'test-user' } }, ...args);
+  }),
+  handleApiError: jest.fn((error) => {
+    throw error;
+  }),
+}));
+
+jest.mock('@nagiyu/aws', () => ({
+  ...jest.requireActual('@nagiyu/aws'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+describe('GET /api/exchanges', () => {
+  const mockGetAll = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createExchangeRepository as jest.Mock).mockReturnValue({ getAll: mockGetAll });
+  });
+
+  it('取引所一覧を正常に返す', async () => {
+    mockGetAll.mockResolvedValue([
+      {
+        ExchangeID: 'NASDAQ',
+        Name: 'NASDAQ',
+        Key: 'NSDQ',
+        Timezone: 'America/New_York',
+        Start: '09:00',
+        End: '17:00',
+        CreatedAt: 1,
+        UpdatedAt: 1,
+      },
+    ]);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.exchanges).toHaveLength(1);
+    expect(body.exchanges[0].exchangeId).toBe('NASDAQ');
+  });
+
+  it('DynamoDB エラー時に reportErrorEvent が呼ばれる', async () => {
+    mockGetAll.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    await expect(GET()).rejects.toThrow('DynamoDB 接続エラー');
+    expect(awsModule.reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'stock-tracker', severity: 'error' })
+    );
+  });
+});
+
+describe('POST /api/exchanges', () => {
+  const mockCreate = jest.fn();
+
+  const validBody = {
+    exchangeId: 'TSE',
+    name: '東京証券取引所',
+    key: 'TSE',
+    timezone: 'Asia/Tokyo',
+    tradingHours: { start: '09:00', end: '15:30' },
+  };
+
+  const createRequest = (body: Record<string, unknown>) =>
+    new Request('http://localhost/api/exchanges', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createExchangeRepository as jest.Mock).mockReturnValue({ create: mockCreate });
+  });
+
+  it('DynamoDB エラー時に reportErrorEvent が呼ばれる', async () => {
+    mockCreate.mockRejectedValue(new Error('DynamoDB 書き込みエラー'));
+
+    await expect(POST(undefined as never, createRequest(validBody))).rejects.toThrow();
+    expect(awsModule.reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'stock-tracker', severity: 'error' })
+    );
+  });
+});

--- a/services/stock-tracker/web/tests/unit/app/api/tickers-id-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/tickers-id-route.test.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server';
+import { PUT, DELETE } from '../../../../app/api/tickers/[id]/route';
+import { createTickerRepository } from '../../../../lib/repository-factory';
+import * as awsModule from '@nagiyu/aws';
+
+jest.mock('../../../../lib/repository-factory', () => ({
+  createTickerRepository: jest.fn(),
+}));
+
+jest.mock('../../../../lib/auth', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@nagiyu/nextjs', () => ({
+  withAuth: jest.fn((_auth, _permission, handler) => {
+    return async (...args: unknown[]) => handler({ user: { userId: 'test-user' } }, ...args);
+  }),
+  handleApiError: jest.fn((error) => {
+    throw error;
+  }),
+}));
+
+jest.mock('@nagiyu/aws', () => ({
+  ...jest.requireActual('@nagiyu/aws'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe('PUT /api/tickers/[id]', () => {
+  const mockUpdate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createTickerRepository as jest.Mock).mockReturnValue({ update: mockUpdate });
+  });
+
+  it('DynamoDB エラー時に reportErrorEvent が呼ばれる', async () => {
+    mockUpdate.mockRejectedValue(new Error('DynamoDB 書き込みエラー'));
+
+    const request = new NextRequest('http://localhost/api/tickers/NSDQ:AAPL', {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'Apple Inc.' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(PUT(undefined as never, request, makeParams('NSDQ:AAPL'))).rejects.toThrow();
+    expect(awsModule.reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'stock-tracker', severity: 'error' })
+    );
+  });
+});
+
+describe('DELETE /api/tickers/[id]', () => {
+  const mockDelete = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createTickerRepository as jest.Mock).mockReturnValue({ delete: mockDelete });
+  });
+
+  it('DynamoDB エラー時に reportErrorEvent が呼ばれる', async () => {
+    mockDelete.mockRejectedValue(new Error('DynamoDB 削除エラー'));
+
+    const request = new NextRequest('http://localhost/api/tickers/NSDQ:AAPL', {
+      method: 'DELETE',
+    });
+
+    await expect(DELETE(undefined as never, request, makeParams('NSDQ:AAPL'))).rejects.toThrow();
+    expect(awsModule.reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceId: 'stock-tracker', severity: 'error' })
+    );
+  });
+});


### PR DESCRIPTION
## 変更の概要

トラッキング Issue #3122 に基づき、各サービスのバッチ・API・Lambda から `@nagiyu/aws` の `reportErrorEvent` / `createErrorReporter` を呼び出し、エラー / 重要イベントを Admin の DynamoDB（`nagiyu-error-events-{env}`）へ集約する対応を、統合ブランチでまとめて develop に反映するための PR。

対象サービス（いずれも子 Issue 単位で実装・integration へマージ済み）:

- 優先度「高」: stock-tracker (#3126) / codec-converter (#3127) / niconico-mylist-assistant (#3128)
- 優先度「中」: quick-clip (#3144) / share-together (#3145) / auth (#3146) / admin（アプリ層・フェーズ1, #3147）

各サービスで以下を実施:

- `services/{svc}` のエラー / 重要イベント発生箇所に `reportErrorEvent` を追加（`serviceId` をサービス単位で付与、`severity` を error / warning / critical / info で使い分け）
- `infra/{svc}` の Lambda / ECS タスクロール / Next.js SSR 実行ロールに `@nagiyu/infra-common` の `grantErrorEventsWrite` で書き込み権限を付与、`ERROR_EVENTS_TABLE_NAME` を注入
- 横展開で判明した知見への対応も反映:
    - A. Docker batch runner ステージへ `libs/common` / `libs/aws` の dist コピー（#3136 ほか）
    - B. catch を経由しない異常終了パス（`process.exit(1)` / 全失敗）でも `reportErrorEvent` を呼ぶ（#3132）
    - C. ESM-only パッケージ用に各レイヤ `jest.config.ts` の `moduleNameMapper` を整備（#3129 / #3130）
- quick-clip は deploy / verify ワークフローの shared-workspaces に `@nagiyu/aws` を追加（#3153 ほか）

98 files changed（約 +2550 / -660）。

## 関連 Issue

Closes #3122

子 Issue: #3126 #3127 #3128 #3144 #3145 #3146 #3147（依存: #3103 #3121、いずれも完了済み）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（永続ドキュメント化は別途検討）
- [x] CI/CD 設定を追加・更新した（quick-clip deploy/verify ほか）
- [x] ローカルでテストが全て通ることを確認した（各子 PR の Fast CI 通過）
- [x] ビルドエラーがないことを確認した

## テスト内容

- 各レイヤの `tests/unit/` で、エラーパスにおいて `reportErrorEvent` が期待される `serviceId` / `severity` / `context` で呼ばれることを単体テストで検証
- 既存テストのカバレッジ閾値（80%）を維持
- 各子 PR が integration ブランチ向けに Fast CI を通過済み

## レビューポイント

- 各サービスの `severity` の妥当性（critical / error / warning の使い分け）
- `infra/{svc}` の権限付与対象 principal の網羅性（Lambda / ECS / SSR ロールの漏れがないか）
- auth: `context` に PII（トークン・email・googleId 等）が混入していないこと
- admin: alarm-ingest 経路との重複レポートが発生していないこと（フェーズ1 はアプリ層 Web API のみ）
- Docker batch を持つサービスの runner ステージで `libs` dist コピーが入っていること（知見 A）

## スクリーンショット（該当する場合）

なし（バックエンド / インフラ変更のみ）。dev 反映後に Admin `/errors` での横断表示を人力で確認予定。

## 補足事項

- 本 PR は **Draft** で作成。CLAUDE.md の運用フローに従い、Ready 化・マージは人力で判断する。
- dev 環境への反映後、Admin `/errors` 画面で各 `serviceId` のイベントが横断的に閲覧できることの最終確認は人力で実施する想定。
- 子 Issue #3144–#3147 は本 PR マージ後にクローズする（#3122 は本 PR の `Closes` で自動クローズ）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01N2dUbM7U5tYgx8YwSVjt5X)_