### PR TITLE
Niconico Mylist Assistant: ニコニコお知らせモーダルの自動 dismiss 対応（#3159）

### DIFF
--- a/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
+++ b/services/niconico-mylist-assistant/batch/src/playwright-automation.ts
@@ -630,6 +630,45 @@ export async function takeScreenshot(page: Page, filename: string): Promise<void
 }
 
 /**
+ * ニコニコ動画のお知らせオーバーレイバナー（OverlayBannerFrame）が出現したとき自動的に閉じる
+ * ハンドラを page に登録する。
+ *
+ * バナーが表示されない場合はハンドラが発火しないため、バナーの有無に関わらず安全に使える。
+ *
+ * @param page Playwright Page オブジェクト
+ */
+export async function registerOverlayBannerHandler(page: Page): Promise<void> {
+  const overlayLocator = page.locator('.OverlayBannerFrame');
+
+  await page.addLocatorHandler(
+    overlayLocator,
+    async () => {
+      console.log('お知らせオーバーレイバナーを検出しました。閉じます...');
+      try {
+        const closeButton = page.locator('.OverlayBannerFrame button').first();
+        const buttonCount = await closeButton.count();
+        if (buttonCount > 0) {
+          await closeButton.click({ timeout: 3000, force: true });
+          console.log('オーバーレイバナーを閉じました');
+        } else {
+          await page.evaluate(() => {
+            document.querySelector('.OverlayBannerFrame')?.remove();
+            document.querySelector('.NC-Modal-overlay')?.remove();
+          });
+          console.log('オーバーレイバナーを DOM から除去しました');
+        }
+      } catch (error) {
+        console.warn(
+          'オーバーレイバナーの除去に失敗しました（処理は継続します）:',
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    },
+    { noWaitAfter: true }
+  );
+}
+
+/**
  * ブラウザを起動する
  *
  * @returns Browser オブジェクト
@@ -675,6 +714,9 @@ export async function executeMylistRegistration(
     // ブラウザ起動
     browser = await launchBrowser();
     page = await browser.newPage();
+
+    // お知らせオーバーレイバナー自動 dismiss ハンドラを登録
+    await registerOverlayBannerHandler(page);
 
     // ログイン
     const loginResult = await login(page, email, password);

--- a/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
+++ b/services/niconico-mylist-assistant/batch/tests/unit/playwright-automation.test.ts
@@ -14,7 +14,11 @@ jest.mock('playwright', () => ({
   },
 }));
 
-import { login, executeMylistRegistration } from '../../src/playwright-automation';
+import {
+  login,
+  executeMylistRegistration,
+  registerOverlayBannerHandler,
+} from '../../src/playwright-automation';
 import { reportErrorEvent } from '@nagiyu/aws';
 import type { Page } from 'playwright';
 
@@ -28,6 +32,8 @@ function createMockPage(overrides: Partial<Record<string, jest.Mock>> = {}): Pag
     screenshot: jest.fn().mockResolvedValue(Buffer.from('')),
     locator: jest.fn().mockReturnValue({ all: jest.fn().mockResolvedValue([]) }),
     on: jest.fn(),
+    addLocatorHandler: jest.fn().mockResolvedValue(undefined),
+    evaluate: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as Page;
 }
@@ -35,6 +41,83 @@ function createMockPage(overrides: Partial<Record<string, jest.Mock>> = {}): Pag
 describe('playwright-automation', () => {
   beforeEach(() => {
     jest.mocked(reportErrorEvent).mockClear();
+  });
+
+  describe('registerOverlayBannerHandler', () => {
+    it('addLocatorHandler を noWaitAfter: true で登録する', async () => {
+      const mockPage = createMockPage();
+      await registerOverlayBannerHandler(mockPage);
+      expect(jest.mocked(mockPage.addLocatorHandler)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Function),
+        { noWaitAfter: true }
+      );
+    });
+
+    it('バナーのボタンが存在する場合はクリックして閉じる', async () => {
+      const mockCloseButton = {
+        count: jest.fn().mockResolvedValue(1),
+        click: jest.fn().mockResolvedValue(undefined),
+      };
+      const mockLocator = {
+        ...mockCloseButton,
+        first: jest.fn().mockReturnValue(mockCloseButton),
+      };
+      const mockPage = createMockPage({
+        locator: jest.fn().mockReturnValue(mockLocator),
+        addLocatorHandler: jest.fn().mockResolvedValue(undefined),
+      });
+
+      await registerOverlayBannerHandler(mockPage);
+      const handler = jest.mocked(mockPage.addLocatorHandler).mock.calls[0][1];
+      await handler();
+
+      expect(mockCloseButton.click).toHaveBeenCalledWith({ timeout: 3000, force: true });
+    });
+
+    it('バナーのボタンが存在しない場合は DOM から除去する', async () => {
+      const mockCloseButton = {
+        count: jest.fn().mockResolvedValue(0),
+        click: jest.fn(),
+      };
+      const mockLocator = {
+        ...mockCloseButton,
+        first: jest.fn().mockReturnValue(mockCloseButton),
+      };
+      const mockEvaluate = jest.fn().mockResolvedValue(undefined);
+      const mockPage = createMockPage({
+        locator: jest.fn().mockReturnValue(mockLocator),
+        addLocatorHandler: jest.fn().mockResolvedValue(undefined),
+        evaluate: mockEvaluate,
+      });
+
+      await registerOverlayBannerHandler(mockPage);
+      const handler = jest.mocked(mockPage.addLocatorHandler).mock.calls[0][1];
+      await handler();
+
+      expect(mockEvaluate).toHaveBeenCalled();
+      expect(mockCloseButton.click).not.toHaveBeenCalled();
+    });
+
+    it('除去処理が失敗しても例外をスローせず処理を継続する', async () => {
+      const mockCloseButton = {
+        count: jest.fn().mockResolvedValue(1),
+        click: jest.fn().mockRejectedValue(new Error('クリック失敗')),
+      };
+      const mockLocator = {
+        ...mockCloseButton,
+        first: jest.fn().mockReturnValue(mockCloseButton),
+      };
+      const mockPage = createMockPage({
+        locator: jest.fn().mockReturnValue(mockLocator),
+        addLocatorHandler: jest.fn().mockResolvedValue(undefined),
+      });
+
+      await registerOverlayBannerHandler(mockPage);
+      const handler = jest.mocked(mockPage.addLocatorHandler).mock.calls[0][1];
+
+      await expect(handler()).resolves.toBeUndefined();
+    });
   });
 
   describe('login', () => {


### PR DESCRIPTION
## 変更の概要

ニコニコ動画側のお知らせモーダル（`OverlayBannerFrame`）が表示されると、Playwright がマイリストリンクをクリックできず、自動登録が prod で全件失敗していた問題を修正。

`page.addLocatorHandler()` を使い、`.OverlayBannerFrame` が出現した際に自動的に閉じるハンドラをブラウザ起動直後に登録する。モーダルが出現しない場合はハンドラが発火しないため、バナー有無に関わらず安全に動作する（ベストエフォート、除去失敗時も非致命的に継続）。

## 関連 Issue

Closes #3159

## 変更種別

- [x] バグ修正

## 実装チェックリスト

- [x] `registerOverlayBannerHandler(page)` を追加（`services/niconico-mylist-assistant/batch/src/playwright-automation.ts`）
  - `.OverlayBannerFrame` 出現時にボタンクリック（fallback: `page.evaluate` で DOM 除去）
  - `noWaitAfter: true`、除去失敗は `console.warn` のみで例外スローなし
- [x] `executeMylistRegistration` の `browser.newPage()` 直後でハンドラ登録
- [x] ユニットテスト 4 ケース追加（登録/ボタンあり/ボタンなし/失敗継続）

## テスト内容

- ユニットテスト: 48 件すべてグリーン（新規 4 件）
- Fast Verification CI（PR #3160）: Lint / Format / Build / Test Batch / Docker / E2E chromium-mobile すべて success
- **dev 環境実ジョブ検証済み**（ジョブ `3f36b690-7b7a-4247-9bed-ca0fbdaf23f5`）:
  - お知らせバナーを検出・クローズ（2回発火、いずれも成功）
  - prod で失敗していたマイリスト削除ステップが成功 → 作成 → 動画登録まで完走
  - DynamoDB: `status=SUCCEEDED`, `registeredCount=2`, `failedCount=0`（投入動画数2に対し全件成功）

## レビューポイント

- `.OverlayBannerFrame` のセレクタは今後ニコニコ側で変わる可能性あり。close ボタンの正確なクラスはログから不明なため `button` 全般を対象にしている
- fallback の `page.evaluate` による DOM 除去は Playwright コンテキスト内のみで本番影響なし

## 補足

- 全件失敗時に DynamoDB ステータスが `SUCCEEDED` に誤更新される問題（Issue #3148）は本 PR のスコープ外で別途対応


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcSQRxcERK496jq5a2sqA6)_