### PR TITLE
[Blog] 週次ブログ記事 Issue 自動作成ワークフロー追加

### DIFF
--- a/.github/workflows/scripts/prepare-blog-article-issue.sh
+++ b/.github/workflows/scripts/prepare-blog-article-issue.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# 週次ブログ記事 Issue の本文を生成するスクリプト
+#
+# 環境変数:
+#   NEXT_DATE   - 次回作成予定日
+#   CREATE_TIME - 作成日時（未指定時は現在 UTC 時刻）
+
+NEXT_DATE="${NEXT_DATE:-未定}"
+CREATE_TIME="${CREATE_TIME:-$(date -u +"%Y-%m-%d %H:%M UTC")}"
+
+TEMPLATE=$(cat .github/workflows/templates/weekly-blog-article-body.md)
+
+BODY=$(echo "$TEMPLATE" | \
+  sed "s|{{NEXT_DATE}}|${NEXT_DATE}|g" | \
+  sed "s|{{CREATE_TIME}}|${CREATE_TIME}|g")
+
+echo "$BODY"

--- a/.github/workflows/templates/weekly-blog-article-body.md
+++ b/.github/workflows/templates/weekly-blog-article-body.md
@@ -1,0 +1,90 @@
+## 📝 週次ブログ記事追加
+
+このIssueは自動作成されました。Portal 技術ブログに記事を **1 本**新規追加してください。
+
+## 📋 実行情報
+
+- 作成日時: {{CREATE_TIME}}
+- 次回作成予定: {{NEXT_DATE}}
+
+---
+
+## 🎯 テーマ選定
+
+`services/portal/web/src/content/tech/` 配下の既存記事（29 本程度）の frontmatter（`title` / `tags` / `relatedServices`）を一覧し、以下の条件を満たす新規テーマを **1 つ**選定すること。
+
+- 既出テーマと重複しない
+- 本リポジトリの技術スタック（AWS / Next.js / TypeScript / CDK / Playwright 等）に沿っている
+- 記事として単独で成立する粒度（チュートリアル・設計解説・ハマり事例・比較等）
+
+---
+
+## 📄 記事仕様
+
+**1 Issue につき記事 1 本を新規作成する**（複数本まとめ作成は不可）。
+
+- **ファイルパス**: `services/portal/web/src/content/tech/{slug}.md`（1 ファイルのみ）
+- **slug**: ファイル名と frontmatter の `slug` フィールドを一致させる（kebab-case 英字）
+- **frontmatter**: 既存記事に準拠する
+
+    ```yaml
+    ---
+    title: "記事タイトル（日本語可）"
+    description: "記事の説明（1〜2文）"
+    slug: "kebab-case-slug"
+    publishedAt: "YYYY-MM-DD"
+    tags:
+      - existing-tag
+    relatedServices:
+      - サービス名
+    ---
+    ```
+
+- **タグ**: 既存タグと整合させ、`isLinkableTag` 対象の ASCII slug タグを最低 1 つ含める
+- **言語**: 日本語で執筆
+
+---
+
+## ✅ 品質基準
+
+- ボリューム: 既存記事と同程度（7〜9 KB 目安）
+- 構成: `## はじめに` → 本文各節 → `## まとめ` を基本とする
+- コードブロック・図表を適宜含め、読者が手を動かせる実用的な内容にする
+
+---
+
+## 🔍 動作確認
+
+`services/portal/web` で以下が正常に生成されることを確認する（`content.ts` 経由）。
+
+- [ ] 記事一覧ページに新記事が表示される
+- [ ] 記事詳細ページが表示される
+- [ ] タグページ（該当タグ）に記事が表示される
+
+---
+
+## 🌿 ブランチ運用
+
+**CLAUDE.md の正規フローに従うこと**（`agent-claude.yml` の簡易フローではなく）。
+
+```
+Issue → integration/{issue-number}-{slug} ブランチ（develop から分岐）
+      → 作業ブランチ（claude/** 等）
+      → 作業ブランチ → integration への Draft PR
+```
+
+- ブランチ名・slug は実装時に判断する
+- `integration/{issue-number}-{slug}` → `develop` の PR 作成は人の確認を取ってから
+
+---
+
+## 📚 参考ドキュメント
+
+- 既存記事: `services/portal/web/src/content/tech/`
+- 記事読み込みロジック: `services/portal/web/src/lib/content.ts`
+- frontmatter 型: `services/portal/web/src/types/content.ts`
+- 開発フロー: `CLAUDE.md`, `docs/development/flow.md`
+
+---
+
+**自動作成**: `weekly-blog-article.yml`

--- a/.github/workflows/weekly-blog-article.yml
+++ b/.github/workflows/weekly-blog-article.yml
@@ -1,0 +1,112 @@
+name: Weekly Blog Article
+
+on:
+  schedule:
+    # 毎週月曜日 11:00 JST (2:00 UTC)
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  create-blog-article-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get current date info
+        id: date_info
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          CREATE_TIME=$(date -u +"%Y-%m-%d %H:%M UTC")
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "create_time=$CREATE_TIME" >> "$GITHUB_OUTPUT"
+          echo "title=[Blog] 技術ブログ記事追加 ($DATE)" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate next issue date
+        id: next_date
+        run: |
+          NEXT_MONDAY=$(date -d "next monday" +%Y-%m-%d)
+          echo "next_date=$NEXT_MONDAY" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure blog-article label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "blog-article" \
+            --description "ブログ記事追加タスク" \
+            --color "0075ca" \
+            2>/dev/null || true
+
+      - name: Check existing open blog-article issue
+        id: duplicate_check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          OPEN_ISSUES_JSON=$(gh issue list \
+            --label "blog-article" \
+            --state open \
+            --limit 1 \
+            --json number,url)
+
+          ISSUE_NUMBER=$(echo "$OPEN_ISSUES_JSON" | jq -r '.[0]? | .number // empty')
+          ISSUE_URL=$(echo "$OPEN_ISSUES_JSON" | jq -r '.[0]? | .url // empty')
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "should_create=false" >> "$GITHUB_OUTPUT"
+            echo "open_issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "open_issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_create=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare issue body from template
+        id: issue_body
+        if: steps.duplicate_check.outputs.should_create == 'true'
+        env:
+          NEXT_DATE: ${{ steps.next_date.outputs.next_date }}
+          CREATE_TIME: ${{ steps.date_info.outputs.create_time }}
+        run: |
+          .github/workflows/scripts/prepare-blog-article-issue.sh > "${RUNNER_TEMP}/issue_body.md"
+          echo "body_file=${RUNNER_TEMP}/issue_body.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create weekly blog article issue
+        id: create_issue
+        if: steps.duplicate_check.outputs.should_create == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: ${{ steps.date_info.outputs.title }}
+          ISSUE_BODY_FILE: ${{ steps.issue_body.outputs.body_file }}
+        run: |
+          ISSUE_URL=$(gh issue create \
+            --title "$ISSUE_TITLE" \
+            --label "blog-article" \
+            --body-file "$ISSUE_BODY_FILE")
+          ISSUE_NUMBER="${ISSUE_URL##*/}"
+          echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Summary (created)
+        if: steps.duplicate_check.outputs.should_create == 'true'
+        run: |
+          echo "✅ 週次ブログ記事 Issue を作成しました" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**タイトル**: ${{ steps.date_info.outputs.title }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Issue**: #${{ steps.create_issue.outputs.issue_number }} (${{ steps.create_issue.outputs.issue_url }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "**次回作成予定**: ${{ steps.next_date.outputs.next_date }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summary (skipped)
+        if: steps.duplicate_check.outputs.should_create != 'true'
+        run: |
+          echo "⏭️ 既存の blog-article ラベル付きオープン Issue が存在するため、新規作成をスキップしました" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ steps.duplicate_check.outputs.open_issue_number }}" ] && [ -n "${{ steps.duplicate_check.outputs.open_issue_url }}" ]; then
+            echo "**既存Issue**: #${{ steps.duplicate_check.outputs.open_issue_number }} (${{ steps.duplicate_check.outputs.open_issue_url }})" >> "$GITHUB_STEP_SUMMARY"
+          elif [ -n "${{ steps.duplicate_check.outputs.open_issue_number }}" ]; then
+            echo "**既存Issue**: #${{ steps.duplicate_check.outputs.open_issue_number }}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**既存Issue**: 取得できませんでした" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## 変更の概要

毎週月曜 11:00 JST（2:00 UTC）に `blog-article` ラベル付きオープン Issue の重複チェックを行い、なければ記事追加タスク Issue を自動作成する GitHub Actions ワークフローを追加。`daily-refactoring-check.yml` と同じパターンを踏襲。

## 関連 Issue

#3162

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（ワークフロー・シェルスクリプトのため対象外）
- [x] 関連ドキュメントを更新した（Issue テンプレートに記事仕様・ブランチ運用を記載）
- [x] CI/CD 設定を追加・更新した
- [x] ローカルでテストが全て通ることを確認した（`bash -n` で構文チェック済み）
- [x] ビルドエラーがないことを確認した

## 追加ファイル

| ファイル | 説明 |
|---|---|
| `.github/workflows/weekly-blog-article.yml` | ワークフロー本体（cron + workflow_dispatch） |
| `.github/workflows/templates/weekly-blog-article-body.md` | 生成 Issue の本文テンプレート |
| `.github/workflows/scripts/prepare-blog-article-issue.sh` | テンプレートのプレースホルダ置換スクリプト |

## テスト内容

- `bash -n` でシェルスクリプトの構文チェック済み
- ワークフロー動作確認は `workflow_dispatch` で手動実行して確認（マージ後に実施）

## レビューポイント

- cron 時刻（月 2:00 UTC）が既存 weekly-docs-review（月 0:00）・weekly-npm-check（月 1:00）と重複しないこと
- `blog-article` ラベル未存在時の冪等作成（`gh label create ... 2>/dev/null || true`）の動作
- 生成 Issue 本文（テンプレート）に CLAUDE.md 正規フロー（integration 経由）の指示が含まれていること

## 補足事項

- `1 Issue = 1 記事固定` の設計判断は Issue #3162 本文に記載
- ワークフロー自体の `workflow_dispatch` 動作確認は integration マージ後に人力で実施する

---
_Generated by [Claude Code](https://claude.ai/code/session_016NcWceXk2RVTxq89FcvGs5)_