### PR TITLE
chore(deps): 2026年第20週 npm パッケージ更新 (fast-uri High 脆弱性解消)

### DIFF
--- a/infra/admin/package.json
+++ b/infra/admin/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@nagiyu/infra-common": "*",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/infra/auth/package.json
+++ b/infra/auth/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@nagiyu/infra-common": "*",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/infra/codec-converter/package.json
+++ b/infra/codec-converter/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "@nagiyu/infra-common": "*",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0"
-  },
-  "devDependencies": {}
+  }
 }

--- a/infra/common/package.json
+++ b/infra/common/package.json
@@ -21,7 +21,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0"
   }
 }

--- a/infra/niconico-mylist-assistant/package.json
+++ b/infra/niconico-mylist-assistant/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@nagiyu/infra-common": "*",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -8,49 +8,45 @@
       "name": "@nagiyu/infra",
       "version": "1.0.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.172.0",
-        "constructs": "^10.4.2"
-      },
-      "devDependencies": {
-        "@types/node": "^22.10.5",
-        "aws-cdk": "^2.172.0"
+        "aws-cdk-lib": "^2.256.1",
+        "constructs": "^10.6.0"
       },
       "engines": {
-        "node": ">=22.0.0",
+        "node": ">=24.0.0",
         "npm": ">=10.0.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.242",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
-      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
-      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "48.20.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.20.0.tgz",
-      "integrity": "sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==",
+      "version": "53.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz",
+      "integrity": "sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.2"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -58,7 +54,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.8.0",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -68,38 +64,13 @@
         "node": ">=10"
       }
     },
-    "node_modules/@types/node": {
-      "version": "22.19.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
-      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/aws-cdk": {
-      "version": "2.1100.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1100.2.tgz",
-      "integrity": "sha512-PK80VEunZGpGW3+66EbPUpoKZKxsK7/BBR3X2qqtgk5wrSVJn+rq3Rwlih5lCD223rpf2RXAnC5weGHdEtgSuA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
     "node_modules/aws-cdk-lib": {
-      "version": "2.233.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.233.0.tgz",
-      "integrity": "sha512-rBOzIA8TGC5eB8TyVIvckAVlX7a0/gVPE634FguhSee9RFaovjgc5+IixGyyLJhu3lLsMSjqDoqTJg2ab+p8ng==",
+      "version": "2.256.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.256.1.tgz",
+      "integrity": "sha512-18xLE+iqzjvpYGGKJy+9zyvF8loUSXjpVV2MtVLPQ/hPgeWHQiVsqLOWNsBemd3pU7o0L9wXfRY+xqG80vlZFw==",
       "bundleDependencies": [
         "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
         "case",
         "fs-extra",
         "ignore",
@@ -113,26 +84,53 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.242",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^48.20.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.2",
+        "fs-extra": "^11.3.3",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.3",
         "punycode": "^2.3.1",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "constructs": "^10.0.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -141,7 +139,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.18.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -186,17 +184,22 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.4",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "5.0.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -223,11 +226,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
@@ -239,7 +237,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -254,7 +252,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.2",
+      "version": "11.3.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -336,14 +334,17 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "10.2.5",
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
@@ -363,7 +364,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -437,7 +438,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -445,32 +446,10 @@
       }
     },
     "node_modules/constructs": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.4.tgz",
-      "integrity": "sha512-lP0qC1oViYf1cutHo9/KQ8QL637f/W29tDmv/6sy35F5zs+MD9f66nbAAIjicwc7fwyuF3rkg6PhZh4sfvWIpA==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }

--- a/infra/package.json
+++ b/infra/package.json
@@ -14,7 +14,7 @@
     "destroy": "cdk destroy"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0"
   },
   "engines": {

--- a/infra/quick-clip/package.json
+++ b/infra/quick-clip/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@nagiyu/infra-common": "*",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/infra/share-together/package.json
+++ b/infra/share-together/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@nagiyu/infra-common": "*",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/infra/shared/package.json
+++ b/infra/shared/package.json
@@ -16,6 +16,6 @@
     "destroy": "cdk destroy"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.248.0"
+    "aws-cdk-lib": "^2.256.1"
   }
 }

--- a/infra/stock-tracker/package.json
+++ b/infra/stock-tracker/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@nagiyu/infra-common": "*",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0"
   },
   "engines": {

--- a/infra/tools/package.json
+++ b/infra/tools/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@nagiyu/infra-common": "*",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/infra/ui-storybook/package.json
+++ b/infra/ui-storybook/package.json
@@ -16,7 +16,7 @@
     "destroy": "npx cdk destroy"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "infra/*"
       ],
       "dependencies": {
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.9",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.13",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^9.0.0",
@@ -52,7 +52,7 @@
         "aws-cdk": "^2.1117.0",
         "aws-sdk-client-mock": "^4.1.0",
         "dotenv": "^17.4.1",
-        "eslint": "^10.2.0",
+        "eslint": "^10.4.0",
         "eslint-config-next": "^16.2.3",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.3.0",
@@ -74,7 +74,7 @@
       "name": "@nagiyu/infra",
       "version": "1.0.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0"
       },
       "engines": {
@@ -87,7 +87,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@nagiyu/infra-common": "*",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
       }
@@ -97,7 +97,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@nagiyu/infra-common": "*",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
       }
@@ -107,19 +107,18 @@
       "version": "0.1.0",
       "dependencies": {
         "@nagiyu/infra-common": "*",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0"
       },
       "bin": {
         "codec-converter": "bin/codec-converter.js"
-      },
-      "devDependencies": {}
+      }
     },
     "infra/common": {
       "name": "@nagiyu/infra-common",
       "version": "1.0.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0"
       }
     },
@@ -128,9 +127,426 @@
       "version": "0.1.0",
       "dependencies": {
         "@nagiyu/infra-common": "*",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
+      }
+    },
+    "infra/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "53.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz",
+      "integrity": "sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "infra/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "infra/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib": {
+      "version": "2.256.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.256.1.tgz",
+      "integrity": "sha512-18xLE+iqzjvpYGGKJy+9zyvF8loUSXjpVV2MtVLPQ/hPgeWHQiVsqLOWNsBemd3pU7o0L9wXfRY+xqG80vlZFw==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.3",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.3",
+        "punycode": "^2.3.1",
+        "semver": "^7.7.4",
+        "table": "^6.9.0",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.8.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.18.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "infra/node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "infra/node_modules/source-map": {
@@ -157,7 +573,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@nagiyu/infra-common": "*",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
       }
@@ -167,7 +583,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@nagiyu/infra-common": "*",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
       }
@@ -176,7 +592,7 @@
       "name": "@nagiyu/infra-shared",
       "version": "1.0.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.248.0"
+        "aws-cdk-lib": "^2.256.1"
       }
     },
     "infra/stock-tracker": {
@@ -184,7 +600,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@nagiyu/infra-common": "*",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0"
       },
       "engines": {
@@ -197,7 +613,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@nagiyu/infra-common": "*",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
       }
@@ -206,7 +622,7 @@
       "name": "@nagiyu/infra-ui-storybook",
       "version": "1.0.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
       }
@@ -392,42 +808,6 @@
       "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
       "license": "Apache-2.0"
     },
-    "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.22.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.22.0.tgz",
-      "integrity": "sha512-2GLhjjf7Db697rRyYt6rjN06fwbBIiewPo/jxSCyUN259ejF7NQQRwvrdAQb9Aq2jPaIIp1cfHSoEdXyA6Bb7Q==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -517,386 +897,143 @@
       }
     },
     "node_modules/@aws-sdk/client-batch": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.1045.0.tgz",
-      "integrity": "sha512-QJ3msfjZmqkwwwTc1NeDi2DOLIQzl1nLMNE6m+5yhE8oKxCwQwUBRzZonKqQs0rNu/mpTtlFegeRAHsF7JWP2g==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-batch/-/client-batch-3.1051.0.tgz",
+      "integrity": "sha512-jqgYAfBjhMp2XgdfHRLMVcavk0IsFsO0ZOACMmDqs/uBbbG8QCObME/zMigMBiwpYmeE4K33y27SWiUCtpWBZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-batch/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1045.0.tgz",
-      "integrity": "sha512-TxZmhpziFxWD3pdXGbuwntKOX5OkW14yvCITYsRz+QDM5EUL4cIygu2xRGHiKDvKmb3QUOA4yKetAQcIMLe2zw==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1051.0.tgz",
+      "integrity": "sha512-HCTEpqErM1yUCgzVSZivqoF5Ha6Qn/flP1bQi+oarzlrhXvULwTPTSLHPrInVgCMpbJLvbGb3+tWLGqL5mHaBw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/dynamodb-codec": "^3.973.8",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.11",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
+        "@aws-sdk/dynamodb-codec": "^3.973.12",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1045.0.tgz",
-      "integrity": "sha512-9EDPinh03XanJQssTBdTY+9E7PkyQ0NLLJiaOAM71/g4DI+0OZboGqhX7KKizwUGqKkj0paKEAwgWaMLgEkQFQ==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1051.0.tgz",
+      "integrity": "sha512-Oc7Rc9R6BbltJGYUls4xYswIujugscTbjAao51izJvW+UKAzgoYg0TenVDslXoPQbkkIAnZjAF6ehLxB8eui4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/eventstream-serde-browser": "^4.2.14",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
-        "@smithy/eventstream-serde-node": "^4.2.14",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1045.0.tgz",
-      "integrity": "sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1051.0.tgz",
+      "integrity": "sha512-0Yhq7AMw2te5YtxDHkm2KKpXF8IccOO4nmCsp12EzYB/e3IKQ73NHH4jA2ki8mQwvAQzFGB+1GoycT00U8sZCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
-        "@aws-sdk/middleware-expect-continue": "^3.972.10",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.16",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.14",
+        "@aws-sdk/middleware-expect-continue": "^3.972.12",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.20",
         "@aws-sdk/middleware-location-constraint": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.41",
         "@aws-sdk/middleware-ssec": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/eventstream-serde-browser": "^4.2.14",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
-        "@smithy/eventstream-serde-node": "^4.2.14",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-blob-browser": "^4.2.15",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/hash-stream-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/md5-js": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1045.0.tgz",
-      "integrity": "sha512-ceXmaTE/3j7bHgVzUrpL/ECjQQ+aE/x8wNbblC/SIb020OxYRMj0DscFimnI5kEjutGHQ+A68bbX2A+bZuAMEA==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1051.0.tgz",
+      "integrity": "sha512-bJN7+ck68aCFnTHGysMYqdXJY7qVMxRo99rZoqR5aG0Zm/uH6ZaFxO5qLSdOBV5CnBEbhmzsS6xNCaBk75WHiA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
-      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.22",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
-      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.8.tgz",
+      "integrity": "sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -907,14 +1044,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
-      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -923,20 +1060,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
-      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -944,23 +1078,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
-      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-env": "^3.972.34",
-        "@aws-sdk/credential-provider-http": "^3.972.36",
-        "@aws-sdk/credential-provider-login": "^3.972.38",
-        "@aws-sdk/credential-provider-process": "^3.972.34",
-        "@aws-sdk/credential-provider-sso": "^3.972.38",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-login": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -969,17 +1102,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
-      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -988,21 +1119,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
-      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.34",
-        "@aws-sdk/credential-provider-http": "^3.972.36",
-        "@aws-sdk/credential-provider-ini": "^3.972.38",
-        "@aws-sdk/credential-provider-process": "^3.972.34",
-        "@aws-sdk/credential-provider-sso": "^3.972.38",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-ini": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1011,15 +1141,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
-      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1028,17 +1157,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
-      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
-        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/token-providers": "3.1049.0",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1047,16 +1175,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
-      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1065,15 +1192,14 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.8.tgz",
-      "integrity": "sha512-dYQ/cQqHZd23hcl8oEGwPphTqyGnmvf2HrVmz4J90Q5Bv89oJjlwcBcifiiTvApqsVpx7Pr0IebMpkYwWJvZlQ==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.12.tgz",
+      "integrity": "sha512-E+qpJPN1QLzfeVDQe1gVmMiHu9PTJWwXqSQjIt8mH5OQXmds2J/IN+Ar6Oa9ZhhuPZb4fPkcgZg4UEpwJM90NA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@smithy/core": "^3.23.17",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1094,15 +1220,14 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1045.0.tgz",
-      "integrity": "sha512-U8PWWu3MGrsivZz8xMuRFnaP7ir9r/GvYRcrFRek8FhndiqB8OPQTCA2e+ki+ApLuPjj1foUs+3arTVptt1QGQ==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1051.0.tgz",
+      "integrity": "sha512-dtxgjDqeeQdtucyxmKV1z4wjpXdYAtTXM6rDn70lTB6ihpNW3LE+qSehkOaTCID54qFOWYvUNhogUF4Rg7Lwgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/util-dynamodb": "^3.996.2",
-        "@smithy/core": "^3.23.17",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1110,21 +1235,19 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1045.0"
+        "@aws-sdk/client-dynamodb": "^3.1051.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
-      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.14.tgz",
+      "integrity": "sha512-Aaj0d+xbo1jJquBWJP0/9V/XZRYukO3LWIRp3dOLHmoFrYKb4YZ0aLefgVHfGcNOVBS2ZTq7L/n5JcrE7DaC+Q==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1132,15 +1255,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.11.tgz",
-      "integrity": "sha512-vXARCZVFQHdsd6qPPZyC/hh+5x2XsCYKqUQDCqnUlpGpChMpDojOOacQWdLJ+FFXKN8X3cmLOGrtgx/zysCKqQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.13.tgz",
+      "integrity": "sha512-1r6EkFdSQ4quTP3pW8yWIcYuyDwdwdBxGr+kfuPFYE3DqR+1gBc6NyJneAyoIs+wc/cUfnyJ4ZYC0T2SQTxP9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.5",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1149,13 +1271,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
-      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.12.tgz",
+      "integrity": "sha512-dA5pKTom/Ls9mgeyeaRBNQrRIVOLVjv4AmKOB0/e4yaiXEUy0gSz2d3liP8JHtYoCAEWySU1jWnyzwLOREN+4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1164,64 +1286,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.16.tgz",
-      "integrity": "sha512-6ru8doI0/XzszqLIPXf0E/V7HhAw1Pu94010XCKYtBUfD0LxF0BuOzrUf8OQGR6j2o6wgKTHUniOmndQycHwCA==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.20.tgz",
+      "integrity": "sha512-NdnMVQCR1YjIcqFAiNLdBiOwr2DyQDB2IiXQrBhzolKOv32ae4d4Ll7IzLMi04eMHiq/o/Y/GjFuVjF9HuG0QA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/crc64-nvme": "^3.972.8",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/is-array-buffer": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.3.2.tgz",
-      "integrity": "sha512-JYNfdKj1kr3ke+Pip+qxiuXW/OuSe8KlCyJz93bU25uKVq6wQGdm6H0/1g2XoFjehJFUmNdS+2/nM6Oabe6/+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1243,72 +1319,22 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
-      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.41.tgz",
+      "integrity": "sha512-M4T2I2WPuH5WQpU8Tsp+u2bcO29zGRkU14ATzuqb9I4xh8tzsLqtp4hzaJM5aO2dhMZnHDzyQwSFVgc3XbnoGg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
@@ -1325,97 +1351,20 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
-      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@smithy/core": "^3.23.17",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
-      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.2.tgz",
-      "integrity": "sha512-Bswgu9zDwZRp5HBQKIaW6QrKrbwQ9RuOyAg2adsIjJTHA2SmE0XXBk+mYP82Ay6I3XzkY5lM7K9R0XZDFzJ3tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1424,17 +1373,15 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1045.0.tgz",
-      "integrity": "sha512-VDRF8GIuUPX+K4DUYrvcODj/h54LOmdJ7DhpLQ0wrYrdxzIiJEpi0n9jZ1bbjT2UxhwTbOorse5EGo+gnOK2aA==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1051.0.tgz",
+      "integrity": "sha512-9ZULJHf5IAObmqtg2XhiufMmgEl+aM9jlRog2V9qbICeSOgDCHekmlRxF9FuqZKMqrpLzGtJPDbd8gGAHJZv/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-format-url": "^3.972.10",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1443,15 +1390,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
-      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1460,16 +1406,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
-      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -1484,18 +1429,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1517,37 +1450,6 @@
         "@aws-sdk/client-dynamodb": "^3.1003.0"
       }
     },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
-      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.965.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
@@ -1558,43 +1460,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
-      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
@@ -2998,9 +2863,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5004,6 +4869,702 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
+      "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
+      "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
+      "integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
+      "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
+      "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
+      "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
+      "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
+      "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
+      "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
+      "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
+      "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
+      "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
+      "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
+      "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
+      "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
+      "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
+      "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
+      "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
+      "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
+      "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -5734,27 +6295,14 @@
         "node": ">=4"
       }
     },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.5.1.tgz",
-      "integrity": "sha512-abXk3LhODsvRHsk0ZS9ztrg/fZatTa9Z/z4pgx65YSLR+rY6kvUG/1IgcDKEUciR8MfdnkT5oPeHJTy/HhzDIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.2.tgz",
-      "integrity": "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5762,52 +6310,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.1.tgz",
-      "integrity": "sha512-0S/acwHnqX4WrjXzhdiDRxsG2s9SC0cpPIK9nZ1R6UOHd+j7uL28+4bHu22urbLk2TVw3fkp6na/+fkUt/pLNQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.3.1.tgz",
-      "integrity": "sha512-X7MyI1fu8M84IPKk49kO4kb27Mqp6un9/0o/MsA1ngZ5OxxWKGUxPS3S/AJ9q1cPVTSGmRcbaGNfGUSsflTJkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.4.1.tgz",
-      "integrity": "sha512-JZGbSXaBk7JY8VPzsh66ksJ0nTWXbApduFDkA/pEl3aTm2EoAiUZE1Iltp6c+X1bB8kxPQW0mHDfVdYCpWTOzg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.3.1.tgz",
-      "integrity": "sha512-6Cn4xTNVxn9PWTHSbvf8zmcDhQW8lrLE1Xq5CJgmX6wEvdjS2S0KuE79Aiznv/jx51jpFJ98OuWyE+Bt+oG1MQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5815,65 +6324,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.1.tgz",
-      "integrity": "sha512-r7bN6spQ+caZC8AnyvSxkRUb57zt2jhhRw3Z+2Ez8hjq6coIikDBFUUI/+CQ1xx9K6eX1Gx6wUKo4ylU66TIqw==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.3.1.tgz",
-      "integrity": "sha512-2fbltQVQYmGd0OzPv2oDMRF0pxkzeIx8cbpx2x6W3UJWGaEyUzVPxF4d0sDXZ/r2obg+RbTyhTidXWlPDsKRKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.3.1.tgz",
-      "integrity": "sha512-u0/zo11mg7yNneoYgTkH4sXwSmcBpbl49o4UNCtQ7hYsXxynsN25KYHmXzqi7TPk5HQL5klGnpU5koOY0O+9hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-stream-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.3.1.tgz",
-      "integrity": "sha512-4NOnngIoXngbJw9By3u8KXRgqt4vYATpAobNBnNWxOREP7JY3kB0bUmbBNhZ7dtZV/b4auO1eFMD4cLj9OauVg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.3.1.tgz",
-      "integrity": "sha512-cLmwtDoulyZvRepAfyV+3rx5oMvuh51dbE+6En3vGC09j3uVSRt1U4oguNu32ub3soGX0oYtBs8E7S2Q4SxTqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5892,157 +6349,14 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/md5-js": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.1.tgz",
-      "integrity": "sha512-98NalujRdzv6ggVQNYPWpL2K57UKeUB8roIr61u6+JiHd7KUlMQ+sn/vk6IG4XxEjw2vlC7eu/xjYXshUE4XXg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.3.1.tgz",
-      "integrity": "sha512-l4BUIP+wljW/Ar+0/QcGdmElI9lalrywfzNijXMBG34Z510FRzPyrDLx/blNTZOAm0C4Mvx5t/bf760CZo1ajg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.1.tgz",
-      "integrity": "sha512-qtqu5TS+8Y18ZDkJoiXN5AMW1G4JAg1+xytzpsUvIR5a4EUsgd5HQg12lekEHWpm2TDUmOgg+hBaHK7dvyWdkA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.6.1.tgz",
-      "integrity": "sha512-eTaQhxs0rfUuAkL2MSKrH8DTO7YCeAgrdN0B2/RAeuHmXQ+x52dk5qUBsi/jtcqe5LxItgq5AG5tI6Cp8c0sow==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.3.1.tgz",
-      "integrity": "sha512-t7YtUe076zWVypVmy1rX91oKi2TFJCkpfFpfMhJFpEIRPP0iL9JxjeSyFQ+1bF45JUfDzOzslUJa150WcSrBug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.3.1.tgz",
-      "integrity": "sha512-1jKwiKZxCMQNqmp4uVPYA6r+MLGjEtH07gnOUdPgbnjuOIrl/0JY/ICdpQtFgeBsQ/Up01gnSv8GYEL0fb8yvg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.4.1.tgz",
-      "integrity": "sha512-q7tDJEJXcaSG/8TVpu2f2l9bzxTzDM9geWmltbzsY6Hfh3yiuXXTpLIO8+zwYASPPVFaTJpdKwjSSjdoDoccgw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.1.tgz",
-      "integrity": "sha512-BdEYko85f/ldp68uH8XEyIvo810xFk6eyPH81SRggTOApYHWA+Xu7B2EzLuHbe37WVLaUA7F1fWR3/zBeme2WA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.3.1.tgz",
-      "integrity": "sha512-3NHoqVBhzpY2b4YBx9AqyKC4C8nnEjl5FyKuxrCjvnjinG0ODj+yg1xX360nNahT6wghYjSw1SooCt3kIdnqIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.1.tgz",
-      "integrity": "sha512-8irPNCQgYxcSFp1aGcnDNFkTwSA+xPUaFq9V/v1+JXWu8sKr5b3cFmg2kBTkjkvypDmGeNffuNu0x5iqw1NoAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.3.1.tgz",
-      "integrity": "sha512-toyi8sXPWDNoVH6yK7sXJ9dm5uxw2tWLCHzPy/t16Fvl62Es4vXQXzlilyNaw+DqFwxSlrFClh0rGLPUF2p9Lg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.5.1.tgz",
-      "integrity": "sha512-FKoKxVzdFPhyynFI+SPTWrgOP60fZ4l1UwukWYj4eyhpSmEI7MJ6p58hawIIt9bwp+aek9NEm8Zika7E+GEoeg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6050,27 +6364,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.1.tgz",
-      "integrity": "sha512-728lZZEWYWubBESrfntNslZQYDKRlJDY4dcDnYbL50+gu35pGPLblu4S0/RH/RDLF6me1M87ECHsHELGL7dA/Q==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.13.1.tgz",
-      "integrity": "sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6083,58 +6383,6 @@
       "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.3.1.tgz",
-      "integrity": "sha512-tuelFlF2PZR/wogFC58NIrPOv+Zna4N1+3kA161/33D1Gbwvl6Nh4WsAsW05ZyPp0O6CMGsdbb0S2b/qVjRMCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.4.1.tgz",
-      "integrity": "sha512-fTHiwW2xbiRiWzfSk4IGAr3gNZCH4fuRYqt8+IuarsP/YON35576iVdePraZ6yJlFxlCL0eMec3/F7xYqoKzlg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.3.1.tgz",
-      "integrity": "sha512-1scg5t4nV3hV7CZs996/XHb80aDZ5YotH4NcvkW/w/rHj+cSz0aCIzwz8aUNKB4nCDPSHRCbrKoj+TvycYefmw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.3.1.tgz",
-      "integrity": "sha512-VRC8MKVPKrgUYThTA7ughcKMfjW6/X92H0wXGJoda0Apw4O5xbXL0GMLz40DTWlsb5hh2iItk6+XL72uJdxYcw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6154,97 +6402,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.3.1.tgz",
-      "integrity": "sha512-lw6L5GF5+W19vO6o3fZwRT2cXEG+8b2LH0b9ppjDT6nIxjUgmljEQGninx5XorylwKZZ4XLVABeroJ8oaF9RmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.4.1.tgz",
-      "integrity": "sha512-1rA7w+LjK1WJClsffC81Z/ZtjFt22QsKhBjUYEnZsGVS2nOTfOENKBzdg4SxhdwFvBCjcbpjscUfXOPwE3UHWQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.3.1.tgz",
-      "integrity": "sha512-1fk1wfQHBenQD5NitVKOFgW0wsISYAFPIXGyStJWAeCtMyRhgHYvtJxBk2rwGWA0L5QX6oM6yeHSLKPFMk59ww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.5.1.tgz",
-      "integrity": "sha512-yORYzJD5zoGbSDkAACr0dIjDiSEA3X8h8lggDENl1dkKpCG0TQIoItPBqtvuJHzFFjRXumcoH+/09xIuixGyCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.3.1.tgz",
-      "integrity": "sha512-SRRMDcIgVXVhVbxviBaSZbuWuVW3jD08wv4ESV0V2oiw0Mki8TPVQ5IxwD3MvSTPg52QYsRP+JoMw5WdUdeWAg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.4.1.tgz",
-      "integrity": "sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.6.1.tgz",
-      "integrity": "sha512-GjZfEft0M0V3n2YM/LGkr5LeLd8gxHUIzW0rUz6VtTtlAq245GxHlJghvoPEjJHKTj255iHFAiA4IsIdK40Ueg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
@@ -6258,23 +6415,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/util-waiter": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.1.tgz",
-      "integrity": "sha512-G/gWDykZNL0NVcd1qXkoKm45jxJECp6q53DSomM5QKMsyAMEsGksVq+HwgonqYxfFJEzzHi6ljtWKXVS1pl0/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@storybook/addon-a11y": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.3.6.tgz",
-      "integrity": "sha512-cbwXIT5CeHZ9AFbTKQ6YB7Ct6TAl/kKOgALbvzzVtFfRvm51JYygGaiJaB7PbPWn9wgJP2olJcFt+erlEc6cRw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.0.tgz",
+      "integrity": "sha512-N1QRmh+PMe5O81KDf8oPDv/csdLAmDCRCYLByukqdUXpTNlcULHDFUJNXl00/rFpbt7PbOZqzRzs72JJt6nWPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6286,13 +6430,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.6"
+        "storybook": "^10.4.0"
       }
     },
     "node_modules/@storybook/addon-themes": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.3.6.tgz",
-      "integrity": "sha512-/6lPU36+nDQzoDJqwy5BrAO0zFHOHDXn6hy/aq2aKF/RTS54+KrA0fdv0sxTssaBo5tjqZ4jKs60hB0iRWKkFA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.4.0.tgz",
+      "integrity": "sha512-ctHlkFBaKOOj4fBkc/cFWLn5CVXDIquAh3qSuebxweQU+wbcTESoZ/jkOEbntSvSHqoCqZDdfTXYOG/EWHQzGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6303,17 +6447,17 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.6"
+        "storybook": "^10.4.0"
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.3.6.tgz",
-      "integrity": "sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.0.tgz",
+      "integrity": "sha512-RCq8uzvTc0vhK2aN0y2Z48DJ9Q7oKXh8A5pdU3YAmkgMcX/+Vi3Ju1nmueLrGIO+tKwYGpYS/ccUtscNt92rCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "10.3.6",
+        "@storybook/csf-plugin": "10.4.0",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -6321,14 +6465,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.6",
+        "storybook": "^10.4.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.3.6.tgz",
-      "integrity": "sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.0.tgz",
+      "integrity": "sha512-iSmrhMyEi2ohCWKu49ZUUf8l+k0OIStbWI1BTWt2FvKySlnqY/aHenus7839SgNL3aUNG5P0y9zlyN6/HlwlEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6341,7 +6485,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.3.6",
+        "storybook": "^10.4.0",
         "vite": "*",
         "webpack": "*"
       },
@@ -6379,14 +6523,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.3.6.tgz",
-      "integrity": "sha512-oZQZ6xayWe5IdHmFUTL0TL8rX/gpNNh9gWhT2vzW5eeUvlkVG/RBKdsja6Ndrk2s1D9vcnwiI6r6CNXy3IEEmg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.0.tgz",
+      "integrity": "sha512-M1pFs4WywzKAlrBR38h8H6Q1VOca7V7tgBD3/pJGEY8z+8smRE7+Y8Gq7wZ3K0j8/0rWPxXMBD44V/1ZUV4OdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.3.6",
+        "@storybook/react-dom-shim": "10.4.0",
         "react-docgen": "^8.0.2",
         "react-docgen-typescript": "^2.2.2"
       },
@@ -6395,21 +6539,29 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.6",
+        "storybook": "^10.4.0",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
         "typescript": {
           "optional": true
         }
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.3.6.tgz",
-      "integrity": "sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.0.tgz",
+      "integrity": "sha512-dcYWzdPaJEHVlyOyyz0/0v3QJXmcnK2sjw4YiFwU9IVJhoJrBlE9lMtmbO3QqIbq4qA0hElYtGkKO7tMLSKDGw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6417,22 +6569,32 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.6"
+        "storybook": "^10.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.3.6.tgz",
-      "integrity": "sha512-tySQRc+8q7V2NkylQMNJjDV8zXy6tkxb8oDqw/DIhHhI9Xn77MTKVZ8Cihbo5NMm7HYTB6xDKr6wqdSMgdufYQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.0.tgz",
+      "integrity": "sha512-k7Lt5Pm9x2N2m56e+99fMo/hMzmiOpmwmxYALGzA0phZCTYalEQRB953TdpVIOQ0V5tlYRhe2VSpVe64/9RcTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.3.6",
-        "@storybook/react": "10.3.6",
+        "@storybook/builder-vite": "10.4.0",
+        "@storybook/react": "10.4.0",
         "empathic": "^2.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -6446,7 +6608,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.6",
+        "storybook": "^10.4.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
@@ -8219,9 +8381,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1121.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1121.0.tgz",
-      "integrity": "sha512-cG7CHt/SytYTfwrK+BUNQpqmS1dwhjt8z6ExKL6GK4n+8/6ZCwFzxlZWA/jUd2+Y9xPc+Q8cLKfMqGmgxEXbkg==",
+      "version": "2.1124.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1124.1.tgz",
+      "integrity": "sha512-sRYdPMdkX+02EHaT946AFV0w0CMfbHKWpLZPv525xTCkaVu1eYu6DzHFuTdimxdSN0uGQ2D4LHrD1sr94tRhow==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8229,380 +8391,6 @@
       },
       "engines": {
         "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib": {
-      "version": "2.253.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
-      "integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
-      "bundleDependencies": [
-        "@balena/dockerignore",
-        "@aws-cdk/cloud-assembly-api",
-        "case",
-        "fs-extra",
-        "ignore",
-        "jsonschema",
-        "minimatch",
-        "punycode",
-        "semver",
-        "table",
-        "yaml",
-        "mime-types"
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.2",
-        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^11.3.3",
-        "ignore": "^5.3.2",
-        "jsonschema": "^1.5.0",
-        "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
-        "punycode": "^2.3.1",
-        "semver": "^7.7.4",
-        "table": "^6.9.0",
-        "yaml": "1.10.3"
-      },
-      "engines": {
-        "node": ">= 20.0.0"
-      },
-      "peerDependencies": {
-        "constructs": "^10.5.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.2",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/case": {
-      "version": "1.6.3",
-      "inBundle": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.3.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.5.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/mime-db": {
-      "version": "1.52.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/mime-types": {
-      "version": "2.1.35",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.5",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/string-width": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.9.0",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.3",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/aws-sdk-client-mock": {
@@ -9728,9 +9516,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10123,16 +9911,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
@@ -12381,12 +12169,12 @@
       "license": "ISC"
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.12.0.tgz",
-      "integrity": "sha512-8n+j+6ypTHvriJwFOQ2qusQ6bzGjZVcR3jbe1pBpLcGI1dn4WIl0ctLBngqE5QttquQBAlKXwJeTMw+X7x7qKw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.14.0.tgz",
+      "integrity": "sha512-64W8/lsfqgaDWfEkvrIVk8FdIk29Mya0Fp39excQEdlcLUPg1Cn7CtCYe6CtPbFW90JpEKTXG0QQtIUNENJ7sw==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^3.4.2",
+        "dompurify": "^3.4.5",
         "jsdom": "^29.1.1"
       },
       "engines": {
@@ -14222,6 +14010,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14243,6 +14032,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14264,6 +14054,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14285,6 +14076,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14306,6 +14098,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14327,6 +14120,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14348,6 +14142,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14369,6 +14164,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14390,6 +14186,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14411,6 +14208,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14432,6 +14230,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15959,9 +15758,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.37.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
-      "integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+      "version": "6.38.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.38.0.tgz",
+      "integrity": "sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -16013,6 +15812,76 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
+      "integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
+        "@oxc-resolver/binding-android-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-x64": "11.19.1",
+        "@oxc-resolver/binding-freebsd-x64": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
+        "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
+        "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
       }
     },
     "node_modules/p-limit": {
@@ -17577,14 +17446,14 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.6.tgz",
-      "integrity": "sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.0.tgz",
+      "integrity": "sha512-zrtctbVa6xEXCXuE3vsiR0At31zLOtzj8QudN/GaBJLZl0Z2DfF1rDPtTxdAbAp11M2J/7JVHaTIQKXauQPbmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^2.0.1",
+        "@storybook/icons": "^2.0.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/user-event": "^14.6.1",
         "@vitest/expect": "3.2.4",
@@ -17592,6 +17461,8 @@
         "@webcontainer/env": "^1.1.1",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
         "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
         "recast": "^0.23.5",
         "semver": "^7.7.3",
         "use-sync-external-store": "^1.5.0",
@@ -17605,10 +17476,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "prettier": "^2 || ^3",
         "vite-plus": "^0.1.15"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
         "prettier": {
           "optional": true
         },
@@ -19757,7 +19632,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.0",
         "@jest/types": "^30.3.0",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "1.60.0",
         "@tailwindcss/postcss": "^4",
         "dotenv": "^17.4.1",
         "eslint-config-next": "^16.2.3",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "handlebars": "^4.7.9",
     "path-to-regexp": "^8.4.0",
     "picomatch": "^4.0.4",
-    "axios": ">=1.15.0",
-    "fast-uri": "^3.1.2"
+    "axios": ">=1.15.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.0",
@@ -59,7 +58,7 @@
     "aws-cdk": "^2.1117.0",
     "aws-sdk-client-mock": "^4.1.0",
     "dotenv": "^17.4.1",
-    "eslint": "^10.2.0",
+    "eslint": "^10.4.0",
     "eslint-config-next": "^16.2.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.3.0",
@@ -73,7 +72,7 @@
     "vite": "^7.3.2"
   },
   "dependencies": {
-    "@aws-sdk/middleware-endpoint-discovery": "^3.972.9",
+    "@aws-sdk/middleware-endpoint-discovery": "^3.972.13",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^9.0.0",

--- a/services/stock-tracker/web/package.json
+++ b/services/stock-tracker/web/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.0",
     "@jest/types": "^30.3.0",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "1.60.0",
     "@tailwindcss/postcss": "^4",
     "dotenv": "^17.4.1",
     "eslint-config-next": "^16.2.3",


### PR DESCRIPTION
## 変更の概要

Issue #3158（2026年第20週 npm 管理レポート）の対応。

**セキュリティ修正（Priority 1）**
- `fast-uri` High 脆弱性を解消（`aws-cdk-lib` 2.253.1 → 2.256.1 へ更新）
  - GHSA-q3j6-qgpj-74h6: path traversal via percent-encoded dot segments (CVSS 7.5)
  - GHSA-v39h-62p7-jpjc: host confusion via percent-encoded authority delimiters (CVSS 7.5)
- 前週（第19週）で追加された `overrides.fast-uri: "^3.1.2"` を削除
  - `aws-cdk-lib` は fast-uri を `bundledDependencies` として同梱しており、npm の `overrides` が届かないため無効だった

**パッケージ更新（Priority 3）**

| パッケージ | 変更前 | 変更後 |
|---|---|---|
| aws-cdk-lib (infra 全 12 WS) | 2.253.1 | 2.256.1 |
| aws-cdk | 2.1121.0 | 2.1124.1 |
| @aws-sdk/* | 3.1045.0 | 3.1051.0 |
| @aws-sdk/middleware-endpoint-discovery | 3.972.11 | 3.972.13 |
| eslint | 10.3.0 | 10.4.0 |
| storybook / @storybook/* | 10.3.6 | 10.4.0 |
| isomorphic-dompurify | 3.12.0 | 3.14.0 |
| openai | 6.37.0 | 6.38.0 |

**バージョン不整合解消（Priority 2）**
- `@playwright/test` (services/stock-tracker/web): `^1.59.1` → `1.60.0`（ルート・niconico-mylist-assistant と統一）

**残存脆弱性（対応不可）**
- `brace-expansion` (Moderate): aws-cdk-lib 2.256.1 のバンドル内に存在、最新版でも未修正
- `postcss` (Moderate): 修正には `next-auth@3.29.10` へのメジャーダウングレードが必要（スコープ外）

**スコープ外（意図的に保留）**
- `next-auth` 5.0.0-beta.31（beta を意図的に使用中）
- `@auth/core` 0.41.2（next-auth beta に連動）
- `@types/node` v25（メジャーアップ、breaking changes 要調査）
- `vite` v8（メジャーアップ）

## 関連 Issue

#3158

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [x] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [ ] ローカルでテストが全て通ることを確認した
- [ ] ビルドエラーがないことを確認した

## テスト内容

- `npm audit` 実行: High 0 件、Moderate 5 件（修正不可のみ残存）を確認
- `fast-uri` が `infra/node_modules/aws-cdk-lib/node_modules/fast-uri` で 3.1.2 に更新されたことを確認
- root `package-lock.json` および `infra/package-lock.json` 両方を更新済み

## レビューポイント

- `overrides.fast-uri` 削除の判断: aws-cdk-lib の bundledDependencies 内には npm overrides が効かないため削除が正しい
- infra 全ワークスペースの aws-cdk-lib が `^2.256.1` に変更されている（以前は `^2.248.0`）
- `infra/package-lock.json`（infra ディレクトリ単体インストール用）も更新済み
- 残存 brace-expansion Moderate は aws-cdk-lib 2.256.1 の最新版でも修正不可。次週の aws-cdk-lib 新版リリース後に再確認

## スクリーンショット（該当する場合）

なし（UI 変更なし）

## 補足事項

- `package.json` の `openai`・`isomorphic-dompurify` は根本的に workspace 配下の依存であり root には含めていない（npm install 操作の副作用で追加されたものを手動で除去済み）

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2ZtDzDEXx8gMU9SeDNTBa)_