### PR TITLE
[#3170] feat(ui): ConfirmDialog を libs/ui に新設し share-together を移行

### DIFF
--- a/libs/ui/src/components/dialogs/ConfirmDialog.stories.tsx
+++ b/libs/ui/src/components/dialogs/ConfirmDialog.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ConfirmDialog from './ConfirmDialog';
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: 'Molecules/ConfirmDialog',
+  component: ConfirmDialog,
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    title: '削除の確認',
+    description: 'この操作は取り消せません。本当に削除しますか？',
+    confirmLabel: '削除',
+    cancelLabel: 'キャンセル',
+    loading: false,
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ConfirmDialog>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+  args: { loading: true },
+};
+
+export const CustomLabels: Story = {
+  args: {
+    title: 'ログアウトの確認',
+    description: 'ログアウトしてもよろしいですか？',
+    confirmLabel: 'ログアウト',
+    cancelLabel: '戻る',
+  },
+};
+
+export const Closed: Story = {
+  args: { open: false },
+};

--- a/libs/ui/src/components/dialogs/ConfirmDialog.tsx
+++ b/libs/ui/src/components/dialogs/ConfirmDialog.tsx
@@ -7,38 +7,40 @@ import {
   DialogContentText,
   DialogTitle,
 } from '@mui/material';
-import { Button } from '@nagiyu/ui';
+import Button from '../Button';
 
-type ConfirmDialogProps = {
+export interface ConfirmDialogProps {
   open: boolean;
   title: string;
   description: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  loading?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
-};
+}
 
-export function ConfirmDialog({
+export default function ConfirmDialog({
   open,
   title,
   description,
   confirmLabel = '削除',
   cancelLabel = 'キャンセル',
+  loading = false,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
   return (
-    <Dialog open={open} onClose={onCancel}>
+    <Dialog open={open} onClose={onCancel} maxWidth="sm" fullWidth>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
         <DialogContentText>{description}</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel} variant="ghost">
+        <Button onClick={onCancel} variant="ghost" disabled={loading}>
           {cancelLabel}
         </Button>
-        <Button onClick={onConfirm} color="danger" variant="solid">
+        <Button onClick={onConfirm} color="danger" variant="solid" loading={loading}>
           {confirmLabel}
         </Button>
       </DialogActions>

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -29,6 +29,8 @@ export { default as PrivacyPolicyDialog } from './components/dialogs/PrivacyPoli
 export type { PrivacyPolicyDialogProps } from './components/dialogs/PrivacyPolicyDialog';
 export { default as TermsOfServiceDialog } from './components/dialogs/TermsOfServiceDialog';
 export type { TermsOfServiceDialogProps } from './components/dialogs/TermsOfServiceDialog';
+export { default as ConfirmDialog } from './components/dialogs/ConfirmDialog';
+export type { ConfirmDialogProps } from './components/dialogs/ConfirmDialog';
 export { ErrorBoundary, useErrorHandler } from './components/error/ErrorBoundary';
 export type { ErrorBoundaryProps } from './components/error/ErrorBoundary';
 export { default as ErrorAlert } from './components/error/ErrorAlert';

--- a/libs/ui/tests/unit/components/dialogs/ConfirmDialog.test.tsx
+++ b/libs/ui/tests/unit/components/dialogs/ConfirmDialog.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConfirmDialog from '../../../../src/components/dialogs/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    title: '削除の確認',
+    description: 'この操作は取り消せません。',
+    onConfirm: jest.fn(),
+    onCancel: jest.fn(),
+  };
+
+  beforeEach(() => {
+    defaultProps.onConfirm.mockClear();
+    defaultProps.onCancel.mockClear();
+  });
+
+  describe('レンダリング', () => {
+    it('openがtrueの時にダイアログが表示される', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('openがfalseの時にダイアログが表示されない', () => {
+      render(<ConfirmDialog {...defaultProps} open={false} />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('タイトルが表示される', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByText('削除の確認')).toBeInTheDocument();
+    });
+
+    it('説明文が表示される', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByText('この操作は取り消せません。')).toBeInTheDocument();
+    });
+
+    it('デフォルトのconfirmLabelが「削除」になる', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: '削除' })).toBeInTheDocument();
+    });
+
+    it('デフォルトのcancelLabelが「キャンセル」になる', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: 'キャンセル' })).toBeInTheDocument();
+    });
+
+    it('カスタムconfirmLabelが適用される', () => {
+      render(<ConfirmDialog {...defaultProps} confirmLabel="ログアウト" />);
+
+      expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument();
+    });
+
+    it('カスタムcancelLabelが適用される', () => {
+      render(<ConfirmDialog {...defaultProps} cancelLabel="戻る" />);
+
+      expect(screen.getByRole('button', { name: '戻る' })).toBeInTheDocument();
+    });
+  });
+
+  describe('操作', () => {
+    it('確認ボタンをクリックするとonConfirmが呼ばれる', async () => {
+      const user = userEvent.setup();
+      render(<ConfirmDialog {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: '削除' }));
+
+      expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('キャンセルボタンをクリックするとonCancelが呼ばれる', async () => {
+      const user = userEvent.setup();
+      render(<ConfirmDialog {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+      expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('ダイアログの外側をクリックするとonCancelが呼ばれる', async () => {
+      const user = userEvent.setup();
+      render(<ConfirmDialog {...defaultProps} />);
+
+      const backdrop = document.querySelector('.MuiBackdrop-root');
+      if (backdrop) {
+        await user.click(backdrop as HTMLElement);
+        expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe('ローディング状態', () => {
+    it('loading=trueの時にキャンセルボタンが無効になる', () => {
+      render(<ConfirmDialog {...defaultProps} loading={true} />);
+
+      expect(screen.getByRole('button', { name: 'キャンセル' })).toBeDisabled();
+    });
+
+    it('loading=falseの時にキャンセルボタンが有効になる', () => {
+      render(<ConfirmDialog {...defaultProps} loading={false} />);
+
+      expect(screen.getByRole('button', { name: 'キャンセル' })).not.toBeDisabled();
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('ダイアログにrole="dialog"が設定されている', () => {
+      render(<ConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14222,6 +14222,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14243,6 +14244,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14264,6 +14266,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14285,6 +14288,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14306,6 +14310,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14327,6 +14332,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14348,6 +14354,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14369,6 +14376,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14390,6 +14398,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14411,6 +14420,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14432,6 +14442,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14222,7 +14222,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14244,7 +14243,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14266,7 +14264,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14288,7 +14285,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14310,7 +14306,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14332,7 +14327,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14354,7 +14348,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14376,7 +14369,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14398,7 +14390,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14420,7 +14411,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14442,7 +14432,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/services/share-together/web/src/app/invitations/page.tsx
+++ b/services/share-together/web/src/app/invitations/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { ConfirmDialog } from '@nagiyu/ui';
 import {
   Box,
   Card,

--- a/services/share-together/web/src/components/GroupDetailClient.tsx
+++ b/services/share-together/web/src/components/GroupDetailClient.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mui/material';
 import { Button, TextField } from '@nagiyu/ui';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { ConfirmDialog } from '@nagiyu/ui';
 import { InviteForm } from '@/components/InviteForm';
 
 type Member = {

--- a/services/share-together/web/src/components/TodoList.tsx
+++ b/services/share-together/web/src/components/TodoList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { List, Paper, Snackbar, Stack, Typography } from '@mui/material';
-import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { ConfirmDialog } from '@nagiyu/ui';
 import { TodoForm } from '@/components/TodoForm';
 import { TodoItem } from '@/components/TodoItem';
 import type { TodoResponse, TodosResponse } from '@/types';

--- a/services/share-together/web/tests/unit/ConfirmDialog.test.tsx
+++ b/services/share-together/web/tests/unit/ConfirmDialog.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { ConfirmDialog } from '@nagiyu/ui';
 
 describe('ConfirmDialog', () => {
   it('タイトル・説明・ボタンを表示する', () => {


### PR DESCRIPTION
## 変更の概要

Issue #3170 スコープ②「ConfirmDialog を libs/ui に新設」の実装。

- `libs/ui/src/components/dialogs/ConfirmDialog.tsx` を新規追加
  - Props: `open / title / description / confirmLabel / cancelLabel / loading / onConfirm / onCancel`
  - `@nagiyu/ui` の `Button` を利用（danger 色の確認ボタン + ghost のキャンセルボタン）
- Storybook story（4 パターン）を整備
- ユニットテスト 14 件を追加（カバレッジ 100%）
- `libs/ui/src/index.ts` に `ConfirmDialog` / `ConfirmDialogProps` をエクスポート追加
- `services/share-together` の独自 `ConfirmDialog.tsx` を削除し、3 箇所のインポートを `@nagiyu/ui` に置換
  - `services/share-together/web/src/app/invitations/page.tsx`
  - `services/share-together/web/src/components/GroupDetailClient.tsx`
  - `services/share-together/web/src/components/TodoList.tsx`
- `services/stock-tracker` の `AlertDeleteConfirmDialog` はアラート詳細 JSX を含む特殊なダイアログのため変更対象外（既に `@nagiyu/ui` Button を使用済み）

## 関連 Issue

関連: #3170

## 変更種別

- [x] 新規機能
- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（ConfirmDialog.tsx カバレッジ 100%、libs/ui 全体 314 tests pass・閾値クリア）
- [ ] 関連ドキュメントを更新した（`docs/development/shared-ui-components.md` は #3170 完了後に一括反映予定）
- [x] ローカルでテストが全て通ることを確認した
- [ ] ビルドエラーがないことを確認した（libs/ui の tsc ビルドエラーは既存問題のため別途対応）

## テスト内容

- `libs/ui/tests/unit/components/dialogs/ConfirmDialog.test.tsx`（新規 14 件）
  - レンダリング: open/close・title・description・デフォルト/カスタムラベル
  - 操作: 確認ボタン・キャンセルボタン・バックドロップクリック
  - ローディング状態: `loading=true` 時にキャンセルボタンが無効化
  - アクセシビリティ: `role="dialog"` の確認

## レビューポイント

- `AlertDeleteConfirmDialog` をスコープ外とした判断（アラート詳細 JSX がある特殊ダイアログのため generic な `ConfirmDialog` で代替困難）
- `loading` prop を issue の API 定義（`open title description confirmLabel cancelLabel onConfirm onCancel`）には明示されていないが、`AlertDeleteConfirmDialog` の `submitting` と用途を合わせて追加。問題であれば削除可

## 補足事項

このブランチには #3170 の複数スコープを順次コミットしていく予定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Twwq5irkj2HUPW1SQFDUZu)_