### PR TITLE
[Feature] #3190 dev 用プラットフォーム共通 ECS Cluster 作成

### DIFF
--- a/infra/shared/bin/shared.ts
+++ b/infra/shared/bin/shared.ts
@@ -14,6 +14,7 @@ import { IamUsersStack } from '../lib/iam/iam-users-stack';
 import { DockerBuildLockStack } from '../lib/docker-build-lock-stack';
 import { ErrorEventsTableStack } from '../lib/error-events-table-stack';
 import { ReportsHostingStack } from '../lib/reports-hosting-stack';
+import { EcsSharedClusterStack } from '../lib/ecs-cluster-stack';
 
 const app = new cdk.App();
 
@@ -108,6 +109,17 @@ new IamUsersStack(app, 'NagiyuSharedIamUsers', {
   env: stackEnv,
   description: 'Shared IAM Users for GitHub Actions, Local Development and Claude Code on the web',
 });
+
+// プラットフォーム共通 ECS Cluster（Portal 専用 nagiyu-root-cluster-{env} とは別物）
+new EcsSharedClusterStack(
+  app,
+  `NagiyuSharedEcsCluster${env.charAt(0).toUpperCase() + env.slice(1)}`,
+  {
+    environment: env as 'dev' | 'prod',
+    env: stackEnv,
+    description: `Platform Shared ECS Cluster - ${env} environment`,
+  }
+);
 
 new DockerBuildLockStack(app, 'NagiyuDockerBuildLock', {
   env: stackEnv,

--- a/infra/shared/lib/ecs-cluster-stack.ts
+++ b/infra/shared/lib/ecs-cluster-stack.ts
@@ -1,0 +1,74 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { SSM_PARAMETERS } from '../libs/utils/ssm';
+
+export interface EcsSharedClusterStackProps extends cdk.StackProps {
+  environment: 'dev' | 'prod';
+}
+
+export class EcsSharedClusterStack extends cdk.Stack {
+  public readonly clusterName: string;
+  public readonly clusterArn: string;
+
+  constructor(scope: Construct, id: string, props: EcsSharedClusterStackProps) {
+    super(scope, id, props);
+
+    const { environment } = props;
+
+    const clusterName = `nagiyu-shared-cluster-${environment}`;
+
+    const cfnCluster = new ecs.CfnCluster(this, 'SharedCluster', {
+      clusterName,
+      clusterSettings: [
+        {
+          name: 'containerInsights',
+          value: 'enabled',
+        },
+      ],
+    });
+
+    new ecs.CfnClusterCapacityProviderAssociations(
+      this,
+      'SharedClusterCapacityProviders',
+      {
+        cluster: cfnCluster.ref,
+        capacityProviders: ['FARGATE', 'FARGATE_SPOT'],
+        defaultCapacityProviderStrategy: [],
+      }
+    );
+
+    this.clusterName = clusterName;
+    this.clusterArn = cfnCluster.attrArn;
+
+    cdk.Tags.of(this).add('Application', 'nagiyu');
+    cdk.Tags.of(this).add('Environment', environment);
+    cdk.Tags.of(this).add('ManagedBy', 'CDK');
+    cdk.Tags.of(this).add('Component', 'shared');
+
+    new cdk.CfnOutput(this, 'ClusterName', {
+      value: this.clusterName,
+      description: 'Shared ECS Cluster name',
+    });
+
+    new cdk.CfnOutput(this, 'ClusterArn', {
+      value: this.clusterArn,
+      description: 'Shared ECS Cluster ARN',
+    });
+
+    new ssm.StringParameter(this, 'ClusterNameParam', {
+      parameterName: SSM_PARAMETERS.SHARED_ECS_CLUSTER_NAME(environment),
+      stringValue: this.clusterName,
+      description: 'Shared ECS Cluster name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'ClusterArnParam', {
+      parameterName: SSM_PARAMETERS.SHARED_ECS_CLUSTER_ARN(environment),
+      stringValue: this.clusterArn,
+      description: 'Shared ECS Cluster ARN',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+  }
+}

--- a/infra/shared/libs/utils/ssm.ts
+++ b/infra/shared/libs/utils/ssm.ts
@@ -15,4 +15,6 @@ export const SSM_PARAMETERS = {
   ALB_SECURITY_GROUP_ID: (env: Environment) => `/nagiyu/root/${env}/alb/security-group-id`,
   ECS_CLUSTER_NAME: (env: Environment) => `/nagiyu/root/${env}/ecs/cluster-name`,
   ECS_CLUSTER_ARN: (env: Environment) => `/nagiyu/root/${env}/ecs/cluster-arn`,
+  SHARED_ECS_CLUSTER_NAME: (env: Environment) => `/nagiyu/shared/${env}/ecs/cluster-name`,
+  SHARED_ECS_CLUSTER_ARN: (env: Environment) => `/nagiyu/shared/${env}/ecs/cluster-arn`,
 } as const;

--- a/infra/shared/tests/unit/ecs-cluster-stack.test.js
+++ b/infra/shared/tests/unit/ecs-cluster-stack.test.js
@@ -1,0 +1,97 @@
+const cdk = require('aws-cdk-lib');
+const { Template } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { EcsSharedClusterStack } = require('../../lib/ecs-cluster-stack');
+
+describe('EcsSharedClusterStack', () => {
+  it('環境名を含む Cluster 名で ECS Cluster を作成する', () => {
+    const app = new cdk.App();
+    const stack = new EcsSharedClusterStack(app, 'TestEcsSharedCluster', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::ECS::Cluster', {
+      ClusterName: 'nagiyu-shared-cluster-dev',
+    });
+  });
+
+  it('Container Insights を有効化する', () => {
+    const app = new cdk.App();
+    const stack = new EcsSharedClusterStack(app, 'TestEcsSharedCluster', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::ECS::Cluster', {
+      ClusterSettings: [{ Name: 'containerInsights', Value: 'enabled' }],
+    });
+  });
+
+  it('FARGATE と FARGATE_SPOT の Capacity Provider を関連付ける', () => {
+    const app = new cdk.App();
+    const stack = new EcsSharedClusterStack(app, 'TestEcsSharedCluster', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::ECS::ClusterCapacityProviderAssociations', {
+      CapacityProviders: ['FARGATE', 'FARGATE_SPOT'],
+    });
+  });
+
+  it('SSM パラメータに Cluster 名を出力する', () => {
+    const app = new cdk.App();
+    const stack = new EcsSharedClusterStack(app, 'TestEcsSharedCluster', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/shared/dev/ecs/cluster-name',
+      Value: 'nagiyu-shared-cluster-dev',
+    });
+  });
+
+  it('SSM パラメータに Cluster ARN を出力する', () => {
+    const app = new cdk.App();
+    const stack = new EcsSharedClusterStack(app, 'TestEcsSharedCluster', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/shared/dev/ecs/cluster-arn',
+    });
+  });
+
+  it('Component=shared タグを付与する', () => {
+    const app = new cdk.App();
+    const stack = new EcsSharedClusterStack(app, 'TestEcsSharedCluster', {
+      environment: 'dev',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::ECS::Cluster', {
+      Tags: [
+        { Key: 'Application', Value: 'nagiyu' },
+        { Key: 'Component', Value: 'shared' },
+        { Key: 'Environment', Value: 'dev' },
+        { Key: 'ManagedBy', Value: 'CDK' },
+      ],
+    });
+  });
+
+  it('prod 環境でも正しい Cluster 名を生成する', () => {
+    const app = new cdk.App();
+    const stack = new EcsSharedClusterStack(app, 'TestEcsSharedClusterProd', {
+      environment: 'prod',
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::ECS::Cluster', {
+      ClusterName: 'nagiyu-shared-cluster-prod',
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

Issue #3190 の対応として、dev 環境にプラットフォーム共通の ECS Cluster を新規作成するための CDK スタックを追加する。

既存の Portal 専用 `nagiyu-root-cluster-{env}`（`infra/root/`）とは別に、リブトークを含む将来の ECS サービスが共用する `nagiyu-shared-cluster-{env}` を `infra/shared/lib/` 配下に新設した。

## 関連 Issue

#3190

## 変更種別

- [x] 新規機能
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## 変更ファイル

| ファイル | 操作 | 内容 |
|---------|------|------|
| `infra/shared/lib/ecs-cluster-stack.ts` | 新規 | `EcsSharedClusterStack` — `nagiyu-shared-cluster-{env}`、Fargate/Fargate Spot、Container Insights 有効、SSM 出力 |
| `infra/shared/bin/shared.ts` | 修正 | `NagiyuSharedEcsCluster{Env}` を deploy 対象に追加 |
| `infra/shared/libs/utils/ssm.ts` | 修正 | `SHARED_ECS_CLUSTER_NAME` / `SHARED_ECS_CLUSTER_ARN` 定数を追加 |
| `infra/shared/tests/unit/ecs-cluster-stack.test.js` | 新規 | CDK Template アサート 7 ケース |

## テスト内容

- `npx jest --config infra/shared/jest.config.js` → 全 40 件パス（新規 7 件 + 既存 33 件）
- `npx cdk synth NagiyuSharedEcsClusterDev -c env=dev -c domainName=nagiyu.com` → CloudFormation テンプレート生成確認
- TypeScript ビルド（`npm run build`）→ エラーなし
- 実 deploy（dev への反映）は人力確認待ち

## レビューポイント

- `infra/root/ecs-cluster-stack.ts`（Portal 専用）には一切変更を加えていないこと
- SSM パス：`/nagiyu/shared/{env}/ecs/cluster-name` / `cluster-arn`（既存 root 用 `/nagiyu/root/{env}/ecs/...` とは別系統）
- タグ `Component=shared`（既存 root 側は `Component=root-domain`）
- `SHARED_ECS_CLUSTER_NAME` / `SHARED_ECS_CLUSTER_ARN` は後続 #3191（ALB）から参照される予定

## 補足事項

- Cluster 自体は無料（Fargate タスク起動時のみ課金）
- prod 環境用も同一スタックで `-c env=prod` で生成可能だが、本 Issue では dev deploy のみ対象
- 後続 Issue #3191（共通 ALB）と組み合わせて初めてサービスを乗せられる状態になる

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrGySb7XAwCPfoFPSdgK1P)_