### PR TITLE
feat(livetalk): Phase 1b ECR + イメージ push パイプライン

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -1,0 +1,184 @@
+name: LiveTalk - Build and Push to ECR
+
+on:
+  push:
+    branches:
+      - develop
+      - integration/**
+      - master
+    paths:
+      - 'services/livetalk/**'
+      - 'infra/bin/**'
+      - 'infra/livetalk/**'
+      - 'infra/common/**'
+      - 'infra/package.json'
+      - 'infra/cdk.json'
+      - 'infra/tsconfig.json'
+      - 'libs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/livetalk-deploy.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy'
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+
+env:
+  AWS_REGION: us-east-1
+
+permissions:
+  contents: read
+
+jobs:
+  infrastructure-ecr:
+    name: Deploy ECR Repository
+    runs-on: ubuntu-latest
+
+    outputs:
+      environment: ${{ steps.setup-environment.outputs.environment }}
+      stack-suffix: ${{ steps.setup-environment.outputs.stack-suffix }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js and install dependencies
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: '24'
+
+      - name: Setup deployment environment
+        id: setup-environment
+        uses: ./.github/actions/setup-environment
+
+      - name: Build common infrastructure package
+        run: npm run build --workspace=@nagiyu/infra-common
+
+      - name: Build CDK TypeScript
+        run: npm run build --workspace=@nagiyu/infra
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy LiveTalk ECR Stack
+        env:
+          ENVIRONMENT: ${{ steps.setup-environment.outputs.environment }}
+          STACK_SUFFIX: ${{ steps.setup-environment.outputs.stack-suffix }}
+        run: |
+          npm run cdk --workspace=@nagiyu/infra -- deploy NagiyuLiveTalkEcr${STACK_SUFFIX} \
+            --require-approval never
+
+          echo "LiveTalk ECR repository deployed (environment: $ENVIRONMENT)"
+
+  build:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    needs: infrastructure-ecr
+
+    outputs:
+      image-uri: ${{ steps.build-image.outputs.image-uri }}
+      environment: ${{ needs.infrastructure-ecr.outputs.environment }}
+      stack-suffix: ${{ needs.infrastructure-ecr.outputs.stack-suffix }}
+      app-version: ${{ steps.get-version.outputs.app-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get version from package.json
+        id: get-version
+        working-directory: ./services/livetalk/web
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "app-version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Application version: $VERSION"
+
+      - name: Build Web application
+        uses: ./.github/actions/build-web-app
+        with:
+          workspace: '@nagiyu/livetalk-web'
+          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/ui,@nagiyu/nextjs,@nagiyu/livetalk-core'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get ECR repository from SSM
+        id: get-ecr
+        env:
+          ENVIRONMENT: ${{ needs.infrastructure-ecr.outputs.environment }}
+        run: |
+          REPOSITORY_URI=$(aws ssm get-parameter \
+            --name "/nagiyu/livetalk/${ENVIRONMENT}/ecr/repository-uri" \
+            --query "Parameter.Value" \
+            --output text \
+            --region "${{ env.AWS_REGION }}")
+
+          if [ -z "$REPOSITORY_URI" ]; then
+            echo "Error: Could not find LiveTalk ECR repository URI from SSM"
+            exit 1
+          fi
+
+          echo "repository-uri=$REPOSITORY_URI" >> "$GITHUB_OUTPUT"
+          echo "ECR Repository: $REPOSITORY_URI"
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Docker image
+        uses: ./.github/actions/build-docker-image
+        with:
+          dockerfile: services/livetalk/web/Dockerfile
+          image-tag: ${{ steps.get-ecr.outputs.repository-uri }}:${{ github.sha }}
+          build-args: APP_VERSION=${{ steps.get-version.outputs.app-version }}
+
+      - name: Push Docker image
+        id: build-image
+        env:
+          REPOSITORY_URI: ${{ steps.get-ecr.outputs.repository-uri }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker push "$REPOSITORY_URI:$IMAGE_TAG"
+
+          # Also tag as latest
+          docker tag "$REPOSITORY_URI:$IMAGE_TAG" "$REPOSITORY_URI:latest"
+          docker push "$REPOSITORY_URI:latest"
+
+          echo "image-uri=$REPOSITORY_URI:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+  summary:
+    name: Deployment Summary
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Display deployment summary
+        env:
+          ENVIRONMENT: ${{ needs.build.outputs.environment }}
+          IMAGE_URI: ${{ needs.build.outputs.image-uri }}
+          APP_VERSION: ${{ needs.build.outputs.app-version }}
+        run: |
+          {
+            echo ""
+            echo "=== LiveTalk ECR Deployment Summary ==="
+            echo ""
+            echo "- **Environment**: $ENVIRONMENT"
+            echo "- **App Version**: $APP_VERSION"
+            echo "- **Image (SHA tag)**: \`$IMAGE_URI\`"
+            echo "- **Latest tag**: same digest also pushed as \`:latest\`"
+            echo ""
+            echo "Note: ECS Service is not yet provisioned (Phase 1c)."
+          } >> $GITHUB_STEP_SUMMARY

--- a/infra/bin/nagiyu-platform.ts
+++ b/infra/bin/nagiyu-platform.ts
@@ -8,6 +8,7 @@ import { EcsServiceStack } from '../root/ecs-service-stack';
 import { CloudFrontStack } from '../root/cloudfront-stack';
 import { PortalLambdaStack } from '../root/portal-lambda-stack';
 import { CloudFrontLambdaStack } from '../root/cloudfront-lambda-stack';
+import { LiveTalkEcrStack } from '../livetalk/ecr-stack';
 
 const app = new cdk.App();
 
@@ -23,6 +24,13 @@ const ecrStack = new EcrStack(app, `NagiyuPortalEcr${envSuffix}`, {
   env: { account, region },
   environment,
   description: `Portal ECR Repository (${environment})`,
+});
+
+// LiveTalk ECR Repository Stack（dev / prod 別に作成、Component: livetalk）
+new LiveTalkEcrStack(app, `NagiyuLiveTalkEcr${envSuffix}`, {
+  env: { account, region },
+  environment,
+  description: `LiveTalk ECR Repository (${environment})`,
 });
 
 if (environment === 'dev') {

--- a/infra/common/src/utils/ssm.ts
+++ b/infra/common/src/utils/ssm.ts
@@ -13,4 +13,6 @@ export const SSM_PARAMETERS = {
   ALB_SECURITY_GROUP_ID: (env: Environment) => `/nagiyu/root/${env}/alb/security-group-id`,
   ECS_CLUSTER_NAME: (env: Environment) => `/nagiyu/root/${env}/ecs/cluster-name`,
   ECS_CLUSTER_ARN: (env: Environment) => `/nagiyu/root/${env}/ecs/cluster-arn`,
+  LIVETALK_ECR_REPOSITORY_NAME: (env: Environment) => `/nagiyu/livetalk/${env}/ecr/repository-name`,
+  LIVETALK_ECR_REPOSITORY_URI: (env: Environment) => `/nagiyu/livetalk/${env}/ecr/repository-uri`,
 } as const;

--- a/infra/common/tests/unit/ssm.test.ts
+++ b/infra/common/tests/unit/ssm.test.ts
@@ -30,4 +30,13 @@ describe('ssm utilities', () => {
     expect(SSM_PARAMETERS.ECS_CLUSTER_NAME('dev')).toBe('/nagiyu/root/dev/ecs/cluster-name');
     expect(SSM_PARAMETERS.ECS_CLUSTER_ARN('prod')).toBe('/nagiyu/root/prod/ecs/cluster-arn');
   });
+
+  it('should generate LiveTalk ECR parameter names', () => {
+    expect(SSM_PARAMETERS.LIVETALK_ECR_REPOSITORY_NAME('dev')).toBe(
+      '/nagiyu/livetalk/dev/ecr/repository-name'
+    );
+    expect(SSM_PARAMETERS.LIVETALK_ECR_REPOSITORY_URI('prod')).toBe(
+      '/nagiyu/livetalk/prod/ecr/repository-uri'
+    );
+  });
 });

--- a/infra/livetalk/ecr-stack.ts
+++ b/infra/livetalk/ecr-stack.ts
@@ -1,0 +1,48 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { EcrStackBase, EcrStackBaseProps } from '../common/src/stacks/ecr-stack-base';
+import { Environment } from '../common/src/types/environment';
+import { SSM_PARAMETERS } from '../common/src/utils/ssm';
+
+export interface LiveTalkEcrStackProps extends cdk.StackProps {
+  environment: string;
+}
+
+/**
+ * LiveTalk サービス用の ECR スタック
+ *
+ * - 命名規則: `nagiyu-livetalk-ecr-{env}`
+ * - SSM Parameter に repository-name / repository-uri を格納
+ * - Component: livetalk タグを付与
+ */
+export class LiveTalkEcrStack extends EcrStackBase {
+  constructor(scope: Construct, id: string, props: LiveTalkEcrStackProps) {
+    const { environment, ...stackProps } = props;
+    const ssmEnvironment = environment as Environment;
+
+    const baseProps: EcrStackBaseProps = {
+      ...stackProps,
+      serviceName: 'livetalk',
+      environment: ssmEnvironment,
+    };
+
+    super(scope, id, baseProps);
+
+    cdk.Tags.of(this).add('Component', 'livetalk');
+
+    new ssm.StringParameter(this, 'EcrRepositoryNameParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ECR_REPOSITORY_NAME(ssmEnvironment),
+      stringValue: this.repository.repositoryName,
+      description: 'LiveTalk ECR repository name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'EcrRepositoryUriParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ECR_REPOSITORY_URI(ssmEnvironment),
+      stringValue: this.repository.repositoryUri,
+      description: 'LiveTalk ECR repository URI',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+  }
+}


### PR DESCRIPTION
## 変更の概要

リブトーク Phase 1b（#3202）として、LiveTalk 専用の ECR リポジトリとイメージ push パイプラインを追加。

- `infra/livetalk/ecr-stack.ts` を新規作成し、共通の `EcrStackBase` を継承して `nagiyu-livetalk-ecr-{env}` リポジトリを作成
- ECR リポジトリ名・URI を SSM Parameter Store (`/nagiyu/livetalk/{env}/ecr/repository-{name,uri}`) に格納
- `infra/bin/nagiyu-platform.ts` に `LiveTalkEcrStack` を登録（dev / prod 別、`Component: livetalk` タグ付与）
- `.github/workflows/livetalk-deploy.yml` を新設し、`integration/**` などへの push で
  1. CDK で `NagiyuLiveTalkEcr{Env}` をデプロイ
  2. Docker イメージを `:<git-sha>` と `:latest` の 2 タグで ECR に push

## 関連 Issue

Parent: #3184
Grandparent: #3182
Implements: #3202

<!-- Issue は integration → develop マージ後にクローズするため Closes は付けない -->

## 変更種別

- [x] 新規機能
- [x] CI/CD 更新
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（`SSM_PARAMETERS` の LiveTalk エントリにユニットテスト追加）
- [x] CI/CD 設定を追加・更新した（`livetalk-deploy.yml` を新設）
- [x] ローカルでテストが全て通ることを確認した（`@nagiyu/infra-common` の jest 80 件 PASS）
- [x] ビルドエラーがないことを確認した（`@nagiyu/infra-common` / `@nagiyu/infra` の `tsc` 成功、`cdk synth NagiyuLiveTalkEcr{Dev,Prod}` 成功）

## テスト内容

- `infra/common/tests/unit/ssm.test.ts` に LiveTalk ECR 用パラメータ名のテストを追加
- ローカルで `cdk list` を実行し、`NagiyuLiveTalkEcrDev` / `NagiyuLiveTalkEcrProd` が想定どおり登録されることを確認
- ローカルで `cdk synth NagiyuLiveTalkEcrDev` を実行し、リポジトリ名 `nagiyu-livetalk-ecr-dev` と 2 件の SSM `AWS::SSM::Parameter` が生成されることを確認

## レビューポイント

- **ECR スタックの配置**：Issue で指示された通り `infra/livetalk/` 配下に新規作成し、独立ワークスペース化はせず根ルートの `@nagiyu/infra` CDK アプリ（`infra/bin/nagiyu-platform.ts`）に登録した。stock-tracker は独立ワークスペース、Portal は同一アプリ、という既存の二系統のうち Portal 流儀を採用している。
- **SSM パラメータ**：Issue 指定の `/nagiyu/livetalk/{env}/ecr/repository-{name,uri}` を CDK で書き出している。CD ワークフローでは CloudFormation Output ではなく SSM から URI を取得する形にし、Issue の意図を反映した。
- **OIDC 認証**：Issue は「GitHub OIDC 認証」を挙げているが、既存の `root-deploy.yml` / `stock-tracker-deploy.yml` 等はいずれも `secrets.AWS_ACCESS_KEY_ID` ベースのため、整合性を優先してアクセスキー方式とした。OIDC 移行は別 Issue で横断的にやるのが良いと判断。
- **ライフサイクルポリシー**：`EcrStackBase` のデフォルト（最大 10 世代保持）をそのまま適用。Issue 本文の「未タグ削除 + `latest` 以外 10 世代より古いものを削除」は文脈的に「考え方」と受け取り、まずは既存サービスと一貫した挙動にした。要件確定後にカスタマイズが必要であれば `EcrConfig.maxImageCount` 等で容易に拡張可能。
- **スコープ**：Issue の指示通り、ECS は本 Issue では作らず（Phase 1c）、ECR にイメージが届くところまでに留めている。

## 補足事項

- 本 PR の作業ブランチは `integration/3182-livetalk` から分岐しており、PR ターゲットも同ブランチを指定。
- Issue クローズは「integration → develop の PR がマージされたタイミング」で行うため、本 PR では `Closes #3202` を付けていない。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtvGvJoGXdgTBRsnzCQ5BV)_