### PR TITLE
ci(livetalk): infra/livetalk のビルド・synth を verify ワークフローに追加

### DIFF
--- a/.github/workflows/livetalk-verify.yml
+++ b/.github/workflows/livetalk-verify.yml
@@ -11,6 +11,8 @@ on:
       - develop
     paths:
       - 'services/livetalk/**'
+      - 'infra/livetalk/**'
+      - 'infra/common/**'
       - 'libs/**'
       - 'package.json'
       - 'package-lock.json'
@@ -59,6 +61,39 @@ jobs:
 
       - name: Check web formatting
         run: npm run format:check --workspace=@nagiyu/livetalk-web
+
+  synth-infra:
+    name: Synthesize Infrastructure
+    runs-on: ubuntu-latest
+    needs: [lint, format-check]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js and install dependencies
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: '24'
+          cache-dependency-path: './package-lock.json'
+
+      - name: Build common infrastructure package
+        run: npm run build --workspace=@nagiyu/infra-common
+
+      - name: Build CDK TypeScript
+        run: npm run build --workspace=@nagiyu/infra-livetalk
+
+      - name: Synthesize CDK stack (dev)
+        env:
+          ENVIRONMENT: dev
+          CDK_DEFAULT_ACCOUNT: '000000000000'
+        run: npm run synth --workspace=@nagiyu/infra-livetalk -- NagiyuLiveTalkEcrDev
+
+      - name: Synthesize CDK stack (prod)
+        env:
+          ENVIRONMENT: prod
+          CDK_DEFAULT_ACCOUNT: '000000000000'
+        run: npm run synth --workspace=@nagiyu/infra-livetalk -- NagiyuLiveTalkEcrProd
 
   build:
     name: Next.js Build Verification
@@ -381,6 +416,7 @@ jobs:
       [
         lint,
         format-check,
+        synth-infra,
         build,
         docker-build,
         unit-test,
@@ -403,6 +439,7 @@ jobs:
             const results = {
               'Lint': '${{ needs.lint.result }}',
               'Format Check': '${{ needs.format-check.result }}',
+              'Synthesize Infrastructure': '${{ needs.synth-infra.result }}',
               'Next.js Build': '${{ needs.build.result }}',
               'Docker Build': '${{ needs.docker-build.result }}',
               'Unit Tests': '${{ needs.unit-test.result }}',


### PR DESCRIPTION
## 変更の概要

#3216 で `@nagiyu/infra-livetalk` を独立ワークスペースに切り出した際に、`livetalk-verify.yml` のパストリガと検証ジョブから `infra/` 配下が漏れていたため補完する。

### 実害シナリオ（補完前）

Phase 1c 以降で `infra/livetalk/lib/alb-stack.ts` などを追加した場合、TypeScript エラーや CDK synth エラーがあっても PR ではブロックされず、merge 後の `livetalk-deploy.yml` で初めて発覚する → integration ブランチ上で hotfix が必要、になる。

### 変更内容

- `paths` トリガに `infra/livetalk/**` と `infra/common/**` を追加
- `synth-infra` ジョブを新設（`lint` / `format-check` の後段で実行）
    - `@nagiyu/infra-common` → `@nagiyu/infra-livetalk` のビルド
    - `cdk synth NagiyuLiveTalkEcrDev` と `NagiyuLiveTalkEcrProd` を両方実行
- `report` ジョブの `needs` と結果サマリ表に `synth-infra` を追加

### 設計上の選択

- `stock-tracker-verify.yml` の `synth-infra` ジョブのパターンに整合
- 別ワークフロー（`infra-livetalk-verify.yml`）への切り出しは行わず、`livetalk-verify.yml` に統合（stock-tracker / share-together と同じ流儀）

## 関連 Issue

Parent: #3184
Implements (CI 漏れの補完): #3202

<!-- Issue は integration → develop マージ後にクローズするため Closes は付けない -->

## 変更種別

- [x] CI/CD 更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] CI/CD 設定を追加・更新した
- [x] ローカルでテストが全て通ることを確認した（`npm run synth --workspace=@nagiyu/infra-livetalk -- NagiyuLiveTalkEcrDev` を手動実行して成功確認）
- [x] YAML 構文を `python3 yaml.safe_load` で検証

## テスト内容

- ローカルで `ENVIRONMENT=dev CDK_DEFAULT_ACCOUNT=000000000000 npm run synth --workspace=@nagiyu/infra-livetalk -- NagiyuLiveTalkEcrDev` を実行し、エラーなく synth が完了することを確認
- 本 PR 自体が `infra/` を変更していないため、CI 上では本 PR のトリガで `synth-infra` ジョブが走らない（path に `.github/workflows/livetalk-verify.yml` 自身は含まれているのでジョブは走る）
- 次回以降の `infra/livetalk/**` 変更を伴う PR で実効性が出る

## レビューポイント

- `Synthesize Infrastructure` ジョブを `lint` / `format-check` に依存させており、`build`（Next.js）と並列実行される
- `CDK_DEFAULT_ACCOUNT` にはダミー値 `000000000000` を渡している（synth はアカウント情報がなくても成立するため、Secret 漏れリスクなしで動かす狙い）
- prod synth も含めているため、prod 用パラメータ参照に問題があれば PR 段階で検出可能

## 補足事項

- 本 PR の作業ブランチは `integration/3182-livetalk` から分岐しており、PR ターゲットも同ブランチを指定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtvGvJoGXdgTBRsnzCQ5BV)_