### PR TITLE
feat(livetalk): Phase 1c ECS Service + ALB デプロイ

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -164,10 +164,117 @@ jobs:
 
           echo "image-uri=$REPOSITORY_URI:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
+  infrastructure-app:
+    name: Deploy ALB and ECS Service Stacks
+    runs-on: ubuntu-latest
+    needs: build
+
+    outputs:
+      environment: ${{ needs.build.outputs.environment }}
+      stack-suffix: ${{ needs.build.outputs.stack-suffix }}
+      alb-dns-name: ${{ steps.fetch-alb-dns.outputs.alb-dns-name }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js and install dependencies
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: '24'
+
+      - name: Build common infrastructure package
+        run: npm run build --workspace=@nagiyu/infra-common
+
+      - name: Build CDK TypeScript
+        run: npm run build --workspace=@nagiyu/infra-livetalk
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy ALB and ECS Service Stacks
+        env:
+          ENVIRONMENT: ${{ needs.build.outputs.environment }}
+          STACK_SUFFIX: ${{ needs.build.outputs.stack-suffix }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          npm run cdk --workspace=@nagiyu/infra-livetalk -- deploy \
+            NagiyuLiveTalkAlb${STACK_SUFFIX} \
+            NagiyuLiveTalkService${STACK_SUFFIX} \
+            --require-approval never
+
+          echo "LiveTalk ALB and ECS Service deployed (environment: $ENVIRONMENT)"
+
+      - name: Force new ECS service deployment
+        env:
+          ENVIRONMENT: ${{ needs.build.outputs.environment }}
+        run: |
+          aws ecs update-service \
+            --cluster "nagiyu-shared-cluster-${ENVIRONMENT}" \
+            --service "nagiyu-livetalk-service-${ENVIRONMENT}" \
+            --force-new-deployment \
+            --region "${{ env.AWS_REGION }}"
+
+          echo "LiveTalk ECS service deployment triggered."
+
+      - name: Wait for ECS service to stabilize
+        env:
+          ENVIRONMENT: ${{ needs.build.outputs.environment }}
+        run: |
+          echo "Waiting for ECS service to stabilize..."
+          aws ecs wait services-stable \
+            --cluster "nagiyu-shared-cluster-${ENVIRONMENT}" \
+            --services "nagiyu-livetalk-service-${ENVIRONMENT}" \
+            --region "${{ env.AWS_REGION }}"
+
+          echo "LiveTalk ECS service is stable."
+
+      - name: Fetch ALB DNS name
+        id: fetch-alb-dns
+        env:
+          ENVIRONMENT: ${{ needs.build.outputs.environment }}
+        run: |
+          ALB_DNS=$(aws ssm get-parameter \
+            --name "/nagiyu/livetalk/${ENVIRONMENT}/alb/dns-name" \
+            --query "Parameter.Value" \
+            --output text \
+            --region "${{ env.AWS_REGION }}")
+
+          if [ -z "$ALB_DNS" ]; then
+            echo "Warning: Could not resolve ALB DNS from SSM."
+          else
+            echo "ALB DNS: $ALB_DNS"
+          fi
+
+          echo "alb-dns-name=$ALB_DNS" >> "$GITHUB_OUTPUT"
+
+      - name: Verify health endpoint via ALB DNS
+        env:
+          ALB_DNS: ${{ steps.fetch-alb-dns.outputs.alb-dns-name }}
+        run: |
+          if [ -z "$ALB_DNS" ]; then
+            echo "Skipping health check: ALB DNS not resolved."
+            exit 0
+          fi
+
+          echo "Probing http://${ALB_DNS}/api/health ..."
+          HTTP_CODE=$(curl -f -s -o /dev/null -w "%{http_code}" "http://${ALB_DNS}/api/health" || echo "000")
+          echo "Health check response: $HTTP_CODE"
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Warning: ALB health endpoint returned $HTTP_CODE"
+          else
+            echo "Health check passed."
+          fi
+
   summary:
     name: Deployment Summary
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, infrastructure-app]
 
     steps:
       - name: Display deployment summary
@@ -175,15 +282,18 @@ jobs:
           ENVIRONMENT: ${{ needs.build.outputs.environment }}
           IMAGE_URI: ${{ needs.build.outputs.image-uri }}
           APP_VERSION: ${{ needs.build.outputs.app-version }}
+          ALB_DNS: ${{ needs.infrastructure-app.outputs.alb-dns-name }}
         run: |
           {
             echo ""
-            echo "=== LiveTalk ECR Deployment Summary ==="
+            echo "=== LiveTalk Deployment Summary ==="
             echo ""
             echo "- **Environment**: $ENVIRONMENT"
             echo "- **App Version**: $APP_VERSION"
             echo "- **Image (SHA tag)**: \`$IMAGE_URI\`"
             echo "- **Latest tag**: same digest also pushed as \`:latest\`"
+            echo "- **ALB DNS**: \`$ALB_DNS\`"
             echo ""
-            echo "Note: ECS Service is not yet provisioned (Phase 1c)."
+            echo "Note: Custom domain / HTTPS termination is added in Phase 1d (CloudFront)."
+            echo "ALB monthly fixed cost: ~\$22/month."
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/livetalk-verify.yml
+++ b/.github/workflows/livetalk-verify.yml
@@ -83,17 +83,28 @@ jobs:
       - name: Build CDK TypeScript
         run: npm run build --workspace=@nagiyu/infra-livetalk
 
-      - name: Synthesize CDK stack (dev)
+      - name: Run infra-livetalk unit tests
+        run: npm run test --workspace=@nagiyu/infra-livetalk
+
+      - name: Synthesize CDK stacks (dev)
         env:
           ENVIRONMENT: dev
           CDK_DEFAULT_ACCOUNT: '000000000000'
-        run: npm run synth --workspace=@nagiyu/infra-livetalk -- NagiyuLiveTalkEcrDev
+        run: |
+          npm run synth --workspace=@nagiyu/infra-livetalk -- \
+            NagiyuLiveTalkEcrDev \
+            NagiyuLiveTalkAlbDev \
+            NagiyuLiveTalkServiceDev
 
-      - name: Synthesize CDK stack (prod)
+      - name: Synthesize CDK stacks (prod)
         env:
           ENVIRONMENT: prod
           CDK_DEFAULT_ACCOUNT: '000000000000'
-        run: npm run synth --workspace=@nagiyu/infra-livetalk -- NagiyuLiveTalkEcrProd
+        run: |
+          npm run synth --workspace=@nagiyu/infra-livetalk -- \
+            NagiyuLiveTalkEcrProd \
+            NagiyuLiveTalkAlbProd \
+            NagiyuLiveTalkServiceProd
 
   build:
     name: Next.js Build Verification

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,5 +1,7 @@
 *.js
 !jest.config.js
+!tests/**/*.js
+!**/tests/**/*.js
 *.d.ts
 node_modules
 

--- a/infra/common/src/utils/ssm.ts
+++ b/infra/common/src/utils/ssm.ts
@@ -13,6 +13,16 @@ export const SSM_PARAMETERS = {
   ALB_SECURITY_GROUP_ID: (env: Environment) => `/nagiyu/root/${env}/alb/security-group-id`,
   ECS_CLUSTER_NAME: (env: Environment) => `/nagiyu/root/${env}/ecs/cluster-name`,
   ECS_CLUSTER_ARN: (env: Environment) => `/nagiyu/root/${env}/ecs/cluster-arn`,
+  SHARED_ECS_CLUSTER_NAME: (env: Environment) => `/nagiyu/shared/${env}/ecs/cluster-name`,
+  SHARED_ECS_CLUSTER_ARN: (env: Environment) => `/nagiyu/shared/${env}/ecs/cluster-arn`,
   LIVETALK_ECR_REPOSITORY_NAME: (env: Environment) => `/nagiyu/livetalk/${env}/ecr/repository-name`,
   LIVETALK_ECR_REPOSITORY_URI: (env: Environment) => `/nagiyu/livetalk/${env}/ecr/repository-uri`,
+  LIVETALK_ALB_DNS_NAME: (env: Environment) => `/nagiyu/livetalk/${env}/alb/dns-name`,
+  LIVETALK_ALB_ARN: (env: Environment) => `/nagiyu/livetalk/${env}/alb/arn`,
+  LIVETALK_ALB_LISTENER_ARN: (env: Environment) => `/nagiyu/livetalk/${env}/alb/listener-arn`,
+  LIVETALK_ALB_SECURITY_GROUP_ID: (env: Environment) =>
+    `/nagiyu/livetalk/${env}/alb/security-group-id`,
+  LIVETALK_ALB_TARGET_GROUP_ARN: (env: Environment) =>
+    `/nagiyu/livetalk/${env}/alb/target-group-arn`,
+  LIVETALK_ECS_SERVICE_NAME: (env: Environment) => `/nagiyu/livetalk/${env}/ecs/service-name`,
 } as const;

--- a/infra/common/tests/unit/ssm.test.ts
+++ b/infra/common/tests/unit/ssm.test.ts
@@ -39,4 +39,38 @@ describe('ssm utilities', () => {
       '/nagiyu/livetalk/prod/ecr/repository-uri'
     );
   });
+
+  it('should generate shared ECS parameter names', () => {
+    expect(SSM_PARAMETERS.SHARED_ECS_CLUSTER_NAME('dev')).toBe(
+      '/nagiyu/shared/dev/ecs/cluster-name'
+    );
+    expect(SSM_PARAMETERS.SHARED_ECS_CLUSTER_ARN('prod')).toBe(
+      '/nagiyu/shared/prod/ecs/cluster-arn'
+    );
+  });
+
+  it('should generate LiveTalk ALB parameter names', () => {
+    expect(SSM_PARAMETERS.LIVETALK_ALB_DNS_NAME('dev')).toBe(
+      '/nagiyu/livetalk/dev/alb/dns-name'
+    );
+    expect(SSM_PARAMETERS.LIVETALK_ALB_ARN('prod')).toBe('/nagiyu/livetalk/prod/alb/arn');
+    expect(SSM_PARAMETERS.LIVETALK_ALB_LISTENER_ARN('dev')).toBe(
+      '/nagiyu/livetalk/dev/alb/listener-arn'
+    );
+    expect(SSM_PARAMETERS.LIVETALK_ALB_SECURITY_GROUP_ID('prod')).toBe(
+      '/nagiyu/livetalk/prod/alb/security-group-id'
+    );
+    expect(SSM_PARAMETERS.LIVETALK_ALB_TARGET_GROUP_ARN('dev')).toBe(
+      '/nagiyu/livetalk/dev/alb/target-group-arn'
+    );
+  });
+
+  it('should generate LiveTalk ECS Service parameter name', () => {
+    expect(SSM_PARAMETERS.LIVETALK_ECS_SERVICE_NAME('dev')).toBe(
+      '/nagiyu/livetalk/dev/ecs/service-name'
+    );
+    expect(SSM_PARAMETERS.LIVETALK_ECS_SERVICE_NAME('prod')).toBe(
+      '/nagiyu/livetalk/prod/ecs/service-name'
+    );
+  });
 });

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -2,21 +2,51 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { LiveTalkEcrStack } from '../lib/ecr-stack';
+import { LiveTalkAlbStack } from '../lib/alb-stack';
+import { LiveTalkEcsServiceStack } from '../lib/ecs-service-stack';
 
 const app = new cdk.App();
 
 // 環境設定
 // 既定値は 'dev'。誤って本番にデプロイしないようガード
-const environment = process.env.ENVIRONMENT || 'dev';
+const rawEnvironment = process.env.ENVIRONMENT || 'dev';
+if (rawEnvironment !== 'dev' && rawEnvironment !== 'prod') {
+  throw new Error(`Invalid ENVIRONMENT: ${rawEnvironment}. Allowed: dev, prod`);
+}
+const environment = rawEnvironment as 'dev' | 'prod';
 const envSuffix = environment.charAt(0).toUpperCase() + environment.slice(1);
 const account = process.env.CDK_DEFAULT_ACCOUNT;
 const region = 'us-east-1';
+const stackEnv = { account, region };
 
 // LiveTalk ECR Repository Stack（dev / prod 別に作成、Component: livetalk）
 new LiveTalkEcrStack(app, `NagiyuLiveTalkEcr${envSuffix}`, {
-  env: { account, region },
+  env: stackEnv,
   environment,
   description: `LiveTalk ECR Repository (${environment})`,
 });
+
+// LiveTalk 専用 ALB Stack（共通 VPC + 個別 ALB / Target Group / Listener）
+// 月額固定費 ~$22/月 が発生する点に留意
+const albStack = new LiveTalkAlbStack(app, `NagiyuLiveTalkAlb${envSuffix}`, {
+  env: stackEnv,
+  environment,
+  description: `LiveTalk ALB (${environment})`,
+});
+
+// LiveTalk ECS Service Stack（共通 Cluster に Attach、ALB Target Group へ登録）
+const ecsServiceStack = new LiveTalkEcsServiceStack(
+  app,
+  `NagiyuLiveTalkService${envSuffix}`,
+  {
+    env: stackEnv,
+    environment,
+    description: `LiveTalk ECS Service (${environment})`,
+  }
+);
+
+// SSM 経由の参照のため CDK は自動的にスタック間依存を検出できない。
+// 明示的に依存を宣言して deploy 順を保証する。
+ecsServiceStack.addDependency(albStack);
 
 app.synth();

--- a/infra/livetalk/jest.config.js
+++ b/infra/livetalk/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.{js,ts}'],
+  modulePathIgnorePatterns: ['<rootDir>/../../package.json'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }],
+  },
+};

--- a/infra/livetalk/lib/alb-stack.ts
+++ b/infra/livetalk/lib/alb-stack.ts
@@ -1,0 +1,176 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { Environment, SSM_PARAMETERS } from '@nagiyu/infra-common';
+
+export interface LiveTalkAlbStackProps extends cdk.StackProps {
+  environment: Environment;
+}
+
+/**
+ * LiveTalk 専用 ALB スタック
+ *
+ * - 命名規則: `nagiyu-livetalk-alb-{env}`
+ * - HTTP リスナー（port 80）→ Target Group へフォワード
+ *   HTTPS は Phase 1d 以降で CloudFront 側で終端する方針（既存 Portal と同パターン）
+ * - アイドルタイムアウト 120 秒（将来の LLM ストリーミング向け）
+ * - Health Check: `/api/health`
+ * - Component: livetalk タグを付与
+ *
+ * 月額固定費（NLB と異なり ALB は最低 ~$22/月 が発生する）に留意。
+ */
+export class LiveTalkAlbStack extends cdk.Stack {
+  public readonly loadBalancer: elbv2.ApplicationLoadBalancer;
+  public readonly targetGroup: elbv2.ApplicationTargetGroup;
+  public readonly listener: elbv2.ApplicationListener;
+  public readonly albSecurityGroup: ec2.SecurityGroup;
+
+  constructor(scope: Construct, id: string, props: LiveTalkAlbStackProps) {
+    super(scope, id, props);
+
+    const { environment } = props;
+
+    const vpcId = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.VPC_ID(environment)
+    );
+    const publicSubnetIdsStr = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.PUBLIC_SUBNET_IDS(environment)
+    );
+
+    // ALB は最低 2 つの AZ の Subnet が必要。
+    // Phase 0 で dev / prod ともに us-east-1a + us-east-1b が整備済み。
+    const publicSubnetIds = cdk.Fn.split(',', publicSubnetIdsStr);
+    const vpc = ec2.Vpc.fromVpcAttributes(this, 'ImportedVpc', {
+      vpcId,
+      availabilityZones: ['us-east-1a', 'us-east-1b'],
+      publicSubnetIds: [
+        cdk.Fn.select(0, publicSubnetIds),
+        cdk.Fn.select(1, publicSubnetIds),
+      ],
+    });
+
+    this.albSecurityGroup = new ec2.SecurityGroup(this, 'AlbSecurityGroup', {
+      vpc,
+      securityGroupName: `nagiyu-livetalk-alb-sg-${environment}`,
+      description: 'Security group for LiveTalk ALB',
+      allowAllOutbound: true,
+    });
+
+    this.albSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(80),
+      'Allow HTTP from anywhere'
+    );
+
+    // Phase 1d で CloudFront → ALB を HTTPS 化する想定で 443 も開けておく。
+    // 現時点では HTTPS リスナーは未設定（CloudFront の REDIRECT_TO_HTTPS で終端する想定）。
+    this.albSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(443),
+      'Allow HTTPS from anywhere (reserved for Phase 1d CloudFront integration)'
+    );
+
+    this.loadBalancer = new elbv2.ApplicationLoadBalancer(this, 'LiveTalkAlb', {
+      vpc,
+      internetFacing: true,
+      loadBalancerName: `nagiyu-livetalk-alb-${environment}`,
+      securityGroup: this.albSecurityGroup,
+      vpcSubnets: {
+        subnets: vpc.publicSubnets,
+      },
+      idleTimeout: cdk.Duration.seconds(120),
+    });
+
+    this.targetGroup = new elbv2.ApplicationTargetGroup(this, 'LiveTalkTargetGroup', {
+      vpc,
+      port: 3000,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      targetType: elbv2.TargetType.IP,
+      targetGroupName: `nagiyu-livetalk-tg-${environment}`,
+      healthCheck: {
+        path: '/api/health',
+        interval: cdk.Duration.seconds(30),
+        timeout: cdk.Duration.seconds(5),
+        healthyThresholdCount: 2,
+        unhealthyThresholdCount: 2,
+        protocol: elbv2.Protocol.HTTP,
+      },
+      deregistrationDelay: cdk.Duration.seconds(30),
+    });
+
+    this.listener = this.loadBalancer.addListener('HttpListener', {
+      port: 80,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      defaultAction: elbv2.ListenerAction.forward([this.targetGroup]),
+    });
+
+    cdk.Tags.of(this).add('Application', 'nagiyu');
+    cdk.Tags.of(this).add('Environment', environment);
+    cdk.Tags.of(this).add('ManagedBy', 'CDK');
+    cdk.Tags.of(this).add('Component', 'livetalk');
+
+    new cdk.CfnOutput(this, 'AlbDnsName', {
+      value: this.loadBalancer.loadBalancerDnsName,
+      description: 'LiveTalk ALB DNS name',
+    });
+
+    new cdk.CfnOutput(this, 'AlbArn', {
+      value: this.loadBalancer.loadBalancerArn,
+      description: 'LiveTalk ALB ARN',
+    });
+
+    new cdk.CfnOutput(this, 'AlbListenerArn', {
+      value: this.listener.listenerArn,
+      description: 'LiveTalk ALB Listener ARN',
+    });
+
+    new cdk.CfnOutput(this, 'TargetGroupArn', {
+      value: this.targetGroup.targetGroupArn,
+      description: 'LiveTalk Target Group ARN',
+    });
+
+    new cdk.CfnOutput(this, 'AlbSecurityGroupId', {
+      value: this.albSecurityGroup.securityGroupId,
+      description: 'LiveTalk ALB Security Group ID',
+    });
+
+    new ssm.StringParameter(this, 'AlbDnsNameParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ALB_DNS_NAME(environment),
+      stringValue: this.loadBalancer.loadBalancerDnsName,
+      description: 'LiveTalk ALB DNS name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'AlbArnParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ALB_ARN(environment),
+      stringValue: this.loadBalancer.loadBalancerArn,
+      description: 'LiveTalk ALB ARN',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'AlbListenerArnParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ALB_LISTENER_ARN(environment),
+      stringValue: this.listener.listenerArn,
+      description: 'LiveTalk ALB Listener ARN',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'TargetGroupArnParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ALB_TARGET_GROUP_ARN(environment),
+      stringValue: this.targetGroup.targetGroupArn,
+      description: 'LiveTalk Target Group ARN',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'AlbSecurityGroupIdParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ALB_SECURITY_GROUP_ID(environment),
+      stringValue: this.albSecurityGroup.securityGroupId,
+      description: 'LiveTalk ALB Security Group ID',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+  }
+}

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -1,0 +1,234 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import {
+  Environment,
+  SSM_PARAMETERS,
+  getEcrRepositoryName,
+} from '@nagiyu/infra-common';
+
+export interface LiveTalkEcsServiceStackProps extends cdk.StackProps {
+  environment: Environment;
+}
+
+/**
+ * LiveTalk ECS Service スタック
+ *
+ * - 共通 ECS Cluster（`nagiyu-shared-cluster-{env}`）に Attach
+ * - Task Definition: Next.js 単一コンテナ（port 3000）
+ *   Phase 1f で同一 Task 内に VOICEVOX コンテナを追加できる構成にしておく
+ * - Service: 1 タスク稼働、health check grace period 60s、ALB Target Group へ登録
+ * - SSM Parameter に Service 名を出力
+ * - Component: livetalk タグを付与
+ *
+ * イメージタグは `IMAGE_TAG` 環境変数から取得し、Task Definition のリビジョンが
+ * 更新されるたびに force-new-deployment でローリングデプロイされる想定。
+ */
+export class LiveTalkEcsServiceStack extends cdk.Stack {
+  public readonly service: ecs.FargateService;
+  public readonly taskDefinition: ecs.FargateTaskDefinition;
+  public readonly ecsTaskSecurityGroup: ec2.SecurityGroup;
+
+  constructor(scope: Construct, id: string, props: LiveTalkEcsServiceStackProps) {
+    super(scope, id, props);
+
+    const { environment } = props;
+
+    const vpcId = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.VPC_ID(environment)
+    );
+    const publicSubnetIdsStr = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.PUBLIC_SUBNET_IDS(environment)
+    );
+
+    const publicSubnetIds = cdk.Fn.split(',', publicSubnetIdsStr);
+    const vpc = ec2.Vpc.fromVpcAttributes(this, 'ImportedVpc', {
+      vpcId,
+      availabilityZones: ['us-east-1a', 'us-east-1b'],
+      publicSubnetIds: [
+        cdk.Fn.select(0, publicSubnetIds),
+        cdk.Fn.select(1, publicSubnetIds),
+      ],
+    });
+
+    const clusterName = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.SHARED_ECS_CLUSTER_NAME(environment)
+    );
+    const cluster = ecs.Cluster.fromClusterAttributes(this, 'ImportedSharedCluster', {
+      clusterName,
+      vpc,
+      securityGroups: [],
+    });
+
+    const albSecurityGroupId = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.LIVETALK_ALB_SECURITY_GROUP_ID(environment)
+    );
+    const albSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
+      this,
+      'ImportedAlbSecurityGroup',
+      albSecurityGroupId
+    );
+
+    const targetGroupArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.LIVETALK_ALB_TARGET_GROUP_ARN(environment)
+    );
+    const targetGroup = elbv2.ApplicationTargetGroup.fromTargetGroupAttributes(
+      this,
+      'ImportedTargetGroup',
+      {
+        targetGroupArn,
+      }
+    );
+
+    this.ecsTaskSecurityGroup = new ec2.SecurityGroup(this, 'EcsTaskSecurityGroup', {
+      vpc,
+      securityGroupName: `nagiyu-livetalk-task-sg-${environment}`,
+      description: 'Security group for LiveTalk ECS Tasks',
+      allowAllOutbound: true,
+    });
+
+    this.ecsTaskSecurityGroup.addIngressRule(
+      albSecurityGroup,
+      ec2.Port.tcp(3000),
+      'Allow traffic from LiveTalk ALB'
+    );
+
+    const logGroup = new logs.LogGroup(this, 'EcsTaskLogGroup', {
+      logGroupName: `/ecs/nagiyu-livetalk-task-${environment}`,
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const taskExecutionRole = new iam.Role(this, 'TaskExecutionRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+      description: 'ECS Task Execution Role for LiveTalk',
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          'service-role/AmazonECSTaskExecutionRolePolicy'
+        ),
+      ],
+    });
+
+    const ecrRepoName = getEcrRepositoryName('livetalk', environment);
+    const ecrRepositoryArn = `arn:aws:ecr:${this.region}:${this.account}:repository/${ecrRepoName}`;
+
+    taskExecutionRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'ecr:BatchCheckLayerAvailability',
+          'ecr:GetDownloadUrlForLayer',
+          'ecr:BatchGetImage',
+        ],
+        resources: [ecrRepositoryArn],
+      })
+    );
+
+    // ECR GetAuthorizationToken は AWS の仕様上 resource: * を要求する
+    taskExecutionRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['ecr:GetAuthorizationToken'],
+        resources: ['*'],
+      })
+    );
+
+    const taskRole = new iam.Role(this, 'TaskRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+      description: 'ECS Task Role for LiveTalk',
+    });
+
+    const ecrRepositoryUri = `${this.account}.dkr.ecr.${this.region}.amazonaws.com/${ecrRepoName}`;
+
+    const imageTag = process.env.IMAGE_TAG || 'latest';
+
+    // Phase 1f で VOICEVOX コンテナを同一 Task に追加できるよう、CPU/メモリは Next.js 単体の
+    // 必要量 + VOICEVOX 想定（CPU 1024 / メモリ 2048）に対応できる枠を確保しておく。
+    // Phase 1c 時点では Next.js 1 コンテナのみだが、リソース枠は将来分も見込んで設定する。
+    this.taskDefinition = new ecs.FargateTaskDefinition(this, 'TaskDefinition', {
+      family: `nagiyu-livetalk-task-${environment}`,
+      cpu: 1024,
+      memoryLimitMiB: 2048,
+      executionRole: taskExecutionRole,
+      taskRole,
+    });
+
+    this.taskDefinition.addContainer('livetalk-web', {
+      containerName: 'livetalk-web',
+      image: ecs.ContainerImage.fromRegistry(`${ecrRepositoryUri}:${imageTag}`),
+      logging: ecs.LogDriver.awsLogs({
+        streamPrefix: 'ecs',
+        logGroup,
+      }),
+      environment: {
+        NODE_ENV: environment === 'prod' ? 'production' : 'development',
+        PORT: '3000',
+      },
+      portMappings: [
+        {
+          containerPort: 3000,
+          protocol: ecs.Protocol.TCP,
+        },
+      ],
+    });
+
+    // VOICEVOX 同居（Phase 1f）を見越して startPeriod は 60s 以上を要件にしているが、
+    // Phase 1c 時点では Next.js 単体なので Service の healthCheckGracePeriod のみで対応。
+    this.service = new ecs.FargateService(this, 'Service', {
+      cluster,
+      taskDefinition: this.taskDefinition,
+      serviceName: `nagiyu-livetalk-service-${environment}`,
+      desiredCount: 1,
+      assignPublicIp: true,
+      securityGroups: [this.ecsTaskSecurityGroup],
+      vpcSubnets: {
+        subnets: vpc.publicSubnets,
+      },
+      healthCheckGracePeriod: cdk.Duration.seconds(60),
+    });
+
+    this.service.attachToApplicationTargetGroup(targetGroup);
+
+    cdk.Tags.of(this).add('Application', 'nagiyu');
+    cdk.Tags.of(this).add('Environment', environment);
+    cdk.Tags.of(this).add('ManagedBy', 'CDK');
+    cdk.Tags.of(this).add('Component', 'livetalk');
+
+    new cdk.CfnOutput(this, 'ServiceName', {
+      value: this.service.serviceName,
+      description: 'LiveTalk ECS Service name',
+    });
+
+    new cdk.CfnOutput(this, 'ServiceArn', {
+      value: this.service.serviceArn,
+      description: 'LiveTalk ECS Service ARN',
+    });
+
+    new cdk.CfnOutput(this, 'TaskDefinitionArn', {
+      value: this.taskDefinition.taskDefinitionArn,
+      description: 'LiveTalk Task Definition ARN',
+    });
+
+    new cdk.CfnOutput(this, 'TaskSecurityGroupId', {
+      value: this.ecsTaskSecurityGroup.securityGroupId,
+      description: 'LiveTalk ECS Task Security Group ID',
+    });
+
+    new ssm.StringParameter(this, 'ServiceNameParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ECS_SERVICE_NAME(environment),
+      stringValue: this.service.serviceName,
+      description: 'LiveTalk ECS Service name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+  }
+}

--- a/infra/livetalk/package.json
+++ b/infra/livetalk/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
+    "test": "jest",
     "cdk": "cdk",
     "bootstrap": "cdk bootstrap",
     "synth": "cdk synth",

--- a/infra/livetalk/tests/unit/alb-stack.test.js
+++ b/infra/livetalk/tests/unit/alb-stack.test.js
@@ -1,0 +1,114 @@
+const cdk = require('aws-cdk-lib');
+const { Template, Match } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { LiveTalkAlbStack } = require('../../lib/alb-stack');
+
+const STACK_ENV = { account: '000000000000', region: 'us-east-1' };
+
+const synth = (environment) => {
+  const app = new cdk.App();
+  const stack = new LiveTalkAlbStack(app, `TestLiveTalkAlb${environment}`, {
+    environment,
+    env: STACK_ENV,
+  });
+  return Template.fromStack(stack);
+};
+
+describe('LiveTalkAlbStack', () => {
+  it('環境名を含む ALB 名で ApplicationLoadBalancer を作成する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+      Name: 'nagiyu-livetalk-alb-dev',
+      Scheme: 'internet-facing',
+      Type: 'application',
+    });
+  });
+
+  it('ALB のアイドルタイムアウトを 120 秒に設定する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+      LoadBalancerAttributes: Match.arrayWith([
+        { Key: 'idle_timeout.timeout_seconds', Value: '120' },
+      ]),
+    });
+  });
+
+  it('Target Group を /api/health で health check する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
+      Name: 'nagiyu-livetalk-tg-dev',
+      Port: 3000,
+      Protocol: 'HTTP',
+      TargetType: 'ip',
+      HealthCheckPath: '/api/health',
+    });
+  });
+
+  it('HTTP リスナー（port 80）を作成する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
+      Port: 80,
+      Protocol: 'HTTP',
+    });
+  });
+
+  it('HTTPS リスナー（port 443）は Phase 1c では作成しない', () => {
+    const template = synth('dev');
+    template.resourcePropertiesCountIs(
+      'AWS::ElasticLoadBalancingV2::Listener',
+      { Port: 443 },
+      0
+    );
+  });
+
+  it('Security Group が 80 / 443 の inbound を許可する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+      GroupName: 'nagiyu-livetalk-alb-sg-dev',
+      SecurityGroupIngress: Match.arrayWith([
+        Match.objectLike({ FromPort: 80, ToPort: 80, IpProtocol: 'tcp' }),
+        Match.objectLike({ FromPort: 443, ToPort: 443, IpProtocol: 'tcp' }),
+      ]),
+    });
+  });
+
+  it('SSM Parameter に ALB の各種 ARN / DNS / Security Group を出力する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/alb/dns-name',
+    });
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/alb/arn',
+    });
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/alb/listener-arn',
+    });
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/alb/target-group-arn',
+    });
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/alb/security-group-id',
+    });
+  });
+
+  it('Component=livetalk タグを付与する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+      Tags: Match.arrayWith([{ Key: 'Component', Value: 'livetalk' }]),
+    });
+  });
+
+  it('prod 環境でも正しい命名で生成する', () => {
+    const template = synth('prod');
+    template.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+      Name: 'nagiyu-livetalk-alb-prod',
+    });
+    template.hasResourceProperties('AWS::ElasticLoadBalancingV2::TargetGroup', {
+      Name: 'nagiyu-livetalk-tg-prod',
+    });
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/prod/alb/dns-name',
+    });
+  });
+});

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -1,0 +1,116 @@
+const cdk = require('aws-cdk-lib');
+const { Template, Match } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { LiveTalkEcsServiceStack } = require('../../lib/ecs-service-stack');
+
+const STACK_ENV = { account: '000000000000', region: 'us-east-1' };
+
+const synth = (environment) => {
+  const app = new cdk.App();
+  const stack = new LiveTalkEcsServiceStack(app, `TestLiveTalkService${environment}`, {
+    environment,
+    env: STACK_ENV,
+  });
+  return Template.fromStack(stack);
+};
+
+describe('LiveTalkEcsServiceStack', () => {
+  it('Task Definition family を環境名込みで作成する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      Family: 'nagiyu-livetalk-task-dev',
+      RequiresCompatibilities: ['FARGATE'],
+      NetworkMode: 'awsvpc',
+      Cpu: '1024',
+      Memory: '2048',
+    });
+  });
+
+  it('livetalk-web コンテナを Next.js port 3000 で定義する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: 'livetalk-web',
+          PortMappings: Match.arrayWith([Match.objectLike({ ContainerPort: 3000 })]),
+        }),
+      ]),
+    });
+  });
+
+  it('ECS Service 名を環境名込みで作成する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECS::Service', {
+      ServiceName: 'nagiyu-livetalk-service-dev',
+      DesiredCount: 1,
+      LaunchType: 'FARGATE',
+      HealthCheckGracePeriodSeconds: 60,
+    });
+  });
+
+  it('Task Security Group が ALB SG からの 3000 番受け入れを設定する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+      GroupName: 'nagiyu-livetalk-task-sg-dev',
+    });
+    template.hasResourceProperties('AWS::EC2::SecurityGroupIngress', {
+      FromPort: 3000,
+      ToPort: 3000,
+      IpProtocol: 'tcp',
+    });
+  });
+
+  it('SSM Parameter に ECS Service 名を出力する', () => {
+    const template = synth('dev');
+    // Value は CFN の Fn::GetAtt 参照になるため Name のみ検証する
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/ecs/service-name',
+    });
+  });
+
+  it('CloudWatch Log Group を 7 日間保持で作成する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::Logs::LogGroup', {
+      LogGroupName: '/ecs/nagiyu-livetalk-task-dev',
+      RetentionInDays: 7,
+    });
+  });
+
+  it('Component=livetalk タグを付与する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECS::Service', {
+      Tags: Match.arrayWith([{ Key: 'Component', Value: 'livetalk' }]),
+    });
+  });
+
+  it('IMAGE_TAG 環境変数からイメージタグを取得する', () => {
+    process.env.IMAGE_TAG = 'abc123';
+    try {
+      const template = synth('dev');
+      template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Name: 'livetalk-web',
+            Image: Match.stringLikeRegexp('.*:abc123$'),
+          }),
+        ]),
+      });
+    } finally {
+      delete process.env.IMAGE_TAG;
+    }
+  });
+
+  it('prod 環境でも正しい命名で生成する', () => {
+    const template = synth('prod');
+    template.hasResourceProperties('AWS::ECS::Service', {
+      ServiceName: 'nagiyu-livetalk-service-prod',
+    });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      Family: 'nagiyu-livetalk-task-prod',
+    });
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/prod/ecs/service-name',
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

LiveTalk Phase 1c（#3203）の実装。Phase 0 で整備した共通 ECS Cluster に LiveTalk 専用の ECS Service を載せ、LiveTalk 専用 ALB 経由でアクセスできる状態にする。

主な追加：
- **LiveTalk 専用 ALB スタック**（`infra/livetalk/lib/alb-stack.ts`）
  - `nagiyu-livetalk-alb-{env}`、HTTP リスナー（port 80）、idle timeout **120s**
  - Target Group は `/api/health` で health check、TargetType=IP、Port 3000
  - Security Group は 80 / 443 inbound を許可（443 は Phase 1d の CloudFront 連携を見越して開けておく）
  - `Component: livetalk` タグ
- **LiveTalk ECS Service スタック**（`infra/livetalk/lib/ecs-service-stack.ts`）
  - 共通 Cluster `nagiyu-shared-cluster-{env}` に Attach
  - Next.js 単一コンテナ（`livetalk-web`、port 3000）、Phase 1f の VOICEVOX 同居を見越して Task に CPU 1024 / Memory 2048
  - `healthCheckGracePeriod: 60s`、ALB Target Group へ自動登録
  - `IMAGE_TAG` 環境変数からイメージタグを取得し、ローリングデプロイ可能
- **SSM Parameter 定数を `infra/common` に追加**
  - `LIVETALK_ALB_*` / `LIVETALK_ECS_SERVICE_NAME` / `SHARED_ECS_CLUSTER_NAME|ARN`
- **CD ワークフロー**（`.github/workflows/livetalk-deploy.yml`）
  - ECR push 後段で ALB / ECS Service スタックを deploy
  - `aws ecs update-service --force-new-deployment` でローリングデプロイ
  - `aws ecs wait services-stable` で安定化を待つ
  - ALB DNS 経由で `/api/health` を curl チェック
- **Verify ワークフロー**（`.github/workflows/livetalk-verify.yml`）
  - infra-livetalk のユニットテスト実行を追加
  - 新スタック 2 つを synth 検証対象に追加

## 関連 Issue

Parent: #3184（Phase 1 親）
Grandparent: #3182（LiveTalk 全体）
This PR: #3203

`Closes #` は使わず（CLAUDE.md ルールに従い）integration → develop マージ時にクローズする想定。

## 変更種別

- [x] 新規機能
- [x] CI/CD 更新
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（infra-livetalk に 18 件追加、infra-common に 3 件追加）
- [x] CI/CD 設定を追加・更新した（livetalk-deploy.yml + livetalk-verify.yml）
- [x] ローカルでテストが全て通ることを確認した（`npm test --workspace=@nagiyu/infra-common` 83 件 / `@nagiyu/infra-livetalk` 18 件すべてパス）
- [x] ビルドエラーがないことを確認した（`npm run build --workspace=@nagiyu/infra-common && @nagiyu/infra-livetalk` 成功）
- [x] CDK synth が dev / prod 共に成功することを確認した

## テスト内容

- **`infra/common/tests/unit/ssm.test.ts`**: 新規 SSM 定数（共有 ECS、LiveTalk ALB、LiveTalk Service 名）の検証
- **`infra/livetalk/tests/unit/alb-stack.test.js`**:
  - ALB 命名・スキーム
  - idle timeout 120s
  - Target Group health check path `/api/health`
  - HTTP リスナーのみ作成・HTTPS リスナーは作成しないこと
  - Security Group の 80 / 443 inbound
  - SSM Parameter 5 種の出力
  - `Component: livetalk` タグ
  - prod 環境の命名
- **`infra/livetalk/tests/unit/ecs-service-stack.test.js`**:
  - Task Definition family / CPU 1024 / Memory 2048
  - `livetalk-web` コンテナ port 3000
  - Service 命名・desired 1・grace 60s
  - Task Security Group + ALB SG → 3000 inbound
  - Log Group `/ecs/nagiyu-livetalk-task-{env}` 保持 7 日
  - `Component: livetalk` タグ
  - `IMAGE_TAG` 環境変数の反映
  - SSM Parameter（service-name）
  - prod 環境の命名

ローカル実行結果：
```
@nagiyu/infra-common:  9 suites, 83 tests passed
@nagiyu/infra-livetalk: 2 suites, 18 tests passed
```

`cdk synth NagiyuLiveTalkEcrDev NagiyuLiveTalkAlbDev NagiyuLiveTalkServiceDev` および prod も成功。

## レビューポイント

### 1. ALB の HTTPS リスナーは未実装（Issue 仕様との差分）

Issue 本文では「HTTPS 443 + HTTP 80 → 443 リダイレクト」と書かれていますが、本 PR では **HTTP（port 80）リスナーのみ** を実装しました。理由：

- 既存の唯一 ALB を持つ Portal（`infra/root/alb-stack.ts`）も HTTP のみで、HTTPS は CloudFront 側（`REDIRECT_TO_HTTPS`）で終端しているため、プラットフォームのパターン一貫性を優先しました
- Phase 1c 完了条件「ALB の AWS DNS で Hello World 表示」をブラウザでクリーンに確認できる（ワイルドカード `*.nagiyu.com` 証明書は ALB DNS では cert mismatch するため）
- Security Group 自体は 443 を inbound 許可しておき、Phase 1d で CloudFront から HTTPS で疎通する余地は残す

ユーザー確認の上で「Portal パターン踏襲」を選択済み。

### 2. 共有 ECS Cluster と LiveTalk 個別 ALB の構成

`tasks/livetalk/design.md` 1.4 節の方針通り、Cluster は共有・ALB は個別。Cluster は SSM `/nagiyu/shared/{env}/ecs/cluster-name` から参照、ALB / Service は `infra/livetalk/` に閉じ込めています。

### 3. SSM 経由のスタック間依存

ALB スタック → ECS Service スタックの依存は CDK が自動検出できない（SSM lookup は deploy-time）ため、`bin/livetalk.ts` で `ecsServiceStack.addDependency(albStack)` を明示。

### 4. Task のリソース割当（CPU 1024 / Memory 2048）

Next.js 単体ならもっと小さくて済みますが、Phase 1f で同一 Task に VOICEVOX コンテナを追加する想定のため、最初から余裕枠を確保。差分は dev の Fargate Spot で吸収する想定。

### 5. ALB 月額固定費

ALB は最低 ~**\$22/月** の固定費が発生します。dev / prod それぞれに 1 台作成するため、計 ~**\$44/月** の固定費増。Issue 本文の通り。

### 6. PR テンプレートの `Closes #` を使っていない理由

CLAUDE.md「PR 本文に `Closes #{issue-number}` を含めない（Issue は integration → develop マージ後にクローズする）」に従っています。

## 補足事項

- リージョン: us-east-1 固定
- 完了条件（Issue #3203）の手動確認は人レビュー時にお願いします：
  - [ ] CDK deploy で dev 環境に LiveTalk 専用 ALB が作成される
  - [ ] ECS Service が共通 Cluster で 1 タスク稼働
  - [ ] ALB の AWS DNS にアクセスして Hello World が表示
  - [ ] CD で新イメージタグを push すると ECS Service がローリングデプロイされる
  - [ ] 既存 Portal / その他サービスに影響なし


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBjUFGzPXxVVp8EKGgBoeB)_