### PR TITLE
fix(livetalk): ECS Task に APP_VERSION env を注入し /api/health の version を反映

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -201,6 +201,9 @@ jobs:
           ENVIRONMENT: ${{ needs.build.outputs.environment }}
           STACK_SUFFIX: ${{ needs.build.outputs.stack-suffix }}
           IMAGE_TAG: ${{ github.sha }}
+          # CDK が process.env.APP_VERSION を読み、ECS Task の environment に注入する
+          # /api/health の version 表示に利用される
+          APP_VERSION: ${{ needs.build.outputs.app-version }}
         run: |
           npm run cdk --workspace=@nagiyu/infra-livetalk -- deploy \
             NagiyuLiveTalkAlb${STACK_SUFFIX} \

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -19,6 +19,10 @@ const account = process.env.CDK_DEFAULT_ACCOUNT;
 const region = 'us-east-1';
 const stackEnv = { account, region };
 
+// CD ワークフローから渡されるアプリバージョン（package.json の version）
+// ECS Task の APP_VERSION env として /api/health の version 表示に利用される
+const appVersion = process.env.APP_VERSION || '1.0.0';
+
 // LiveTalk ECR Repository Stack（dev / prod 別に作成、Component: livetalk）
 new LiveTalkEcrStack(app, `NagiyuLiveTalkEcr${envSuffix}`, {
   env: stackEnv,
@@ -41,6 +45,7 @@ const ecsServiceStack = new LiveTalkEcsServiceStack(
   {
     env: stackEnv,
     environment,
+    appVersion,
     description: `LiveTalk ECS Service (${environment})`,
   }
 );

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -14,6 +14,12 @@ import {
 
 export interface LiveTalkEcsServiceStackProps extends cdk.StackProps {
   environment: Environment;
+  /**
+   * アプリバージョン（services/livetalk/web/package.json の version）。
+   * ECS Task の `APP_VERSION` env として container に渡し、ランタイムで
+   * `/api/health` の version フィールドに反映する。
+   */
+  appVersion?: string;
 }
 
 /**
@@ -37,7 +43,7 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: LiveTalkEcsServiceStackProps) {
     super(scope, id, props);
 
-    const { environment } = props;
+    const { environment, appVersion = '1.0.0' } = props;
 
     const vpcId = ssm.StringParameter.valueForStringParameter(
       this,
@@ -173,6 +179,7 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
       environment: {
         NODE_ENV: environment === 'prod' ? 'production' : 'development',
         PORT: '3000',
+        APP_VERSION: appVersion,
       },
       portMappings: [
         {

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -6,11 +6,12 @@ const { LiveTalkEcsServiceStack } = require('../../lib/ecs-service-stack');
 
 const STACK_ENV = { account: '000000000000', region: 'us-east-1' };
 
-const synth = (environment) => {
+const synth = (environment, props = {}) => {
   const app = new cdk.App();
   const stack = new LiveTalkEcsServiceStack(app, `TestLiveTalkService${environment}`, {
     environment,
     env: STACK_ENV,
+    ...props,
   });
   return Template.fromStack(stack);
 };
@@ -81,6 +82,30 @@ describe('LiveTalkEcsServiceStack', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::ECS::Service', {
       Tags: Match.arrayWith([{ Key: 'Component', Value: 'livetalk' }]),
+    });
+  });
+
+  it('APP_VERSION を container environment に注入する（明示指定）', () => {
+    const template = synth('dev', { appVersion: '1.2.3' });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: 'livetalk-web',
+          Environment: Match.arrayWith([{ Name: 'APP_VERSION', Value: '1.2.3' }]),
+        }),
+      ]),
+    });
+  });
+
+  it('APP_VERSION 未指定時は 1.0.0 をデフォルトで注入する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: 'livetalk-web',
+          Environment: Match.arrayWith([{ Name: 'APP_VERSION', Value: '1.0.0' }]),
+        }),
+      ]),
     });
   });
 


### PR DESCRIPTION
## 変更の概要

#3218（Phase 1c）で実装漏れだった **ECS Task への `APP_VERSION` env 注入** を補完する小さな fix PR です。

### 背景
LiveTalk dev の `/api/health` を実機で叩いたところ：
```json
{"status":"ok","version":"unknown"}
```
となっており、他サービスは package.json のバージョンが正しく表示されていることが判明。

調査の結果、Dockerfile の問題ではなく **CDK の Lambda environment / ECS Task environment で `APP_VERSION` を渡すパターン** がプラットフォーム標準で、Phase 1c の ECS Task Definition にこれが漏れていました。

| サービス | APP_VERSION 注入箇所 |
|---|---|
| admin / auth / share-together / codec-converter / niconico-mylist-assistant | CDK Lambda environment |
| **livetalk（本 PR で追加）** | CDK ECS Task container environment |

### 変更内容
- `infra/livetalk/bin/livetalk.ts`: `process.env.APP_VERSION` を読み（default `'1.0.0'`）、ECS Service Stack へ props で渡す
- `infra/livetalk/lib/ecs-service-stack.ts`: `appVersion` prop を受け取り、container environment に `APP_VERSION: appVersion` を追加
- `.github/workflows/livetalk-deploy.yml`: ALB / ECS Service デプロイ step に `APP_VERSION` env を渡す（既存の `app-version` outputs を流用）
- ユニットテスト 2 件追加（明示指定 / デフォルト）

## 関連 Issue

- Parent: #3184（Phase 1）
- Source: #3203（Phase 1c）の実装補完
- Sibling PR: #3218（マージ済み）

`Closes #` は使いません（CLAUDE.md ルール、integration → develop マージ時に親 Issue クローズ想定）。

## 変更種別

- [x] バグ修正
- [x] CI/CD 更新
- [x] インフラ更新

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（ECS Service スタックのユニットテストに 2 件追加、合計 20 件）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した
- [x] `cdk synth` で生成された CFN テンプレートに `APP_VERSION: 1.2.3` が出力されることを確認

## テスト内容

- **`infra/livetalk/tests/unit/ecs-service-stack.test.js`** に 2 件追加
  - `appVersion: '1.2.3'` を明示指定 → container env に `APP_VERSION=1.2.3` が出る
  - `appVersion` 未指定 → default `1.0.0` が container env に出る

ローカル実行結果：`@nagiyu/infra-livetalk` 2 suites / **20 tests passed**

`ENVIRONMENT=dev APP_VERSION=1.2.3 npm run synth -- NagiyuLiveTalkServiceDev` で CFN 出力に：
```yaml
- Name: APP_VERSION
  Value: 1.2.3
```
が含まれることを確認済み。

## レビューポイント

### なぜ Issue 起票せず本 PR で直接修正したか

#3203 のスコープ内の実装漏れ（他サービスとの一貫性を欠いた状態）であり、`/api/health` の version 表示は内部監視用フィールドで緊急性は低いものの、本来 #3203 で含むべきだった内容。新 Issue 起票よりもインライン修正の方が経路としてシンプルなため、本 PR は #3203 の補完として扱います。

### appVersion のデフォルト値

他サービス（`infra/admin/bin/admin.ts:18` 等）と揃えて `'1.0.0'` をデフォルトに設定。

## 補足事項

マージ後、CD ワークフロー経由で dev 環境にデプロイされ、`/api/health` の version が `services/livetalk/web/package.json` の `"1.0.0"` を反映するはずです（package.json バージョンを上げた時点で動的に追随）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBjUFGzPXxVVp8EKGgBoeB)_