### PR TITLE
feat(livetalk): Phase 1e 認可（livetalk:chat permission）を追加

### DIFF
--- a/libs/common/src/auth/roles.ts
+++ b/libs/common/src/auth/roles.ts
@@ -70,6 +70,12 @@ export const ROLES = {
       'stocks:read-evaluation',
     ],
   },
+  'livetalk-user': {
+    id: 'livetalk-user',
+    name: 'LiveTalk ユーザー',
+    description: 'LiveTalk のチャット UI および API にアクセス可能',
+    permissions: ['livetalk:chat'],
+  },
 } as const satisfies Record<string, RoleDefinition>;
 
 /**

--- a/libs/common/src/auth/types.ts
+++ b/libs/common/src/auth/types.ts
@@ -54,6 +54,9 @@ export interface Session {
  * Auth Service permissions:
  * - auth:read - View auth configuration and user data
  * - auth:write - Manage auth configuration and user data
+ *
+ * LiveTalk permissions:
+ * - livetalk:chat - Access LiveTalk chat UI and API
  */
 export type Permission =
   | 'users:read'
@@ -66,7 +69,8 @@ export type Permission =
   | 'stocks:manage-data'
   | 'stocks:read-evaluation'
   | 'auth:read'
-  | 'auth:write';
+  | 'auth:write'
+  | 'livetalk:chat';
 
 /**
  * Valid role IDs defined in ROLES constant

--- a/libs/common/tests/unit/auth/permissions.test.ts
+++ b/libs/common/tests/unit/auth/permissions.test.ts
@@ -291,6 +291,34 @@ describe('Permission Functions', () => {
       });
     });
 
+    describe('livetalk-user role', () => {
+      it('should have livetalk:chat permission', () => {
+        expect(hasPermission(['livetalk-user'], 'livetalk:chat')).toBe(true);
+      });
+
+      it('should not have stocks:read permission', () => {
+        expect(hasPermission(['livetalk-user'], 'stocks:read')).toBe(false);
+      });
+
+      it('should not have users:read permission', () => {
+        expect(hasPermission(['livetalk-user'], 'users:read')).toBe(false);
+      });
+    });
+
+    describe('livetalk:chat permission', () => {
+      it('livetalk-user should have livetalk:chat', () => {
+        expect(hasPermission(['livetalk-user'], 'livetalk:chat')).toBe(true);
+      });
+
+      it('admin should not have livetalk:chat', () => {
+        expect(hasPermission(['admin'], 'livetalk:chat')).toBe(false);
+      });
+
+      it('stock-admin should not have livetalk:chat', () => {
+        expect(hasPermission(['stock-admin'], 'livetalk:chat')).toBe(false);
+      });
+    });
+
     describe('requirePermission with Stock Tracker roles', () => {
       it('should not throw for stock-user with stocks:read', () => {
         expect(() => requirePermission(['stock-user'], 'stocks:read')).not.toThrow();

--- a/libs/common/tests/unit/auth/roles.test.ts
+++ b/libs/common/tests/unit/auth/roles.test.ts
@@ -12,6 +12,7 @@ describe('VALID_ROLES', () => {
     expect(VALID_ROLES).toContain('stock-viewer');
     expect(VALID_ROLES).toContain('stock-user');
     expect(VALID_ROLES).toContain('stock-admin');
+    expect(VALID_ROLES).toContain('livetalk-user');
   });
 
   it('配列として提供されるべき', () => {
@@ -132,6 +133,32 @@ describe('ROLES', () => {
       expect(ROLES['stock-user'].permissions).not.toContain('stocks:read-evaluation');
       expect(ROLES.admin.permissions).not.toContain('stocks:read-evaluation');
       expect(ROLES['user-manager'].permissions).not.toContain('stocks:read-evaluation');
+    });
+  });
+
+  describe('livetalk-user role', () => {
+    it('正しい構造を持つべき', () => {
+      expect(ROLES['livetalk-user']).toBeDefined();
+      expect(ROLES['livetalk-user'].id).toBe('livetalk-user');
+      expect(ROLES['livetalk-user'].name).toBe('LiveTalk ユーザー');
+      expect(ROLES['livetalk-user'].description).toBeDefined();
+      expect(Array.isArray(ROLES['livetalk-user'].permissions)).toBe(true);
+    });
+
+    it('livetalk:chat 権限のみを持つべき', () => {
+      expect(ROLES['livetalk-user'].permissions).toContain('livetalk:chat');
+      expect(ROLES['livetalk-user'].permissions).toHaveLength(1);
+    });
+  });
+
+  describe('livetalk:chat 権限の付与範囲', () => {
+    it('livetalk-user のみが livetalk:chat を持つべき', () => {
+      expect(ROLES['livetalk-user'].permissions).toContain('livetalk:chat');
+      expect(ROLES.admin.permissions).not.toContain('livetalk:chat');
+      expect(ROLES['user-manager'].permissions).not.toContain('livetalk:chat');
+      expect(ROLES['stock-viewer'].permissions).not.toContain('livetalk:chat');
+      expect(ROLES['stock-user'].permissions).not.toContain('livetalk:chat');
+      expect(ROLES['stock-admin'].permissions).not.toContain('livetalk:chat');
     });
   });
 });

--- a/libs/nextjs/src/middleware.ts
+++ b/libs/nextjs/src/middleware.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+import { ERROR_CODES, hasPermission } from '@nagiyu/common';
+import type { Permission } from '@nagiyu/common';
 
 export interface AuthMiddlewareRequest {
   auth?: unknown;
@@ -17,12 +19,38 @@ export interface CreateAuthMiddlewareOptions {
   signInPath?: string;
   getCallbackUrl?: (request: AuthMiddlewareRequest) => string;
   onAuthConfigError?: () => NextResponse;
+  /**
+   * 認証済みユーザーに対して追加で要求する権限。
+   * 指定された場合、`request.auth.user.roles` に当該 permission を含む role が
+   * 1 つでもあれば通過、なければ 403 を返す（または `onForbidden` の戻り値）。
+   */
+  requiredPermission?: Permission;
+  /**
+   * `requiredPermission` を満たさなかった場合に返すレスポンス。
+   * 未指定時は `{ error: 'FORBIDDEN', message: 'この操作を実行する権限がありません' }` を 403 で返す。
+   */
+  onForbidden?: (request: AuthMiddlewareRequest) => NextResponse;
 }
 
 const MIDDLEWARE_ERROR_MESSAGES = {
   AUTH_URL_NOT_SET: 'NEXT_PUBLIC_AUTH_URL or NEXTAUTH_URL is not set',
   AUTH_CONFIGURATION_ERROR: 'Authentication configuration error',
+  FORBIDDEN: 'この操作を実行する権限がありません',
 } as const;
+
+interface SessionWithRoles {
+  user?: {
+    roles?: unknown;
+  };
+}
+
+function extractRoles(auth: unknown): string[] {
+  const session = auth as SessionWithRoles | null | undefined;
+  const roles = session?.user?.roles;
+  return Array.isArray(roles)
+    ? roles.filter((role): role is string => typeof role === 'string')
+    : [];
+}
 
 function getDefaultCallbackUrl(request: AuthMiddlewareRequest): string {
   const appUrl = process.env.APP_URL;
@@ -41,6 +69,8 @@ export function createAuthMiddleware(options: CreateAuthMiddlewareOptions = {}) 
     signInPath = '/signin',
     getCallbackUrl = getDefaultCallbackUrl,
     onAuthConfigError,
+    requiredPermission,
+    onForbidden,
   } = options;
 
   const publicPathSet = new Set(publicPaths);
@@ -56,6 +86,21 @@ export function createAuthMiddleware(options: CreateAuthMiddlewareOptions = {}) 
     }
 
     if (request.auth) {
+      if (requiredPermission) {
+        const roles = extractRoles(request.auth);
+        if (!hasPermission(roles, requiredPermission)) {
+          return (
+            onForbidden?.(request) ??
+            NextResponse.json(
+              {
+                error: ERROR_CODES.FORBIDDEN,
+                message: MIDDLEWARE_ERROR_MESSAGES.FORBIDDEN,
+              },
+              { status: 403 }
+            )
+          );
+        }
+      }
       return NextResponse.next();
     }
 

--- a/libs/nextjs/tests/unit/middleware.test.ts
+++ b/libs/nextjs/tests/unit/middleware.test.ts
@@ -36,6 +36,10 @@ function createRequest(url: string, auth?: unknown): MockRequest {
   };
 }
 
+function createSession(roles: string[]): { user: { roles: string[] } } {
+  return { user: { roles } };
+}
+
 describe('createAuthMiddleware', () => {
   beforeEach(() => {
     delete process.env.SKIP_AUTH_CHECK;
@@ -98,6 +102,94 @@ describe('createAuthMiddleware', () => {
     expect(response).toEqual({
       type: 'redirect',
       url: 'https://example.com/signin?callbackUrl=%2Fprivate',
+    });
+  });
+
+  describe('requiredPermission', () => {
+    it('指定 permission を保持する role があれば通過する', () => {
+      const middleware = createAuthMiddleware({
+        requiredPermission: 'livetalk:chat',
+      });
+
+      const response = middleware(
+        createRequest('https://example.com/chat', createSession(['livetalk-user']))
+      );
+
+      expect(response).toEqual({ type: 'next' });
+    });
+
+    it('認証済みでも permission がなければ 403 を返す', () => {
+      const middleware = createAuthMiddleware({
+        requiredPermission: 'livetalk:chat',
+      });
+
+      const response = middleware(
+        createRequest('https://example.com/chat', createSession(['stock-viewer']))
+      );
+
+      expect(response).toEqual({
+        type: 'json',
+        status: 403,
+        body: { error: 'FORBIDDEN', message: 'この操作を実行する権限がありません' },
+      });
+    });
+
+    it('roles が空配列でも 403 を返す', () => {
+      const middleware = createAuthMiddleware({
+        requiredPermission: 'livetalk:chat',
+      });
+
+      const response = middleware(createRequest('https://example.com/chat', createSession([])));
+
+      expect(response).toEqual({
+        type: 'json',
+        status: 403,
+        body: { error: 'FORBIDDEN', message: 'この操作を実行する権限がありません' },
+      });
+    });
+
+    it('onForbidden を指定すればその戻り値を返す', () => {
+      process.env.APP_URL = 'https://app.example.com';
+      const middleware = createAuthMiddleware({
+        requiredPermission: 'livetalk:chat',
+        onForbidden: () =>
+          ({ type: 'redirect', url: 'https://auth.example.com/signin' }) as unknown as never,
+      });
+
+      const response = middleware(
+        createRequest('https://example.com/chat', createSession(['stock-viewer']))
+      );
+
+      expect(response).toEqual({
+        type: 'redirect',
+        url: 'https://auth.example.com/signin',
+      });
+    });
+
+    it('未認証の場合は permission チェックを経由せずサインインへリダイレクトする', () => {
+      process.env.APP_URL = 'https://app.example.com';
+      const middleware = createAuthMiddleware({
+        requiredPermission: 'livetalk:chat',
+        getSignInBaseUrl: () => 'https://auth.example.com',
+      });
+
+      const response = middleware(createRequest('https://example.com/chat'));
+
+      expect(response).toEqual({
+        type: 'redirect',
+        url: 'https://auth.example.com/signin?callbackUrl=https%3A%2F%2Fapp.example.com%2Fchat',
+      });
+    });
+
+    it('publicPaths は permission チェックなしで通過する', () => {
+      const middleware = createAuthMiddleware({
+        publicPaths: ['/'],
+        requiredPermission: 'livetalk:chat',
+      });
+
+      const response = middleware(createRequest('https://example.com/'));
+
+      expect(response).toEqual({ type: 'next' });
     });
   });
 });

--- a/services/livetalk/web/.env.test
+++ b/services/livetalk/web/.env.test
@@ -1,0 +1,14 @@
+# Node Environment
+NODE_ENV=test
+
+# Application Configuration
+APP_VERSION=0.0.0
+
+# NextAuth Configuration
+# NextAuth v5 で使用される環境変数
+# Required for NextAuth initialization (even though auth check is skipped)
+AUTH_SECRET=test-secret-key-for-e2e-tests
+
+# Skip authentication check in test environment
+# This allows E2E tests to run without Auth service
+SKIP_AUTH_CHECK=true

--- a/services/livetalk/web/.gitignore
+++ b/services/livetalk/web/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!.env.test
 
 # vercel
 .vercel

--- a/services/livetalk/web/playwright.config.ts
+++ b/services/livetalk/web/playwright.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+config({ path: resolve(__dirname, '.env.test') });
 
 const isCI = !!process.env.CI;
 
@@ -61,7 +65,7 @@ export default defineConfig({
 
   webServer: {
     command: webServerCommand,
-    url: 'http://localhost:3000',
+    url: 'http://localhost:3000/api/health',
     reuseExistingServer: !isCI,
     timeout: 2 * 60 * 1000,
   },

--- a/services/livetalk/web/src/auth.ts
+++ b/services/livetalk/web/src/auth.ts
@@ -1,0 +1,18 @@
+import NextAuth, { type NextAuthConfig } from 'next-auth';
+import { createServiceAuthConfig } from '@nagiyu/nextjs';
+
+/**
+ * LiveTalk サービスの NextAuth 設定
+ *
+ * Auth サービスから発行された JWT を検証する。
+ * OAuth プロバイダーは Auth サービスで管理されるため定義しない。
+ */
+export const authConfig: NextAuthConfig = {
+  providers: [],
+  trustHost: true,
+  ...createServiceAuthConfig(),
+};
+
+const nextAuth = NextAuth(authConfig);
+
+export const { handlers, auth, signIn, signOut } = nextAuth;

--- a/services/livetalk/web/src/middleware.ts
+++ b/services/livetalk/web/src/middleware.ts
@@ -1,0 +1,23 @@
+import { auth } from './auth';
+import { createAuthMiddleware } from '@nagiyu/nextjs/middleware';
+
+/**
+ * LiveTalk サービスのミドルウェア
+ *
+ * Auth サービスから発行された JWT を検証し、`livetalk:chat` permission を持つ
+ * ユーザーのみアクセスを許可する。未認証ユーザーは Auth サービスのサインインへ
+ * リダイレクトし、認証済みでも permission がない場合は 403 を返す。
+ *
+ * 開発・テスト環境では、SKIP_AUTH_CHECK=true を設定することで
+ * 認証チェックをスキップできます。
+ */
+export default auth(
+  createAuthMiddleware({
+    getSignInBaseUrl: () => process.env.NEXT_PUBLIC_AUTH_URL || process.env.NEXTAUTH_URL,
+    requiredPermission: 'livetalk:chat',
+  })
+);
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
## 変更の概要

リブトーク Phase 1e（#3205）の実装。既存 RBAC に `livetalk:chat` permission と `livetalk-user` role を追加し、LiveTalk サービスにミドルウェア経由の認可を導入する。認可されたユーザーのみが `dev-live-talk.nagiyu.com` の UI にアクセスでき、未認証は Auth サービスのサインインへリダイレクト、認証済みでも permission を持たない場合は 403 を返す。`/api/health` は ALB ヘルスチェック用に認可不要のまま残す。

## 関連 Issue

Refs #3205
Parent: #3184
Grandparent: #3182

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## 主な変更

### `libs/common/src/auth/`
- `types.ts`: Permission 型に `'livetalk:chat'` を追加（JSDoc 更新含む）
- `roles.ts`: ROLES に `livetalk-user`（permissions: `['livetalk:chat']`）を追加

### `libs/nextjs/src/middleware.ts`
- `createAuthMiddleware()` に `requiredPermission?: Permission` / `onForbidden?: (request) => NextResponse` オプションを追加
- 認証済みかつ permission を保持しない場合、デフォルトでは `{ error: 'FORBIDDEN', message: 'この操作を実行する権限がありません' }` を 403 で返す
- 既存の admin / niconico-mylist-assistant 等は permission オプション未指定のため挙動は変化しない

### `services/livetalk/web/src/`
- `auth.ts`（新規）: 既存 admin / niconico-mylist-assistant と同じ `createServiceAuthConfig()` パターン
- `middleware.ts`（新規）: `createAuthMiddleware({ requiredPermission: 'livetalk:chat', ... })` を `auth()` でラップ。matcher は `/((?!api|...).*)` で `/api/*` を除外しているため `/api/health` は影響なし

### E2E
- `services/livetalk/web/.env.test`（新規）: `SKIP_AUTH_CHECK=true` 等のテスト用設定（admin と同パターン）
- `playwright.config.ts`: `dotenv` で `.env.test` を読み込み、webServer URL を `/api/health` に変更
- `.gitignore`: `.env.test` / `.env.example` をホワイトリスト化

## テスト内容

- `libs/common` 全 282 テスト ✅（`livetalk-user` role / `livetalk:chat` permission のケース追加）
- `libs/nextjs` 全 83 テスト ✅（middleware の `requiredPermission` 系 6 ケース追加：通過 / 403 / 空 roles / `onForbidden` カスタム / 未認証時のリダイレクト / publicPaths 優先）
- `libs/ui` / `libs/browser` / `services/admin` / `services/auth` も既存テスト全通過（リグレッションなし）
- `npm run build --workspace=@nagiyu/livetalk-web` 成功（ミドルウェアが Proxy として登録される）

## レビューポイント

- `createAuthMiddleware` への `requiredPermission` 追加は破壊的変更ではなくオプション追加に留めている。既存呼び出し元（admin / niconico-mylist-assistant / share-together / auth）には影響なし
- `request.auth` は元々 `unknown` 型のため、内部で `SessionWithRoles` に narrow して `roles` 抽出（`extractRoles`）。`Array.isArray` チェックで防御的に処理
- 自分の Google アカウントへの `livetalk-user` role 付与は本 PR のコード変更外。Auth サービスの管理画面（`/api/users/{userId}/roles`、`roles:assign` permission 必須）から手動で実施する運用

## 補足事項

- 完了条件「dev-live-talk.nagiyu.com で認可ユーザーが Hello World、認可なしは 403/リダイレクト」の実物確認は dev デプロイ後に人力検証が必要
- `/api/chat` などの今後追加される API ルートには `withAuth(auth, 'livetalk:chat', handler)` を適用する想定（Phase 1f 以降）

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAPHJijLkjmgPBSV1hUg8x)_