### PR TITLE
fix(livetalk): ECS タスクに AUTH_SECRET 等の認証関連 env を追加（#3205 follow-up）

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -196,6 +196,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Fetch secrets from Secrets Manager
+        id: fetch-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            NEXTAUTH_SECRET,nagiyu-auth-nextauth-secret-${{ needs.build.outputs.environment }}
+          parse-json-secrets: true
+
       - name: Deploy ALB and ECS Service Stacks
         env:
           ENVIRONMENT: ${{ needs.build.outputs.environment }}
@@ -204,10 +212,12 @@ jobs:
           # CDK が process.env.APP_VERSION を読み、ECS Task の environment に注入する
           # /api/health の version 表示に利用される
           APP_VERSION: ${{ needs.build.outputs.app-version }}
+          SECRET_VALUE: ${{ env.NEXTAUTH_SECRET }}
         run: |
           npm run cdk --workspace=@nagiyu/infra-livetalk -- deploy \
             NagiyuLiveTalkAlb${STACK_SUFFIX} \
             NagiyuLiveTalkService${STACK_SUFFIX} \
+            --context nextAuthSecret="$SECRET_VALUE" \
             --require-approval never
 
           echo "LiveTalk ALB and ECS Service deployed (environment: $ENVIRONMENT)"

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -45,6 +45,19 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
 
     const { environment, appVersion = '1.0.0' } = props;
 
+    // CDK context から secrets を取得
+    // 未指定の場合はプレースホルダーを使用（deploy ジョブで実際の値に更新される）
+    const nextAuthSecret =
+      scope.node.tryGetContext('nextAuthSecret') || 'PLACEHOLDER_NEXTAUTH_SECRET';
+
+    const authUrl =
+      environment === 'prod' ? 'https://auth.nagiyu.com' : `https://dev-auth.nagiyu.com`;
+
+    const appUrl =
+      environment === 'prod'
+        ? 'https://live-talk.nagiyu.com'
+        : 'https://dev-live-talk.nagiyu.com';
+
     const vpcId = ssm.StringParameter.valueForStringParameter(
       this,
       SSM_PARAMETERS.VPC_ID(environment)
@@ -177,9 +190,18 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
         logGroup,
       }),
       environment: {
-        NODE_ENV: environment === 'prod' ? 'production' : 'development',
+        // admin / niconico-mylist-assistant 等と同じく environment 値をそのまま渡す。
+        // 'development' にすると @nagiyu/nextjs の cookie 名サフィックスと domain スコープが
+        // Auth サービスの発行 cookie とずれるため、'dev' / 'prod' を使う。
+        NODE_ENV: environment,
         PORT: '3000',
         APP_VERSION: appVersion,
+        // NextAuth v5 が JWT 署名・検証に使用する secret。Auth サービスと同じ値が必要。
+        AUTH_SECRET: nextAuthSecret,
+        // Auth サービスの URL（サインインリダイレクト先）
+        NEXT_PUBLIC_AUTH_URL: authUrl,
+        // 自サービスのベース URL（callbackUrl 生成用）
+        APP_URL: appUrl,
       },
       portMappings: [
         {


### PR DESCRIPTION
## 変更の概要

Phase 1e (#3205) のスコープ漏れ修正。ECS タスクに認証関連の環境変数が不足していたため、`dev-live-talk.nagiyu.com` でのアクセス時に `MissingSecret` エラーが発生し 403 になっていた。

CloudWatch Logs で確認した直接原因：
```
[auth][error] MissingSecret: Please define a `secret`.
```

## 関連 Issue

Refs #3205 (Phase 1e: 認可 - follow-up)
Parent: #3184 / #3182

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した

## 実装チェックリスト

- [x] ローカルでビルド・synth が通ることを確認した（`NagiyuLiveTalkServiceDev` の CloudFormation テンプレートで env 変数の存在を確認）
- [x] infra-livetalk の unit test 33 件が通ることを確認した

## 修正内容

### `infra/livetalk/lib/ecs-service-stack.ts`

| 項目 | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| `NODE_ENV` | `'development'` / `'production'` | `environment`（`'dev'` / `'prod'`） | cookie 名サフィックス（`.dev`）と domain（`.nagiyu.com`）を Auth サービスの発行 cookie に合わせる |
| `AUTH_SECRET` | なし | CDK context `nextAuthSecret` | NextAuth v5 が JWT 検証に必須 |
| `NEXT_PUBLIC_AUTH_URL` | なし | `https://dev-auth.nagiyu.com` 等 | 未認証時の signin リダイレクト先 |
| `APP_URL` | なし | `https://dev-live-talk.nagiyu.com` 等 | callbackUrl 生成用の自サービス URL |

### `.github/workflows/livetalk-deploy.yml`

`infrastructure-app` ジョブに Secrets Manager fetch ステップを追加し、`nagiyu-auth-nextauth-secret-{env}` を取得して CDK context `nextAuthSecret` として渡すようにした（admin の同パターンを踏襲）。

## テスト内容

- CDK synth で env 変数が正しく CloudFormation テンプレートに展開されることを確認
- infra-livetalk unit tests（33件）通過

## レビューポイント

- `AUTH_SECRET` を ECS の `environment`（平文 env）として渡している点は他サービスと同一の方針。ECS Secrets（Secrets Manager ARN 直接参照）への移行は既存サービスとの整合性を取りながら別途検討
- `nagiyu-auth-nextauth-secret-{env}` というシークレット名は admin-deploy.yml で使用済みのものを流用しており、Auth サービスと同一の secret を参照している

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAPHJijLkjmgPBSV1hUg8x)_