### PR TITLE
fix(livetalk-infra): ALB ターゲットに livetalk-web:3000 を明示指定（Phase 1f デプロイ詰まりの修正）

### DIFF
--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -264,7 +264,17 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
       healthCheckGracePeriod: cdk.Duration.seconds(120),
     });
 
-    this.service.attachToApplicationTargetGroup(targetGroup);
+    // ALB ターゲットには明示的に livetalk-web:3000 を指定する。
+    // attachToApplicationTargetGroup() の暗黙的なデフォルトは「最初に addContainer された
+    // コンテナ」を拾うため、複数コンテナ構成では voicevox:50021 が誤ってターゲットになり
+    // ALB health check が voicevox に向かい全タスクが unhealthy で再起動を繰り返す事故が起きた。
+    // 順番依存を排除するため、container/port を明示的に渡す。
+    targetGroup.addTarget(
+      this.service.loadBalancerTarget({
+        containerName: 'livetalk-web',
+        containerPort: 3000,
+      })
+    );
 
     cdk.Tags.of(this).add('Application', 'nagiyu');
     cdk.Tags.of(this).add('Environment', environment);

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -87,6 +87,18 @@ describe('LiveTalkEcsServiceStack', () => {
     });
   });
 
+  it('ALB ターゲットは livetalk-web:3000 を明示的に指定する（voicevox に誤マッピングしない）', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECS::Service', {
+      LoadBalancers: Match.arrayWith([
+        Match.objectLike({
+          ContainerName: 'livetalk-web',
+          ContainerPort: 3000,
+        }),
+      ]),
+    });
+  });
+
   it('Task Security Group が ALB SG からの 3000 番受け入れを設定する', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::EC2::SecurityGroup', {


### PR DESCRIPTION
## 変更の概要

Phase 1f マージ後の dev デプロイが ECS タスクの起動 → 停止を繰り返して完走しない問題を修正する。

### 症状

`integration/3182-livetalk` への Phase 1f マージ（commit `03c62bc`）後、`LiveTalk - Build and Push to ECR` ワークフローが 45 分以上経っても完了せず、ECS Service の新リビジョン (rev 6) のタスクが下記サイクルを延々繰り返していた：

1. タスク開始（voicevox + livetalk-web）
2. voicevox が HEALTHY、web も Next.js Ready ログ出力
3. ~80 秒後に `Task failed ELB health checks` で task 停止（livetalk-web exit 143 = SIGTERM）
4. 新タスク起動 → 1 へ戻る

旧リビジョン (rev 5, Phase 1e) のタスクは生きており、dev URL は依然として 200 を返していた（curl 確認済み）。

### 原因

CDK の `service.attachToApplicationTargetGroup(targetGroup)` は、ALB ターゲットの container/port を明示指定しない場合、**Task Definition に最初に追加されたコンテナを暗黙的に default として拾う**仕様（`Cluster.defaultContainer = containers[0]`）。

Phase 1f の `infra/livetalk/lib/ecs-service-stack.ts` では：

```ts
const voicevoxContainer = this.taskDefinition.addContainer('voicevox', ...);   // ← 先に追加
const webContainer = this.taskDefinition.addContainer('livetalk-web', ...);    // ← 後
...
this.service.attachToApplicationTargetGroup(targetGroup);
```

の順序で voicevox を先に追加していたため、ALB は voicevox:50021 を target として登録していた（`aws ecs describe-services` で `containerName: "voicevox", containerPort: 50021` を確認）。VOICEVOX エンジンは `/api/health` を持たないため 404 → ALB が全タスクを unhealthy 判定。

旧リビジョン (rev 5) はコンテナが web 1 つだけだったので default が正しく livetalk-web:3000 になっていて影響を受けていなかった。

### 修正

`targetGroup.addTarget(service.loadBalancerTarget({containerName, containerPort}))` を使い container/port を明示する。これにより `addContainer` の呼び出し順への暗黙依存を排除する。

```ts
targetGroup.addTarget(
  this.service.loadBalancerTarget({
    containerName: 'livetalk-web',
    containerPort: 3000,
  })
);
```

CDK synth で生成される CloudFormation でも `LoadBalancers: [{ ContainerName: livetalk-web, ContainerPort: 3000 }]` になることを確認済み。

ユニットテストに該当アサーションを追加（既存 11 件 → 12 件、全 36 件パス）。

## 関連 Issue

Phase 1f (#3206) のフォローアップ。`integration/3182-livetalk` → `develop` マージ時に Closes は付けない（親 Issue #3206 のステータスはそのまま）。

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [ ] 関連ドキュメントを更新した（インフラ実装の内部修正のため不要）
- [ ] CI/CD 設定を追加・更新した（既存 verify / deploy フローのまま）
- [x] ローカルでテストが全て通ることを確認した（infra-livetalk 36 件 / synth OK）
- [x] ビルドエラーがないことを確認した

## テスト内容

- `npm run test --workspace=@nagiyu/infra-livetalk` 全 36 件パス
- 新規アサーション：`AWS::ECS::Service` の `LoadBalancers` に `{ContainerName: 'livetalk-web', ContainerPort: 3000}` が含まれることを検証
- CDK synth で生成される CloudFormation の `LoadBalancers` セクションを目視確認

## レビューポイント

- マージ後の dev 自動デプロイで rev 7 タスクが ELB HC を通過し Service が安定状態に到達するか
- 古い rev 6 デプロイは自動的に置き換わるはず（service update force-new-deployment が CD で走る）
- 念のため、修正反映後も rev 5 (Phase 1e) のタスクが完全に置き換わる過程を AWS Console で確認推奨

https://claude.ai/code/session_01RCZ2gaLMMdTUEfnQCVG8T3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCZ2gaLMMdTUEfnQCVG8T3)_