### PR TITLE
feat(livetalk-infra): Phase 1g-1 Live2D assets S3 バケット + CloudFront /assets/* behavior を追加

### DIFF
--- a/infra/common/src/utils/ssm.ts
+++ b/infra/common/src/utils/ssm.ts
@@ -31,4 +31,6 @@ export const SSM_PARAMETERS = {
     `/nagiyu/livetalk/${env}/cloudfront/domain-name`,
   LIVETALK_CLOUDFRONT_CUSTOM_DOMAIN: (env: Environment) =>
     `/nagiyu/livetalk/${env}/cloudfront/custom-domain`,
+  LIVETALK_ASSETS_BUCKET_NAME: (env: Environment) =>
+    `/nagiyu/livetalk/${env}/assets/bucket-name`,
 } as const;

--- a/infra/livetalk/lib/cloudfront-stack.ts
+++ b/infra/livetalk/lib/cloudfront-stack.ts
@@ -4,6 +4,7 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as targets from 'aws-cdk-lib/aws-route53-targets';
+import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 import { Environment, SSM_PARAMETERS } from '@nagiyu/infra-common';
@@ -15,35 +16,44 @@ export interface LiveTalkCloudFrontStackProps extends cdk.StackProps {
 /**
  * LiveTalk 専用 CloudFront Distribution スタック
  *
- * - Origin: LiveTalk 専用 ALB（SSM `/nagiyu/livetalk/{env}/alb/dns-name` から取得）
+ * - defaultBehavior: LiveTalk 専用 ALB（SSM `/nagiyu/livetalk/{env}/alb/dns-name` から取得）
+ * - additionalBehavior `/assets/*`: Live2D モデルファイル / Cubism Core を配信する
+ *   private S3 bucket（OAC 経由、CACHING_OPTIMIZED）
  * - 証明書: 共通ワイルドカード ACM（`*.nagiyu.com`、us-east-1）
  * - カスタムドメイン:
  *     - dev: `dev-live-talk.nagiyu.com`
  *     - prod: `live-talk.nagiyu.com`
  * - Route53 ALIAS レコードを同一スタック内で作成（`infra/ui-storybook` と同じパターン）。
- *   `targets.CloudFrontTarget(this.distribution)` を使うため SSM / cross-stack 参照不要。
- *   shared 側 `route53-records-stack` は XServer 移行 CNAME 専用のまま触らない。
- * - 既存 Portal の `infra/root/cloudfront-stack.ts` のパターン（HTTP オリジン /
- *   CACHING_DISABLED / ALL_VIEWER_EXCEPT_HOST_HEADER / ALLOW_ALL）を踏襲。
- * - 後続 Phase の LLM ストリーミング向けにオリジンタイムアウトを 60s に延長
- *   （HttpOrigin の `readTimeout` / `keepaliveTimeout` 上限）。
+ * - 後続 Phase の LLM ストリーミング向けにオリジンタイムアウトを 60s に延長。
  * - 出力:
- *     - CfnOutput: DistributionId / DistributionDomainName / CustomDomainName
+ *     - CfnOutput: DistributionId / DistributionDomainName / CustomDomainName / AssetsBucketName
  *     - SSM Parameter:
  *         - `/nagiyu/livetalk/{env}/cloudfront/distribution-id`
- *         - `/nagiyu/livetalk/{env}/cloudfront/domain-name`（`dxxxx.cloudfront.net`）
- *         - `/nagiyu/livetalk/{env}/cloudfront/custom-domain`（`dev-live-talk.nagiyu.com` 等）
+ *         - `/nagiyu/livetalk/{env}/cloudfront/domain-name`
+ *         - `/nagiyu/livetalk/{env}/cloudfront/custom-domain`
+ *         - `/nagiyu/livetalk/{env}/assets/bucket-name`
  *
  * リージョンは CloudFront 用 ACM の都合で `us-east-1` 固定。
- * Distribution の作成・更新には 15 分以上かかる場合がある（CDK deploy のタイムアウト注意）。
  */
 export class LiveTalkCloudFrontStack extends cdk.Stack {
   public readonly distribution: cloudfront.Distribution;
+  public readonly assetsBucket: s3.Bucket;
 
   constructor(scope: Construct, id: string, props: LiveTalkCloudFrontStackProps) {
     super(scope, id, props);
 
     const { environment } = props;
+
+    // Live2D モデル・Cubism Core 配信用 private S3 バケット。
+    // reports-hosting-stack / storybook-stack と同様に CloudFront スタック内で S3 + OAC を一体管理する。
+    this.assetsBucket = new s3.Bucket(this, 'AssetsBucket', {
+      bucketName: `nagiyu-livetalk-assets-${environment}`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      versioned: false,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
 
     const certificateArn = ssm.StringParameter.valueForStringParameter(
       this,
@@ -88,6 +98,16 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
           cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
         compress: true,
       },
+      additionalBehaviors: {
+        '/assets/*': {
+          origin: origins.S3BucketOrigin.withOriginAccessControl(this.assetsBucket),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+          cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
+        },
+      },
     });
 
     // Route53 hosted zone を SSM 経由で参照し、CloudFront 向け ALIAS A レコードを作成
@@ -131,6 +151,11 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
       description: 'LiveTalk custom domain name',
     });
 
+    new cdk.CfnOutput(this, 'AssetsBucketName', {
+      value: this.assetsBucket.bucketName,
+      description: 'LiveTalk assets S3 bucket name (Live2D models, Cubism Core)',
+    });
+
     new ssm.StringParameter(this, 'DistributionIdParam', {
       parameterName: SSM_PARAMETERS.LIVETALK_CLOUDFRONT_DISTRIBUTION_ID(environment),
       stringValue: this.distribution.distributionId,
@@ -149,6 +174,13 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
       parameterName: SSM_PARAMETERS.LIVETALK_CLOUDFRONT_CUSTOM_DOMAIN(environment),
       stringValue: customDomain,
       description: 'LiveTalk custom domain name (mapped via Route53 to this CloudFront)',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'AssetsBucketNameParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_ASSETS_BUCKET_NAME(environment),
+      stringValue: this.assetsBucket.bucketName,
+      description: 'LiveTalk assets S3 bucket name',
       tier: ssm.ParameterTier.STANDARD,
     });
   }

--- a/infra/livetalk/tests/unit/cloudfront-stack.test.js
+++ b/infra/livetalk/tests/unit/cloudfront-stack.test.js
@@ -187,4 +187,86 @@ describe('LiveTalkCloudFrontStack', () => {
     expect(zoneIdRef).toBeDefined();
     expect(zoneNameRef).toBeDefined();
   });
+
+  // /assets/* Behavior と S3 バケット
+  it('assets S3 バケットを Block Public Access + S3 マネージド暗号化で作成する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: 'nagiyu-livetalk-assets-dev',
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+      BucketEncryption: Match.objectLike({
+        ServerSideEncryptionConfiguration: Match.arrayWith([
+          Match.objectLike({
+            ServerSideEncryptionByDefault: Match.objectLike({
+              SSEAlgorithm: 'AES256',
+            }),
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it('prod 環境では nagiyu-livetalk-assets-prod バケット名を使用する', () => {
+    const template = synth('prod');
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: 'nagiyu-livetalk-assets-prod',
+    });
+  });
+
+  it('/assets/* の Additional Behavior で S3 OAC オリジンを使い CACHING_OPTIMIZED を適用する', () => {
+    const template = synth('dev');
+    // CACHING_OPTIMIZED マネージドポリシー ID
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        CacheBehaviors: Match.arrayWith([
+          Match.objectLike({
+            PathPattern: '/assets/*',
+            CachePolicyId: '658327ea-f89d-4fab-a63d-7e88639e58f6',
+            ViewerProtocolPolicy: 'redirect-to-https',
+            AllowedMethods: ['GET', 'HEAD', 'OPTIONS'],
+            Compress: true,
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it('S3 オリジン用の OriginAccessControl を作成する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::CloudFront::OriginAccessControl', {
+      OriginAccessControlConfig: Match.objectLike({
+        OriginAccessControlOriginType: 's3',
+        SigningBehavior: 'always',
+        SigningProtocol: 'sigv4',
+      }),
+    });
+  });
+
+  it('assets バケット名を SSM Parameter に出力する（dev パス）', () => {
+    const template = synth('dev');
+    // Value は CDK Ref トークン（{ Ref: 'AssetsBucket...' }）のため Name のみ検証する。
+    // 既存の cloudfront/distribution-id テストと同じ検証スタイル。
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/assets/bucket-name',
+    });
+  });
+
+  it('prod 環境でも assets バケット名を SSM Parameter (prod パス) で出力する', () => {
+    const template = synth('prod');
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/prod/assets/bucket-name',
+    });
+  });
+
+  it('assets バケット名を CfnOutput に出力する', () => {
+    const template = synth('dev');
+    template.hasOutput('AssetsBucketName', {
+      Description: 'LiveTalk assets S3 bucket name (Live2D models, Cubism Core)',
+    });
+  });
 });


### PR DESCRIPTION
## 変更の概要

リブトーク Phase 1g (#3207) の前半。Live2D モデルファイル（桃瀬ひより）と Cubism Core を配信するための S3 バケット + CloudFront `/assets/*` behavior を追加する。

- **private S3 bucket** `nagiyu-livetalk-assets-{env}` を CloudFront スタック内に新規作成
  - Block Public Access BLOCK_ALL / S3 管理暗号化 / enforceSSL / RemovalPolicy.RETAIN
- **`/assets/*` Additional Behavior** を既存 LiveTalk Distribution に追加
  - Origin: S3BucketOrigin.withOriginAccessControl（OAC 自動生成）
  - CachePolicy: CACHING_OPTIMIZED（静的モデルファイル向け長期キャッシュ）
- SSM Parameter: `/nagiyu/livetalk/{env}/assets/bucket-name` を追加
- CfnOutput: `AssetsBucketName` を追加
- `infra/common/src/utils/ssm.ts` に `LIVETALK_ASSETS_BUCKET_NAME` パスを追加

Phase 1g-2（Live2D 統合 PR）では、アプリが `https://{domain}/assets/characters/hiyori/runtime/` からモデルをフェッチし、`/assets/cubism-core/live2dcubismcore.min.js` から Cubism Core を読み込む前提で実装する。

## 関連 Issue

Refs #3207 (Phase 1g-1: Assets 配信基盤)
Parent: #3184 / #3182

`Closes` は付けない。integration/3182-livetalk → develop のマージ時に #3207 をクローズする。

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（cloudfront-stack.test.js に 7 件追加、計 43 件通過）
- [ ] 関連ドキュメントを更新した（Phase 1g-2 完了後に docs/ へ反映予定）
- [ ] CI/CD 設定を追加・更新した（既存 livetalk-deploy.yml / livetalk-verify.yml で対応済み、変更不要）
- [x] ビルドエラーがないことを確認した（tsc + synth 通過）

## テスト内容

`infra/livetalk` 単体テスト計 43 件パス：

- assets S3 バケットを Block Public Access + S3 管理暗号化で作成する（dev / prod）
- `/assets/*` の Additional Behavior で S3 OAC オリジンを使い CACHING_OPTIMIZED を適用する
- S3 オリジン用の OriginAccessControl (sigv4 / always / s3) を作成する
- assets バケット名を SSM Parameter に出力する（dev パス / prod パス）
- assets バケット名を CfnOutput に出力する
- 既存テスト（ALB / ECS Service / CloudFront Distribution/Route53/Certificate 等）36 件はリグレッションなし

CDK synth: dev / prod 両スタック通過確認済み

## レビューポイント

- S3 バケットを `assets-stack.ts` として分離せず `cloudfront-stack.ts` 内に統合した理由：`S3BucketOrigin.withOriginAccessControl()` は CDK が同スタック内の bucket にのみ自動 bucket policy（OAC 用 `s3:GetObject`）を付与できるため。既存 `infra/shared/lib/reports-hosting-stack.ts` / `infra/ui-storybook/lib/storybook-stack.ts` も同パターン。Issue 本文では「assets-stack.ts 新規」と記載していたが、この実装に変更した。
- RemovalPolicy.RETAIN を選択。Stack destroy 時にモデルファイルを誤削除しないようにするため。

## 補足事項

### PR-1 マージ後の人手作業（必須）

本 PR をマージ・dev デプロイ後、以下 AWS CLI コマンドで S3 に assets を投入する（CDK では S3 の中身を管理しない）。

```bash
BUCKET=nagiyu-livetalk-assets-dev

# 桃瀬ひより モデルファイル一式
# ローカルに Live2D 公式からダウンロードした Hiyori モデルを配置済みとして:
aws s3 sync ./hiyori/ "s3://${BUCKET}/characters/hiyori/runtime/" --no-progress

# Live2D Cubism Core（Cubism SDK for Web から取得した live2dcubismcore.min.js）
aws s3 cp ./live2dcubismcore.min.js "s3://${BUCKET}/cubism-core/live2dcubismcore.min.js"
```

想定パス構成:
```
s3://nagiyu-livetalk-assets-{env}/
├── characters/
│   └── hiyori/
│       └── runtime/
│           ├── hiyori.model3.json
│           ├── hiyori.moc3
│           ├── hiyori.physics3.json
│           └── textures/
│               ├── hiyori.2048/
│               │   └── texture_00.png
│               └── ...
└── cubism-core/
    └── live2dcubismcore.min.js
```

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_