### PR TITLE
feat(livetalk-web): Phase 1g-2 Live2D（桃瀬ひより）統合 + ライセンス表記追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4183,6 +4183,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -5599,6 +5610,387 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@pixi/accessibility": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.4.3.tgz",
+      "integrity": "sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/app": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.4.3.tgz",
+      "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/assets": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.4.3.tgz",
+      "integrity": "sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/css-font-loading-module": "^0.0.12"
+      },
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/color": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
+      "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/colord": "^2.9.6"
+      }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.4.3.tgz",
+      "integrity": "sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/constants": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
+      "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/math": "7.4.3",
+        "@pixi/runner": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/ticker": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/@pixi/display": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.4.3.tgz",
+      "integrity": "sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.4.3.tgz",
+      "integrity": "sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/extensions": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
+      "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/extract": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.4.3.tgz",
+      "integrity": "sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-alpha": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.4.3.tgz",
+      "integrity": "sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-blur": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.4.3.tgz",
+      "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-color-matrix": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.4.3.tgz",
+      "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-displacement": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.4.3.tgz",
+      "integrity": "sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-fxaa": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.4.3.tgz",
+      "integrity": "sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/filter-noise": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.4.3.tgz",
+      "integrity": "sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/graphics": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.4.3.tgz",
+      "integrity": "sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/math": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
+      "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/mesh": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.4.3.tgz",
+      "integrity": "sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mesh-extras": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.4.3.tgz",
+      "integrity": "sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/mesh": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.4.3.tgz",
+      "integrity": "sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.4.3.tgz",
+      "integrity": "sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/mixin-get-global-position": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.4.3.tgz",
+      "integrity": "sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/particle-container": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.4.3.tgz",
+      "integrity": "sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/prepare": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.4.3.tgz",
+      "integrity": "sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/runner": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
+      "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
+      "license": "MIT"
+    },
+    "node_modules/@pixi/settings": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
+      "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/constants": "7.4.3",
+        "@types/css-font-loading-module": "^0.0.12",
+        "ismobilejs": "^1.1.0"
+      }
+    },
+    "node_modules/@pixi/sprite": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.4.3.tgz",
+      "integrity": "sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/sprite-animated": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.4.3.tgz",
+      "integrity": "sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/sprite-tiling": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.4.3.tgz",
+      "integrity": "sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/spritesheet": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.4.3.tgz",
+      "integrity": "sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.4.3.tgz",
+      "integrity": "sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/sprite": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text-bitmap": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.4.3.tgz",
+      "integrity": "sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/text-html": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.4.3.tgz",
+      "integrity": "sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/text": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/ticker": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
+      "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/extensions": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@pixi/utils": "7.4.3"
+      }
+    },
+    "node_modules/@pixi/utils": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
+      "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/color": "7.4.3",
+        "@pixi/constants": "7.4.3",
+        "@pixi/settings": "7.4.3",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -6163,7 +6555,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7132,6 +7523,12 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -7153,6 +7550,12 @@
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
       "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/earcut": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
@@ -8801,7 +9204,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -9065,6 +9467,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -9574,6 +9983,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -10500,6 +10915,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -12192,6 +12613,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
     },
     "node_modules/isomorphic-dompurify": {
       "version": "3.14.0",
@@ -15624,7 +16051,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -16166,6 +16592,61 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pixi-live2d-display-lipsyncpatch": {
+      "version": "0.5.0-ls-8",
+      "resolved": "https://registry.npmjs.org/pixi-live2d-display-lipsyncpatch/-/pixi-live2d-display-lipsyncpatch-0.5.0-ls-8.tgz",
+      "integrity": "sha512-m0PNx6kbnuB8JgdrFMsW/Z1Yt/qVwUxIzG8RjDdNyralkpSFsJX0usqSo5B/nnbL2YUNRqeUkFbq1/e6ktLzeA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.40.1",
+        "terser": "^5.30.3"
+      },
+      "peerDependencies": {
+        "pixi.js": "^7.0.0"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.4.3.tgz",
+      "integrity": "sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/accessibility": "7.4.3",
+        "@pixi/app": "7.4.3",
+        "@pixi/assets": "7.4.3",
+        "@pixi/compressed-textures": "7.4.3",
+        "@pixi/core": "7.4.3",
+        "@pixi/display": "7.4.3",
+        "@pixi/events": "7.4.3",
+        "@pixi/extensions": "7.4.3",
+        "@pixi/extract": "7.4.3",
+        "@pixi/filter-alpha": "7.4.3",
+        "@pixi/filter-blur": "7.4.3",
+        "@pixi/filter-color-matrix": "7.4.3",
+        "@pixi/filter-displacement": "7.4.3",
+        "@pixi/filter-fxaa": "7.4.3",
+        "@pixi/filter-noise": "7.4.3",
+        "@pixi/graphics": "7.4.3",
+        "@pixi/mesh": "7.4.3",
+        "@pixi/mesh-extras": "7.4.3",
+        "@pixi/mixin-cache-as-bitmap": "7.4.3",
+        "@pixi/mixin-get-child-by-name": "7.4.3",
+        "@pixi/mixin-get-global-position": "7.4.3",
+        "@pixi/particle-container": "7.4.3",
+        "@pixi/prepare": "7.4.3",
+        "@pixi/sprite": "7.4.3",
+        "@pixi/sprite-animated": "7.4.3",
+        "@pixi/sprite-tiling": "7.4.3",
+        "@pixi/spritesheet": "7.4.3",
+        "@pixi/text": "7.4.3",
+        "@pixi/text-bitmap": "7.4.3",
+        "@pixi/text-html": "7.4.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -16467,6 +16948,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -17247,7 +17743,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -17267,7 +17762,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -17284,7 +17778,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17303,7 +17796,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -17908,6 +18400,46 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/terser/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/test-exclude": {
@@ -18664,6 +19196,25 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
@@ -19471,7 +20022,9 @@
         "@nagiyu/common": "*",
         "@nagiyu/livetalk-core": "*",
         "@nagiyu/nextjs": "*",
-        "@nagiyu/ui": "*"
+        "@nagiyu/ui": "*",
+        "pixi-live2d-display-lipsyncpatch": "0.5.0-ls-8",
+        "pixi.js": "^7.4.3"
       }
     },
     "services/niconico-mylist-assistant/batch": {

--- a/services/livetalk/web/package.json
+++ b/services/livetalk/web/package.json
@@ -22,6 +22,8 @@
     "@nagiyu/common": "*",
     "@nagiyu/livetalk-core": "*",
     "@nagiyu/nextjs": "*",
-    "@nagiyu/ui": "*"
+    "@nagiyu/ui": "*",
+    "pixi-live2d-display-lipsyncpatch": "0.5.0-ls-8",
+    "pixi.js": "^7.4.3"
   }
 }

--- a/services/livetalk/web/src/app/layout.tsx
+++ b/services/livetalk/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from 'next';
+import Script from 'next/script';
 import { ServiceLayout } from '@nagiyu/ui';
 import '@nagiyu/ui/tokens.css';
 
@@ -16,6 +17,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <html lang="ja">
+      {/* Cubism Core は pixi-live2d-display が window.Live2DCubismCore を参照するため
+          他のスクリプトより先にロードする必要がある */}
+      <Script src="/assets/cubism-core/live2dcubismcore.min.js" strategy="beforeInteractive" />
       <body>
         <ServiceLayout
           headerProps={{

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,22 +1,27 @@
 'use client';
 
 import { useCallback, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { Box, Container, Stack } from '@mui/material';
-import CharacterArea from '@/components/CharacterArea';
 import ChatInput from '@/components/ChatInput';
 import LicenseFooter from '@/components/LicenseFooter';
 import ResponseDisplay from '@/components/ResponseDisplay';
+import { Live2DCanvasFallback } from '@/components/Live2DCanvas';
+
+// PixiJS は browser API (WebGL, Canvas) を使うため SSR 不可。
+const Live2DCanvas = dynamic(() => import('@/components/Live2DCanvas'), {
+  ssr: false,
+  loading: ({ error }) => (error ? null : <Live2DCanvasFallback statusText="読み込み中…" />),
+});
 
 type ChatPhase = 'idle' | 'loading' | 'playing';
 
 /**
- * Phase 1f のチャット画面。
- * - 上部: プレースホルダーキャラクター + 簡易リップシンク
+ * Phase 1g のチャット画面。
+ * - 上部: 桃瀬ひより（Live2D）+ リップシンク
  * - 中央: 応答テキスト
  * - 下部: 入力欄
- * - 最下部: VOICEVOX ライセンス表記
- *
- * Phase 1g で CharacterArea が Live2D に置き換わる前提。
+ * - 最下部: VOICEVOX / Live2D ライセンス表記
  */
 export default function HomePage() {
   const [phase, setPhase] = useState<ChatPhase>('idle');
@@ -77,7 +82,7 @@ export default function HomePage() {
       }}
     >
       <Box sx={{ flex: '0 1 60%', minHeight: 240, mb: 1 }}>
-        <CharacterArea audioLevel={audioLevel} statusText={statusText} />
+        <Live2DCanvas audioLevel={audioLevel} statusText={statusText} />
       </Box>
       <Stack
         spacing={1}

--- a/services/livetalk/web/src/components/LicenseFooter.tsx
+++ b/services/livetalk/web/src/components/LicenseFooter.tsx
@@ -1,8 +1,8 @@
 import { Box, Typography } from '@mui/material';
 
 /**
- * VOICEVOX 等のライセンス表記。UI 上で常時表示される必要があるため、
- * チャット画面下部に常駐させる。Phase 1g で Live2D（桃瀬ひより / かにビーム）の表記が追加される。
+ * VOICEVOX・Live2D のライセンス表記。UI 上で常時表示される必要があるため、
+ * チャット画面下部に常駐させる。
  */
 export default function LicenseFooter() {
   return (
@@ -17,7 +17,7 @@ export default function LicenseFooter() {
       data-testid="license-footer"
     >
       <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-        VOICEVOX:冥鳴ひまり
+        VOICEVOX:冥鳴ひまり / Live2D キャラクター: 桃瀬ひより ©2010 Live2D Inc.
       </Typography>
     </Box>
   );

--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { HIYORI_MODEL_PATH, CUBISM_PARAMETER_MOUTH_OPEN_Y } from '@/lib/character-renderer';
+
+// coreModel の型定義がサードパーティ側で object に留まっているため、使用するメソッドのみ宣言する
+type CubismCoreModel = {
+  setParameterValueById(parameterId: string, value: number, weight?: number): void;
+};
+
+export interface Live2DCanvasProps {
+  audioLevel: number;
+  statusText?: string;
+}
+
+/**
+ * PixiJS + pixi-live2d-display-lipsyncpatch で桃瀬ひよりを描画するキャンバスコンポーネント。
+ *
+ * Cubism Core (live2dcubismcore.min.js) は layout.tsx の <Script strategy="beforeInteractive">
+ * で事前にロードされ window.Live2DCubismCore として参照可能な状態になっている前提。
+ *
+ * PixiJS v7 と pixi-live2d-display-lipsyncpatch は browser API を直接使うため
+ * SSR 不可。next/dynamic + ssr:false で呼び出し元がラップする。
+ */
+export default function Live2DCanvas({ audioLevel, statusText }: Live2DCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const appRef = useRef<import('pixi.js').Application | null>(null);
+  const modelRef = useRef<import('pixi-live2d-display-lipsyncpatch').Live2DModel | null>(null);
+  const loadedRef = useRef(false);
+
+  useEffect(() => {
+    if (!containerRef.current || loadedRef.current) return;
+    loadedRef.current = true;
+
+    let cancelled = false;
+
+    (async () => {
+      const [{ Application, utils }, { Live2DModel }] = await Promise.all([
+        import('pixi.js'),
+        import('pixi-live2d-display-lipsyncpatch'),
+      ]);
+
+      if (cancelled || !containerRef.current) return;
+
+      // PixiJS ログを抑制
+      utils.skipHello();
+
+      const container = containerRef.current;
+      const w = container.clientWidth || 360;
+      const h = container.clientHeight || 480;
+
+      const app = new Application({
+        width: w,
+        height: h,
+        backgroundAlpha: 0,
+        antialias: true,
+        resolution: window.devicePixelRatio || 1,
+        autoDensity: true,
+      });
+      appRef.current = app;
+      container.appendChild(app.view as HTMLCanvasElement);
+
+      try {
+        const model = await Live2DModel.from(HIYORI_MODEL_PATH, { autoInteract: false });
+        if (cancelled) {
+          model.destroy();
+          return;
+        }
+        modelRef.current = model;
+
+        // モデルをキャンバスに合わせてスケール・センタリング
+        const scaleX = w / model.width;
+        const scaleY = h / model.height;
+        const scale = Math.min(scaleX, scaleY) * 0.95;
+        model.scale.set(scale);
+        model.x = (w - model.width * scale) / 2;
+        model.y = (h - model.height * scale) / 2;
+
+        app.stage.addChild(model);
+      } catch (err) {
+        console.error('[Live2DCanvas] モデルのロードに失敗しました', err);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      modelRef.current?.destroy();
+      modelRef.current = null;
+      appRef.current?.destroy(true);
+      appRef.current = null;
+      loadedRef.current = false;
+    };
+  }, []);
+
+  // audioLevel → ParamMouthOpenY に反映
+  useEffect(() => {
+    const model = modelRef.current;
+    if (!model) return;
+    try {
+      (model.internalModel.coreModel as CubismCoreModel).setParameterValueById(
+        CUBISM_PARAMETER_MOUTH_OPEN_Y,
+        Math.max(0, Math.min(1, audioLevel))
+      );
+    } catch {
+      // Cubism Core が未ロードのタイミングでは無視
+    }
+  }, [audioLevel]);
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'background.default',
+        position: 'relative',
+      }}
+      data-testid="live2d-canvas-container"
+    >
+      <Box
+        ref={containerRef}
+        sx={{ width: '100%', height: '100%', canvas: { display: 'block' } }}
+      />
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          position: 'absolute',
+          bottom: 4,
+          left: 0,
+          right: 0,
+          textAlign: 'center',
+        }}
+      >
+        {statusText ?? '待機中'}
+      </Typography>
+    </Box>
+  );
+}
+
+export function Live2DCanvasFallback({ statusText }: { statusText?: string }) {
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'background.default',
+        gap: 1,
+      }}
+      data-testid="live2d-canvas-fallback"
+    >
+      <CircularProgress size={32} />
+      <Typography variant="caption" color="text.secondary">
+        {statusText ?? '待機中'}
+      </Typography>
+    </Box>
+  );
+}

--- a/services/livetalk/web/src/lib/character-renderer/constants.ts
+++ b/services/livetalk/web/src/lib/character-renderer/constants.ts
@@ -1,0 +1,3 @@
+export const HIYORI_MODEL_PATH = '/assets/characters/hiyori/runtime/hiyori_free_t08.model3.json';
+
+export const CUBISM_PARAMETER_MOUTH_OPEN_Y = 'ParamMouthOpenY';

--- a/services/livetalk/web/src/lib/character-renderer/index.ts
+++ b/services/livetalk/web/src/lib/character-renderer/index.ts
@@ -1,0 +1,1 @@
+export { HIYORI_MODEL_PATH, CUBISM_PARAMETER_MOUTH_OPEN_Y } from './constants';

--- a/services/livetalk/web/tests/unit/lib/character-renderer/constants.test.ts
+++ b/services/livetalk/web/tests/unit/lib/character-renderer/constants.test.ts
@@ -1,0 +1,14 @@
+import {
+  HIYORI_MODEL_PATH,
+  CUBISM_PARAMETER_MOUTH_OPEN_Y,
+} from '@/lib/character-renderer/constants';
+
+describe('character-renderer constants', () => {
+  it('HIYORI_MODEL_PATH は S3 配信パスを指す', () => {
+    expect(HIYORI_MODEL_PATH).toBe('/assets/characters/hiyori/runtime/hiyori_free_t08.model3.json');
+  });
+
+  it('CUBISM_PARAMETER_MOUTH_OPEN_Y は LipSync パラメータ ID と一致する', () => {
+    expect(CUBISM_PARAMETER_MOUTH_OPEN_Y).toBe('ParamMouthOpenY');
+  });
+});


### PR DESCRIPTION
## 変更の概要

Phase 1g (#3207) の後半。プレースホルダー SVG キャラクター（Phase 1f）を、S3 から配信される桃瀬ひより Live2D モデルに置き換える。

**追加・変更ファイル:**

| ファイル | 変更内容 |
|---|---|
| `package.json` | `pixi.js@7.4.3` + `pixi-live2d-display-lipsyncpatch@0.5.0-ls-8` 追加 |
| `app/layout.tsx` | Cubism Core (`/assets/cubism-core/live2dcubismcore.min.js`) を `beforeInteractive` Script でプリロード |
| `components/Live2DCanvas.tsx` | **新規**: PixiJS + pixi-live2d-display-lipsyncpatch による Live2D キャンバス。`audioLevel` → `ParamMouthOpenY` でリップシンク。`Live2DCanvasFallback`（ローディング中表示）も同ファイルで提供 |
| `app/page.tsx` | `CharacterArea`（SVG プレースホルダー）→ `dynamic(Live2DCanvas, {ssr:false})` に差し替え |
| `components/LicenseFooter.tsx` | Live2D キャラクターライセンス表記を追加 |
| `lib/character-renderer/constants.ts` | モデルパス・Cubism パラメータ ID 定数を分離 |
| `lib/character-renderer/index.ts` | public API export |
| `tests/unit/lib/character-renderer/constants.test.ts` | 定数テスト 2 件 |

**モデルファイルパス（S3 に配置済み）:**
- `/assets/characters/hiyori/runtime/hiyori_free_t08.model3.json`
- Cubism Core: `/assets/cubism-core/live2dcubismcore.min.js`

## 関連 Issue

Refs #3207 (Phase 1g-2: Live2D 統合)
依存 PR: #3236（マージ済み）

`Closes` は付けない。integration/3182-livetalk → develop のマージ時に #3207 をクローズする。

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（constants.test.ts 2 件追加、計 19 件通過）
- [ ] 関連ドキュメントを更新した（Phase 1g 完了後に docs/ へ反映予定）
- [x] ビルドエラーがないことを確認した（tsc + Next.js build 通過）

## テスト内容

- `tests/unit/lib/character-renderer/constants.test.ts`: モデルパス・Cubism パラメータ ID が正しい値を持つことを確認（2 件）
- 全テスト 19 件通過
- `Live2DCanvas.tsx` のキャンバス初期化は PixiJS/WebGL が JSDOM で動かせないため単体テスト対象外。dev 環境での実機検証が必要（下記参照）

## レビューポイント

1. **`coreModel as CubismCoreModel` キャスト**: `pixi-live2d-display-lipsyncpatch` の型定義で `InternalModel.coreModel` が `abstract readonly coreModel: object` と定義されているため、使用する `setParameterValueById` のシグネチャだけを宣言したローカル型でキャストしている。`as any` を避けた最小限のキャストとして適切と判断した。
2. **`beforeInteractive` Script**: Cubism Core が `window.Live2DCubismCore` を設定するのに必要。App Router では `<html>` タグの直後に配置することでページ JS より先にロードされる。
3. **`next/dynamic + ssr:false`**: PixiJS v7 は Node.js 環境で動かないため必須。

## スクリーンショット（該当する場合）

実機確認はレビュアー側での dev 環境確認をお願いします。
- `https://dev-live-talk.nagiyu.com` でキャラクターが Live2D に切り替わっていること
- テキスト入力 → 音声再生中に口が動くこと（リップシンク）
- ページ下部に「桃瀬ひより ©2010 Live2D Inc.」表記が出ていること

## 補足事項

`CharacterArea.tsx`（Phase 1f のプレースホルダー）は未削除。Phase 1g 完了確認後、必要であれば別 PR で削除する。

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_