### PR TITLE
fix(livetalk-infra): /assets/* CF Function で S3 キーの /assets prefix を除去

### DIFF
--- a/infra/livetalk/lib/cloudfront-stack.ts
+++ b/infra/livetalk/lib/cloudfront-stack.ts
@@ -74,6 +74,22 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
       environment === 'prod' ? 'live-talk.nagiyu.com' : 'dev-live-talk.nagiyu.com';
     const recordName = environment === 'prod' ? 'live-talk' : 'dev-live-talk';
 
+    // CloudFront behavior のパスパターン /assets/* にマッチしたリクエストは
+    // URI がそのまま S3 キーになるため /assets/ prefix を除去する必要がある。
+    // 例: /assets/cubism-core/foo.js → /cubism-core/foo.js (S3 キー)
+    const assetsUriRewrite = new cloudfront.Function(this, 'AssetsUriRewrite', {
+      comment: '/assets/* リクエストから /assets prefix を除去して S3 キーにマッピング',
+      code: cloudfront.FunctionCode.fromInline(
+        [
+          'function handler(event) {',
+          '  var request = event.request;',
+          "  request.uri = request.uri.replace(/^\\/assets/, '');",
+          '  return request;',
+          '}',
+        ].join('\n')
+      ),
+    });
+
     this.distribution = new cloudfront.Distribution(this, 'Distribution', {
       comment: `LiveTalk Service Distribution (${environment})`,
       domainNames: [customDomain],
@@ -106,6 +122,12 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
           cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
           compress: true,
+          functionAssociations: [
+            {
+              function: assetsUriRewrite,
+              eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+            },
+          ],
         },
       },
     });

--- a/infra/livetalk/tests/unit/cloudfront-stack.test.js
+++ b/infra/livetalk/tests/unit/cloudfront-stack.test.js
@@ -269,4 +269,34 @@ describe('LiveTalkCloudFrontStack', () => {
       Description: 'LiveTalk assets S3 bucket name (Live2D models, Cubism Core)',
     });
   });
+
+  it('/assets/* Behavior に AssetsUriRewrite CloudFront Function を VIEWER_REQUEST で関連付ける', () => {
+    const template = synth('dev');
+    // CloudFront Function リソースが作成されることを確認
+    template.hasResourceProperties('AWS::CloudFront::Function', {
+      FunctionConfig: Match.objectLike({
+        Runtime: 'cloudfront-js-1.0',
+      }),
+    });
+    // /assets/* behavior に FunctionAssociation が設定されることを確認
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        CacheBehaviors: Match.arrayWith([
+          Match.objectLike({
+            PathPattern: '/assets/*',
+            FunctionAssociations: Match.arrayWith([
+              Match.objectLike({
+                EventType: 'viewer-request',
+                FunctionARN: Match.objectLike({
+                  'Fn::GetAtt': Match.arrayWith([
+                    Match.stringLikeRegexp('^AssetsUriRewrite'),
+                  ]),
+                }),
+              }),
+            ]),
+          }),
+        ]),
+      }),
+    });
+  });
 });


### PR DESCRIPTION
## 変更の概要

dev 環境で `/assets/cubism-core/live2dcubismcore.min.js` が 403 になる不具合を修正。

**原因**: CloudFront behavior `/assets/*` は受け取ったリクエスト URI をそのまま S3 キーとして転送する。  
- CloudFront が受け取る URI: `/assets/cubism-core/live2dcubismcore.min.js`  
- S3 に探しに行くキー: `assets/cubism-core/live2dcubismcore.min.js` ← 存在しない  
- S3 の実際のキー: `cubism-core/live2dcubismcore.min.js` ← `/assets/` prefix なし

**修正**: `AssetsUriRewrite` CloudFront Function (VIEWER_REQUEST) を追加し、  
`/assets/foo` → `/foo` に書き換えてから S3 origin に転送するようにした。

```js
function handler(event) {
  var request = event.request;
  request.uri = request.uri.replace(/^\/assets/, '');
  return request;
}
```

## 関連 Issue

Refs #3207 (Phase 1g バグ修正)

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（CF Function の作成・関連付けテスト 1 件追加、計 44 件通過）
- [x] ビルドエラーがないことを確認した（tsc + synth 通過）

## テスト内容

- `AssetsUriRewrite` CloudFront Function (Runtime: `cloudfront-js-1.0`) が作成されることを確認
- `/assets/*` behavior の `FunctionAssociations` に VIEWER_REQUEST で紐付けられることを確認
- 既存 43 件リグレッションなし、合計 44 件通過

## レビューポイント

- S3 バケット側の再配置（`assets/` prefix 付きで置き直す）は不要
- CloudFront Function は軽量（CF Functions は Lambda@Edge より低レイテンシ・低コスト）
- `/assets` prefix を除去するだけなので `replace` は一度だけ実行される（先頭一致）

## 補足事項

デプロイ後、CloudFront の変更伝播（数分〜最大 15 分）が完了するとアクセス可能になります。

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_