### PR TITLE
fix(livetalk-web): Live2D モデルに PIXI.Ticker を渡してアイドル動作を駆動

### DIFF
--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -97,7 +97,11 @@ export default function Live2DCanvas({ audioLevel, statusText }: Live2DCanvasPro
       container.appendChild(app.view as HTMLCanvasElement);
 
       try {
-        const model = await Live2DModel.from(HIYORI_MODEL_PATH, { autoInteract: false });
+        const model = await Live2DModel.from(HIYORI_MODEL_PATH, {
+          autoInteract: false,
+          // PIXI Application のティッカーを渡してアイドルモーション・呼吸・まばたきを駆動する
+          ticker: app.ticker,
+        });
         if (cancelled) {
           model.destroy();
           return;


### PR DESCRIPTION
## 変更の概要

dev 環境で Live2D モデル（桃瀬ひより）の表示には成功しているものの、呼吸・まばたき・アイドルモーションが動作しない不具合を修正。

**原因**: `pixi-live2d-display-lipsyncpatch` の Automator は `PIXI.Ticker.shared` をグローバル `window.PIXI` 経由で取得しようとする実装になっており、Next.js App Router のように PIXI をモジュール import で使う構成では `window.PIXI` が未定義のためティッカーが取得できない。結果として `internalModel.update(deltaTime)` に常に 0 が渡され、モデルが静止状態のままになる。

```ts
// ライブラリ内部 (cubism4.es.js)
} else if (typeof PIXI !== "undefined") {
    ticker = PIXI.Ticker.shared;
}
```

**修正**: `Live2DModel.from()` のオプションに `ticker: app.ticker` を明示的に渡すことで、PIXI Application のティッカーをモデルに直接紐づける。グローバル汚染（`window.PIXI = PIXI`）を避けつつ確実にティッカーを供給する方式。

## 関連 Issue

Refs #3207 (Phase 1g バグ修正)

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 既存テストにリグレッションなし（19 件全通過）
- [x] ビルドエラーがないことを確認した（tsc 通過）

## テスト内容

- 既存 19 件全通過
- `ticker` オプションは型レベルで `Live2DFactoryOptions extends Live2DModelOptions extends AutomatorOptions { ticker?: Ticker }` として定義されており、TypeScript エラーなし
- 動作確認は dev 環境で実施予定

## レビューポイント

- **方式選択**: `window.PIXI = PIXI` でグローバル汚染するパターンも一般的だが、Next.js のような module 環境ではグローバル経由は避けたいので `ticker` オプション経由を採用
- `app.ticker` を渡すことで、PIXI Application の destroy 時にティッカーも一緒にクリーンアップされ、メモリリークの心配なし
- `autoUpdate` はデフォルト true なので、ticker さえ渡せば自動的に毎フレーム更新される

## 補足事項

これにより model3.json で定義されている以下が自動的に動作する:
- 呼吸（`updateNaturalMovements` を library が毎フレーム呼ぶ）
- まばたき（`Groups[EyeBlink]` の値ベースで自動制御）
- アイドルモーション（`Motions.Idle` が定義されていれば自動再生）

## 前提

PR #3236-3240 のマージ済み + Cubism Core 5.1.0 への差し替え（Cubism 6.0.1 はライブラリ非対応） により描画は既に成功している状態。本 PR でアニメーションが動作するようになる想定。

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_