### PR TITLE
fix(livetalk-web): リップシンクをライブラリ標準 model.speak() に置き換え

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { Box, Container, Stack } from '@mui/material';
 import ChatInput from '@/components/ChatInput';
@@ -22,51 +22,77 @@ type ChatPhase = 'idle' | 'loading' | 'playing';
  * - 中央: 応答テキスト
  * - 下部: 入力欄
  * - 最下部: VOICEVOX / Live2D ライセンス表記
+ *
+ * 音声再生 + リップシンクは Live2DCanvas が model.speak() 経由で内部処理する。
  */
 export default function HomePage() {
   const [phase, setPhase] = useState<ChatPhase>('idle');
   const [userText, setUserText] = useState<string | null>(null);
   const [responseText, setResponseText] = useState<string | null>(null);
-  const [audioLevel, setAudioLevel] = useState(0);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const handleSubmit = useCallback(async (text: string) => {
-    setUserText(text);
-    setResponseText(null);
-    setErrorMessage(null);
-    setPhase('loading');
+  // Blob URL の revoke 用に現在再生中の URL を保持する
+  const audioUrlRef = useRef<string | null>(null);
 
-    try {
-      const response = await fetch('/api/echo', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text }),
-      });
-
-      if (!response.ok) {
-        setErrorMessage('音声合成に失敗しました。時間を置いて再度お試しください。');
-        setPhase('idle');
-        return;
-      }
-
-      const audioBuffer = await response.arrayBuffer();
-      const blob = new Blob([audioBuffer], { type: 'audio/wav' });
-      const audioUrl = URL.createObjectURL(blob);
-
-      setResponseText(text);
-      setPhase('playing');
-
-      await playAudioWithLipSync(audioUrl, setAudioLevel);
-      URL.revokeObjectURL(audioUrl);
-      setAudioLevel(0);
-      setPhase('idle');
-    } catch (error) {
-      console.error('[LiveTalk] エコー再生に失敗しました', error);
-      setErrorMessage('音声再生中にエラーが発生しました。');
-      setAudioLevel(0);
-      setPhase('idle');
+  const releaseAudioUrl = useCallback(() => {
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current);
+      audioUrlRef.current = null;
     }
   }, []);
+
+  const handleSubmit = useCallback(
+    async (text: string) => {
+      setUserText(text);
+      setResponseText(null);
+      setErrorMessage(null);
+      setPhase('loading');
+      releaseAudioUrl();
+      setAudioUrl(null);
+
+      try {
+        const response = await fetch('/api/echo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text }),
+        });
+
+        if (!response.ok) {
+          setErrorMessage('音声合成に失敗しました。時間を置いて再度お試しください。');
+          setPhase('idle');
+          return;
+        }
+
+        const audioBuffer = await response.arrayBuffer();
+        const blob = new Blob([audioBuffer], { type: 'audio/wav' });
+        const url = URL.createObjectURL(blob);
+
+        audioUrlRef.current = url;
+        setResponseText(text);
+        setAudioUrl(url);
+        setPhase('playing');
+      } catch (error) {
+        console.error('[LiveTalk] エコー再生に失敗しました', error);
+        setErrorMessage('音声再生中にエラーが発生しました。');
+        setPhase('idle');
+      }
+    },
+    [releaseAudioUrl]
+  );
+
+  const handlePlaybackEnd = useCallback(() => {
+    releaseAudioUrl();
+    setAudioUrl(null);
+    setPhase('idle');
+  }, [releaseAudioUrl]);
+
+  const handlePlaybackError = useCallback(() => {
+    setErrorMessage('音声再生中にエラーが発生しました。');
+    releaseAudioUrl();
+    setAudioUrl(null);
+    setPhase('idle');
+  }, [releaseAudioUrl]);
 
   const statusText =
     phase === 'loading' ? '考え中…' : phase === 'playing' ? '話している' : '待機中';
@@ -82,7 +108,12 @@ export default function HomePage() {
       }}
     >
       <Box sx={{ flex: '0 1 60%', minHeight: 240, mb: 1 }}>
-        <Live2DCanvas audioLevel={audioLevel} statusText={statusText} />
+        <Live2DCanvas
+          audioUrl={audioUrl}
+          statusText={statusText}
+          onPlaybackEnd={handlePlaybackEnd}
+          onPlaybackError={handlePlaybackError}
+        />
       </Box>
       <Stack
         spacing={1}
@@ -111,77 +142,4 @@ export default function HomePage() {
       <LicenseFooter />
     </Container>
   );
-}
-
-/**
- * HTML5 Audio + Web Audio API で音声を再生しつつ、
- * AnalyserNode で振幅を取得して onLevelChange に通知する。
- * 再生終了時に resolve、エラー時に reject。
- */
-async function playAudioWithLipSync(
-  audioUrl: string,
-  onLevelChange: (level: number) => void
-): Promise<void> {
-  const AudioContextCtor =
-    typeof window !== 'undefined'
-      ? window.AudioContext ||
-        (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
-      : undefined;
-
-  // Web Audio API が使えない環境では音量解析を諦め、再生のみ行う。
-  if (!AudioContextCtor) {
-    return playAudioOnly(audioUrl);
-  }
-
-  const audio = new Audio(audioUrl);
-  audio.crossOrigin = 'anonymous';
-
-  const ctx = new AudioContextCtor();
-  const source = ctx.createMediaElementSource(audio);
-  const analyser = ctx.createAnalyser();
-  analyser.fftSize = 256;
-  source.connect(analyser);
-  analyser.connect(ctx.destination);
-
-  const data = new Uint8Array(analyser.frequencyBinCount);
-  let rafId: number | null = null;
-  const tick = () => {
-    analyser.getByteTimeDomainData(data);
-    let sum = 0;
-    for (let i = 0; i < data.length; i++) {
-      const v = (data[i] - 128) / 128;
-      sum += v * v;
-    }
-    const rms = Math.sqrt(sum / data.length);
-    onLevelChange(Math.min(1, rms * 4));
-    rafId = requestAnimationFrame(tick);
-  };
-
-  return new Promise<void>((resolve, reject) => {
-    audio.addEventListener('ended', () => {
-      if (rafId !== null) cancelAnimationFrame(rafId);
-      ctx.close().catch(() => {});
-      resolve();
-    });
-    audio.addEventListener('error', () => {
-      if (rafId !== null) cancelAnimationFrame(rafId);
-      ctx.close().catch(() => {});
-      reject(new Error('Audio playback failed'));
-    });
-    audio
-      .play()
-      .then(() => {
-        tick();
-      })
-      .catch(reject);
-  });
-}
-
-async function playAudioOnly(audioUrl: string): Promise<void> {
-  const audio = new Audio(audioUrl);
-  return new Promise<void>((resolve, reject) => {
-    audio.addEventListener('ended', () => resolve());
-    audio.addEventListener('error', () => reject(new Error('Audio playback failed')));
-    audio.play().catch(reject);
-  });
 }

--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -1,13 +1,8 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Box, CircularProgress, Typography } from '@mui/material';
-import { HIYORI_MODEL_PATH, CUBISM_PARAMETER_MOUTH_OPEN_Y } from '@/lib/character-renderer';
-
-// coreModel の型定義がサードパーティ側で object に留まっているため、使用するメソッドのみ宣言する
-type CubismCoreModel = {
-  setParameterValueById(parameterId: string, value: number, weight?: number): void;
-};
+import { HIYORI_MODEL_PATH } from '@/lib/character-renderer';
 
 // beforeInteractive Script のネットワーク遅延を吸収するため、
 // window.Live2DCubismCore が定義されるまで最大 timeout ms だけ待機する。
@@ -31,8 +26,11 @@ function waitForCubismCore(timeout = 10000): Promise<void> {
 }
 
 export interface Live2DCanvasProps {
-  audioLevel: number;
+  /** 再生対象の音声 URL。null または undefined のときは再生しない。 */
+  audioUrl?: string | null;
   statusText?: string;
+  onPlaybackEnd?: () => void;
+  onPlaybackError?: (error: Error) => void;
 }
 
 /**
@@ -43,14 +41,32 @@ export interface Live2DCanvasProps {
  *
  * PixiJS v7 と pixi-live2d-display-lipsyncpatch は browser API を直接使うため
  * SSR 不可。next/dynamic + ssr:false で呼び出し元がラップする。
+ *
+ * audioUrl を受け取ると model.speak() を呼び、ライブラリ内部の AudioContext +
+ * AnalyserNode で再生 + リップシンクをモデルの update サイクル内で同期駆動する。
  */
-export default function Live2DCanvas({ audioLevel, statusText }: Live2DCanvasProps) {
+export default function Live2DCanvas({
+  audioUrl,
+  statusText,
+  onPlaybackEnd,
+  onPlaybackError,
+}: Live2DCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const appRef = useRef<import('pixi.js').Application | null>(null);
   const modelRef = useRef<import('pixi-live2d-display-lipsyncpatch/cubism4').Live2DModel | null>(
     null
   );
   const loadedRef = useRef(false);
+  const [modelReady, setModelReady] = useState(false);
+
+  // コールバックは ref 経由で参照することで、speak の useEffect が
+  // 親側のコールバック識別子変更で再走するのを避ける
+  const onPlaybackEndRef = useRef(onPlaybackEnd);
+  const onPlaybackErrorRef = useRef(onPlaybackError);
+  useEffect(() => {
+    onPlaybackEndRef.current = onPlaybackEnd;
+    onPlaybackErrorRef.current = onPlaybackError;
+  }, [onPlaybackEnd, onPlaybackError]);
 
   useEffect(() => {
     if (!containerRef.current || loadedRef.current) return;
@@ -117,6 +133,7 @@ export default function Live2DCanvas({ audioLevel, statusText }: Live2DCanvasPro
         model.y = (h - model.height * scale) / 2;
 
         app.stage.addChild(model);
+        setModelReady(true);
       } catch (err) {
         console.error('[Live2DCanvas] モデルのロードに失敗しました', err);
       }
@@ -129,22 +146,41 @@ export default function Live2DCanvas({ audioLevel, statusText }: Live2DCanvasPro
       appRef.current?.destroy(true);
       appRef.current = null;
       loadedRef.current = false;
+      setModelReady(false);
     };
   }, []);
 
-  // audioLevel → ParamMouthOpenY に反映
+  // audioUrl を受け取ったら model.speak() で再生 + リップシンク。
+  // model.speak は内部で AudioContext / AnalyserNode を構築し、
+  // ライブラリの update サイクル内で LipSync パラメータを更新する。
   useEffect(() => {
     const model = modelRef.current;
-    if (!model) return;
-    try {
-      (model.internalModel.coreModel as CubismCoreModel).setParameterValueById(
-        CUBISM_PARAMETER_MOUTH_OPEN_Y,
-        Math.max(0, Math.min(1, audioLevel))
-      );
-    } catch {
-      // Cubism Core が未ロードのタイミングでは無視
-    }
-  }, [audioLevel]);
+    if (!model || !modelReady || !audioUrl) return;
+
+    let cancelled = false;
+    model
+      .speak(audioUrl, {
+        volume: 1.0,
+        crossOrigin: 'anonymous',
+        onFinish: () => {
+          if (!cancelled) onPlaybackEndRef.current?.();
+        },
+        onError: (e) => {
+          if (!cancelled) onPlaybackErrorRef.current?.(e);
+        },
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          onPlaybackErrorRef.current?.(error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      model.stopSpeaking();
+    };
+  }, [audioUrl, modelReady]);
 
   return (
     <Box


### PR DESCRIPTION
## 変更の概要

dev 環境でリップシンクが効かない（口がほぼ動かない）不具合を修正。

**原因**: 既存実装では `page.tsx` の `playAudioWithLipSync()` で Web Audio API の AnalyserNode から RMS 振幅を計算し、`Live2DCanvas` に `audioLevel` prop として渡して `useEffect` で `coreModel.setParameterValueById('ParamMouthOpenY', audioLevel)` を呼んでいた。しかしモデルの ticker による `internalModel.update()` 内でモーション値がパラメータを上書きするため、React useEffect 由来の値が描画前に消えてしまう。

**修正**: `pixi-live2d-display-lipsyncpatch` のライブラリ標準 API `model.speak(soundURL, options)` に置き換え。`speak()` は内部で AudioContext + AnalyserNode を構築し、**モデルの update サイクル内で LipSync グループのパラメータを更新する** ため、モーション上書きと衝突しない。

## 関連 Issue

Refs #3207 (Phase 1g バグ修正)

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 既存テスト 19 件全通過（リグレッションなし）
- [x] ビルドエラーがないことを確認した（tsc 通過）

## 変更詳細

### `Live2DCanvas.tsx`

**props 変更**:
- 削除: `audioLevel: number`
- 追加: `audioUrl?: string | null` / `onPlaybackEnd?: () => void` / `onPlaybackError?: (e: Error) => void`

**ロジック変更**:
- `setParameterValueById` 経由の useEffect を削除
- `audioUrl` 変更時に `model.speak(audioUrl, { onFinish, onError })` を呼ぶ useEffect を追加
- モデル準備完了を `modelReady` state で追跡 → audioUrl 設定タイミングと model 準備完了タイミングのレースを解消
- コールバックは ref 経由で参照 → 親側のコールバック識別子変更で speak useEffect が再走しないよう抑制
- `CubismCoreModel` 型および `CUBISM_PARAMETER_MOUTH_OPEN_Y` の import を削除

### `page.tsx`

**state 変更**:
- 削除: `audioLevel: number`
- 追加: `audioUrl: string | null`、 `audioUrlRef`（revoke 用）

**ロジック変更**:
- 自前の `playAudioWithLipSync()` / `playAudioOnly()` 関数（60+ 行）を削除
- `handleSubmit`: 音声 URL を生成して state にセットするだけに簡略化（再生は Live2DCanvas に委譲）
- `handlePlaybackEnd` / `handlePlaybackError`: 再生終了時の URL revoke と phase リセットを担当

## レビューポイント

- `model.speak()` は `Promise<boolean>` を返す。`.catch()` で例外時のフォールバックも追加
- Blob URL は再生開始時に `URL.createObjectURL`、終了/エラー/再送信時に `URL.revokeObjectURL` で解放（メモリリーク防止）
- `useState<boolean>(modelReady)` を 1 つ追加するため、Live2DCanvas の再レンダリングが 1 回追加されるが、子要素は MUI 静的構造のみで影響軽微
- `crossOrigin: 'anonymous'` は Blob URL に対しては実質効果がないが、将来的に直接 URL を渡せる柔軟性を残すため指定

## テスト内容

- 既存 19 件全通過
- `Live2DCanvas` 自体のテストは存在せず（PixiJS + WebGL のため Jest 環境では困難）
- 動作確認は dev 環境で実施予定: 入力 → 「話している」状態で口が音声に追従するか確認

## 前提

- Phase 1g までのインフラ + Live2D 統合（PR #3236-3241）マージ済み
- S3 上の Cubism Core が 5.x 系（6.0.1 は本ライブラリ非対応）

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_