### PR TITLE
fix(livetalk-web): Live2D モデルの表示位置とスケールを調整してキャラを中央に

### DIFF
--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -124,13 +124,22 @@ export default function Live2DCanvas({
         }
         modelRef.current = model;
 
-        // モデルをキャンバスに合わせてスケール・センタリング
-        const scaleX = w / model.width;
-        const scaleY = h / model.height;
-        const scale = Math.min(scaleX, scaleY) * 0.95;
+        // Live2D モデルの枠 (model.width / model.height) は描画可能領域で、
+        // キャラクター本体は通常その内側に配置される。Hiyori の場合は枠中央より
+        // 下寄りに描かれているため、アンカー Y を 0.45 に設定して胸〜腰のあたりが
+        // アンカー基準点（= canvas 中央）に来るよう調整する。
+        model.anchor.set(0.5, 0.45);
+
+        // canvas に対するスケール。縦方向 90% / 横方向 95% を上限として
+        // どちらか小さい方を採用（アスペクト比に応じて自動調整）。
+        const scaleByHeight = (h * 0.9) / model.height;
+        const scaleByWidth = (w * 0.95) / model.width;
+        const scale = Math.min(scaleByHeight, scaleByWidth);
         model.scale.set(scale);
-        model.x = (w - model.width * scale) / 2;
-        model.y = (h - model.height * scale) / 2;
+
+        // アンカー基準点を canvas 中央に配置
+        model.x = w / 2;
+        model.y = h / 2;
 
         app.stage.addChild(model);
         setModelReady(true);


### PR DESCRIPTION
## 変更の概要

Live2D モデル（桃瀬ひより）が画面の右下寄りに表示される不具合を修正し、キャラクターを画面中央に配置するよう調整。

**原因**: 既存実装は `model.width / model.height`（Live2D の描画枠サイズ）ベースで単純に枠をセンタリングしていたが、キャラクター本体は枠内で中央ではなく下寄りに描かれているため、結果として画面上はキャラが下に寄って表示されていた。

**修正**:
- `model.anchor.set(0.5, 0.45)` で胸〜腰のあたりがアンカー基準点になるよう調整
- スケールを縦 90% / 横 95% の小さい方を採用（縦長キャンバスでもアスペクト比を保ったまま大きめに表示）
- `model.x = w/2, model.y = h/2` でアンカー基準点をキャンバス中央に配置

## 関連 Issue

Refs #3207 (Phase 1g 見た目調整)

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 既存テスト 19 件全通過（リグレッションなし）
- [x] ビルドエラーがないことを確認した（tsc 通過）

## レビューポイント

- `anchor.y = 0.45` は Hiyori モデル前提の値。他のモデルを使う場合は要調整
- スケール上限値（縦 90% / 横 95%）はマージンを残してキャラが端で切れない設計
- `Math.min(scaleByHeight, scaleByWidth)` でアスペクト比保持

## テスト内容

- 既存 19 件全通過
- 動作確認は dev 環境で実施予定: キャラクターが画面中央に来るか、端で切れていないか

## 前提

PR #3242 までマージ済み（リップシンクが model.speak() ベース）

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_