### PR TITLE
fix(livetalk-web): Live2D モデルを上半身フォーカスのレイアウトに変更

### DIFF
--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -124,16 +124,15 @@ export default function Live2DCanvas({
         }
         modelRef.current = model;
 
-        // Live2D モデルの枠 (model.width / model.height) は描画可能領域で、
-        // キャラクター本体は通常その内側に配置される。Hiyori の場合は枠中央より
-        // 下寄りに描かれているため、アンカー Y を 0.45 に設定して胸〜腰のあたりが
-        // アンカー基準点（= canvas 中央）に来るよう調整する。
-        model.anchor.set(0.5, 0.45);
+        // 上半身フォーカスのレイアウト。
+        // anchor Y を 0.3 にすることで、顔〜胸のあたりが基準点（= canvas 中央）になる。
+        // 結果として頭は画面上部、上半身が中央、足は画面下端より下に位置する。
+        model.anchor.set(0.5, 0.3);
 
-        // canvas に対するスケール。縦方向 90% / 横方向 95% を上限として
-        // どちらか小さい方を採用（アスペクト比に応じて自動調整）。
-        const scaleByHeight = (h * 0.9) / model.height;
-        const scaleByWidth = (w * 0.95) / model.width;
+        // canvas に対するスケール。縦は 95% × 1.5 倍を上限（上半身フォーカスのためのズーム）。
+        // 横は 140% まで許容（モデル枠 = キャラ本体ではなく余白を含む。少しはみ出してもキャラは収まる）。
+        const scaleByHeight = (h * 0.95 * 1.5) / model.height;
+        const scaleByWidth = (w * 1.4) / model.width;
         const scale = Math.min(scaleByHeight, scaleByWidth);
         model.scale.set(scale);
 


### PR DESCRIPTION
## 変更の概要

Live2D キャラクター（桃瀬ひより）の表示を全身レイアウトから「上半身フォーカス」のレイアウトに変更。リップシンクや表情を主役にする UX 設計に合わせる。

## 変更詳細

- `model.anchor.set(0.5, 0.45)` → `model.anchor.set(0.5, 0.3)` で基準点を顔〜胸あたりに変更
- 縦方向スケールに 1.5 倍の係数を追加（縦 95% × 1.5）
- 横方向上限を 95% → 140% に緩和（モデル枠は描画可能領域で余白を含むため、キャラ本体は収まる）

結果として:
- 頭は画面上部に
- 上半身（顔〜腰）が画面中央に大きく
- 足は画面下端より下に位置（一部は表示されない）

## 関連 Issue

Refs #3207 (Phase 1g 見た目調整)

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング（UI 調整）
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 既存テスト 19 件全通過（リグレッションなし）
- [x] ビルドエラーがないことを確認した（tsc 通過）

## レビューポイント

- `anchor.y = 0.3` と `1.5` スケール係数は Hiyori モデル前提の経験値。他モデルでは要調整
- `Math.min(scaleByHeight, scaleByWidth)` でアスペクト比保持しつつ、どちらか小さい方を採用
- 端末アスペクト比によって `scaleByWidth` が limiting factor になる場合あり（細長い縦長端末で特に）

## テスト内容

- 既存 19 件全通過
- 動作確認は dev 環境で実施予定: 上半身がメインに、リップシンク時の口元が見やすくなるか

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_