### PR TITLE
fix(livetalk-web): ResizeObserver で Live2D canvas を Box サイズ追従させる

### DIFF
--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -25,6 +25,23 @@ function waitForCubismCore(timeout = 10000): Promise<void> {
   });
 }
 
+type Live2DModelInstance = import('pixi-live2d-display-lipsyncpatch/cubism4').Live2DModel;
+
+/**
+ * 上半身フォーカスのレイアウト。
+ * - anchor Y = 0.3: 顔〜胸が基準点（= canvas 中央）になる
+ * - scale: 縦は 95% × 1.5 倍、横は 140% を上限とした小さい方
+ */
+function layoutModel(model: Live2DModelInstance, w: number, h: number): void {
+  model.anchor.set(0.5, 0.3);
+  const scaleByHeight = (h * 0.95 * 1.5) / model.height;
+  const scaleByWidth = (w * 1.4) / model.width;
+  const scale = Math.min(scaleByHeight, scaleByWidth);
+  model.scale.set(scale);
+  model.x = w / 2;
+  model.y = h / 2;
+}
+
 export interface Live2DCanvasProps {
   /** 再生対象の音声 URL。null または undefined のときは再生しない。 */
   audioUrl?: string | null;
@@ -53,9 +70,7 @@ export default function Live2DCanvas({
 }: Live2DCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const appRef = useRef<import('pixi.js').Application | null>(null);
-  const modelRef = useRef<import('pixi-live2d-display-lipsyncpatch/cubism4').Live2DModel | null>(
-    null
-  );
+  const modelRef = useRef<Live2DModelInstance | null>(null);
   const loadedRef = useRef(false);
   const [modelReady, setModelReady] = useState(false);
 
@@ -124,22 +139,7 @@ export default function Live2DCanvas({
         }
         modelRef.current = model;
 
-        // 上半身フォーカスのレイアウト。
-        // anchor Y を 0.3 にすることで、顔〜胸のあたりが基準点（= canvas 中央）になる。
-        // 結果として頭は画面上部、上半身が中央、足は画面下端より下に位置する。
-        model.anchor.set(0.5, 0.3);
-
-        // canvas に対するスケール。縦は 95% × 1.5 倍を上限（上半身フォーカスのためのズーム）。
-        // 横は 140% まで許容（モデル枠 = キャラ本体ではなく余白を含む。少しはみ出してもキャラは収まる）。
-        const scaleByHeight = (h * 0.95 * 1.5) / model.height;
-        const scaleByWidth = (w * 1.4) / model.width;
-        const scale = Math.min(scaleByHeight, scaleByWidth);
-        model.scale.set(scale);
-
-        // アンカー基準点を canvas 中央に配置
-        model.x = w / 2;
-        model.y = h / 2;
-
+        layoutModel(model, w, h);
         app.stage.addChild(model);
         setModelReady(true);
       } catch (err) {
@@ -147,8 +147,24 @@ export default function Live2DCanvas({
       }
     })();
 
+    // Container サイズ変化（画面回転・レスポンシブレイアウト・メッセージ追加による
+    // flex 再分配など）を観測して PIXI canvas とモデルを再レイアウトする。
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      if (width === 0 || height === 0) return;
+
+      appRef.current?.renderer.resize(width, height);
+      if (modelRef.current) {
+        layoutModel(modelRef.current, width, height);
+      }
+    });
+    observer.observe(containerRef.current);
+
     return () => {
       cancelled = true;
+      observer.disconnect();
       modelRef.current?.destroy();
       modelRef.current = null;
       appRef.current?.destroy(true);
@@ -201,6 +217,9 @@ export default function Live2DCanvas({
         justifyContent: 'center',
         backgroundColor: 'background.default',
         position: 'relative',
+        // ResizeObserver の追従が一瞬遅れても canvas が下にはみ出してメッセージ欄に
+        // 重ならないようにするセーフティネット
+        overflow: 'hidden',
       }}
       data-testid="live2d-canvas-container"
     >


### PR DESCRIPTION
## 変更の概要

メッセージ送信後（応答メッセージ表示時）にキャラクターの足がメッセージ欄に重なって見える不具合を修正。

**原因**: Live2DCanvas の Box サイズはマウント時に 1 回だけ読まれて PIXI canvas に固定されていた。メッセージが追加されると Container 内の flex 再分配が起きて Live2DCanvas Box が縮むが、PIXI canvas は元のサイズのまま → Box の外（下のメッセージ欄）にはみ出して見える状態だった。

**修正**: `ResizeObserver` で Container Box のサイズ変化を観測し、変化があれば PIXI canvas とモデル位置を再計算する。

## 変更詳細

- レイアウト計算ロジック（anchor / scale / position）を `layoutModel()` 関数として切り出し
- 既存の useEffect 内に `ResizeObserver` を設置:
  - Container Box のサイズ変化を観測
  - 変化検知時に `app.renderer.resize(w, h)` + `layoutModel(model, w, h)` を呼ぶ
  - クリーンアップ時に `observer.disconnect()`
- セーフティネットとして outer Box に `overflow: hidden` を追加（ResizeObserver の追従が一瞬遅れた場合の保険）

これにより:
- 画面回転（縦↔横）に追従
- レスポンシブレイアウトに追従
- メッセージ追加で Box が縮んでもキャラクターが Box 内に収まる

## 関連 Issue

Refs #3207 (Phase 1g 見た目調整)

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 既存テスト 19 件全通過（リグレッションなし）
- [x] ビルドエラーがないことを確認した（tsc 通過）

## レビューポイント

- `ResizeObserver` は標準 Web API（IE 非対応だが LiveTalk のターゲット環境は問題なし）
- 観測対象は `containerRef.current`（外側の Box ではなく、PIXI canvas を直接含む内側 Box）。これにより canvas のサイズ計算と一致
- レイアウト計算は単純な算術なので毎フレームでも問題なし（リサイズ頻度は元々低い）
- `overflow: hidden` は ResizeObserver の追従遅延に対する保険であり、通常時には影響しない

## テスト内容

- 既存 19 件全通過
- 動作確認は dev 環境で実施予定:
  - メッセージ送信前/送信後でキャラクターが Box 内に収まること
  - 画面回転でレイアウトが破綻しないこと

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_