### PR TITLE
fix(livetalk-web): リサイズで Live2D モデルが暴走拡大する不具合を修正

### DIFF
--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -31,11 +31,18 @@ type Live2DModelInstance = import('pixi-live2d-display-lipsyncpatch/cubism4').Li
  * 上半身フォーカスのレイアウト。
  * - anchor Y = 0.3: 顔〜胸が基準点（= canvas 中央）になる
  * - scale: 縦は 95% × 1.5 倍、横は 140% を上限とした小さい方
+ *
+ * 注意: model.width / model.height は PIXI Container の getter で `scale * localBounds`
+ * を返すため、現在の scale 適用後の値になる。リサイズの度にそれを基準に再計算すると
+ * 倍率が暴走するため、layout transform 適用後の原寸固定値である
+ * `internalModel.width / height` を使う。
  */
 function layoutModel(model: Live2DModelInstance, w: number, h: number): void {
+  const modelWidth = model.internalModel.width;
+  const modelHeight = model.internalModel.height;
   model.anchor.set(0.5, 0.3);
-  const scaleByHeight = (h * 0.95 * 1.5) / model.height;
-  const scaleByWidth = (w * 1.4) / model.width;
+  const scaleByHeight = (h * 0.95 * 1.5) / modelHeight;
+  const scaleByWidth = (w * 1.4) / modelWidth;
   const scale = Math.min(scaleByHeight, scaleByWidth);
   model.scale.set(scale);
   model.x = w / 2;


### PR DESCRIPTION
## 変更の概要

PR #3245 で追加した ResizeObserver 経由の再レイアウトで、メッセージ送信時にキャラクターが極端にズームインする不具合を修正。

**原因**: `layoutModel()` で参照していた `model.width` / `model.height` は PIXI Container の getter で **`scale.x * localBounds.width`** を返す（= 現在の scale 適用後の値）。一度 scale を 0.227 に設定した後、再び `model.height` を分母に使って `scaleByHeight = (h * factor) / model.height` を計算すると、分母が既に縮小済みのため新しい scale が大きく算出され、再描画のたびにスケールが累積的に拡大していた。

**修正**: PIXI scale の影響を受けない原寸固定値 `model.internalModel.width / height`（layout transform 適用後の値）を使うことで、何度リサイズしても常に同じ原寸基準で再計算されるようにした。

## 関連 Issue

Refs #3207 (Phase 1g バグ修正、PR #3245 のリグレッション修正)

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 既存テスト 19 件全通過（リグレッションなし）
- [x] ビルドエラーがないことを確認した（tsc 通過）

## レビューポイント

- `internalModel.width / height` は `originalWidth * localTransform.a` で計算され、PIXI scale には影響されない固定値（型定義: `pixi-live2d-display-lipsyncpatch/types/index.d.ts:1309-1313`）
- 同じく `internalModel.originalWidth / originalHeight` もあるが、こちらは layout transform 適用前の生のピクセル値。今回は layout 適用後の値を使う方が Live2D 仕様に沿う
- なぜテストで検知できなかったか: 既存テストは constants と CDK stack のみで Live2DCanvas の動作テストが無いため。PIXI + WebGL は Jest 環境で実行困難

## テスト内容

- 既存 19 件全通過
- 動作確認は dev 環境で実施予定:
  - メッセージ送信前/送信後でキャラクターのサイズが変わらないこと
  - 画面回転時もキャラクターが適切なサイズに収まること

https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARFPKEkcDUoUeF4XfoZwQk)_