### PR TITLE
feat(livetalk): DynamoDB Single Table + 会話履歴永続化（Phase 2a / #3247）

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/build-web-app
         with:
           workspace: '@nagiyu/livetalk-web'
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/ui,@nagiyu/nextjs,@nagiyu/livetalk-core'
+          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/ui,@nagiyu/nextjs,@nagiyu/aws,@nagiyu/livetalk-core'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/livetalk-verify.yml
+++ b/.github/workflows/livetalk-verify.yml
@@ -121,7 +121,7 @@ jobs:
         uses: ./.github/actions/build-web-app
         with:
           workspace: '@nagiyu/livetalk-web'
-          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/ui,@nagiyu/nextjs,@nagiyu/livetalk-core'
+          shared-workspaces: '@nagiyu/common,@nagiyu/browser,@nagiyu/ui,@nagiyu/nextjs,@nagiyu/aws,@nagiyu/livetalk-core'
 
   docker-build:
     name: Docker Build Verification
@@ -174,6 +174,7 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
+          npm run build --workspace @nagiyu/aws
           npm run build --workspace @nagiyu/livetalk-core
 
       - name: Run core unit tests
@@ -204,6 +205,7 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
+          npm run build --workspace @nagiyu/aws
           npm run build --workspace @nagiyu/livetalk-core
 
       - name: Run core tests with coverage
@@ -236,6 +238,7 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
+          npm run build --workspace @nagiyu/aws
           npm run build --workspace @nagiyu/livetalk-core
 
       - name: Build web application
@@ -306,6 +309,7 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
+          npm run build --workspace @nagiyu/aws
           npm run build --workspace @nagiyu/livetalk-core
 
       - name: Build web application
@@ -376,6 +380,7 @@ jobs:
           npm run build --workspace @nagiyu/browser
           npm run build --workspace @nagiyu/ui
           npm run build --workspace @nagiyu/nextjs
+          npm run build --workspace @nagiyu/aws
           npm run build --workspace @nagiyu/livetalk-core
 
       - name: Build web application

--- a/infra/common/src/utils/ssm.ts
+++ b/infra/common/src/utils/ssm.ts
@@ -33,4 +33,8 @@ export const SSM_PARAMETERS = {
     `/nagiyu/livetalk/${env}/cloudfront/custom-domain`,
   LIVETALK_ASSETS_BUCKET_NAME: (env: Environment) =>
     `/nagiyu/livetalk/${env}/assets/bucket-name`,
+  LIVETALK_DYNAMODB_TABLE_NAME: (env: Environment) =>
+    `/nagiyu/livetalk/${env}/dynamodb/table-name`,
+  LIVETALK_DYNAMODB_TABLE_ARN: (env: Environment) =>
+    `/nagiyu/livetalk/${env}/dynamodb/table-arn`,
 } as const;

--- a/infra/common/src/utils/ssm.ts
+++ b/infra/common/src/utils/ssm.ts
@@ -33,8 +33,4 @@ export const SSM_PARAMETERS = {
     `/nagiyu/livetalk/${env}/cloudfront/custom-domain`,
   LIVETALK_ASSETS_BUCKET_NAME: (env: Environment) =>
     `/nagiyu/livetalk/${env}/assets/bucket-name`,
-  LIVETALK_DYNAMODB_TABLE_NAME: (env: Environment) =>
-    `/nagiyu/livetalk/${env}/dynamodb/table-name`,
-  LIVETALK_DYNAMODB_TABLE_ARN: (env: Environment) =>
-    `/nagiyu/livetalk/${env}/dynamodb/table-arn`,
 } as const;

--- a/infra/common/src/utils/ssm.ts
+++ b/infra/common/src/utils/ssm.ts
@@ -31,6 +31,5 @@ export const SSM_PARAMETERS = {
     `/nagiyu/livetalk/${env}/cloudfront/domain-name`,
   LIVETALK_CLOUDFRONT_CUSTOM_DOMAIN: (env: Environment) =>
     `/nagiyu/livetalk/${env}/cloudfront/custom-domain`,
-  LIVETALK_ASSETS_BUCKET_NAME: (env: Environment) =>
-    `/nagiyu/livetalk/${env}/assets/bucket-name`,
+  LIVETALK_ASSETS_BUCKET_NAME: (env: Environment) => `/nagiyu/livetalk/${env}/assets/bucket-name`,
 } as const;

--- a/infra/common/tests/unit/ssm.test.ts
+++ b/infra/common/tests/unit/ssm.test.ts
@@ -50,9 +50,7 @@ describe('ssm utilities', () => {
   });
 
   it('should generate LiveTalk ALB parameter names', () => {
-    expect(SSM_PARAMETERS.LIVETALK_ALB_DNS_NAME('dev')).toBe(
-      '/nagiyu/livetalk/dev/alb/dns-name'
-    );
+    expect(SSM_PARAMETERS.LIVETALK_ALB_DNS_NAME('dev')).toBe('/nagiyu/livetalk/dev/alb/dns-name');
     expect(SSM_PARAMETERS.LIVETALK_ALB_ARN('prod')).toBe('/nagiyu/livetalk/prod/alb/arn');
     expect(SSM_PARAMETERS.LIVETALK_ALB_LISTENER_ARN('dev')).toBe(
       '/nagiyu/livetalk/dev/alb/listener-arn'

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -42,7 +42,9 @@ const albStack = new LiveTalkAlbStack(app, `NagiyuLiveTalkAlb${envSuffix}`, {
 
 // LiveTalk DynamoDB Single Table Stack（Phase 2a で追加）
 // 会話履歴・プロファイル・キャラ状態を 1 テーブルで保持する。
-// テーブル名 / ARN は SSM パラメータ経由で ECS Service Stack から参照される。
+// テーブル名 / ARN は ECS Service Stack 側でも `getDynamoDBTableName('livetalk', env)`
+// / `getDynamoDBTableArn(...)` を呼んで独立に組み立てる（SSM もクロススタック参照も
+// 介さない方針）。両 stack の deploy 順序や export 依存は発生しない。
 const dynamoDbStack = new LiveTalkDynamoDbStack(
   app,
   `NagiyuLiveTalkDynamoDB${envSuffix}`,

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -82,9 +82,11 @@ const cloudFrontStack = new LiveTalkCloudFrontStack(
 // SSM 経由の参照のため CDK は自動的にスタック間依存を検出できない。
 // 明示的に依存を宣言して deploy 順を保証する。
 ecsServiceStack.addDependency(albStack);
-// ECS Service は DynamoDB テーブル名 / ARN を SSM から参照する。
-ecsServiceStack.addDependency(dynamoDbStack);
 // CloudFront は ALB DNS を SSM から参照する。明示的に依存を宣言。
 cloudFrontStack.addDependency(albStack);
+// DynamoDB stack は ECS Service stack と直接依存しない：
+// ECS 側は `getDynamoDBTableName('livetalk', env)` で名前 / ARN を決定論的に
+// 組み立てており、SSM もクロススタック参照も介さないため、deploy 順は不問。
+// （IAM ポリシーが指す ARN は実テーブル作成より先に書き出されても問題なし）
 
 app.synth();

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -3,6 +3,7 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { LiveTalkEcrStack } from '../lib/ecr-stack';
 import { LiveTalkAlbStack } from '../lib/alb-stack';
+import { LiveTalkDynamoDbStack } from '../lib/dynamodb-stack';
 import { LiveTalkEcsServiceStack } from '../lib/ecs-service-stack';
 import { LiveTalkCloudFrontStack } from '../lib/cloudfront-stack';
 
@@ -39,6 +40,19 @@ const albStack = new LiveTalkAlbStack(app, `NagiyuLiveTalkAlb${envSuffix}`, {
   description: `LiveTalk ALB (${environment})`,
 });
 
+// LiveTalk DynamoDB Single Table Stack（Phase 2a で追加）
+// 会話履歴・プロファイル・キャラ状態を 1 テーブルで保持する。
+// テーブル名 / ARN は SSM パラメータ経由で ECS Service Stack から参照される。
+const dynamoDbStack = new LiveTalkDynamoDbStack(
+  app,
+  `NagiyuLiveTalkDynamoDB${envSuffix}`,
+  {
+    env: stackEnv,
+    environment,
+    description: `LiveTalk DynamoDB Single Table (${environment})`,
+  }
+);
+
 // LiveTalk ECS Service Stack（共通 Cluster に Attach、ALB Target Group へ登録）
 const ecsServiceStack = new LiveTalkEcsServiceStack(
   app,
@@ -68,6 +82,8 @@ const cloudFrontStack = new LiveTalkCloudFrontStack(
 // SSM 経由の参照のため CDK は自動的にスタック間依存を検出できない。
 // 明示的に依存を宣言して deploy 順を保証する。
 ecsServiceStack.addDependency(albStack);
+// ECS Service は DynamoDB テーブル名 / ARN を SSM から参照する。
+ecsServiceStack.addDependency(dynamoDbStack);
 // CloudFront は ALB DNS を SSM から参照する。明示的に依存を宣言。
 cloudFrontStack.addDependency(albStack);
 

--- a/infra/livetalk/lib/dynamodb-stack.ts
+++ b/infra/livetalk/lib/dynamodb-stack.ts
@@ -1,8 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
-import { Environment, SSM_PARAMETERS } from '@nagiyu/infra-common';
+import { Environment, getDynamoDBTableName } from '@nagiyu/infra-common';
 
 export interface LiveTalkDynamoDbStackProps extends cdk.StackProps {
   environment: Environment;
@@ -11,14 +10,19 @@ export interface LiveTalkDynamoDbStackProps extends cdk.StackProps {
 /**
  * LiveTalk DynamoDB Single Table スタック
  *
- * - 命名: `nagiyu-livetalk-{env}`（`tasks/livetalk/design.md` 3.2 節に準拠）
+ * - 命名: 共通ヘルパー `getDynamoDBTableName('livetalk', env)` で決定
  * - PK / SK の 2 キー Single Table 構成。MVP では GSI を作成しない
- *   （`design.md` 3.2 節：「MVP では GSI 不要、Phase 進行で必要になれば追加」）
+ *   （`tasks/livetalk/design.md` 3.2 節：「MVP では GSI 不要、Phase 進行で必要になれば追加」）
  * - Message は TTL（属性名 `TTL`、Unix 秒）で 90 日後に自動削除
  * - Point-in-time Recovery 有効、AWS マネージドキーで at-rest 暗号化
  * - dev は破棄、prod は保持
- * - 他スタック（ECS Service など）から参照しやすいよう、テーブル名 / ARN を
- *   SSM パラメータに出力する
+ * - 他スタック（ECS Service など）からは `getDynamoDBTableName('livetalk', env)` /
+ *   `getDynamoDBTableArn(...)` を使って同じ値を独立に組み立てる。
+ *   CDK のクロススタック参照（`Fn::ImportValue`）を避けることで、CloudFormation
+ *   の export 依存に伴うカスケード再デプロイを発生させない。SSM 経由でも同じ
+ *   結合が生じるため、サービス固有のキーを `infra/common` に追加しない。
+ * - `public readonly table` はテストや CfnOutput 用に保持するが、他スタックへの
+ *   prop パススルー目的では使わない。
  */
 export class LiveTalkDynamoDbStack extends cdk.Stack {
   public readonly table: dynamodb.Table;
@@ -29,7 +33,7 @@ export class LiveTalkDynamoDbStack extends cdk.Stack {
     const { environment } = props;
 
     this.table = new dynamodb.Table(this, 'MainTable', {
-      tableName: `nagiyu-livetalk-${environment}`,
+      tableName: getDynamoDBTableName('livetalk', environment),
       partitionKey: {
         name: 'PK',
         type: dynamodb.AttributeType.STRING,
@@ -50,20 +54,6 @@ export class LiveTalkDynamoDbStack extends cdk.Stack {
     cdk.Tags.of(this).add('Environment', environment);
     cdk.Tags.of(this).add('ManagedBy', 'CDK');
     cdk.Tags.of(this).add('Component', 'livetalk');
-
-    new ssm.StringParameter(this, 'TableNameParam', {
-      parameterName: SSM_PARAMETERS.LIVETALK_DYNAMODB_TABLE_NAME(environment),
-      stringValue: this.table.tableName,
-      description: 'LiveTalk DynamoDB Single Table 名',
-      tier: ssm.ParameterTier.STANDARD,
-    });
-
-    new ssm.StringParameter(this, 'TableArnParam', {
-      parameterName: SSM_PARAMETERS.LIVETALK_DYNAMODB_TABLE_ARN(environment),
-      stringValue: this.table.tableArn,
-      description: 'LiveTalk DynamoDB Single Table ARN',
-      tier: ssm.ParameterTier.STANDARD,
-    });
 
     new cdk.CfnOutput(this, 'TableName', {
       value: this.table.tableName,

--- a/infra/livetalk/lib/dynamodb-stack.ts
+++ b/infra/livetalk/lib/dynamodb-stack.ts
@@ -1,0 +1,78 @@
+import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { Environment, SSM_PARAMETERS } from '@nagiyu/infra-common';
+
+export interface LiveTalkDynamoDbStackProps extends cdk.StackProps {
+  environment: Environment;
+}
+
+/**
+ * LiveTalk DynamoDB Single Table スタック
+ *
+ * - 命名: `nagiyu-livetalk-{env}`（`tasks/livetalk/design.md` 3.2 節に準拠）
+ * - PK / SK の 2 キー Single Table 構成。MVP では GSI を作成しない
+ *   （`design.md` 3.2 節：「MVP では GSI 不要、Phase 進行で必要になれば追加」）
+ * - Message は TTL（属性名 `TTL`、Unix 秒）で 90 日後に自動削除
+ * - Point-in-time Recovery 有効、AWS マネージドキーで at-rest 暗号化
+ * - dev は破棄、prod は保持
+ * - 他スタック（ECS Service など）から参照しやすいよう、テーブル名 / ARN を
+ *   SSM パラメータに出力する
+ */
+export class LiveTalkDynamoDbStack extends cdk.Stack {
+  public readonly table: dynamodb.Table;
+
+  constructor(scope: Construct, id: string, props: LiveTalkDynamoDbStackProps) {
+    super(scope, id, props);
+
+    const { environment } = props;
+
+    this.table = new dynamodb.Table(this, 'MainTable', {
+      tableName: `nagiyu-livetalk-${environment}`,
+      partitionKey: {
+        name: 'PK',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'SK',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true,
+      timeToLiveAttribute: 'TTL',
+      removalPolicy:
+        environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    cdk.Tags.of(this).add('Application', 'nagiyu');
+    cdk.Tags.of(this).add('Environment', environment);
+    cdk.Tags.of(this).add('ManagedBy', 'CDK');
+    cdk.Tags.of(this).add('Component', 'livetalk');
+
+    new ssm.StringParameter(this, 'TableNameParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_DYNAMODB_TABLE_NAME(environment),
+      stringValue: this.table.tableName,
+      description: 'LiveTalk DynamoDB Single Table 名',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'TableArnParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_DYNAMODB_TABLE_ARN(environment),
+      stringValue: this.table.tableArn,
+      description: 'LiveTalk DynamoDB Single Table ARN',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new cdk.CfnOutput(this, 'TableName', {
+      value: this.table.tableName,
+      description: 'LiveTalk DynamoDB Table Name',
+    });
+
+    new cdk.CfnOutput(this, 'TableArn', {
+      value: this.table.tableArn,
+      description: 'LiveTalk DynamoDB Table ARN',
+    });
+  }
+}

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
@@ -107,6 +108,25 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
       {
         targetGroupArn,
       }
+    );
+
+    // DynamoDB Single Table を SSM 経由で参照する。
+    // - env var（DYNAMODB_TABLE_NAME）はテーブル名を直接渡せばよいので SSM から取得
+    // - IAM grant 用の `ITable` は ARN ベースで生成する。
+    //   `fromTableAttributes` は tableArn と tableName を同時に渡すと CDK が衝突
+    //   とみなしてエラーになるため、ARN 一本で渡してテーブル名は名前として別途扱う。
+    const dynamoTableName = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.LIVETALK_DYNAMODB_TABLE_NAME(environment)
+    );
+    const dynamoTableArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.LIVETALK_DYNAMODB_TABLE_ARN(environment)
+    );
+    const dynamoTable = dynamodb.Table.fromTableArn(
+      this,
+      'ImportedDynamoTable',
+      dynamoTableArn
     );
 
     this.ecsTaskSecurityGroup = new ec2.SecurityGroup(this, 'EcsTaskSecurityGroup', {
@@ -233,6 +253,9 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
         APP_URL: appUrl,
         // VOICEVOX エンジンの接続先（同 Task 内 localhost）
         VOICEVOX_URL: 'http://localhost:50021',
+        // DynamoDB Single Table 名（Phase 2a で導入）。
+        // `@nagiyu/aws` の `getTableName()` がこの環境変数を参照する。
+        DYNAMODB_TABLE_NAME: dynamoTableName,
       },
       portMappings: [
         {
@@ -263,6 +286,10 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
       },
       healthCheckGracePeriod: cdk.Duration.seconds(120),
     });
+
+    // ECS Task が DynamoDB Single Table を読み書きできるよう IAM 権限を付与する。
+    // PITR や Backup 系の操作は不要、Read/Write のみで十分。
+    dynamoTable.grantReadWriteData(taskRole);
 
     // ALB ターゲットには明示的に livetalk-web:3000 を指定する。
     // attachToApplicationTargetGroup() の暗黙的なデフォルトは「最初に addContainer された

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -10,6 +10,8 @@ import { Construct } from 'constructs';
 import {
   Environment,
   SSM_PARAMETERS,
+  getDynamoDBTableArn,
+  getDynamoDBTableName,
   getEcrRepositoryName,
 } from '@nagiyu/infra-common';
 
@@ -110,19 +112,13 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
       }
     );
 
-    // DynamoDB Single Table を SSM 経由で参照する。
-    // - env var（DYNAMODB_TABLE_NAME）はテーブル名を直接渡せばよいので SSM から取得
-    // - IAM grant 用の `ITable` は ARN ベースで生成する。
-    //   `fromTableAttributes` は tableArn と tableName を同時に渡すと CDK が衝突
-    //   とみなしてエラーになるため、ARN 一本で渡してテーブル名は名前として別途扱う。
-    const dynamoTableName = ssm.StringParameter.valueForStringParameter(
-      this,
-      SSM_PARAMETERS.LIVETALK_DYNAMODB_TABLE_NAME(environment)
-    );
-    const dynamoTableArn = ssm.StringParameter.valueForStringParameter(
-      this,
-      SSM_PARAMETERS.LIVETALK_DYNAMODB_TABLE_ARN(environment)
-    );
+    // DynamoDB Single Table はヘルパーで決定論的に名前 / ARN を組み立てる。
+    // CloudFormation の Export/Import によるクロススタック依存を避けるため、
+    // SSM ルックアップやスタック参照は使わず、`getDynamoDBTableName` /
+    // `getDynamoDBTableArn` を DynamoDB stack 側と揃えて呼ぶ。
+    // これにより ECS Service stack は DynamoDB stack の deploy 順序に縛られない。
+    const dynamoTableName = getDynamoDBTableName('livetalk', environment);
+    const dynamoTableArn = getDynamoDBTableArn(this.region, this.account, dynamoTableName);
     const dynamoTable = dynamodb.Table.fromTableArn(
       this,
       'ImportedDynamoTable',

--- a/infra/livetalk/tests/unit/dynamodb-stack.test.js
+++ b/infra/livetalk/tests/unit/dynamodb-stack.test.js
@@ -16,10 +16,10 @@ const synth = (environment) => {
 };
 
 describe('LiveTalkDynamoDbStack', () => {
-  it('テーブル名は環境名込みで `nagiyu-livetalk-{env}` になる', () => {
+  it('テーブル名はヘルパー命名規則 `nagiyu-livetalk-dynamodb-{env}` に従う', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::DynamoDB::Table', {
-      TableName: 'nagiyu-livetalk-dev',
+      TableName: 'nagiyu-livetalk-dynamodb-dev',
     });
   });
 
@@ -59,10 +59,10 @@ describe('LiveTalkDynamoDbStack', () => {
     expect(table.UpdateReplacePolicy).toBe('Delete');
   });
 
-  it('prod 環境は RETAIN ポリシー', () => {
+  it('prod 環境は RETAIN ポリシーで命名も prod を反映する', () => {
     const template = synth('prod');
     template.hasResourceProperties('AWS::DynamoDB::Table', {
-      TableName: 'nagiyu-livetalk-prod',
+      TableName: 'nagiyu-livetalk-dynamodb-prod',
     });
     const tableResource = template.findResources('AWS::DynamoDB::Table');
     const table = Object.values(tableResource)[0];
@@ -70,27 +70,16 @@ describe('LiveTalkDynamoDbStack', () => {
     expect(table.UpdateReplacePolicy).toBe('Retain');
   });
 
-  it('SSM Parameter にテーブル名と ARN を出力する', () => {
+  it('SSM パラメータは発行しない（サービス固有名を infra/common に増やさない方針）', () => {
     const template = synth('dev');
-    template.hasResourceProperties('AWS::SSM::Parameter', {
-      Name: '/nagiyu/livetalk/dev/dynamodb/table-name',
-    });
-    template.hasResourceProperties('AWS::SSM::Parameter', {
-      Name: '/nagiyu/livetalk/dev/dynamodb/table-arn',
-    });
+    const ssm = template.findResources('AWS::SSM::Parameter');
+    expect(Object.keys(ssm)).toHaveLength(0);
   });
 
   it('Component=livetalk タグを付与する', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::DynamoDB::Table', {
       Tags: Match.arrayWith([{ Key: 'Component', Value: 'livetalk' }]),
-    });
-  });
-
-  it('prod 環境の SSM パラメータ名にも prod が反映される', () => {
-    const template = synth('prod');
-    template.hasResourceProperties('AWS::SSM::Parameter', {
-      Name: '/nagiyu/livetalk/prod/dynamodb/table-name',
     });
   });
 });

--- a/infra/livetalk/tests/unit/dynamodb-stack.test.js
+++ b/infra/livetalk/tests/unit/dynamodb-stack.test.js
@@ -1,0 +1,96 @@
+const cdk = require('aws-cdk-lib');
+const { Template, Match } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { LiveTalkDynamoDbStack } = require('../../lib/dynamodb-stack');
+
+const STACK_ENV = { account: '000000000000', region: 'us-east-1' };
+
+const synth = (environment) => {
+  const app = new cdk.App();
+  const stack = new LiveTalkDynamoDbStack(app, `TestLiveTalkDynamoDB${environment}`, {
+    environment,
+    env: STACK_ENV,
+  });
+  return Template.fromStack(stack);
+};
+
+describe('LiveTalkDynamoDbStack', () => {
+  it('テーブル名は環境名込みで `nagiyu-livetalk-{env}` になる', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      TableName: 'nagiyu-livetalk-dev',
+    });
+  });
+
+  it('PK / SK の 2 キー Single Table 構成（GSI なし）', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      KeySchema: [
+        { AttributeName: 'PK', KeyType: 'HASH' },
+        { AttributeName: 'SK', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: Match.arrayWith([
+        { AttributeName: 'PK', AttributeType: 'S' },
+        { AttributeName: 'SK', AttributeType: 'S' },
+      ]),
+    });
+    // MVP では GSI を作成しない
+    const tableResource = template.findResources('AWS::DynamoDB::Table');
+    const table = Object.values(tableResource)[0];
+    expect(table.Properties.GlobalSecondaryIndexes).toBeUndefined();
+  });
+
+  it('PAY_PER_REQUEST + PITR + TTL 属性 + AWS_MANAGED 暗号化を設定する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      BillingMode: 'PAY_PER_REQUEST',
+      PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+      TimeToLiveSpecification: { AttributeName: 'TTL', Enabled: true },
+      SSESpecification: Match.objectLike({ SSEEnabled: true }),
+    });
+  });
+
+  it('dev 環境は DESTROY ポリシー', () => {
+    const template = synth('dev');
+    const tableResource = template.findResources('AWS::DynamoDB::Table');
+    const table = Object.values(tableResource)[0];
+    expect(table.DeletionPolicy).toBe('Delete');
+    expect(table.UpdateReplacePolicy).toBe('Delete');
+  });
+
+  it('prod 環境は RETAIN ポリシー', () => {
+    const template = synth('prod');
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      TableName: 'nagiyu-livetalk-prod',
+    });
+    const tableResource = template.findResources('AWS::DynamoDB::Table');
+    const table = Object.values(tableResource)[0];
+    expect(table.DeletionPolicy).toBe('Retain');
+    expect(table.UpdateReplacePolicy).toBe('Retain');
+  });
+
+  it('SSM Parameter にテーブル名と ARN を出力する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/dynamodb/table-name',
+    });
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/dev/dynamodb/table-arn',
+    });
+  });
+
+  it('Component=livetalk タグを付与する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      Tags: Match.arrayWith([{ Key: 'Component', Value: 'livetalk' }]),
+    });
+  });
+
+  it('prod 環境の SSM パラメータ名にも prod が反映される', () => {
+    const template = synth('prod');
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: '/nagiyu/livetalk/prod/dynamodb/table-name',
+    });
+  });
+});

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -175,14 +175,14 @@ describe('LiveTalkEcsServiceStack', () => {
     }
   });
 
-  it('DYNAMODB_TABLE_NAME を container environment に注入する', () => {
+  it('DYNAMODB_TABLE_NAME はヘルパー命名規則の値をそのまま注入する（SSM 経由ではない）', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::ECS::TaskDefinition', {
       ContainerDefinitions: Match.arrayWith([
         Match.objectLike({
           Name: 'livetalk-web',
           Environment: Match.arrayWith([
-            Match.objectLike({ Name: 'DYNAMODB_TABLE_NAME' }),
+            { Name: 'DYNAMODB_TABLE_NAME', Value: 'nagiyu-livetalk-dynamodb-dev' },
           ]),
         }),
       ]),

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -175,6 +175,54 @@ describe('LiveTalkEcsServiceStack', () => {
     }
   });
 
+  it('DYNAMODB_TABLE_NAME を container environment に注入する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: 'livetalk-web',
+          Environment: Match.arrayWith([
+            Match.objectLike({ Name: 'DYNAMODB_TABLE_NAME' }),
+          ]),
+        }),
+      ]),
+    });
+  });
+
+  it('Task Role に DynamoDB の Read/Write 権限を付与する', () => {
+    const template = synth('dev');
+    // grantReadWriteData が生成する Allow Statement の Action を見て、
+    // 順序非依存（CDK のバージョン更新で並びが変わっても壊れない）に
+    // Read/Write 両系統の代表アクションを検証する。
+    const policies = template.findResources('AWS::IAM::Policy');
+    const taskRolePolicy = Object.values(policies).find((p) => {
+      const statements = (p.Properties?.PolicyDocument?.Statement ?? []);
+      return statements.some(
+        (stmt) =>
+          stmt.Effect === 'Allow' &&
+          Array.isArray(stmt.Action) &&
+          stmt.Action.includes('dynamodb:PutItem')
+      );
+    });
+    expect(taskRolePolicy).toBeDefined();
+    const allowStatement = taskRolePolicy.Properties.PolicyDocument.Statement.find(
+      (stmt) =>
+        stmt.Effect === 'Allow' &&
+        Array.isArray(stmt.Action) &&
+        stmt.Action.includes('dynamodb:PutItem')
+    );
+    const actions = allowStatement.Action;
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        'dynamodb:GetItem',
+        'dynamodb:Query',
+        'dynamodb:PutItem',
+        'dynamodb:UpdateItem',
+        'dynamodb:DeleteItem',
+      ])
+    );
+  });
+
   it('prod 環境でも正しい命名で生成する', () => {
     const template = synth('prod');
     template.hasResourceProperties('AWS::ECS::Service', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9014,6 +9014,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.29",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
@@ -14161,6 +14181,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -18986,6 +19015,15 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/ulid": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-3.0.2.tgz",
+      "integrity": "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "dist/cli.js"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -20011,13 +20049,19 @@
       "name": "@nagiyu/livetalk-core",
       "version": "1.0.0",
       "dependencies": {
-        "@nagiyu/common": "*"
+        "@aws-sdk/client-dynamodb": "^3.1024.0",
+        "@aws-sdk/lib-dynamodb": "^3.1024.0",
+        "@nagiyu/aws": "*",
+        "@nagiyu/common": "*",
+        "js-tiktoken": "^1.0.21",
+        "ulid": "^3.0.1"
       }
     },
     "services/livetalk/web": {
       "name": "@nagiyu/livetalk-web",
       "version": "1.0.0",
       "dependencies": {
+        "@nagiyu/aws": "*",
         "@nagiyu/browser": "*",
         "@nagiyu/common": "*",
         "@nagiyu/livetalk-core": "*",

--- a/services/livetalk/core/jest.config.ts
+++ b/services/livetalk/core/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
   testMatch: ['**/*.test.ts'],
   moduleNameMapper: {
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   modulePathIgnorePatterns: ['<rootDir>/../../../package.json'],

--- a/services/livetalk/core/package.json
+++ b/services/livetalk/core/package.json
@@ -15,6 +15,11 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@nagiyu/common": "*"
+    "@aws-sdk/client-dynamodb": "^3.1024.0",
+    "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@nagiyu/aws": "*",
+    "@nagiyu/common": "*",
+    "js-tiktoken": "^1.0.21",
+    "ulid": "^3.0.1"
   }
 }

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -1,0 +1,25 @@
+/**
+ * リブトーク全体で参照するドメイン定数。
+ *
+ * MVP では桃瀬ひより 1 キャラのみを扱うため characterId は固定値とする
+ * （`tasks/livetalk/external-design.md` 5 章「将来の拡張ポイント」も参照）。
+ */
+export const DEFAULT_CHARACTER_ID = 'hiyori';
+
+/**
+ * Message に付与する DynamoDB TTL（秒）。
+ * Phase 3 で圧縮要約に置き換わるまでの保持期間。
+ */
+export const MESSAGE_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+/**
+ * LLM プロンプトに渡せるコンテキストのトークン上限の既定値。
+ * 環境変数 `LLM_CONTEXT_TOKEN_LIMIT` で上書きできる。
+ */
+export const DEFAULT_LLM_CONTEXT_TOKEN_LIMIT = 40_000;
+
+/**
+ * トークン上限ベースのスキャンで 1 ページに読み込むメッセージ件数。
+ * 上限到達時に余分な RCU を消費しないよう小さめに設定する。
+ */
+export const TOKEN_BUDGETED_QUERY_PAGE_SIZE = 50;

--- a/services/livetalk/core/src/entities/character-state.entity.ts
+++ b/services/livetalk/core/src/entities/character-state.entity.ts
@@ -2,18 +2,17 @@
  * ユーザー × キャラの状態。
  *
  * `tasks/livetalk/design.md` 3.1 / 3.2 節の `CharacterState` に対応。
- * 親密度・サイクルなどの本格的な値は Phase 3 以降で拡張するが、Phase 2a の段階で
- * Repository 抽象を用意して将来の追加に備える。
+ *
+ * Phase 2a スコープでは Repository 抽象とキー設計の確立のみが目的。
+ * 親密度（`AffectionLevel`）/ オンボーディングフラグ（`Onboarded`）は
+ * それぞれ Phase 3（記憶と性格の育成）/ Phase 2e（規約 + 18 歳同意）で
+ * 利用が始まるため、必要になった段階で attribute を追加する方針。
  */
 export interface CharacterStateEntity {
   UserID: string;
   CharacterID: string;
-  /** 親密度（上昇のみ。Phase 2a では既定値 0 を入れて Phase 3 で更新する） */
-  AffectionLevel: number;
   /** 最終インタラクション時刻（Unix ms） */
   LastInteractionAt: number;
-  /** オンボーディング完了フラグ */
-  Onboarded: boolean;
   CreatedAt: number;
   UpdatedAt: number;
 }
@@ -24,6 +23,4 @@ export interface CharacterStateKey {
 }
 
 export type CreateCharacterStateInput = Omit<CharacterStateEntity, 'CreatedAt' | 'UpdatedAt'>;
-export type UpdateCharacterStateInput = Partial<
-  Pick<CharacterStateEntity, 'AffectionLevel' | 'LastInteractionAt' | 'Onboarded'>
->;
+export type UpdateCharacterStateInput = Partial<Pick<CharacterStateEntity, 'LastInteractionAt'>>;

--- a/services/livetalk/core/src/entities/character-state.entity.ts
+++ b/services/livetalk/core/src/entities/character-state.entity.ts
@@ -1,0 +1,29 @@
+/**
+ * ユーザー × キャラの状態。
+ *
+ * `tasks/livetalk/design.md` 3.1 / 3.2 節の `CharacterState` に対応。
+ * 親密度・サイクルなどの本格的な値は Phase 3 以降で拡張するが、Phase 2a の段階で
+ * Repository 抽象を用意して将来の追加に備える。
+ */
+export interface CharacterStateEntity {
+  UserID: string;
+  CharacterID: string;
+  /** 親密度（上昇のみ。Phase 2a では既定値 0 を入れて Phase 3 で更新する） */
+  AffectionLevel: number;
+  /** 最終インタラクション時刻（Unix ms） */
+  LastInteractionAt: number;
+  /** オンボーディング完了フラグ */
+  Onboarded: boolean;
+  CreatedAt: number;
+  UpdatedAt: number;
+}
+
+export interface CharacterStateKey {
+  userId: string;
+  characterId: string;
+}
+
+export type CreateCharacterStateInput = Omit<CharacterStateEntity, 'CreatedAt' | 'UpdatedAt'>;
+export type UpdateCharacterStateInput = Partial<
+  Pick<CharacterStateEntity, 'AffectionLevel' | 'LastInteractionAt' | 'Onboarded'>
+>;

--- a/services/livetalk/core/src/entities/message.entity.ts
+++ b/services/livetalk/core/src/entities/message.entity.ts
@@ -4,10 +4,13 @@
  * `tasks/livetalk/design.md` 3.1 / 3.2 節に対応：
  *   - 1 メッセージ = 1 item（配列保持禁止）
  *   - 並べ替え用 ID は ULID（時系列順）
- *   - audio S3 key / 各種メタは optional
  *
  * DynamoDB 上の attribute はすべて PascalCase（プラットフォーム共通ルール）で
  * 保存する。エンティティ側もそれに合わせて PascalCase で表現している。
+ *
+ * Phase 2a スコープでは音声 / トークン / レイテンシ / モーション系のメタは
+ * 保持しない（design.md の `meta` 相当）。Phase 2c の LLM 統合 / VOICEVOX
+ * パイプライン構築時に必要なフィールドだけ追加する方針。
  */
 export interface MessageEntity {
   /** ユーザー識別子（Google ID をそのまま使う） */
@@ -20,14 +23,6 @@ export interface MessageEntity {
   Role: 'user' | 'assistant';
   /** メッセージ本文 */
   Text: string;
-  /** 合成音声を保管する S3 key（任意、Phase 2c 以降で利用） */
-  AudioS3Key?: string;
-  /** LLM で消費したトークン数（任意、Phase 2c 以降で利用） */
-  TokenCount?: number;
-  /** 応答時間 ms（任意、Phase 2c 以降で利用） */
-  LatencyMs?: number;
-  /** 採用したモーション名（任意、Phase 2c 以降で利用） */
-  MotionUsed?: string;
   /** 作成 / 更新時刻（Unix ms） */
   CreatedAt: number;
   UpdatedAt: number;

--- a/services/livetalk/core/src/entities/message.entity.ts
+++ b/services/livetalk/core/src/entities/message.entity.ts
@@ -1,0 +1,52 @@
+/**
+ * 会話メッセージ 1 件を表すビジネスオブジェクト。
+ *
+ * `tasks/livetalk/design.md` 3.1 / 3.2 節に対応：
+ *   - 1 メッセージ = 1 item（配列保持禁止）
+ *   - 並べ替え用 ID は ULID（時系列順）
+ *   - audio S3 key / 各種メタは optional
+ *
+ * DynamoDB 上の attribute はすべて PascalCase（プラットフォーム共通ルール）で
+ * 保存する。エンティティ側もそれに合わせて PascalCase で表現している。
+ */
+export interface MessageEntity {
+  /** ユーザー識別子（Google ID をそのまま使う） */
+  UserID: string;
+  /** キャラクター識別子（例: `hiyori`） */
+  CharacterID: string;
+  /** メッセージ ID（ULID、時系列ソート可能） */
+  MessageID: string;
+  /** 発言者 */
+  Role: 'user' | 'assistant';
+  /** メッセージ本文 */
+  Text: string;
+  /** 合成音声を保管する S3 key（任意、Phase 2c 以降で利用） */
+  AudioS3Key?: string;
+  /** LLM で消費したトークン数（任意、Phase 2c 以降で利用） */
+  TokenCount?: number;
+  /** 応答時間 ms（任意、Phase 2c 以降で利用） */
+  LatencyMs?: number;
+  /** 採用したモーション名（任意、Phase 2c 以降で利用） */
+  MotionUsed?: string;
+  /** 作成 / 更新時刻（Unix ms） */
+  CreatedAt: number;
+  UpdatedAt: number;
+}
+
+/**
+ * 単一メッセージを取得する際のキー。
+ */
+export interface MessageKey {
+  userId: string;
+  characterId: string;
+  messageId: string;
+}
+
+/**
+ * メッセージ作成入力（`CreatedAt` / `UpdatedAt` はリポジトリ側で付与）。
+ * MessageID も省略可能：未指定なら ULID を自動採番する。
+ */
+export type CreateMessageInput = Omit<MessageEntity, 'MessageID' | 'CreatedAt' | 'UpdatedAt'> & {
+  /** 明示的に ULID を指定したい場合のみ渡す（テスト用途） */
+  MessageID?: string;
+};

--- a/services/livetalk/core/src/entities/profile.entity.ts
+++ b/services/livetalk/core/src/entities/profile.entity.ts
@@ -1,21 +1,21 @@
 /**
- * ユーザープロファイル（リブトーク内部で保持する最小情報）。
+ * リブトークが独自に保持するユーザープロファイル。
  *
- * `tasks/livetalk/design.md` 3.1 / 3.2 節 の `User` に対応する。
- * Auth サービスの session から得られる情報を必要に応じてキャッシュする位置づけ。
+ * 表示名 / メール / Google ID 等の認証側情報はここに持たない：
+ *   - Google ID は `UserID` と同値（セッションの `user.googleId` をそのまま使う）ため重複
+ *   - 表示名 / メールは Auth サービスのセッションから都度取得できる
+ *   - PII を LiveTalk 側に複製しないことで漏洩時の影響範囲を縮小する
+ *
+ * よって LiveTalk が単独で必要とする属性のみ保持する：
+ *   - 最初にリブトークを開いた時刻（`CreatedAt`）
+ *   - 最後にリブトークを開いた時刻（`LastActiveAt`、久しぶり挨拶等で参照）
  */
 export interface ProfileEntity {
-  /** ユーザー識別子（Google ID） */
+  /** ユーザー識別子（= Google ID。セッションから供給される） */
   UserID: string;
-  /** Google ID（UserID と同値でも明示的に持つ：将来の認証方式拡張時の保険） */
-  GoogleID: string;
-  /** 表示名（Google プロフィール由来） */
-  DisplayName: string;
-  /** Email（PII：ログ等への露出禁止） */
-  Email: string;
   /** 最終アクセス時刻（Unix ms） */
   LastActiveAt: number;
-  /** 作成 / 更新時刻（Unix ms） */
+  /** リブトーク初回登録時刻 / 更新時刻（Unix ms） */
   CreatedAt: number;
   UpdatedAt: number;
 }
@@ -24,7 +24,18 @@ export interface ProfileKey {
   userId: string;
 }
 
-export type CreateProfileInput = Omit<ProfileEntity, 'CreatedAt' | 'UpdatedAt'>;
-export type UpdateProfileInput = Partial<
-  Pick<ProfileEntity, 'DisplayName' | 'Email' | 'LastActiveAt'>
->;
+/**
+ * 初回登録時の入力。
+ * `LastActiveAt` を省略した場合は呼び出し時刻が採用される。
+ */
+export interface CreateProfileInput {
+  UserID: string;
+  LastActiveAt?: number;
+}
+
+/**
+ * 既存プロファイルへの差分更新。Phase 2a では `LastActiveAt` のみ。
+ */
+export interface UpdateProfileInput {
+  LastActiveAt?: number;
+}

--- a/services/livetalk/core/src/entities/profile.entity.ts
+++ b/services/livetalk/core/src/entities/profile.entity.ts
@@ -1,0 +1,30 @@
+/**
+ * ユーザープロファイル（リブトーク内部で保持する最小情報）。
+ *
+ * `tasks/livetalk/design.md` 3.1 / 3.2 節 の `User` に対応する。
+ * Auth サービスの session から得られる情報を必要に応じてキャッシュする位置づけ。
+ */
+export interface ProfileEntity {
+  /** ユーザー識別子（Google ID） */
+  UserID: string;
+  /** Google ID（UserID と同値でも明示的に持つ：将来の認証方式拡張時の保険） */
+  GoogleID: string;
+  /** 表示名（Google プロフィール由来） */
+  DisplayName: string;
+  /** Email（PII：ログ等への露出禁止） */
+  Email: string;
+  /** 最終アクセス時刻（Unix ms） */
+  LastActiveAt: number;
+  /** 作成 / 更新時刻（Unix ms） */
+  CreatedAt: number;
+  UpdatedAt: number;
+}
+
+export interface ProfileKey {
+  userId: string;
+}
+
+export type CreateProfileInput = Omit<ProfileEntity, 'CreatedAt' | 'UpdatedAt'>;
+export type UpdateProfileInput = Partial<
+  Pick<ProfileEntity, 'DisplayName' | 'Email' | 'LastActiveAt'>
+>;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -1,1 +1,58 @@
 export * from './voicevox/index.js';
+export * from './constants.js';
+
+// Entities
+export type { MessageEntity, MessageKey, CreateMessageInput } from './entities/message.entity.js';
+export type {
+  ProfileEntity,
+  ProfileKey,
+  CreateProfileInput,
+  UpdateProfileInput,
+} from './entities/profile.entity.js';
+export type {
+  CharacterStateEntity,
+  CharacterStateKey,
+  CreateCharacterStateInput,
+  UpdateCharacterStateInput,
+} from './entities/character-state.entity.js';
+
+// Mappers
+export { MessageMapper } from './mappers/message.mapper.js';
+export { ProfileMapper } from './mappers/profile.mapper.js';
+export { CharacterStateMapper } from './mappers/character-state.mapper.js';
+export {
+  buildUserPK,
+  buildProfileSK,
+  buildCharacterStateSK,
+  buildMessageSK,
+  buildMessageSKPrefix,
+} from './mappers/keys.js';
+
+// Repository interfaces
+export type {
+  MessageRepository,
+  GetRecentByTokenBudgetOptions,
+  RecentMessagesResult,
+} from './repositories/message.repository.interface.js';
+export type { ProfileRepository } from './repositories/profile.repository.interface.js';
+export type { CharacterStateRepository } from './repositories/character-state.repository.interface.js';
+
+// Repository implementations
+export { DynamoDBMessageRepository } from './repositories/dynamodb-message.repository.js';
+export { DynamoDBProfileRepository } from './repositories/dynamodb-profile.repository.js';
+export { DynamoDBCharacterStateRepository } from './repositories/dynamodb-character-state.repository.js';
+export { InMemoryMessageRepository } from './repositories/in-memory-message.repository.js';
+export { InMemoryProfileRepository } from './repositories/in-memory-profile.repository.js';
+export { InMemoryCharacterStateRepository } from './repositories/in-memory-character-state.repository.js';
+
+// Token counter
+export {
+  TiktokenCounter,
+  getDefaultTokenCounter,
+  resolveContextTokenLimit,
+  setTokenCounterForTesting,
+  type TokenCounter,
+} from './lib/token-counter.js';
+
+// ULID factory（テストで差し替え可能にしておく）
+export { defaultUlidFactory, type UlidFactory } from './lib/ulid.js';

--- a/services/livetalk/core/src/lib/token-counter.ts
+++ b/services/livetalk/core/src/lib/token-counter.ts
@@ -1,0 +1,91 @@
+import { encodingForModel, type Tiktoken, type TiktokenModel } from 'js-tiktoken';
+import { DEFAULT_LLM_CONTEXT_TOKEN_LIMIT } from '../constants.js';
+
+/**
+ * テキストのトークン数を見積もるカウンタ。
+ *
+ * Phase 2a では「直近メッセージをトークン上限ベースで取得する」要件のためだけに
+ * 利用する。Phase 2c で LLM 統合される際にも同じインスタンスを再利用できる。
+ */
+export interface TokenCounter {
+  /**
+   * メッセージ 1 件分のテキストのトークン数を返す（純粋関数）。
+   */
+  countTokens(text: string): number;
+  /**
+   * メッセージのオーバーヘッド（role tag 等）を含めた概算トークン数を返す。
+   * LLM プロンプト構築の正確性は Phase 2c で精緻化するため、ここでは
+   * 「テキストのトークン数 + 4」程度のラフな見積もりとする
+   * （OpenAI の Chat Completions のトークン換算ガイドに準拠した既定値）。
+   */
+  countTokensForMessage(text: string): number;
+}
+
+/**
+ * 既定モデル。コスト・速度のトレードオフから Phase 2c で会話用に
+ * `gpt-4o` を採用する予定のため、トークン換算もそれに合わせる。
+ */
+const DEFAULT_MODEL: TiktokenModel = 'gpt-4o';
+
+/**
+ * 1 メッセージあたりに加算する固定オーバーヘッド（OpenAI 公式 cookbook 由来）。
+ */
+const PER_MESSAGE_OVERHEAD_TOKENS = 4;
+
+export class TiktokenCounter implements TokenCounter {
+  private readonly encoder: Tiktoken;
+
+  constructor(model: TiktokenModel = DEFAULT_MODEL) {
+    this.encoder = encodingForModel(model);
+  }
+
+  public countTokens(text: string): number {
+    if (!text) return 0;
+    return this.encoder.encode(text).length;
+  }
+
+  public countTokensForMessage(text: string): number {
+    return this.countTokens(text) + PER_MESSAGE_OVERHEAD_TOKENS;
+  }
+}
+
+/**
+ * シングルトン的に取り回すためのキャッシュ。
+ * `js-tiktoken` のエンコーダ生成は数 MB の BPE テーブル読み込みを含むため、
+ * リクエストごとの再生成を避ける。
+ */
+let cachedCounter: TokenCounter | null = null;
+
+/**
+ * 既定のトークンカウンタ（`gpt-4o`）を返す。
+ * テスト等で差し替えたい場合は `setTokenCounterForTesting()` を利用する。
+ */
+export function getDefaultTokenCounter(): TokenCounter {
+  if (!cachedCounter) {
+    cachedCounter = new TiktokenCounter();
+  }
+  return cachedCounter;
+}
+
+export function setTokenCounterForTesting(counter: TokenCounter | null): void {
+  cachedCounter = counter;
+}
+
+/**
+ * 環境変数または定数からトークン上限を解決する。
+ *
+ * @param override 明示的に上限を指定する場合の値（テスト用）。
+ */
+export function resolveContextTokenLimit(override?: number): number {
+  if (override !== undefined && Number.isFinite(override) && override > 0) {
+    return override;
+  }
+  const fromEnv = process.env.LLM_CONTEXT_TOKEN_LIMIT;
+  if (fromEnv) {
+    const parsed = Number.parseInt(fromEnv, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_LLM_CONTEXT_TOKEN_LIMIT;
+}

--- a/services/livetalk/core/src/lib/ulid.ts
+++ b/services/livetalk/core/src/lib/ulid.ts
@@ -1,0 +1,12 @@
+import { ulid } from 'ulid';
+
+/**
+ * ULID 生成関数を抽象化するためのインターフェース。
+ * リポジトリ実装に DI 可能にしてテストで決定論的な ID を発行するための薄いラッパー。
+ */
+export type UlidFactory = (seedTime?: number) => string;
+
+/**
+ * デフォルト実装。Phase 2a では `ulid` パッケージをそのまま使う。
+ */
+export const defaultUlidFactory: UlidFactory = (seedTime) => ulid(seedTime);

--- a/services/livetalk/core/src/mappers/character-state.mapper.ts
+++ b/services/livetalk/core/src/mappers/character-state.mapper.ts
@@ -1,6 +1,4 @@
 import {
-  validateBooleanField,
-  validateNumberField,
   validateStringField,
   validateTimestampField,
   type DynamoDBItem,
@@ -26,9 +24,7 @@ export class CharacterStateMapper implements EntityMapper<CharacterStateEntity, 
       Type: this.entityType,
       UserID: entity.UserID,
       CharacterID: entity.CharacterID,
-      AffectionLevel: entity.AffectionLevel,
       LastInteractionAt: entity.LastInteractionAt,
-      Onboarded: entity.Onboarded,
       CreatedAt: entity.CreatedAt,
       UpdatedAt: entity.UpdatedAt,
     };
@@ -38,9 +34,7 @@ export class CharacterStateMapper implements EntityMapper<CharacterStateEntity, 
     return {
       UserID: validateStringField(item.UserID, 'UserID'),
       CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
-      AffectionLevel: validateNumberField(item.AffectionLevel, 'AffectionLevel', { min: 0 }),
       LastInteractionAt: validateTimestampField(item.LastInteractionAt, 'LastInteractionAt'),
-      Onboarded: validateBooleanField(item.Onboarded, 'Onboarded'),
       CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
       UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
     };

--- a/services/livetalk/core/src/mappers/character-state.mapper.ts
+++ b/services/livetalk/core/src/mappers/character-state.mapper.ts
@@ -1,0 +1,55 @@
+import {
+  validateBooleanField,
+  validateNumberField,
+  validateStringField,
+  validateTimestampField,
+  type DynamoDBItem,
+  type EntityMapper,
+} from '@nagiyu/aws';
+import type {
+  CharacterStateEntity,
+  CharacterStateKey,
+} from '../entities/character-state.entity.js';
+import { buildCharacterStateSK, buildUserPK } from './keys.js';
+
+export class CharacterStateMapper implements EntityMapper<CharacterStateEntity, CharacterStateKey> {
+  public readonly entityType = 'CharacterState';
+
+  public toItem(entity: CharacterStateEntity): DynamoDBItem {
+    const { pk, sk } = this.buildKeys({
+      userId: entity.UserID,
+      characterId: entity.CharacterID,
+    });
+    return {
+      PK: pk,
+      SK: sk,
+      Type: this.entityType,
+      UserID: entity.UserID,
+      CharacterID: entity.CharacterID,
+      AffectionLevel: entity.AffectionLevel,
+      LastInteractionAt: entity.LastInteractionAt,
+      Onboarded: entity.Onboarded,
+      CreatedAt: entity.CreatedAt,
+      UpdatedAt: entity.UpdatedAt,
+    };
+  }
+
+  public toEntity(item: DynamoDBItem): CharacterStateEntity {
+    return {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
+      AffectionLevel: validateNumberField(item.AffectionLevel, 'AffectionLevel', { min: 0 }),
+      LastInteractionAt: validateTimestampField(item.LastInteractionAt, 'LastInteractionAt'),
+      Onboarded: validateBooleanField(item.Onboarded, 'Onboarded'),
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
+    };
+  }
+
+  public buildKeys(key: CharacterStateKey): { pk: string; sk: string } {
+    return {
+      pk: buildUserPK(key.userId),
+      sk: buildCharacterStateSK(key.characterId),
+    };
+  }
+}

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -1,0 +1,30 @@
+/**
+ * Single Table 設計の PK / SK を組み立てるための共通ヘルパー。
+ *
+ * 設計は `tasks/livetalk/design.md` 3.2 節「SK パターン一覧」に準拠する。
+ * PK は全エンティティで `USER#<googleId>` に統一する。
+ */
+
+export function buildUserPK(userId: string): string {
+  return `USER#${userId}`;
+}
+
+export function buildProfileSK(): string {
+  return 'PROFILE';
+}
+
+export function buildCharacterStateSK(characterId: string): string {
+  return `CHAR#${characterId}#STATE`;
+}
+
+/**
+ * メッセージ範囲クエリ用の SK プレフィックス。
+ * `begins_with(SK, prefix)` で 1 キャラ分のメッセージのみを抽出する。
+ */
+export function buildMessageSKPrefix(characterId: string): string {
+  return `CHAR#${characterId}#MSG#`;
+}
+
+export function buildMessageSK(characterId: string, messageId: string): string {
+  return `${buildMessageSKPrefix(characterId)}${messageId}`;
+}

--- a/services/livetalk/core/src/mappers/message.mapper.ts
+++ b/services/livetalk/core/src/mappers/message.mapper.ts
@@ -1,7 +1,6 @@
 import {
-  validateStringField,
-  validateNumberField,
   validateEnumField,
+  validateStringField,
   validateTimestampField,
   type DynamoDBItem,
   type EntityMapper,
@@ -22,7 +21,7 @@ export class MessageMapper implements EntityMapper<MessageEntity, MessageKey> {
       messageId: entity.MessageID,
     });
 
-    const item: DynamoDBItem = {
+    return {
       PK: pk,
       SK: sk,
       Type: this.entityType,
@@ -34,27 +33,12 @@ export class MessageMapper implements EntityMapper<MessageEntity, MessageKey> {
       CreatedAt: entity.CreatedAt,
       UpdatedAt: entity.UpdatedAt,
     };
-
-    if (entity.AudioS3Key !== undefined) {
-      item.AudioS3Key = entity.AudioS3Key;
-    }
-    if (entity.TokenCount !== undefined) {
-      item.TokenCount = entity.TokenCount;
-    }
-    if (entity.LatencyMs !== undefined) {
-      item.LatencyMs = entity.LatencyMs;
-    }
-    if (entity.MotionUsed !== undefined) {
-      item.MotionUsed = entity.MotionUsed;
-    }
-
-    return item;
   }
 
   public toEntity(item: DynamoDBItem): MessageEntity {
     const role = validateEnumField(item.Role, 'Role', ['user', 'assistant'] as const);
 
-    const entity: MessageEntity = {
+    return {
       UserID: validateStringField(item.UserID, 'UserID'),
       CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
       MessageID: validateStringField(item.MessageID, 'MessageID'),
@@ -64,21 +48,6 @@ export class MessageMapper implements EntityMapper<MessageEntity, MessageKey> {
       CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
       UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
     };
-
-    if (item.AudioS3Key !== undefined) {
-      entity.AudioS3Key = validateStringField(item.AudioS3Key, 'AudioS3Key');
-    }
-    if (item.TokenCount !== undefined) {
-      entity.TokenCount = validateNumberField(item.TokenCount, 'TokenCount');
-    }
-    if (item.LatencyMs !== undefined) {
-      entity.LatencyMs = validateNumberField(item.LatencyMs, 'LatencyMs');
-    }
-    if (item.MotionUsed !== undefined) {
-      entity.MotionUsed = validateStringField(item.MotionUsed, 'MotionUsed');
-    }
-
-    return entity;
   }
 
   public buildKeys(key: MessageKey): { pk: string; sk: string } {

--- a/services/livetalk/core/src/mappers/message.mapper.ts
+++ b/services/livetalk/core/src/mappers/message.mapper.ts
@@ -1,0 +1,90 @@
+import {
+  validateStringField,
+  validateNumberField,
+  validateEnumField,
+  validateTimestampField,
+  type DynamoDBItem,
+  type EntityMapper,
+} from '@nagiyu/aws';
+import type { MessageEntity, MessageKey } from '../entities/message.entity.js';
+import { buildMessageSK, buildUserPK } from './keys.js';
+
+/**
+ * `MessageEntity ↔ DynamoDB Item` の変換と PK/SK 組み立てを担当する Mapper。
+ */
+export class MessageMapper implements EntityMapper<MessageEntity, MessageKey> {
+  public readonly entityType = 'Message';
+
+  public toItem(entity: MessageEntity): DynamoDBItem {
+    const { pk, sk } = this.buildKeys({
+      userId: entity.UserID,
+      characterId: entity.CharacterID,
+      messageId: entity.MessageID,
+    });
+
+    const item: DynamoDBItem = {
+      PK: pk,
+      SK: sk,
+      Type: this.entityType,
+      UserID: entity.UserID,
+      CharacterID: entity.CharacterID,
+      MessageID: entity.MessageID,
+      Role: entity.Role,
+      Text: entity.Text,
+      CreatedAt: entity.CreatedAt,
+      UpdatedAt: entity.UpdatedAt,
+    };
+
+    if (entity.AudioS3Key !== undefined) {
+      item.AudioS3Key = entity.AudioS3Key;
+    }
+    if (entity.TokenCount !== undefined) {
+      item.TokenCount = entity.TokenCount;
+    }
+    if (entity.LatencyMs !== undefined) {
+      item.LatencyMs = entity.LatencyMs;
+    }
+    if (entity.MotionUsed !== undefined) {
+      item.MotionUsed = entity.MotionUsed;
+    }
+
+    return item;
+  }
+
+  public toEntity(item: DynamoDBItem): MessageEntity {
+    const role = validateEnumField(item.Role, 'Role', ['user', 'assistant'] as const);
+
+    const entity: MessageEntity = {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
+      MessageID: validateStringField(item.MessageID, 'MessageID'),
+      Role: role,
+      // Text は空文字を許可する（例: モデルがエラーで空応答した場合のログ性質）。
+      Text: validateStringField(item.Text, 'Text', { allowEmpty: true }),
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
+    };
+
+    if (item.AudioS3Key !== undefined) {
+      entity.AudioS3Key = validateStringField(item.AudioS3Key, 'AudioS3Key');
+    }
+    if (item.TokenCount !== undefined) {
+      entity.TokenCount = validateNumberField(item.TokenCount, 'TokenCount');
+    }
+    if (item.LatencyMs !== undefined) {
+      entity.LatencyMs = validateNumberField(item.LatencyMs, 'LatencyMs');
+    }
+    if (item.MotionUsed !== undefined) {
+      entity.MotionUsed = validateStringField(item.MotionUsed, 'MotionUsed');
+    }
+
+    return entity;
+  }
+
+  public buildKeys(key: MessageKey): { pk: string; sk: string } {
+    return {
+      pk: buildUserPK(key.userId),
+      sk: buildMessageSK(key.characterId, key.messageId),
+    };
+  }
+}

--- a/services/livetalk/core/src/mappers/profile.mapper.ts
+++ b/services/livetalk/core/src/mappers/profile.mapper.ts
@@ -1,0 +1,48 @@
+import {
+  validateStringField,
+  validateTimestampField,
+  type DynamoDBItem,
+  type EntityMapper,
+} from '@nagiyu/aws';
+import type { ProfileEntity, ProfileKey } from '../entities/profile.entity.js';
+import { buildProfileSK, buildUserPK } from './keys.js';
+
+export class ProfileMapper implements EntityMapper<ProfileEntity, ProfileKey> {
+  public readonly entityType = 'Profile';
+
+  public toItem(entity: ProfileEntity): DynamoDBItem {
+    const { pk, sk } = this.buildKeys({ userId: entity.UserID });
+    return {
+      PK: pk,
+      SK: sk,
+      Type: this.entityType,
+      UserID: entity.UserID,
+      GoogleID: entity.GoogleID,
+      DisplayName: entity.DisplayName,
+      Email: entity.Email,
+      LastActiveAt: entity.LastActiveAt,
+      CreatedAt: entity.CreatedAt,
+      UpdatedAt: entity.UpdatedAt,
+    };
+  }
+
+  public toEntity(item: DynamoDBItem): ProfileEntity {
+    return {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      GoogleID: validateStringField(item.GoogleID, 'GoogleID'),
+      // DisplayName は Google アカウントによっては空のことがあるため empty 許容。
+      DisplayName: validateStringField(item.DisplayName, 'DisplayName', { allowEmpty: true }),
+      Email: validateStringField(item.Email, 'Email', { allowEmpty: true }),
+      LastActiveAt: validateTimestampField(item.LastActiveAt, 'LastActiveAt'),
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
+    };
+  }
+
+  public buildKeys(key: ProfileKey): { pk: string; sk: string } {
+    return {
+      pk: buildUserPK(key.userId),
+      sk: buildProfileSK(),
+    };
+  }
+}

--- a/services/livetalk/core/src/mappers/profile.mapper.ts
+++ b/services/livetalk/core/src/mappers/profile.mapper.ts
@@ -17,9 +17,6 @@ export class ProfileMapper implements EntityMapper<ProfileEntity, ProfileKey> {
       SK: sk,
       Type: this.entityType,
       UserID: entity.UserID,
-      GoogleID: entity.GoogleID,
-      DisplayName: entity.DisplayName,
-      Email: entity.Email,
       LastActiveAt: entity.LastActiveAt,
       CreatedAt: entity.CreatedAt,
       UpdatedAt: entity.UpdatedAt,
@@ -29,10 +26,6 @@ export class ProfileMapper implements EntityMapper<ProfileEntity, ProfileKey> {
   public toEntity(item: DynamoDBItem): ProfileEntity {
     return {
       UserID: validateStringField(item.UserID, 'UserID'),
-      GoogleID: validateStringField(item.GoogleID, 'GoogleID'),
-      // DisplayName は Google アカウントによっては空のことがあるため empty 許容。
-      DisplayName: validateStringField(item.DisplayName, 'DisplayName', { allowEmpty: true }),
-      Email: validateStringField(item.Email, 'Email', { allowEmpty: true }),
       LastActiveAt: validateTimestampField(item.LastActiveAt, 'LastActiveAt'),
       CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
       UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),

--- a/services/livetalk/core/src/repositories/character-state.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/character-state.repository.interface.ts
@@ -1,0 +1,17 @@
+import type {
+  CharacterStateEntity,
+  CharacterStateKey,
+  CreateCharacterStateInput,
+  UpdateCharacterStateInput,
+} from '../entities/character-state.entity.js';
+
+/**
+ * ユーザー × キャラの状態リポジトリ。
+ */
+export interface CharacterStateRepository {
+  getById(key: CharacterStateKey): Promise<CharacterStateEntity | null>;
+  upsert(
+    input: CreateCharacterStateInput,
+    updates?: UpdateCharacterStateInput
+  ): Promise<CharacterStateEntity>;
+}

--- a/services/livetalk/core/src/repositories/dynamodb-character-state.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-character-state.repository.ts
@@ -56,9 +56,7 @@ export class DynamoDBCharacterStateRepository implements CharacterStateRepositor
     const merged: CharacterStateEntity = {
       UserID: input.UserID,
       CharacterID: input.CharacterID,
-      AffectionLevel: updates.AffectionLevel ?? input.AffectionLevel,
       LastInteractionAt: updates.LastInteractionAt ?? input.LastInteractionAt,
-      Onboarded: updates.Onboarded ?? input.Onboarded,
       CreatedAt: existing?.CreatedAt ?? now,
       UpdatedAt: now,
     };

--- a/services/livetalk/core/src/repositories/dynamodb-character-state.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-character-state.repository.ts
@@ -1,0 +1,79 @@
+import { GetCommand, PutCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
+import type {
+  CharacterStateEntity,
+  CharacterStateKey,
+  CreateCharacterStateInput,
+  UpdateCharacterStateInput,
+} from '../entities/character-state.entity.js';
+import { CharacterStateMapper } from '../mappers/character-state.mapper.js';
+import type { CharacterStateRepository } from './character-state.repository.interface.js';
+
+export class DynamoDBCharacterStateRepository implements CharacterStateRepository {
+  private readonly mapper: CharacterStateMapper;
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly nowMs: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.nowMs = nowMs;
+    this.mapper = new CharacterStateMapper();
+  }
+
+  public async getById(key: CharacterStateKey): Promise<CharacterStateEntity | null> {
+    try {
+      const { pk, sk } = this.mapper.buildKeys(key);
+      const result = await this.docClient.send(
+        new GetCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+        })
+      );
+      if (!result.Item) return null;
+      return this.mapper.toEntity(result.Item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async upsert(
+    input: CreateCharacterStateInput,
+    updates: UpdateCharacterStateInput = {}
+  ): Promise<CharacterStateEntity> {
+    const now = this.nowMs();
+    const existing = await this.getById({
+      userId: input.UserID,
+      characterId: input.CharacterID,
+    });
+
+    const merged: CharacterStateEntity = {
+      UserID: input.UserID,
+      CharacterID: input.CharacterID,
+      AffectionLevel: updates.AffectionLevel ?? input.AffectionLevel,
+      LastInteractionAt: updates.LastInteractionAt ?? input.LastInteractionAt,
+      Onboarded: updates.Onboarded ?? input.Onboarded,
+      CreatedAt: existing?.CreatedAt ?? now,
+      UpdatedAt: now,
+    };
+
+    try {
+      await this.docClient.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: this.mapper.toItem(merged),
+        })
+      );
+      return merged;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+}

--- a/services/livetalk/core/src/repositories/dynamodb-message.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-message.repository.ts
@@ -1,0 +1,190 @@
+import {
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  type DynamoDBDocumentClient,
+  type QueryCommandOutput,
+} from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, EntityAlreadyExistsError, type DynamoDBItem } from '@nagiyu/aws';
+import { logger } from '@nagiyu/common';
+import { MESSAGE_TTL_SECONDS, TOKEN_BUDGETED_QUERY_PAGE_SIZE } from '../constants.js';
+import type { CreateMessageInput, MessageEntity, MessageKey } from '../entities/message.entity.js';
+import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+import { getDefaultTokenCounter, resolveContextTokenLimit } from '../lib/token-counter.js';
+import { MessageMapper } from '../mappers/message.mapper.js';
+import { buildMessageSKPrefix, buildUserPK } from '../mappers/keys.js';
+import type {
+  GetRecentByTokenBudgetOptions,
+  MessageRepository,
+  RecentMessagesResult,
+} from './message.repository.interface.js';
+
+const DEFAULT_HARD_LIMIT = 500;
+
+export class DynamoDBMessageRepository implements MessageRepository {
+  private readonly mapper: MessageMapper;
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly ulidFactory: UlidFactory;
+  private readonly nowMs: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    ulidFactory: UlidFactory = defaultUlidFactory,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.ulidFactory = ulidFactory;
+    this.nowMs = nowMs;
+    this.mapper = new MessageMapper();
+  }
+
+  public async create(input: CreateMessageInput): Promise<MessageEntity> {
+    const now = this.nowMs();
+    const messageId = input.MessageID ?? this.ulidFactory(now);
+
+    const entity: MessageEntity = {
+      ...input,
+      MessageID: messageId,
+      CreatedAt: now,
+      UpdatedAt: now,
+    };
+
+    const item: DynamoDBItem & { TTL: number } = {
+      ...this.mapper.toItem(entity),
+      // TTL は Unix 秒。Message は 90 日後に DynamoDB が自動削除する。
+      TTL: Math.floor(now / 1000) + MESSAGE_TTL_SECONDS,
+    };
+
+    try {
+      await this.docClient.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: item,
+          ConditionExpression: 'attribute_not_exists(PK)',
+        })
+      );
+      return entity;
+    } catch (error) {
+      if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
+        throw new EntityAlreadyExistsError(
+          this.mapper.entityType,
+          `${entity.UserID}#${entity.CharacterID}#${messageId}`
+        );
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async getById(key: MessageKey): Promise<MessageEntity | null> {
+    try {
+      const { pk, sk } = this.mapper.buildKeys(key);
+      const result = await this.docClient.send(
+        new GetCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+        })
+      );
+      if (!result.Item) return null;
+      return this.mapper.toEntity(result.Item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async getRecentByTokenBudget(
+    options: GetRecentByTokenBudgetOptions
+  ): Promise<RecentMessagesResult> {
+    const { userId, characterId } = options;
+    const tokenLimit = resolveContextTokenLimit(options.tokenLimit);
+    const tokenCounter = options.tokenCounter ?? getDefaultTokenCounter();
+    const hardLimit = options.hardLimit ?? DEFAULT_HARD_LIMIT;
+
+    const pk = buildUserPK(userId);
+    const skPrefix = buildMessageSKPrefix(characterId);
+
+    const collected: MessageEntity[] = [];
+    let totalTokens = 0;
+    let truncated = false;
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    while (collected.length < hardLimit) {
+      let result: QueryCommandOutput;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: {
+              '#pk': 'PK',
+              '#sk': 'SK',
+            },
+            ExpressionAttributeValues: {
+              ':pk': pk,
+              ':prefix': skPrefix,
+            },
+            // 新しい順にスキャンし、トークン上限到達で打ち切る
+            ScanIndexForward: false,
+            Limit: TOKEN_BUDGETED_QUERY_PAGE_SIZE,
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      const items = result.Items ?? [];
+      let pageExhausted = true;
+      for (const raw of items) {
+        let entity: MessageEntity;
+        try {
+          entity = this.mapper.toEntity(raw as unknown as DynamoDBItem);
+        } catch (error) {
+          // 単一アイテムの破損で全体を壊さない（既存リポジトリと同様の運用）。
+          const record = raw as Record<string, unknown>;
+          logger.warn('無効なメッセージデータをスキップしました', {
+            pk: record.PK,
+            sk: record.SK,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
+
+        const cost = tokenCounter.countTokensForMessage(entity.Text);
+        // 既に 1 件以上拾った後で上限超過なら、今のメッセージは含めずに打ち切る。
+        // まだ 0 件ならコンテキスト皆無を避けるため最初の 1 件は強制的に採用する。
+        if (collected.length > 0 && totalTokens + cost > tokenLimit) {
+          truncated = true;
+          pageExhausted = false;
+          break;
+        }
+        collected.push(entity);
+        totalTokens += cost;
+        if (collected.length >= hardLimit) {
+          // hardLimit に達した場合、まだ古いメッセージが残っていれば truncated 扱い
+          truncated = true;
+          pageExhausted = false;
+          break;
+        }
+      }
+
+      if (!pageExhausted) break;
+      if (!result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    // ULID 降順で集めたものを LLM プロンプト用に時系列昇順へ並べ直す。
+    collected.reverse();
+
+    return {
+      messages: collected,
+      totalTokens,
+      truncated,
+    };
+  }
+}

--- a/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
@@ -13,7 +13,7 @@ import type { ProfileRepository } from './profile.repository.interface.js';
  * DynamoDB Profile Repository。
  *
  * upsert は Put 1 回で十分なため、conditional 系は使わずに最新値で上書きする。
- * 既存値の `CreatedAt` を保持したい場合のみ Get → Put の 2 段書きを行う。
+ * 既存値の `CreatedAt` は維持するため Get → Put の 2 段書きとする。
  */
 export class DynamoDBProfileRepository implements ProfileRepository {
   private readonly mapper: ProfileMapper;
@@ -58,10 +58,7 @@ export class DynamoDBProfileRepository implements ProfileRepository {
 
     const merged: ProfileEntity = {
       UserID: input.UserID,
-      GoogleID: input.GoogleID,
-      DisplayName: updates.DisplayName ?? input.DisplayName,
-      Email: updates.Email ?? input.Email,
-      LastActiveAt: updates.LastActiveAt ?? input.LastActiveAt,
+      LastActiveAt: updates.LastActiveAt ?? input.LastActiveAt ?? now,
       CreatedAt: existing?.CreatedAt ?? now,
       UpdatedAt: now,
     };

--- a/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
@@ -1,0 +1,82 @@
+import { GetCommand, PutCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
+import type {
+  CreateProfileInput,
+  ProfileEntity,
+  ProfileKey,
+  UpdateProfileInput,
+} from '../entities/profile.entity.js';
+import { ProfileMapper } from '../mappers/profile.mapper.js';
+import type { ProfileRepository } from './profile.repository.interface.js';
+
+/**
+ * DynamoDB Profile Repository。
+ *
+ * upsert は Put 1 回で十分なため、conditional 系は使わずに最新値で上書きする。
+ * 既存値の `CreatedAt` を保持したい場合のみ Get → Put の 2 段書きを行う。
+ */
+export class DynamoDBProfileRepository implements ProfileRepository {
+  private readonly mapper: ProfileMapper;
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly nowMs: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.nowMs = nowMs;
+    this.mapper = new ProfileMapper();
+  }
+
+  public async getById(key: ProfileKey): Promise<ProfileEntity | null> {
+    try {
+      const { pk, sk } = this.mapper.buildKeys(key);
+      const result = await this.docClient.send(
+        new GetCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+        })
+      );
+      if (!result.Item) return null;
+      return this.mapper.toEntity(result.Item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async upsert(
+    input: CreateProfileInput,
+    updates: UpdateProfileInput = {}
+  ): Promise<ProfileEntity> {
+    const now = this.nowMs();
+    const existing = await this.getById({ userId: input.UserID });
+
+    const merged: ProfileEntity = {
+      UserID: input.UserID,
+      GoogleID: input.GoogleID,
+      DisplayName: updates.DisplayName ?? input.DisplayName,
+      Email: updates.Email ?? input.Email,
+      LastActiveAt: updates.LastActiveAt ?? input.LastActiveAt,
+      CreatedAt: existing?.CreatedAt ?? now,
+      UpdatedAt: now,
+    };
+
+    try {
+      await this.docClient.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: this.mapper.toItem(merged),
+        })
+      );
+      return merged;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-character-state.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-character-state.repository.ts
@@ -38,9 +38,7 @@ export class InMemoryCharacterStateRepository implements CharacterStateRepositor
     const merged: CharacterStateEntity = {
       UserID: input.UserID,
       CharacterID: input.CharacterID,
-      AffectionLevel: updates.AffectionLevel ?? input.AffectionLevel,
       LastInteractionAt: updates.LastInteractionAt ?? input.LastInteractionAt,
-      Onboarded: updates.Onboarded ?? input.Onboarded,
       CreatedAt: existing?.CreatedAt ?? now,
       UpdatedAt: now,
     };

--- a/services/livetalk/core/src/repositories/in-memory-character-state.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-character-state.repository.ts
@@ -1,0 +1,50 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import type {
+  CharacterStateEntity,
+  CharacterStateKey,
+  CreateCharacterStateInput,
+  UpdateCharacterStateInput,
+} from '../entities/character-state.entity.js';
+import { CharacterStateMapper } from '../mappers/character-state.mapper.js';
+import type { CharacterStateRepository } from './character-state.repository.interface.js';
+
+export class InMemoryCharacterStateRepository implements CharacterStateRepository {
+  private readonly mapper: CharacterStateMapper;
+  private readonly store: InMemorySingleTableStore;
+  private readonly nowMs: () => number;
+
+  constructor(store: InMemorySingleTableStore, nowMs: () => number = () => Date.now()) {
+    this.store = store;
+    this.nowMs = nowMs;
+    this.mapper = new CharacterStateMapper();
+  }
+
+  public async getById(key: CharacterStateKey): Promise<CharacterStateEntity | null> {
+    const { pk, sk } = this.mapper.buildKeys(key);
+    const item = this.store.get(pk, sk);
+    if (!item) return null;
+    return this.mapper.toEntity(item);
+  }
+
+  public async upsert(
+    input: CreateCharacterStateInput,
+    updates: UpdateCharacterStateInput = {}
+  ): Promise<CharacterStateEntity> {
+    const now = this.nowMs();
+    const existing = await this.getById({
+      userId: input.UserID,
+      characterId: input.CharacterID,
+    });
+    const merged: CharacterStateEntity = {
+      UserID: input.UserID,
+      CharacterID: input.CharacterID,
+      AffectionLevel: updates.AffectionLevel ?? input.AffectionLevel,
+      LastInteractionAt: updates.LastInteractionAt ?? input.LastInteractionAt,
+      Onboarded: updates.Onboarded ?? input.Onboarded,
+      CreatedAt: existing?.CreatedAt ?? now,
+      UpdatedAt: now,
+    };
+    this.store.put(this.mapper.toItem(merged));
+    return merged;
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-message.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-message.repository.ts
@@ -1,4 +1,4 @@
-import { EntityAlreadyExistsError, InMemorySingleTableStore, type DynamoDBItem } from '@nagiyu/aws';
+import { InMemorySingleTableStore, type DynamoDBItem } from '@nagiyu/aws';
 import { MESSAGE_TTL_SECONDS } from '../constants.js';
 import type { CreateMessageInput, MessageEntity, MessageKey } from '../entities/message.entity.js';
 import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
@@ -47,12 +47,9 @@ export class InMemoryMessageRepository implements MessageRepository {
       TTL: Math.floor(now / 1000) + MESSAGE_TTL_SECONDS,
     };
 
-    try {
-      this.store.put(item, { attributeNotExists: true });
-    } catch (error) {
-      if (error instanceof EntityAlreadyExistsError) throw error;
-      throw error;
-    }
+    // 既存（同一 ULID）の場合は store 側が `EntityAlreadyExistsError` を投げる。
+    // 呼び出し側でハンドリングする想定なのでここでは何もせず透過させる。
+    this.store.put(item, { attributeNotExists: true });
     return entity;
   }
 

--- a/services/livetalk/core/src/repositories/in-memory-message.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-message.repository.ts
@@ -1,0 +1,108 @@
+import { EntityAlreadyExistsError, InMemorySingleTableStore, type DynamoDBItem } from '@nagiyu/aws';
+import { MESSAGE_TTL_SECONDS } from '../constants.js';
+import type { CreateMessageInput, MessageEntity, MessageKey } from '../entities/message.entity.js';
+import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+import { getDefaultTokenCounter, resolveContextTokenLimit } from '../lib/token-counter.js';
+import { MessageMapper } from '../mappers/message.mapper.js';
+import { buildMessageSKPrefix, buildUserPK } from '../mappers/keys.js';
+import type {
+  GetRecentByTokenBudgetOptions,
+  MessageRepository,
+  RecentMessagesResult,
+} from './message.repository.interface.js';
+
+const DEFAULT_HARD_LIMIT = 500;
+
+export class InMemoryMessageRepository implements MessageRepository {
+  private readonly mapper: MessageMapper;
+  private readonly store: InMemorySingleTableStore;
+  private readonly ulidFactory: UlidFactory;
+  private readonly nowMs: () => number;
+
+  constructor(
+    store: InMemorySingleTableStore,
+    ulidFactory: UlidFactory = defaultUlidFactory,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.store = store;
+    this.ulidFactory = ulidFactory;
+    this.nowMs = nowMs;
+    this.mapper = new MessageMapper();
+  }
+
+  public async create(input: CreateMessageInput): Promise<MessageEntity> {
+    const now = this.nowMs();
+    const messageId = input.MessageID ?? this.ulidFactory(now);
+
+    const entity: MessageEntity = {
+      ...input,
+      MessageID: messageId,
+      CreatedAt: now,
+      UpdatedAt: now,
+    };
+
+    const baseItem = this.mapper.toItem(entity);
+    const item: DynamoDBItem & { TTL: number } = {
+      ...baseItem,
+      TTL: Math.floor(now / 1000) + MESSAGE_TTL_SECONDS,
+    };
+
+    try {
+      this.store.put(item, { attributeNotExists: true });
+    } catch (error) {
+      if (error instanceof EntityAlreadyExistsError) throw error;
+      throw error;
+    }
+    return entity;
+  }
+
+  public async getById(key: MessageKey): Promise<MessageEntity | null> {
+    const { pk, sk } = this.mapper.buildKeys(key);
+    const item = this.store.get(pk, sk);
+    if (!item) return null;
+    return this.mapper.toEntity(item);
+  }
+
+  public async getRecentByTokenBudget(
+    options: GetRecentByTokenBudgetOptions
+  ): Promise<RecentMessagesResult> {
+    const tokenLimit = resolveContextTokenLimit(options.tokenLimit);
+    const tokenCounter = options.tokenCounter ?? getDefaultTokenCounter();
+    const hardLimit = options.hardLimit ?? DEFAULT_HARD_LIMIT;
+
+    const pk = buildUserPK(options.userId);
+    const prefix = buildMessageSKPrefix(options.characterId);
+
+    // InMemorySingleTableStore.query は SK 昇順しか返さないので、自分で降順に並べ替える。
+    const { items } = this.store.query(
+      {
+        pk,
+        sk: { operator: 'begins_with', value: prefix },
+      },
+      { limit: Number.MAX_SAFE_INTEGER }
+    );
+    const descSorted = [...items].sort((a, b) => (a.SK < b.SK ? 1 : a.SK > b.SK ? -1 : 0));
+
+    const collected: MessageEntity[] = [];
+    let totalTokens = 0;
+    let truncated = false;
+
+    for (const raw of descSorted) {
+      const entity = this.mapper.toEntity(raw);
+      const cost = tokenCounter.countTokensForMessage(entity.Text);
+      if (collected.length > 0 && totalTokens + cost > tokenLimit) {
+        truncated = true;
+        break;
+      }
+      collected.push(entity);
+      totalTokens += cost;
+      if (collected.length >= hardLimit) {
+        truncated = true;
+        break;
+      }
+    }
+
+    collected.reverse();
+    return { messages: collected, totalTokens, truncated };
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-profile.repository.ts
@@ -34,10 +34,7 @@ export class InMemoryProfileRepository implements ProfileRepository {
     const existing = await this.getById({ userId: input.UserID });
     const merged: ProfileEntity = {
       UserID: input.UserID,
-      GoogleID: input.GoogleID,
-      DisplayName: updates.DisplayName ?? input.DisplayName,
-      Email: updates.Email ?? input.Email,
-      LastActiveAt: updates.LastActiveAt ?? input.LastActiveAt,
+      LastActiveAt: updates.LastActiveAt ?? input.LastActiveAt ?? now,
       CreatedAt: existing?.CreatedAt ?? now,
       UpdatedAt: now,
     };

--- a/services/livetalk/core/src/repositories/in-memory-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-profile.repository.ts
@@ -1,0 +1,47 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import type {
+  CreateProfileInput,
+  ProfileEntity,
+  ProfileKey,
+  UpdateProfileInput,
+} from '../entities/profile.entity.js';
+import { ProfileMapper } from '../mappers/profile.mapper.js';
+import type { ProfileRepository } from './profile.repository.interface.js';
+
+export class InMemoryProfileRepository implements ProfileRepository {
+  private readonly mapper: ProfileMapper;
+  private readonly store: InMemorySingleTableStore;
+  private readonly nowMs: () => number;
+
+  constructor(store: InMemorySingleTableStore, nowMs: () => number = () => Date.now()) {
+    this.store = store;
+    this.nowMs = nowMs;
+    this.mapper = new ProfileMapper();
+  }
+
+  public async getById(key: ProfileKey): Promise<ProfileEntity | null> {
+    const { pk, sk } = this.mapper.buildKeys(key);
+    const item = this.store.get(pk, sk);
+    if (!item) return null;
+    return this.mapper.toEntity(item);
+  }
+
+  public async upsert(
+    input: CreateProfileInput,
+    updates: UpdateProfileInput = {}
+  ): Promise<ProfileEntity> {
+    const now = this.nowMs();
+    const existing = await this.getById({ userId: input.UserID });
+    const merged: ProfileEntity = {
+      UserID: input.UserID,
+      GoogleID: input.GoogleID,
+      DisplayName: updates.DisplayName ?? input.DisplayName,
+      Email: updates.Email ?? input.Email,
+      LastActiveAt: updates.LastActiveAt ?? input.LastActiveAt,
+      CreatedAt: existing?.CreatedAt ?? now,
+      UpdatedAt: now,
+    };
+    this.store.put(this.mapper.toItem(merged));
+    return merged;
+  }
+}

--- a/services/livetalk/core/src/repositories/message.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/message.repository.interface.ts
@@ -1,0 +1,64 @@
+import type { CreateMessageInput, MessageEntity, MessageKey } from '../entities/message.entity.js';
+import type { TokenCounter } from '../lib/token-counter.js';
+
+/**
+ * トークン上限ベースでメッセージを取得する際のオプション。
+ */
+export interface GetRecentByTokenBudgetOptions {
+  /** ユーザー ID（Google ID） */
+  userId: string;
+  /** キャラクター ID（既定は `hiyori` だが呼び出し側で明示する） */
+  characterId: string;
+  /**
+   * トークン上限。
+   * 未指定時は `resolveContextTokenLimit()` の解決値を使う。
+   */
+  tokenLimit?: number;
+  /**
+   * トークン換算に使うカウンタ。
+   * 未指定時は既定の `getDefaultTokenCounter()` 実装を使う。
+   */
+  tokenCounter?: TokenCounter;
+  /**
+   * 安全弁としての最大件数（DynamoDB 無限ループ防止）。
+   * 既定 500 件。これに到達する前にトークン上限で打ち切られる想定。
+   */
+  hardLimit?: number;
+}
+
+/**
+ * トークン上限ベースで取得した結果。
+ */
+export interface RecentMessagesResult {
+  /** メッセージは時系列昇順（古い順）で返される（LLM プロンプト連結に直接使える形） */
+  messages: MessageEntity[];
+  /** 取得時に積み上げた合計トークン数（メッセージごとのオーバーヘッド込み） */
+  totalTokens: number;
+  /** トークン上限に達して打ち切ったかどうか（true なら更に古いメッセージがある可能性） */
+  truncated: boolean;
+}
+
+/**
+ * 会話メッセージのリポジトリ。
+ *
+ * Phase 2a では「保存」と「トークン上限ベースの直近取得」のみを公開する。
+ * 単発取得・削除等は今後の Phase で必要になった時点で追加する。
+ */
+export interface MessageRepository {
+  /**
+   * メッセージを保存する。`MessageID` 未指定時は ULID を自動採番する。
+   * TTL（90 日）はリポジトリ側で自動付与する。
+   */
+  create(input: CreateMessageInput): Promise<MessageEntity>;
+
+  /**
+   * 単一メッセージを取得する（主にテスト用、本番フローでは使わない）。
+   */
+  getById(key: MessageKey): Promise<MessageEntity | null>;
+
+  /**
+   * 直近メッセージから新しい順にスキャンし、トークン累積が上限に達した時点で打ち切る。
+   * 返す配列は時系列昇順（古い順）に並び替えてある。
+   */
+  getRecentByTokenBudget(options: GetRecentByTokenBudgetOptions): Promise<RecentMessagesResult>;
+}

--- a/services/livetalk/core/src/repositories/profile.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/profile.repository.interface.ts
@@ -1,0 +1,22 @@
+import type {
+  CreateProfileInput,
+  ProfileEntity,
+  ProfileKey,
+  UpdateProfileInput,
+} from '../entities/profile.entity.js';
+
+/**
+ * ユーザープロファイルのリポジトリ。
+ *
+ * `getById` / `upsert` のみを公開する。明示的な create / update を分けないのは、
+ * Auth サービスのセッションを受けて「初回はレコード作成、以降は更新」という
+ * 単純なユースケースしかないため。Phase 2 以降で複雑になったら分割する。
+ */
+export interface ProfileRepository {
+  getById(key: ProfileKey): Promise<ProfileEntity | null>;
+  /**
+   * プロファイルを upsert する。
+   * 既存があれば渡された `updates` を適用、無ければ create + updates 反映で新規作成する。
+   */
+  upsert(input: CreateProfileInput, updates?: UpdateProfileInput): Promise<ProfileEntity>;
+}

--- a/services/livetalk/core/tests/unit/lib/token-counter.test.ts
+++ b/services/livetalk/core/tests/unit/lib/token-counter.test.ts
@@ -1,0 +1,78 @@
+import {
+  TiktokenCounter,
+  getDefaultTokenCounter,
+  resolveContextTokenLimit,
+  setTokenCounterForTesting,
+} from '../../../src/lib/token-counter.js';
+import { DEFAULT_LLM_CONTEXT_TOKEN_LIMIT } from '../../../src/constants.js';
+
+describe('TiktokenCounter', () => {
+  it('空文字列は 0 トークン', () => {
+    const c = new TiktokenCounter();
+    expect(c.countTokens('')).toBe(0);
+  });
+
+  it('日本語テキストでも正の整数を返す', () => {
+    const c = new TiktokenCounter();
+    const n = c.countTokens('こんにちは、桃瀬ひよりです');
+    expect(Number.isInteger(n)).toBe(true);
+    expect(n).toBeGreaterThan(0);
+  });
+
+  it('countTokensForMessage はメッセージ単位オーバーヘッドを加算する', () => {
+    const c = new TiktokenCounter();
+    const t = c.countTokens('test');
+    expect(c.countTokensForMessage('test')).toBeGreaterThanOrEqual(t + 1);
+  });
+});
+
+describe('resolveContextTokenLimit', () => {
+  const originalEnv = process.env.LLM_CONTEXT_TOKEN_LIMIT;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.LLM_CONTEXT_TOKEN_LIMIT;
+    else process.env.LLM_CONTEXT_TOKEN_LIMIT = originalEnv;
+  });
+
+  it('明示指定があればそれを返す', () => {
+    expect(resolveContextTokenLimit(1234)).toBe(1234);
+  });
+
+  it('環境変数が有効な数値ならそれを返す', () => {
+    process.env.LLM_CONTEXT_TOKEN_LIMIT = '8000';
+    expect(resolveContextTokenLimit()).toBe(8000);
+  });
+
+  it('環境変数が不正な値なら既定値にフォールバック', () => {
+    process.env.LLM_CONTEXT_TOKEN_LIMIT = 'abc';
+    expect(resolveContextTokenLimit()).toBe(DEFAULT_LLM_CONTEXT_TOKEN_LIMIT);
+  });
+
+  it('未設定なら既定値', () => {
+    delete process.env.LLM_CONTEXT_TOKEN_LIMIT;
+    expect(resolveContextTokenLimit()).toBe(DEFAULT_LLM_CONTEXT_TOKEN_LIMIT);
+  });
+
+  it('明示指定が 0 や負値の場合は既定値にフォールバック', () => {
+    expect(resolveContextTokenLimit(0)).toBe(DEFAULT_LLM_CONTEXT_TOKEN_LIMIT);
+    expect(resolveContextTokenLimit(-100)).toBe(DEFAULT_LLM_CONTEXT_TOKEN_LIMIT);
+  });
+});
+
+describe('getDefaultTokenCounter', () => {
+  afterEach(() => setTokenCounterForTesting(null));
+
+  it('同じインスタンスをキャッシュして返す', () => {
+    const a = getDefaultTokenCounter();
+    const b = getDefaultTokenCounter();
+    expect(a).toBe(b);
+  });
+
+  it('setTokenCounterForTesting で差し替え可能', () => {
+    const fake = {
+      countTokens: () => 1,
+      countTokensForMessage: () => 1,
+    };
+    setTokenCounterForTesting(fake);
+    expect(getDefaultTokenCounter()).toBe(fake);
+  });
+});

--- a/services/livetalk/core/tests/unit/mappers/character-state.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/character-state.mapper.test.ts
@@ -6,9 +6,7 @@ describe('CharacterStateMapper', () => {
   const baseEntity: CharacterStateEntity = {
     UserID: 'google-12345',
     CharacterID: 'hiyori',
-    AffectionLevel: 0,
     LastInteractionAt: 1_700_000_000_000,
-    Onboarded: false,
     CreatedAt: 1_700_000_000_000,
     UpdatedAt: 1_700_000_000_000,
   };
@@ -28,8 +26,9 @@ describe('CharacterStateMapper', () => {
     expect(mapper.toEntity(item)).toEqual(baseEntity);
   });
 
-  it('AffectionLevel が負値だと検証で弾かれる', () => {
+  it('Phase 3 以降で追加するフィールド（AffectionLevel / Onboarded）は保持しない', () => {
     const item = mapper.toItem(baseEntity);
-    expect(() => mapper.toEntity({ ...item, AffectionLevel: -1 })).toThrow(/AffectionLevel/);
+    expect(item.AffectionLevel).toBeUndefined();
+    expect(item.Onboarded).toBeUndefined();
   });
 });

--- a/services/livetalk/core/tests/unit/mappers/character-state.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/character-state.mapper.test.ts
@@ -1,0 +1,35 @@
+import { CharacterStateMapper } from '../../../src/mappers/character-state.mapper.js';
+import type { CharacterStateEntity } from '../../../src/entities/character-state.entity.js';
+
+describe('CharacterStateMapper', () => {
+  const mapper = new CharacterStateMapper();
+  const baseEntity: CharacterStateEntity = {
+    UserID: 'google-12345',
+    CharacterID: 'hiyori',
+    AffectionLevel: 0,
+    LastInteractionAt: 1_700_000_000_000,
+    Onboarded: false,
+    CreatedAt: 1_700_000_000_000,
+    UpdatedAt: 1_700_000_000_000,
+  };
+
+  it('buildKeys は PK=USER# / SK=CHAR#<charId>#STATE を返す', () => {
+    expect(mapper.buildKeys({ userId: 'google-12345', characterId: 'hiyori' })).toEqual({
+      pk: 'USER#google-12345',
+      sk: 'CHAR#hiyori#STATE',
+    });
+  });
+
+  it('toItem / toEntity は roundtrip する', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(item.PK).toBe('USER#google-12345');
+    expect(item.SK).toBe('CHAR#hiyori#STATE');
+    expect(item.Type).toBe('CharacterState');
+    expect(mapper.toEntity(item)).toEqual(baseEntity);
+  });
+
+  it('AffectionLevel が負値だと検証で弾かれる', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(() => mapper.toEntity({ ...item, AffectionLevel: -1 })).toThrow(/AffectionLevel/);
+  });
+});

--- a/services/livetalk/core/tests/unit/mappers/message.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/message.mapper.test.ts
@@ -27,48 +27,26 @@ describe('MessageMapper', () => {
     });
   });
 
-  it('toItem は必須属性 + Type=Message を含む Item を返す', () => {
+  it('toItem は必須属性 + Type=Message のみを含む', () => {
     const item = mapper.toItem(baseEntity);
     expect(item.PK).toBe('USER#google-12345');
     expect(item.SK).toBe('CHAR#hiyori#MSG#01J9Z000000000000000000001');
     expect(item.Type).toBe('Message');
     expect(item.Role).toBe('user');
     expect(item.Text).toBe('こんにちは');
+  });
+
+  it('Phase 2c 以降で追加する meta 系（AudioS3Key / TokenCount / LatencyMs / MotionUsed）は保持しない', () => {
+    const item = mapper.toItem(baseEntity);
     expect(item.AudioS3Key).toBeUndefined();
     expect(item.TokenCount).toBeUndefined();
     expect(item.LatencyMs).toBeUndefined();
     expect(item.MotionUsed).toBeUndefined();
   });
 
-  it('toItem は optional 属性を持つときだけ書き出す', () => {
-    const item = mapper.toItem({
-      ...baseEntity,
-      AudioS3Key: 'audio/abc.wav',
-      TokenCount: 42,
-      LatencyMs: 1234,
-      MotionUsed: 'talking',
-    });
-    expect(item.AudioS3Key).toBe('audio/abc.wav');
-    expect(item.TokenCount).toBe(42);
-    expect(item.LatencyMs).toBe(1234);
-    expect(item.MotionUsed).toBe('talking');
-  });
-
   it('toEntity は item を Entity に戻す（ラウンドトリップ）', () => {
     const item = mapper.toItem(baseEntity);
     expect(mapper.toEntity(item)).toEqual(baseEntity);
-  });
-
-  it('toEntity は optional 属性も再現する', () => {
-    const original: MessageEntity = {
-      ...baseEntity,
-      AudioS3Key: 'audio/abc.wav',
-      TokenCount: 42,
-      LatencyMs: 1234,
-      MotionUsed: 'talking',
-    };
-    const item = mapper.toItem(original);
-    expect(mapper.toEntity(item)).toEqual(original);
   });
 
   it('toEntity は Role が user/assistant 以外の場合エラーを投げる', () => {

--- a/services/livetalk/core/tests/unit/mappers/message.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/message.mapper.test.ts
@@ -1,0 +1,95 @@
+import { MessageMapper } from '../../../src/mappers/message.mapper.js';
+import type { MessageEntity } from '../../../src/entities/message.entity.js';
+import type { DynamoDBItem } from '@nagiyu/aws';
+
+describe('MessageMapper', () => {
+  const mapper = new MessageMapper();
+  const baseEntity: MessageEntity = {
+    UserID: 'google-12345',
+    CharacterID: 'hiyori',
+    MessageID: '01J9Z000000000000000000001',
+    Role: 'user',
+    Text: 'こんにちは',
+    CreatedAt: 1_700_000_000_000,
+    UpdatedAt: 1_700_000_000_000,
+  };
+
+  it('buildKeys は PK=USER# / SK=CHAR#<charId>#MSG#<ulid> を返す', () => {
+    expect(
+      mapper.buildKeys({
+        userId: 'google-12345',
+        characterId: 'hiyori',
+        messageId: '01J9Z',
+      })
+    ).toEqual({
+      pk: 'USER#google-12345',
+      sk: 'CHAR#hiyori#MSG#01J9Z',
+    });
+  });
+
+  it('toItem は必須属性 + Type=Message を含む Item を返す', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(item.PK).toBe('USER#google-12345');
+    expect(item.SK).toBe('CHAR#hiyori#MSG#01J9Z000000000000000000001');
+    expect(item.Type).toBe('Message');
+    expect(item.Role).toBe('user');
+    expect(item.Text).toBe('こんにちは');
+    expect(item.AudioS3Key).toBeUndefined();
+    expect(item.TokenCount).toBeUndefined();
+    expect(item.LatencyMs).toBeUndefined();
+    expect(item.MotionUsed).toBeUndefined();
+  });
+
+  it('toItem は optional 属性を持つときだけ書き出す', () => {
+    const item = mapper.toItem({
+      ...baseEntity,
+      AudioS3Key: 'audio/abc.wav',
+      TokenCount: 42,
+      LatencyMs: 1234,
+      MotionUsed: 'talking',
+    });
+    expect(item.AudioS3Key).toBe('audio/abc.wav');
+    expect(item.TokenCount).toBe(42);
+    expect(item.LatencyMs).toBe(1234);
+    expect(item.MotionUsed).toBe('talking');
+  });
+
+  it('toEntity は item を Entity に戻す（ラウンドトリップ）', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(mapper.toEntity(item)).toEqual(baseEntity);
+  });
+
+  it('toEntity は optional 属性も再現する', () => {
+    const original: MessageEntity = {
+      ...baseEntity,
+      AudioS3Key: 'audio/abc.wav',
+      TokenCount: 42,
+      LatencyMs: 1234,
+      MotionUsed: 'talking',
+    };
+    const item = mapper.toItem(original);
+    expect(mapper.toEntity(item)).toEqual(original);
+  });
+
+  it('toEntity は Role が user/assistant 以外の場合エラーを投げる', () => {
+    const item = mapper.toItem(baseEntity);
+    const corrupted: DynamoDBItem = { ...item, Role: 'system' as unknown as string };
+    expect(() => mapper.toEntity(corrupted)).toThrow(/Role/);
+  });
+
+  it('toEntity は Text が空文字でも許容する（モデルが空応答した場合の記録性質）', () => {
+    const item = mapper.toItem({ ...baseEntity, Text: '' });
+    expect(mapper.toEntity(item).Text).toBe('');
+  });
+
+  it('toEntity は CreatedAt が文字列でも互換変換する', () => {
+    const item = mapper.toItem(baseEntity);
+    const legacy = {
+      ...item,
+      CreatedAt: '2024-01-01T00:00:00Z' as unknown as number,
+    };
+    const entity = mapper.toEntity(legacy);
+    expect(typeof entity.CreatedAt).toBe('number');
+    expect(entity.CreatedAt).toBeGreaterThan(0);
+  });
+});

--- a/services/livetalk/core/tests/unit/mappers/profile.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/profile.mapper.test.ts
@@ -5,9 +5,6 @@ describe('ProfileMapper', () => {
   const mapper = new ProfileMapper();
   const baseEntity: ProfileEntity = {
     UserID: 'google-12345',
-    GoogleID: 'google-12345',
-    DisplayName: '山田太郎',
-    Email: 'taro@example.com',
     LastActiveAt: 1_700_000_000_000,
     CreatedAt: 1_700_000_000_000,
     UpdatedAt: 1_700_000_000_000,
@@ -28,10 +25,10 @@ describe('ProfileMapper', () => {
     expect(mapper.toEntity(item)).toEqual(baseEntity);
   });
 
-  it('DisplayName / Email は空文字でも許容する', () => {
-    const item = mapper.toItem({ ...baseEntity, DisplayName: '', Email: '' });
-    const entity = mapper.toEntity(item);
-    expect(entity.DisplayName).toBe('');
-    expect(entity.Email).toBe('');
+  it('Auth 側の情報（DisplayName / Email / GoogleID）は永続化しない', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(item.DisplayName).toBeUndefined();
+    expect(item.Email).toBeUndefined();
+    expect(item.GoogleID).toBeUndefined();
   });
 });

--- a/services/livetalk/core/tests/unit/mappers/profile.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/profile.mapper.test.ts
@@ -1,0 +1,37 @@
+import { ProfileMapper } from '../../../src/mappers/profile.mapper.js';
+import type { ProfileEntity } from '../../../src/entities/profile.entity.js';
+
+describe('ProfileMapper', () => {
+  const mapper = new ProfileMapper();
+  const baseEntity: ProfileEntity = {
+    UserID: 'google-12345',
+    GoogleID: 'google-12345',
+    DisplayName: '山田太郎',
+    Email: 'taro@example.com',
+    LastActiveAt: 1_700_000_000_000,
+    CreatedAt: 1_700_000_000_000,
+    UpdatedAt: 1_700_000_000_000,
+  };
+
+  it('buildKeys は PK=USER# / SK=PROFILE を返す', () => {
+    expect(mapper.buildKeys({ userId: 'google-12345' })).toEqual({
+      pk: 'USER#google-12345',
+      sk: 'PROFILE',
+    });
+  });
+
+  it('toItem / toEntity は roundtrip する', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(item.PK).toBe('USER#google-12345');
+    expect(item.SK).toBe('PROFILE');
+    expect(item.Type).toBe('Profile');
+    expect(mapper.toEntity(item)).toEqual(baseEntity);
+  });
+
+  it('DisplayName / Email は空文字でも許容する', () => {
+    const item = mapper.toItem({ ...baseEntity, DisplayName: '', Email: '' });
+    const entity = mapper.toEntity(item);
+    expect(entity.DisplayName).toBe('');
+    expect(entity.Email).toBe('');
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-character-state.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-character-state.repository.test.ts
@@ -1,0 +1,99 @@
+import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError } from '@nagiyu/aws';
+import { DynamoDBCharacterStateRepository } from '../../../src/repositories/dynamodb-character-state.repository.js';
+
+type SendHandler = (command: unknown) => Promise<unknown>;
+const makeClient = (handler: SendHandler) => ({ send: handler });
+
+describe('DynamoDBCharacterStateRepository', () => {
+  const tableName = 'nagiyu-livetalk-dev';
+  const now = 1_700_000_000_000;
+
+  it('upsert 初回は CreatedAt=now で PutCommand を送る', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      if (cmd instanceof GetCommand) return { Item: undefined };
+      return {};
+    });
+    const repo = new DynamoDBCharacterStateRepository(client as never, tableName, () => now);
+    const result = await repo.upsert({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      AffectionLevel: 0,
+      LastInteractionAt: now,
+      Onboarded: false,
+    });
+    const put = (sent[1] as PutCommand).input;
+    expect(put.Item?.PK).toBe('USER#u1');
+    expect(put.Item?.SK).toBe('CHAR#hiyori#STATE');
+    expect(result.CreatedAt).toBe(now);
+  });
+
+  it('既存があれば CreatedAt は既存値を保持し、updates の差分を反映する', async () => {
+    const existing = {
+      PK: 'USER#u1',
+      SK: 'CHAR#hiyori#STATE',
+      Type: 'CharacterState',
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      AffectionLevel: 1,
+      LastInteractionAt: now - 5000,
+      Onboarded: false,
+      CreatedAt: 1_600_000_000_000,
+      UpdatedAt: now - 5000,
+    };
+    const client = makeClient(async (cmd) => {
+      if (cmd instanceof GetCommand) return { Item: existing };
+      return {};
+    });
+    const repo = new DynamoDBCharacterStateRepository(client as never, tableName, () => now);
+    const result = await repo.upsert(
+      {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        AffectionLevel: 1,
+        LastInteractionAt: now,
+        Onboarded: false,
+      },
+      { AffectionLevel: 5, Onboarded: true }
+    );
+    expect(result.AffectionLevel).toBe(5);
+    expect(result.Onboarded).toBe(true);
+    expect(result.CreatedAt).toBe(1_600_000_000_000);
+    expect(result.UpdatedAt).toBe(now);
+  });
+
+  it('getById は未登録時 null', async () => {
+    const client = makeClient(async () => ({ Item: undefined }));
+    const repo = new DynamoDBCharacterStateRepository(client as never, tableName, () => now);
+    expect(await repo.getById({ userId: 'u1', characterId: 'hiyori' })).toBeNull();
+  });
+
+  it('getById エラーは DatabaseError でラップ', async () => {
+    const client = makeClient(async () => {
+      throw new Error('boom');
+    });
+    const repo = new DynamoDBCharacterStateRepository(client as never, tableName, () => now);
+    await expect(repo.getById({ userId: 'u1', characterId: 'hiyori' })).rejects.toBeInstanceOf(
+      DatabaseError
+    );
+  });
+
+  it('upsert の Put エラーは DatabaseError でラップ', async () => {
+    const client = makeClient(async (cmd) => {
+      if (cmd instanceof GetCommand) return { Item: undefined };
+      throw new Error('put failure');
+    });
+    const repo = new DynamoDBCharacterStateRepository(client as never, tableName, () => now);
+    await expect(
+      repo.upsert({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        AffectionLevel: 0,
+        LastInteractionAt: now,
+        Onboarded: false,
+      })
+    ).rejects.toBeInstanceOf(DatabaseError);
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-character-state.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-character-state.repository.test.ts
@@ -9,6 +9,31 @@ describe('DynamoDBCharacterStateRepository', () => {
   const tableName = 'nagiyu-livetalk-dev';
   const now = 1_700_000_000_000;
 
+  it('nowMs を省略した場合は Date.now が使われる', async () => {
+    const client = makeClient(async (cmd) => {
+      if (cmd instanceof GetCommand) return { Item: undefined };
+      return {};
+    });
+    const repo = new DynamoDBCharacterStateRepository(client as never, tableName);
+    const before = Date.now();
+    const result = await repo.upsert({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      LastInteractionAt: Date.now(),
+    });
+    expect(result.CreatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('Error 以外の例外も DatabaseError でラップする', async () => {
+    const client = makeClient(async () => {
+      throw 'string error';
+    });
+    const repo = new DynamoDBCharacterStateRepository(client as never, tableName, () => now);
+    await expect(repo.getById({ userId: 'u1', characterId: 'hiyori' })).rejects.toBeInstanceOf(
+      DatabaseError
+    );
+  });
+
   it('upsert 初回は CreatedAt=now で PutCommand を送る', async () => {
     const sent: unknown[] = [];
     const client = makeClient(async (cmd) => {
@@ -20,26 +45,26 @@ describe('DynamoDBCharacterStateRepository', () => {
     const result = await repo.upsert({
       UserID: 'u1',
       CharacterID: 'hiyori',
-      AffectionLevel: 0,
       LastInteractionAt: now,
-      Onboarded: false,
     });
     const put = (sent[1] as PutCommand).input;
     expect(put.Item?.PK).toBe('USER#u1');
     expect(put.Item?.SK).toBe('CHAR#hiyori#STATE');
+    expect(put.Item?.LastInteractionAt).toBe(now);
+    // Phase 3 以降のフィールドは書き出さない
+    expect(put.Item?.AffectionLevel).toBeUndefined();
+    expect(put.Item?.Onboarded).toBeUndefined();
     expect(result.CreatedAt).toBe(now);
   });
 
-  it('既存があれば CreatedAt は既存値を保持し、updates の差分を反映する', async () => {
+  it('既存があれば CreatedAt は既存値を保持し、LastInteractionAt 差分を反映する', async () => {
     const existing = {
       PK: 'USER#u1',
       SK: 'CHAR#hiyori#STATE',
       Type: 'CharacterState',
       UserID: 'u1',
       CharacterID: 'hiyori',
-      AffectionLevel: 1,
       LastInteractionAt: now - 5000,
-      Onboarded: false,
       CreatedAt: 1_600_000_000_000,
       UpdatedAt: now - 5000,
     };
@@ -52,14 +77,11 @@ describe('DynamoDBCharacterStateRepository', () => {
       {
         UserID: 'u1',
         CharacterID: 'hiyori',
-        AffectionLevel: 1,
         LastInteractionAt: now,
-        Onboarded: false,
       },
-      { AffectionLevel: 5, Onboarded: true }
+      { LastInteractionAt: now }
     );
-    expect(result.AffectionLevel).toBe(5);
-    expect(result.Onboarded).toBe(true);
+    expect(result.LastInteractionAt).toBe(now);
     expect(result.CreatedAt).toBe(1_600_000_000_000);
     expect(result.UpdatedAt).toBe(now);
   });
@@ -87,13 +109,7 @@ describe('DynamoDBCharacterStateRepository', () => {
     });
     const repo = new DynamoDBCharacterStateRepository(client as never, tableName, () => now);
     await expect(
-      repo.upsert({
-        UserID: 'u1',
-        CharacterID: 'hiyori',
-        AffectionLevel: 0,
-        LastInteractionAt: now,
-        Onboarded: false,
-      })
+      repo.upsert({ UserID: 'u1', CharacterID: 'hiyori', LastInteractionAt: now })
     ).rejects.toBeInstanceOf(DatabaseError);
   });
 });

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-message.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-message.repository.test.ts
@@ -1,0 +1,272 @@
+import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, EntityAlreadyExistsError } from '@nagiyu/aws';
+import { DynamoDBMessageRepository } from '../../../src/repositories/dynamodb-message.repository.js';
+import { MESSAGE_TTL_SECONDS } from '../../../src/constants.js';
+import type { TokenCounter } from '../../../src/lib/token-counter.js';
+
+const fixedCounter: TokenCounter = {
+  countTokens: (t) => t.length,
+  countTokensForMessage: (t) => t.length,
+};
+
+type SendHandler = (command: unknown) => Promise<unknown>;
+
+const makeClient = (handler: SendHandler) => ({ send: handler });
+
+describe('DynamoDBMessageRepository', () => {
+  const tableName = 'nagiyu-livetalk-dev';
+  const now = 1_700_000_000_000;
+  const ulidFactory = () => 'ULID-FIXED';
+
+  it('create は PutCommand を attribute_not_exists(PK) 条件で送り、TTL を 90 日後に設定する', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      return {};
+    });
+    const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+
+    const entity = await repo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'user',
+      Text: 'hello',
+    });
+
+    expect(entity.MessageID).toBe('ULID-FIXED');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toBeInstanceOf(PutCommand);
+    const input = (sent[0] as PutCommand).input;
+    expect(input.TableName).toBe(tableName);
+    expect(input.ConditionExpression).toBe('attribute_not_exists(PK)');
+    expect(input.Item?.PK).toBe('USER#u1');
+    expect(input.Item?.SK).toBe('CHAR#hiyori#MSG#ULID-FIXED');
+    expect(input.Item?.Type).toBe('Message');
+    expect(input.Item?.TTL).toBe(Math.floor(now / 1000) + MESSAGE_TTL_SECONDS);
+  });
+
+  it('create は明示指定された MessageID を尊重する', async () => {
+    const client = makeClient(async () => ({}));
+    const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+    const entity = await repo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'assistant',
+      Text: 'hi',
+      MessageID: 'manual-id',
+    });
+    expect(entity.MessageID).toBe('manual-id');
+  });
+
+  it('create は ConditionalCheckFailedException を EntityAlreadyExistsError に変換する', async () => {
+    const conditionError = new Error('conditional');
+    conditionError.name = 'ConditionalCheckFailedException';
+    const client = makeClient(async () => {
+      throw conditionError;
+    });
+    const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+    await expect(
+      repo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'x' })
+    ).rejects.toBeInstanceOf(EntityAlreadyExistsError);
+  });
+
+  it('create のその他エラーは DatabaseError でラップ', async () => {
+    const client = makeClient(async () => {
+      throw new Error('boom');
+    });
+    const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+    await expect(
+      repo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'x' })
+    ).rejects.toBeInstanceOf(DatabaseError);
+  });
+
+  it('getById は GetCommand を送り、見つからなければ null', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      return { Item: undefined };
+    });
+    const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+    const result = await repo.getById({
+      userId: 'u1',
+      characterId: 'hiyori',
+      messageId: 'm1',
+    });
+    expect(result).toBeNull();
+    expect(sent[0]).toBeInstanceOf(GetCommand);
+    const input = (sent[0] as GetCommand).input;
+    expect(input.Key).toEqual({
+      PK: 'USER#u1',
+      SK: 'CHAR#hiyori#MSG#m1',
+    });
+  });
+
+  it('getById は Item があれば Entity を返す', async () => {
+    const item = {
+      PK: 'USER#u1',
+      SK: 'CHAR#hiyori#MSG#m1',
+      Type: 'Message',
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      MessageID: 'm1',
+      Role: 'user',
+      Text: 'hello',
+      CreatedAt: now,
+      UpdatedAt: now,
+    };
+    const client = makeClient(async () => ({ Item: item }));
+    const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+    const result = await repo.getById({
+      userId: 'u1',
+      characterId: 'hiyori',
+      messageId: 'm1',
+    });
+    expect(result?.Text).toBe('hello');
+  });
+
+  describe('getRecentByTokenBudget', () => {
+    const baseItem = (id: string, text: string) => ({
+      PK: 'USER#u1',
+      SK: `CHAR#hiyori#MSG#${id}`,
+      Type: 'Message',
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      MessageID: id,
+      Role: 'user',
+      Text: text,
+      CreatedAt: now,
+      UpdatedAt: now,
+    });
+
+    it('ScanIndexForward=false で QueryCommand を投げ、結果を昇順に並べ替える', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        // 新しい順（降順）に返す
+        return {
+          Items: [baseItem('m3', 'cc'), baseItem('m2', 'bb'), baseItem('m1', 'aa')],
+        };
+      });
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
+
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 100,
+      });
+
+      expect(sent[0]).toBeInstanceOf(QueryCommand);
+      const input = (sent[0] as QueryCommand).input;
+      expect(input.ScanIndexForward).toBe(false);
+      expect(input.KeyConditionExpression).toContain('begins_with');
+      expect(input.ExpressionAttributeValues?.[':pk']).toBe('USER#u1');
+      expect(input.ExpressionAttributeValues?.[':prefix']).toBe('CHAR#hiyori#MSG#');
+
+      // 返却順は昇順
+      expect(result.messages.map((m) => m.MessageID)).toEqual(['m1', 'm2', 'm3']);
+      expect(result.totalTokens).toBe(6);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('LastEvaluatedKey がある間はページング継続する', async () => {
+      let call = 0;
+      const client = makeClient(async () => {
+        call++;
+        if (call === 1) {
+          return {
+            Items: [baseItem('m2', 'b')],
+            LastEvaluatedKey: { PK: 'x', SK: 'y' },
+          };
+        }
+        return { Items: [baseItem('m1', 'a')] };
+      });
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 100,
+      });
+      expect(call).toBe(2);
+      expect(result.messages.map((m) => m.MessageID)).toEqual(['m1', 'm2']);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('トークン上限超過で打ち切り、truncated=true', async () => {
+      const client = makeClient(async () => ({
+        Items: [
+          baseItem('m4', 'd'), // 1
+          baseItem('m3', 'cc'), // 2 → これ以上はカット
+          baseItem('m2', 'bbb'),
+          baseItem('m1', 'aaaa'),
+        ],
+      }));
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 3,
+      });
+      // d(1) + cc(2) = 3 で次の bbb(3) は超過
+      expect(result.messages.map((m) => m.MessageID)).toEqual(['m3', 'm4']);
+      expect(result.totalTokens).toBe(3);
+      expect(result.truncated).toBe(true);
+    });
+
+    it('壊れた item はログ警告でスキップして処理を続行する', async () => {
+      const broken = { ...baseItem('m1', 'ok'), Role: 'invalid' };
+      const client = makeClient(async () => ({
+        Items: [baseItem('m2', 'ok'), broken],
+      }));
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 100,
+      });
+      expect(result.messages.map((m) => m.MessageID)).toEqual(['m2']);
+    });
+
+    it('DynamoDB エラーは DatabaseError でラップ', async () => {
+      const client = makeClient(async () => {
+        throw new Error('throttling');
+      });
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
+      await expect(
+        repo.getRecentByTokenBudget({
+          userId: 'u1',
+          characterId: 'hiyori',
+          tokenCounter: fixedCounter,
+        })
+      ).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-message.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-message.repository.test.ts
@@ -45,6 +45,30 @@ describe('DynamoDBMessageRepository', () => {
     expect(input.Item?.TTL).toBe(Math.floor(now / 1000) + MESSAGE_TTL_SECONDS);
   });
 
+  it('nowMs / ulidFactory を省略した場合は既定実装（Date.now / ulid）が使われる', async () => {
+    const client = makeClient(async () => ({}));
+    const repo = new DynamoDBMessageRepository(client as never, tableName);
+    const before = Date.now();
+    const entity = await repo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'user',
+      Text: 'x',
+    });
+    expect(entity.CreatedAt).toBeGreaterThanOrEqual(before);
+    expect(entity.MessageID).toMatch(/^[0-9A-Z]{26}$/);
+  });
+
+  it('Error 以外の例外（文字列等）も DatabaseError でラップする', async () => {
+    const client = makeClient(async () => {
+      throw 'string error';
+    });
+    const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+    await expect(
+      repo.getById({ userId: 'u1', characterId: 'hiyori', messageId: 'm1' })
+    ).rejects.toBeInstanceOf(DatabaseError);
+  });
+
   it('create は明示指定された MessageID を尊重する', async () => {
     const client = makeClient(async () => ({}));
     const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
@@ -9,6 +9,25 @@ describe('DynamoDBProfileRepository', () => {
   const tableName = 'nagiyu-livetalk-dev';
   const now = 1_700_000_000_000;
 
+  it('nowMs を省略した場合は Date.now が使われる', async () => {
+    const client = makeClient(async (cmd) => {
+      if (cmd instanceof GetCommand) return { Item: undefined };
+      return {};
+    });
+    const repo = new DynamoDBProfileRepository(client as never, tableName);
+    const before = Date.now();
+    const result = await repo.upsert({ UserID: 'u1' });
+    expect(result.CreatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('Error 以外の例外も DatabaseError でラップする', async () => {
+    const client = makeClient(async () => {
+      throw 'string error';
+    });
+    const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+    await expect(repo.getById({ userId: 'u1' })).rejects.toBeInstanceOf(DatabaseError);
+  });
+
   it('upsert は GetCommand → PutCommand の順に送り、初回は CreatedAt=now', async () => {
     const sent: unknown[] = [];
     const client = makeClient(async (cmd) => {

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
@@ -9,7 +9,7 @@ describe('DynamoDBProfileRepository', () => {
   const tableName = 'nagiyu-livetalk-dev';
   const now = 1_700_000_000_000;
 
-  it('upsert は GetCommand → PutCommand の順に送る（初回は CreatedAt=now）', async () => {
+  it('upsert は GetCommand → PutCommand の順に送り、初回は CreatedAt=now', async () => {
     const sent: unknown[] = [];
     const client = makeClient(async (cmd) => {
       sent.push(cmd);
@@ -18,13 +18,7 @@ describe('DynamoDBProfileRepository', () => {
     });
     const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
 
-    const result = await repo.upsert({
-      UserID: 'u1',
-      GoogleID: 'g1',
-      DisplayName: 'Taro',
-      Email: 't@example.com',
-      LastActiveAt: now,
-    });
+    const result = await repo.upsert({ UserID: 'u1' });
 
     expect(sent[0]).toBeInstanceOf(GetCommand);
     expect(sent[1]).toBeInstanceOf(PutCommand);
@@ -32,18 +26,20 @@ describe('DynamoDBProfileRepository', () => {
     expect(put.Item?.PK).toBe('USER#u1');
     expect(put.Item?.SK).toBe('PROFILE');
     expect(put.Item?.CreatedAt).toBe(now);
+    expect(put.Item?.LastActiveAt).toBe(now);
+    // PII を持ち込まない
+    expect(put.Item?.DisplayName).toBeUndefined();
+    expect(put.Item?.Email).toBeUndefined();
+    expect(put.Item?.GoogleID).toBeUndefined();
     expect(result.CreatedAt).toBe(now);
   });
 
-  it('既存があれば CreatedAt は既存値を保持する', async () => {
+  it('既存があれば CreatedAt は維持しつつ LastActiveAt と UpdatedAt を反映する', async () => {
     const existing = {
       PK: 'USER#u1',
       SK: 'PROFILE',
       Type: 'Profile',
       UserID: 'u1',
-      GoogleID: 'g1',
-      DisplayName: 'Taro',
-      Email: 't@example.com',
       LastActiveAt: now - 1000,
       CreatedAt: 1_600_000_000_000,
       UpdatedAt: now - 1000,
@@ -54,20 +50,10 @@ describe('DynamoDBProfileRepository', () => {
     });
     const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
 
-    const result = await repo.upsert(
-      {
-        UserID: 'u1',
-        GoogleID: 'g1',
-        DisplayName: 'Taro',
-        Email: 't@example.com',
-        LastActiveAt: now,
-      },
-      { LastActiveAt: now, DisplayName: 'Updated' }
-    );
+    const result = await repo.upsert({ UserID: 'u1' }, { LastActiveAt: now });
 
     expect(result.CreatedAt).toBe(1_600_000_000_000);
     expect(result.UpdatedAt).toBe(now);
-    expect(result.DisplayName).toBe('Updated');
     expect(result.LastActiveAt).toBe(now);
   });
 
@@ -91,14 +77,6 @@ describe('DynamoDBProfileRepository', () => {
       throw new Error('put failure');
     });
     const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
-    await expect(
-      repo.upsert({
-        UserID: 'u1',
-        GoogleID: 'g1',
-        DisplayName: 'Taro',
-        Email: 't@example.com',
-        LastActiveAt: now,
-      })
-    ).rejects.toBeInstanceOf(DatabaseError);
+    await expect(repo.upsert({ UserID: 'u1' })).rejects.toBeInstanceOf(DatabaseError);
   });
 });

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
@@ -1,0 +1,104 @@
+import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError } from '@nagiyu/aws';
+import { DynamoDBProfileRepository } from '../../../src/repositories/dynamodb-profile.repository.js';
+
+type SendHandler = (command: unknown) => Promise<unknown>;
+const makeClient = (handler: SendHandler) => ({ send: handler });
+
+describe('DynamoDBProfileRepository', () => {
+  const tableName = 'nagiyu-livetalk-dev';
+  const now = 1_700_000_000_000;
+
+  it('upsert は GetCommand → PutCommand の順に送る（初回は CreatedAt=now）', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      if (cmd instanceof GetCommand) return { Item: undefined };
+      return {};
+    });
+    const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+
+    const result = await repo.upsert({
+      UserID: 'u1',
+      GoogleID: 'g1',
+      DisplayName: 'Taro',
+      Email: 't@example.com',
+      LastActiveAt: now,
+    });
+
+    expect(sent[0]).toBeInstanceOf(GetCommand);
+    expect(sent[1]).toBeInstanceOf(PutCommand);
+    const put = (sent[1] as PutCommand).input;
+    expect(put.Item?.PK).toBe('USER#u1');
+    expect(put.Item?.SK).toBe('PROFILE');
+    expect(put.Item?.CreatedAt).toBe(now);
+    expect(result.CreatedAt).toBe(now);
+  });
+
+  it('既存があれば CreatedAt は既存値を保持する', async () => {
+    const existing = {
+      PK: 'USER#u1',
+      SK: 'PROFILE',
+      Type: 'Profile',
+      UserID: 'u1',
+      GoogleID: 'g1',
+      DisplayName: 'Taro',
+      Email: 't@example.com',
+      LastActiveAt: now - 1000,
+      CreatedAt: 1_600_000_000_000,
+      UpdatedAt: now - 1000,
+    };
+    const client = makeClient(async (cmd) => {
+      if (cmd instanceof GetCommand) return { Item: existing };
+      return {};
+    });
+    const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+
+    const result = await repo.upsert(
+      {
+        UserID: 'u1',
+        GoogleID: 'g1',
+        DisplayName: 'Taro',
+        Email: 't@example.com',
+        LastActiveAt: now,
+      },
+      { LastActiveAt: now, DisplayName: 'Updated' }
+    );
+
+    expect(result.CreatedAt).toBe(1_600_000_000_000);
+    expect(result.UpdatedAt).toBe(now);
+    expect(result.DisplayName).toBe('Updated');
+    expect(result.LastActiveAt).toBe(now);
+  });
+
+  it('getById は未登録時に null を返す', async () => {
+    const client = makeClient(async () => ({ Item: undefined }));
+    const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+    expect(await repo.getById({ userId: 'unknown' })).toBeNull();
+  });
+
+  it('getById エラーは DatabaseError でラップ', async () => {
+    const client = makeClient(async () => {
+      throw new Error('failure');
+    });
+    const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+    await expect(repo.getById({ userId: 'u1' })).rejects.toBeInstanceOf(DatabaseError);
+  });
+
+  it('upsert の Put エラーは DatabaseError でラップ', async () => {
+    const client = makeClient(async (cmd) => {
+      if (cmd instanceof GetCommand) return { Item: undefined };
+      throw new Error('put failure');
+    });
+    const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+    await expect(
+      repo.upsert({
+        UserID: 'u1',
+        GoogleID: 'g1',
+        DisplayName: 'Taro',
+        Email: 't@example.com',
+        LastActiveAt: now,
+      })
+    ).rejects.toBeInstanceOf(DatabaseError);
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/in-memory-character-state.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-character-state.repository.test.ts
@@ -1,0 +1,79 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryCharacterStateRepository } from '../../../src/repositories/in-memory-character-state.repository.js';
+
+describe('InMemoryCharacterStateRepository', () => {
+  let store: InMemorySingleTableStore;
+  let repo: InMemoryCharacterStateRepository;
+  const baseNow = 1_700_000_000_000;
+  let now = baseNow;
+
+  beforeEach(() => {
+    store = new InMemorySingleTableStore();
+    now = baseNow;
+    repo = new InMemoryCharacterStateRepository(store, () => now);
+  });
+
+  it('初回 upsert で AffectionLevel / Onboarded などを保存する', async () => {
+    const state = await repo.upsert({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      AffectionLevel: 0,
+      LastInteractionAt: now,
+      Onboarded: false,
+    });
+    expect(state.AffectionLevel).toBe(0);
+    expect(state.Onboarded).toBe(false);
+    expect(state.CreatedAt).toBe(baseNow);
+  });
+
+  it('再 upsert は CreatedAt を保持しつつ UpdatedAt / フィールドを更新する', async () => {
+    await repo.upsert({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      AffectionLevel: 0,
+      LastInteractionAt: now,
+      Onboarded: false,
+    });
+
+    now += 5000;
+    const updated = await repo.upsert(
+      {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        AffectionLevel: 0,
+        LastInteractionAt: now,
+        Onboarded: false,
+      },
+      { AffectionLevel: 3, Onboarded: true, LastInteractionAt: now }
+    );
+    expect(updated.AffectionLevel).toBe(3);
+    expect(updated.Onboarded).toBe(true);
+    expect(updated.UpdatedAt).toBe(baseNow + 5000);
+    expect(updated.CreatedAt).toBe(baseNow);
+  });
+
+  it('getById は未登録なら null', async () => {
+    expect(await repo.getById({ userId: 'u1', characterId: 'hiyori' })).toBeNull();
+  });
+
+  it('複数キャラを分けて保持できる', async () => {
+    await repo.upsert({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      AffectionLevel: 1,
+      LastInteractionAt: now,
+      Onboarded: false,
+    });
+    await repo.upsert({
+      UserID: 'u1',
+      CharacterID: 'other',
+      AffectionLevel: 5,
+      LastInteractionAt: now,
+      Onboarded: true,
+    });
+    const a = await repo.getById({ userId: 'u1', characterId: 'hiyori' });
+    const b = await repo.getById({ userId: 'u1', characterId: 'other' });
+    expect(a?.AffectionLevel).toBe(1);
+    expect(b?.AffectionLevel).toBe(5);
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/in-memory-character-state.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-character-state.repository.test.ts
@@ -13,26 +13,35 @@ describe('InMemoryCharacterStateRepository', () => {
     repo = new InMemoryCharacterStateRepository(store, () => now);
   });
 
-  it('初回 upsert で AffectionLevel / Onboarded などを保存する', async () => {
+  it('nowMs を省略した場合は Date.now が使われる', async () => {
+    const localStore = new InMemorySingleTableStore();
+    const repo = new InMemoryCharacterStateRepository(localStore);
+    const before = Date.now();
+    const result = await repo.upsert({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      LastInteractionAt: Date.now(),
+    });
+    expect(result.CreatedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('初回 upsert で LastInteractionAt を保存する', async () => {
     const state = await repo.upsert({
       UserID: 'u1',
       CharacterID: 'hiyori',
-      AffectionLevel: 0,
       LastInteractionAt: now,
-      Onboarded: false,
     });
-    expect(state.AffectionLevel).toBe(0);
-    expect(state.Onboarded).toBe(false);
+    expect(state.UserID).toBe('u1');
+    expect(state.CharacterID).toBe('hiyori');
+    expect(state.LastInteractionAt).toBe(baseNow);
     expect(state.CreatedAt).toBe(baseNow);
   });
 
-  it('再 upsert は CreatedAt を保持しつつ UpdatedAt / フィールドを更新する', async () => {
+  it('再 upsert は CreatedAt を保持しつつ LastInteractionAt / UpdatedAt を更新する', async () => {
     await repo.upsert({
       UserID: 'u1',
       CharacterID: 'hiyori',
-      AffectionLevel: 0,
       LastInteractionAt: now,
-      Onboarded: false,
     });
 
     now += 5000;
@@ -40,14 +49,11 @@ describe('InMemoryCharacterStateRepository', () => {
       {
         UserID: 'u1',
         CharacterID: 'hiyori',
-        AffectionLevel: 0,
         LastInteractionAt: now,
-        Onboarded: false,
       },
-      { AffectionLevel: 3, Onboarded: true, LastInteractionAt: now }
+      { LastInteractionAt: now }
     );
-    expect(updated.AffectionLevel).toBe(3);
-    expect(updated.Onboarded).toBe(true);
+    expect(updated.LastInteractionAt).toBe(baseNow + 5000);
     expect(updated.UpdatedAt).toBe(baseNow + 5000);
     expect(updated.CreatedAt).toBe(baseNow);
   });
@@ -57,23 +63,23 @@ describe('InMemoryCharacterStateRepository', () => {
   });
 
   it('複数キャラを分けて保持できる', async () => {
-    await repo.upsert({
-      UserID: 'u1',
-      CharacterID: 'hiyori',
-      AffectionLevel: 1,
-      LastInteractionAt: now,
-      Onboarded: false,
-    });
-    await repo.upsert({
-      UserID: 'u1',
-      CharacterID: 'other',
-      AffectionLevel: 5,
-      LastInteractionAt: now,
-      Onboarded: true,
-    });
+    await repo.upsert({ UserID: 'u1', CharacterID: 'hiyori', LastInteractionAt: now });
+    now += 1;
+    await repo.upsert({ UserID: 'u1', CharacterID: 'other', LastInteractionAt: now });
     const a = await repo.getById({ userId: 'u1', characterId: 'hiyori' });
     const b = await repo.getById({ userId: 'u1', characterId: 'other' });
-    expect(a?.AffectionLevel).toBe(1);
-    expect(b?.AffectionLevel).toBe(5);
+    expect(a?.LastInteractionAt).toBe(baseNow);
+    expect(b?.LastInteractionAt).toBe(baseNow + 1);
+  });
+
+  it('AffectionLevel / Onboarded などの Phase 3 以降のフィールドは保持されない', async () => {
+    const state = await repo.upsert({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      LastInteractionAt: now,
+    });
+    expect(Object.keys(state).sort()).toEqual(
+      ['CharacterID', 'CreatedAt', 'LastInteractionAt', 'UpdatedAt', 'UserID'].sort()
+    );
   });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-message.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-message.repository.test.ts
@@ -40,6 +40,20 @@ describe('InMemoryMessageRepository', () => {
     });
   };
 
+  it('ulidFactory / nowMs を省略した場合は既定実装が使われる', async () => {
+    const localStore = new InMemorySingleTableStore();
+    const repo = new InMemoryMessageRepository(localStore);
+    const before = Date.now();
+    const result = await repo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'user',
+      Text: 'x',
+    });
+    expect(result.CreatedAt).toBeGreaterThanOrEqual(before);
+    expect(result.MessageID).toMatch(/^[0-9A-Z]{26}$/);
+  });
+
   it('create はメッセージを保存し ULID と CreatedAt を付与する', async () => {
     const msg = await createMessage('user', 'hello');
     expect(msg.MessageID).toMatch(/^ULID-/);

--- a/services/livetalk/core/tests/unit/repositories/in-memory-message.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-message.repository.test.ts
@@ -1,0 +1,205 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryMessageRepository } from '../../../src/repositories/in-memory-message.repository.js';
+import { MESSAGE_TTL_SECONDS } from '../../../src/constants.js';
+import type { TokenCounter } from '../../../src/lib/token-counter.js';
+
+/**
+ * 各文字列を「1 トークン = 1 文字 + メッセージあたり 0」として扱う固定カウンタ。
+ * 確定的に件数制御できるようにするためのテスト用 fake。
+ */
+const fixedCounter: TokenCounter = {
+  countTokens: (t) => t.length,
+  countTokensForMessage: (t) => t.length,
+};
+
+describe('InMemoryMessageRepository', () => {
+  let store: InMemorySingleTableStore;
+  let repo: InMemoryMessageRepository;
+  const baseNow = 1_700_000_000_000;
+  let currentTime = baseNow;
+
+  beforeEach(() => {
+    store = new InMemorySingleTableStore();
+    currentTime = baseNow;
+    // 各 create で 1ms ずつ時刻を進めて ULID の単調性を保つ
+    const ulidFactory = (seedTime?: number) => {
+      const t = seedTime ?? currentTime;
+      // ULID 形式（26 文字）を簡易再現：時刻を昇順比較できればよい
+      return `ULID-${String(t).padStart(20, '0')}`;
+    };
+    repo = new InMemoryMessageRepository(store, ulidFactory, () => currentTime);
+  });
+
+  const createMessage = async (role: 'user' | 'assistant', text: string) => {
+    currentTime += 1;
+    return repo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: role,
+      Text: text,
+    });
+  };
+
+  it('create はメッセージを保存し ULID と CreatedAt を付与する', async () => {
+    const msg = await createMessage('user', 'hello');
+    expect(msg.MessageID).toMatch(/^ULID-/);
+    expect(msg.CreatedAt).toBe(currentTime);
+    expect(msg.Role).toBe('user');
+    expect(msg.Text).toBe('hello');
+  });
+
+  it('create は TTL を 90 日後の Unix 秒として書き込む', async () => {
+    await createMessage('user', 'hello');
+    const items = Array.from(
+      (store as unknown as { store: Map<string, Record<string, unknown>> }).store.values()
+    );
+    expect(items).toHaveLength(1);
+    const ttl = items[0].TTL as number;
+    const expected = Math.floor(currentTime / 1000) + MESSAGE_TTL_SECONDS;
+    expect(ttl).toBe(expected);
+  });
+
+  it('getById で保存した内容を取得できる', async () => {
+    const saved = await createMessage('assistant', 'こんにちは');
+    const found = await repo.getById({
+      userId: 'u1',
+      characterId: 'hiyori',
+      messageId: saved.MessageID,
+    });
+    expect(found).not.toBeNull();
+    expect(found?.Text).toBe('こんにちは');
+  });
+
+  it('存在しない MessageID なら null', async () => {
+    const found = await repo.getById({
+      userId: 'u1',
+      characterId: 'hiyori',
+      messageId: 'missing',
+    });
+    expect(found).toBeNull();
+  });
+
+  describe('getRecentByTokenBudget', () => {
+    it('保存ゼロなら空配列を返す', async () => {
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 100,
+      });
+      expect(result).toEqual({ messages: [], totalTokens: 0, truncated: false });
+    });
+
+    it('上限以下なら全件を時系列昇順で返す', async () => {
+      const a = await createMessage('user', 'aaaa');
+      const b = await createMessage('assistant', 'bb');
+      const c = await createMessage('user', 'cc');
+
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 100,
+      });
+
+      expect(result.messages.map((m) => m.MessageID)).toEqual([
+        a.MessageID,
+        b.MessageID,
+        c.MessageID,
+      ]);
+      expect(result.totalTokens).toBe(4 + 2 + 2);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('上限超過時は古いメッセージから打ち切られ truncated=true になる', async () => {
+      const a = await createMessage('user', 'aaaa'); // 4
+      await createMessage('assistant', 'bbb'); // 3
+      const c = await createMessage('user', 'cc'); // 2
+      const d = await createMessage('assistant', 'd'); // 1
+
+      // 上限 5：新しい順に d(1) + c(2) で 3、次に b(3) を入れると 6 で超過 → b は含めない
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 5,
+      });
+
+      expect(result.messages.map((m) => m.MessageID)).toEqual([c.MessageID, d.MessageID]);
+      expect(result.totalTokens).toBe(3);
+      expect(result.truncated).toBe(true);
+      // a は明示的に含まれない
+      expect(result.messages.find((m) => m.MessageID === a.MessageID)).toBeUndefined();
+    });
+
+    it('上限が極端に小さくても最初の 1 件は必ず含める（コンテキスト皆無回避）', async () => {
+      await createMessage('user', 'aaaaaaaaaa'); // 10
+      await createMessage('assistant', 'bb');
+
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 1, // どれを入れても超過する
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].Text).toBe('bb');
+      expect(result.truncated).toBe(true);
+    });
+
+    it('別キャラのメッセージは混入しない', async () => {
+      await createMessage('user', 'hi');
+      // hiyori 以外を 1 件挿入
+      currentTime += 1;
+      await repo.create({
+        UserID: 'u1',
+        CharacterID: 'other',
+        Role: 'user',
+        Text: 'other-char',
+      });
+
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+      });
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].Text).toBe('hi');
+    });
+
+    it('別ユーザーのメッセージは混入しない', async () => {
+      await createMessage('user', 'mine');
+      currentTime += 1;
+      await repo.create({
+        UserID: 'u2',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: 'other-user',
+      });
+
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+      });
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].Text).toBe('mine');
+    });
+
+    it('hardLimit 以上のメッセージがあると truncated=true で打ち切る', async () => {
+      for (let i = 0; i < 10; i++) {
+        await createMessage('user', String(i));
+      }
+      const result = await repo.getRecentByTokenBudget({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tokenCounter: fixedCounter,
+        tokenLimit: 1000,
+        hardLimit: 3,
+      });
+      expect(result.messages).toHaveLength(3);
+      expect(result.truncated).toBe(true);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
@@ -1,0 +1,61 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryProfileRepository } from '../../../src/repositories/in-memory-profile.repository.js';
+
+describe('InMemoryProfileRepository', () => {
+  let store: InMemorySingleTableStore;
+  let repo: InMemoryProfileRepository;
+  const baseNow = 1_700_000_000_000;
+  let now = baseNow;
+
+  beforeEach(() => {
+    store = new InMemorySingleTableStore();
+    now = baseNow;
+    repo = new InMemoryProfileRepository(store, () => now);
+  });
+
+  it('初回 upsert で新規作成、再 upsert で UpdatedAt のみ更新 (CreatedAt 保持)', async () => {
+    const first = await repo.upsert({
+      UserID: 'u1',
+      GoogleID: 'g1',
+      DisplayName: 'Taro',
+      Email: 't@example.com',
+      LastActiveAt: now,
+    });
+    expect(first.CreatedAt).toBe(baseNow);
+    expect(first.UpdatedAt).toBe(baseNow);
+
+    now += 1000;
+    const updated = await repo.upsert(
+      {
+        UserID: 'u1',
+        GoogleID: 'g1',
+        DisplayName: 'Taro',
+        Email: 't@example.com',
+        LastActiveAt: now,
+      },
+      { DisplayName: 'New Name', LastActiveAt: now }
+    );
+
+    expect(updated.CreatedAt).toBe(baseNow);
+    expect(updated.UpdatedAt).toBe(baseNow + 1000);
+    expect(updated.DisplayName).toBe('New Name');
+    expect(updated.LastActiveAt).toBe(baseNow + 1000);
+  });
+
+  it('getById は未登録なら null を返す', async () => {
+    expect(await repo.getById({ userId: 'unknown' })).toBeNull();
+  });
+
+  it('getById は登録済みデータを返す', async () => {
+    await repo.upsert({
+      UserID: 'u1',
+      GoogleID: 'g1',
+      DisplayName: 'Taro',
+      Email: 't@example.com',
+      LastActiveAt: now,
+    });
+    const got = await repo.getById({ userId: 'u1' });
+    expect(got?.UserID).toBe('u1');
+    expect(got?.Email).toBe('t@example.com');
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
@@ -13,32 +13,22 @@ describe('InMemoryProfileRepository', () => {
     repo = new InMemoryProfileRepository(store, () => now);
   });
 
-  it('初回 upsert で新規作成、再 upsert で UpdatedAt のみ更新 (CreatedAt 保持)', async () => {
-    const first = await repo.upsert({
-      UserID: 'u1',
-      GoogleID: 'g1',
-      DisplayName: 'Taro',
-      Email: 't@example.com',
-      LastActiveAt: now,
-    });
+  it('初回 upsert で新規作成され、LastActiveAt 未指定なら現在時刻が入る', async () => {
+    const first = await repo.upsert({ UserID: 'u1' });
+    expect(first.UserID).toBe('u1');
     expect(first.CreatedAt).toBe(baseNow);
     expect(first.UpdatedAt).toBe(baseNow);
+    expect(first.LastActiveAt).toBe(baseNow);
+  });
+
+  it('再 upsert は CreatedAt を保持し UpdatedAt / LastActiveAt のみ更新する', async () => {
+    await repo.upsert({ UserID: 'u1', LastActiveAt: baseNow });
 
     now += 1000;
-    const updated = await repo.upsert(
-      {
-        UserID: 'u1',
-        GoogleID: 'g1',
-        DisplayName: 'Taro',
-        Email: 't@example.com',
-        LastActiveAt: now,
-      },
-      { DisplayName: 'New Name', LastActiveAt: now }
-    );
+    const updated = await repo.upsert({ UserID: 'u1' }, { LastActiveAt: now });
 
     expect(updated.CreatedAt).toBe(baseNow);
     expect(updated.UpdatedAt).toBe(baseNow + 1000);
-    expect(updated.DisplayName).toBe('New Name');
     expect(updated.LastActiveAt).toBe(baseNow + 1000);
   });
 
@@ -47,15 +37,17 @@ describe('InMemoryProfileRepository', () => {
   });
 
   it('getById は登録済みデータを返す', async () => {
-    await repo.upsert({
-      UserID: 'u1',
-      GoogleID: 'g1',
-      DisplayName: 'Taro',
-      Email: 't@example.com',
-      LastActiveAt: now,
-    });
+    await repo.upsert({ UserID: 'u1' });
     const got = await repo.getById({ userId: 'u1' });
     expect(got?.UserID).toBe('u1');
-    expect(got?.Email).toBe('t@example.com');
+    expect(got?.LastActiveAt).toBe(baseNow);
+  });
+
+  it('Auth 側情報を渡さなくても upsert が成立する（PII は LiveTalk に持ち込まない）', async () => {
+    const result = await repo.upsert({ UserID: 'u1' });
+    // 余計な属性がリポジトリ側で勝手に生成されていないこと
+    expect(Object.keys(result).sort()).toEqual(
+      ['CreatedAt', 'LastActiveAt', 'UpdatedAt', 'UserID'].sort()
+    );
   });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
@@ -13,6 +13,14 @@ describe('InMemoryProfileRepository', () => {
     repo = new InMemoryProfileRepository(store, () => now);
   });
 
+  it('nowMs を省略した場合は Date.now が使われる', async () => {
+    const localStore = new InMemorySingleTableStore();
+    const repo = new InMemoryProfileRepository(localStore);
+    const before = Date.now();
+    const result = await repo.upsert({ UserID: 'u1' });
+    expect(result.CreatedAt).toBeGreaterThanOrEqual(before);
+  });
+
   it('初回 upsert で新規作成され、LastActiveAt 未指定なら現在時刻が入る', async () => {
     const first = await repo.upsert({ UserID: 'u1' });
     expect(first.UserID).toBe('u1');

--- a/services/livetalk/core/tsconfig.json
+++ b/services/livetalk/core/tsconfig.json
@@ -10,5 +10,5 @@
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "dist"],
-  "references": [{ "path": "../../../libs/common" }]
+  "references": [{ "path": "../../../libs/common" }, { "path": "../../../libs/aws" }]
 }

--- a/services/livetalk/web/Dockerfile
+++ b/services/livetalk/web/Dockerfile
@@ -27,6 +27,7 @@ RUN npm run build --workspace=@nagiyu/common
 RUN npm run build --workspace=@nagiyu/browser
 RUN npm run build --workspace=@nagiyu/ui
 RUN npm run build --workspace=@nagiyu/nextjs
+RUN npm run build --workspace=@nagiyu/aws
 RUN npm run build --workspace=@nagiyu/livetalk-core
 RUN npm run build --workspace=@nagiyu/livetalk-web
 

--- a/services/livetalk/web/jest.config.ts
+++ b/services/livetalk/web/jest.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
     '^@nagiyu/nextjs$': '<rootDir>/../../../libs/nextjs/src/index.ts',
     '^@nagiyu/livetalk-core$': '<rootDir>/../core/src/index.ts',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   testPathIgnorePatterns: ['/node_modules/', '/e2e/'],

--- a/services/livetalk/web/package.json
+++ b/services/livetalk/web/package.json
@@ -18,6 +18,7 @@
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
+    "@nagiyu/aws": "*",
     "@nagiyu/browser": "*",
     "@nagiyu/common": "*",
     "@nagiyu/livetalk-core": "*",

--- a/services/livetalk/web/src/app/api/echo/constants.ts
+++ b/services/livetalk/web/src/app/api/echo/constants.ts
@@ -8,6 +8,7 @@ export const ECHO_ERROR_MESSAGES = {
   EMPTY_TEXT: 'メッセージを入力してください',
   TEXT_TOO_LONG: 'メッセージが長すぎます（200 文字以内で入力してください）',
   SYNTHESIS_FAILED: '音声合成に失敗しました',
+  PERSISTENCE_FAILED: 'メッセージの保存に失敗しました',
 } as const;
 
 export const ECHO_MAX_TEXT_LENGTH = 200;

--- a/services/livetalk/web/src/app/api/echo/route.ts
+++ b/services/livetalk/web/src/app/api/echo/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { withAuth } from '@nagiyu/nextjs';
+import { DEFAULT_CHARACTER_ID } from '@nagiyu/livetalk-core';
 import { getSession } from '@/lib/server/session';
 import { getVoicevoxClient } from '@/lib/server/voicevox';
+import { getMessageRepository } from '@/lib/server/repositories';
 import { ECHO_ERROR_MESSAGES, ECHO_MAX_TEXT_LENGTH } from './constants';
 
 interface EchoRequest {
@@ -19,13 +21,18 @@ function isEchoRequest(body: unknown): body is EchoRequest {
 /**
  * POST /api/echo
  *
- * Phase 1f のエコー API。受け取ったテキストをそのまま VOICEVOX に投げ、
- * 合成された WAV を返す。Phase 2 で LLM 統合に置き換わる。
+ * Phase 1f で導入した「テキストをそのまま VOICEVOX に投げて WAV を返す」エコー API。
  *
- * 認可: `livetalk:chat` permission を要求（middleware は /api をスキップするため、
- * route 側で withAuth する）。
+ * Phase 2a の改修：
+ * - リクエスト受信時にユーザー発話を DynamoDB に保存
+ * - 応答返却前にキャラの応答（= 入力と同じテキスト）を DynamoDB に保存
+ * - 認可は変わらず `livetalk:chat` permission を要求
+ *
+ * 永続化に失敗した場合は 5xx を返し、ユーザーに保存できなかったことを伝える
+ * （UI ストリームから外れたまま黙って消えるよりは、見える壊れ方の方が良い）。
+ * LLM 統合（Phase 2c）で `/api/chat` に置き換わるまでの暫定実装。
  */
-export const POST = withAuth(getSession, 'livetalk:chat', async (_session, request: Request) => {
+export const POST = withAuth(getSession, 'livetalk:chat', async (session, request: Request) => {
   let body: unknown;
   try {
     body = await request.json();
@@ -57,15 +64,28 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (_session, reque
     );
   }
 
+  const userId = session.user.googleId;
+  const characterId = DEFAULT_CHARACTER_ID;
+  const messageRepository = getMessageRepository();
+
   try {
-    const audioBuffer = await getVoicevoxClient().synthesize(text);
-    return new NextResponse(audioBuffer, {
-      status: 200,
-      headers: {
-        'Content-Type': 'audio/wav',
-        'Cache-Control': 'no-store',
-      },
+    await messageRepository.create({
+      UserID: userId,
+      CharacterID: characterId,
+      Role: 'user',
+      Text: text,
     });
+  } catch (error) {
+    console.error('[POST /api/echo] ユーザーメッセージの保存に失敗しました', error);
+    return NextResponse.json(
+      { error: 'PERSISTENCE_FAILED', message: ECHO_ERROR_MESSAGES.PERSISTENCE_FAILED },
+      { status: 500 }
+    );
+  }
+
+  let audioBuffer: ArrayBuffer;
+  try {
+    audioBuffer = await getVoicevoxClient().synthesize(text);
   } catch (error) {
     console.error('[POST /api/echo] VOICEVOX 合成に失敗しました', error);
     return NextResponse.json(
@@ -73,4 +93,28 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (_session, reque
       { status: 502 }
     );
   }
+
+  try {
+    await messageRepository.create({
+      UserID: userId,
+      CharacterID: characterId,
+      Role: 'assistant',
+      // Phase 2a 時点ではキャラの応答 = ユーザー入力（エコー）。
+      Text: text,
+    });
+  } catch (error) {
+    console.error('[POST /api/echo] キャラ応答メッセージの保存に失敗しました', error);
+    return NextResponse.json(
+      { error: 'PERSISTENCE_FAILED', message: ECHO_ERROR_MESSAGES.PERSISTENCE_FAILED },
+      { status: 500 }
+    );
+  }
+
+  return new NextResponse(audioBuffer, {
+    status: 200,
+    headers: {
+      'Content-Type': 'audio/wav',
+      'Cache-Control': 'no-store',
+    },
+  });
 });

--- a/services/livetalk/web/src/app/api/messages/constants.ts
+++ b/services/livetalk/web/src/app/api/messages/constants.ts
@@ -1,0 +1,11 @@
+export const MESSAGES_ERROR_MESSAGES = {
+  INVALID_REQUEST: 'リクエスト形式が不正です',
+  FETCH_FAILED: 'メッセージの取得に失敗しました',
+} as const;
+
+/**
+ * クエリパラメータ `tokenLimit` で許容する範囲。
+ * デフォルト（40K）よりも極端に小さい・大きい値を渡されないよう保護する。
+ */
+export const MESSAGES_MIN_TOKEN_LIMIT = 100;
+export const MESSAGES_MAX_TOKEN_LIMIT = 200_000;

--- a/services/livetalk/web/src/app/api/messages/route.ts
+++ b/services/livetalk/web/src/app/api/messages/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import { DEFAULT_CHARACTER_ID } from '@nagiyu/livetalk-core';
+import { getSession } from '@/lib/server/session';
+import { getMessageRepository } from '@/lib/server/repositories';
+import {
+  MESSAGES_ERROR_MESSAGES,
+  MESSAGES_MAX_TOKEN_LIMIT,
+  MESSAGES_MIN_TOKEN_LIMIT,
+} from './constants';
+
+/**
+ * GET /api/messages
+ *
+ * 認証ユーザーの直近メッセージを「トークン上限ベース」で返す。
+ *
+ * Query パラメータ：
+ * - `characterId`（任意、既定 `hiyori`）
+ * - `tokenLimit`（任意、未指定なら `LLM_CONTEXT_TOKEN_LIMIT` env または 40K）
+ *
+ * Phase 2a では Phase 2c の `/api/chat` 統合までの中継 API。LLM プロンプト用に
+ * 時系列昇順で返すため、UI 側で「最新メッセージ N 件」UI を作る場合は反転する想定。
+ */
+export const GET = withAuth(getSession, 'livetalk:chat', async (session, request: Request) => {
+  const url = new URL(request.url);
+  const characterId = url.searchParams.get('characterId') || DEFAULT_CHARACTER_ID;
+
+  let tokenLimit: number | undefined;
+  const rawTokenLimit = url.searchParams.get('tokenLimit');
+  if (rawTokenLimit !== null) {
+    const parsed = Number.parseInt(rawTokenLimit, 10);
+    if (
+      !Number.isFinite(parsed) ||
+      parsed < MESSAGES_MIN_TOKEN_LIMIT ||
+      parsed > MESSAGES_MAX_TOKEN_LIMIT
+    ) {
+      return NextResponse.json(
+        { error: 'INVALID_REQUEST', message: MESSAGES_ERROR_MESSAGES.INVALID_REQUEST },
+        { status: 400 }
+      );
+    }
+    tokenLimit = parsed;
+  }
+
+  try {
+    const result = await getMessageRepository().getRecentByTokenBudget({
+      userId: session.user.googleId,
+      characterId,
+      tokenLimit,
+    });
+    return NextResponse.json({
+      messages: result.messages.map((m) => ({
+        messageId: m.MessageID,
+        characterId: m.CharacterID,
+        role: m.Role,
+        text: m.Text,
+        createdAt: m.CreatedAt,
+      })),
+      totalTokens: result.totalTokens,
+      truncated: result.truncated,
+    });
+  } catch (error) {
+    console.error('[GET /api/messages] メッセージ取得に失敗しました', error);
+    return NextResponse.json(
+      { error: 'FETCH_FAILED', message: MESSAGES_ERROR_MESSAGES.FETCH_FAILED },
+      { status: 500 }
+    );
+  }
+});

--- a/services/livetalk/web/src/lib/server/repositories.ts
+++ b/services/livetalk/web/src/lib/server/repositories.ts
@@ -1,0 +1,73 @@
+/**
+ * リブトーク Web 層が使う DynamoDB リポジトリのファクトリ。
+ *
+ * - 本番 / dev: 既存の `@nagiyu/aws` クライアントから生成した DynamoDB Document Client を使う
+ * - テスト・ローカル: `USE_IN_MEMORY_DB=true` で全リポジトリが共有の InMemory store に差し替わる
+ *
+ * 各リポジトリはシングルトンとして再利用される。
+ */
+
+import { InMemorySingleTableStore, registerDynamoRepositories } from '@nagiyu/aws';
+import type {
+  CharacterStateRepository,
+  MessageRepository,
+  ProfileRepository,
+} from '@nagiyu/livetalk-core';
+import {
+  DynamoDBCharacterStateRepository,
+  DynamoDBMessageRepository,
+  DynamoDBProfileRepository,
+  InMemoryCharacterStateRepository,
+  InMemoryMessageRepository,
+  InMemoryProfileRepository,
+} from '@nagiyu/livetalk-core';
+
+const registry = registerDynamoRepositories<
+  {
+    message: MessageRepository;
+    profile: ProfileRepository;
+    characterState: CharacterStateRepository;
+  },
+  InMemorySingleTableStore
+>(
+  {
+    message: {
+      createInMemoryRepository: (store) => new InMemoryMessageRepository(store),
+      createDynamoDBRepository: ({ docClient, tableName }) =>
+        new DynamoDBMessageRepository(docClient, tableName),
+    },
+    profile: {
+      createInMemoryRepository: (store) => new InMemoryProfileRepository(store),
+      createDynamoDBRepository: ({ docClient, tableName }) =>
+        new DynamoDBProfileRepository(docClient, tableName),
+    },
+    characterState: {
+      createInMemoryRepository: (store) => new InMemoryCharacterStateRepository(store),
+      createDynamoDBRepository: ({ docClient, tableName }) =>
+        new DynamoDBCharacterStateRepository(docClient, tableName),
+    },
+  },
+  {
+    keyPrefix: 'livetalk',
+    createSharedStore: () => new InMemorySingleTableStore(),
+  }
+);
+
+export function getMessageRepository(): MessageRepository {
+  return registry.message.createRepository();
+}
+
+export function getProfileRepository(): ProfileRepository {
+  return registry.profile.createRepository();
+}
+
+export function getCharacterStateRepository(): CharacterStateRepository {
+  return registry.characterState.createRepository();
+}
+
+/**
+ * テスト・E2E 用：全リポジトリと共有 store を破棄する。
+ */
+export function resetRepositoriesForTesting(): void {
+  registry.resetAll();
+}

--- a/services/livetalk/web/tests/unit/app/api/echo/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/echo/route.test.ts
@@ -5,6 +5,8 @@ import { POST } from '@/app/api/echo/route';
 import { ECHO_ERROR_MESSAGES, ECHO_MAX_TEXT_LENGTH } from '@/app/api/echo/constants';
 import { getSession } from '@/lib/server/session';
 import { getVoicevoxClient } from '@/lib/server/voicevox';
+import { getMessageRepository } from '@/lib/server/repositories';
+import type { MessageRepository } from '@nagiyu/livetalk-core';
 
 jest.mock('@/lib/server/session', () => ({
   getSession: jest.fn(),
@@ -14,8 +16,13 @@ jest.mock('@/lib/server/voicevox', () => ({
   getVoicevoxClient: jest.fn(),
 }));
 
+jest.mock('@/lib/server/repositories', () => ({
+  getMessageRepository: jest.fn(),
+}));
+
 const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
 const mockGetClient = getVoicevoxClient as jest.MockedFunction<typeof getVoicevoxClient>;
+const mockGetRepo = getMessageRepository as jest.MockedFunction<typeof getMessageRepository>;
 
 const buildRequest = (body: unknown): Request =>
   new Request('http://localhost/api/echo', {
@@ -37,9 +44,29 @@ const validSession = {
   expires: new Date(Date.now() + 60 * 1000).toISOString(),
 };
 
+const makeRepo = (overrides: Partial<MessageRepository> = {}): MessageRepository => {
+  const create: MessageRepository['create'] = jest.fn(async (input) => ({
+    UserID: input.UserID,
+    CharacterID: input.CharacterID,
+    MessageID: 'ULID-X',
+    Role: input.Role,
+    Text: input.Text,
+    CreatedAt: 0,
+    UpdatedAt: 0,
+  }));
+  const getById: MessageRepository['getById'] = jest.fn(async () => null);
+  const getRecentByTokenBudget: MessageRepository['getRecentByTokenBudget'] = jest.fn(async () => ({
+    messages: [],
+    totalTokens: 0,
+    truncated: false,
+  }));
+  return { create, getById, getRecentByTokenBudget, ...overrides };
+};
+
 describe('POST /api/echo', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetRepo.mockReturnValue(makeRepo());
   });
 
   it('未認証時は 401 を返す', async () => {
@@ -91,20 +118,41 @@ describe('POST /api/echo', () => {
       expect(json.message).toBe(ECHO_ERROR_MESSAGES.TEXT_TOO_LONG);
     });
 
-    it('VOICEVOX が成功すれば audio/wav で ArrayBuffer を返す', async () => {
+    it('成功時にユーザー発話とキャラ応答を DynamoDB に保存し、audio/wav で返す', async () => {
       const audio = new ArrayBuffer(16);
-      mockGetClient.mockReturnValueOnce({
-        synthesize: jest.fn(async () => audio),
-      });
+      const synthesize = jest.fn(async () => audio);
+      mockGetClient.mockReturnValueOnce({ synthesize });
+      const repo = makeRepo();
+      mockGetRepo.mockReturnValue(repo);
+
       const response = await POST(buildRequest({ text: '  おはよう  ' }));
+
       expect(response.status).toBe(200);
       expect(response.headers.get('content-type')).toBe('audio/wav');
       const returned = await response.arrayBuffer();
       expect(returned.byteLength).toBe(16);
+
+      // ユーザー発話 → 応答の順で 2 件保存される
+      expect(repo.create).toHaveBeenCalledTimes(2);
+      expect(repo.create).toHaveBeenNthCalledWith(1, {
+        UserID: 'g1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: 'おはよう',
+      });
+      expect(repo.create).toHaveBeenNthCalledWith(2, {
+        UserID: 'g1',
+        CharacterID: 'hiyori',
+        Role: 'assistant',
+        Text: 'おはよう',
+      });
+      expect(synthesize).toHaveBeenCalledWith('おはよう');
     });
 
-    it('VOICEVOX が失敗すると 502 SYNTHESIS_FAILED', async () => {
+    it('VOICEVOX が失敗すると 502 SYNTHESIS_FAILED、ユーザー発話は既に保存済み', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const repo = makeRepo();
+      mockGetRepo.mockReturnValue(repo);
       mockGetClient.mockReturnValueOnce({
         synthesize: jest.fn(async () => {
           throw new Error('connection refused');
@@ -114,14 +162,61 @@ describe('POST /api/echo', () => {
       expect(response.status).toBe(502);
       const json = await response.json();
       expect(json.message).toBe(ECHO_ERROR_MESSAGES.SYNTHESIS_FAILED);
+      // user の 1 件のみ。assistant は保存されない（VOICEVOX エラーで応答テキストが
+      // 確定できない状況のため）。
+      expect(repo.create).toHaveBeenCalledTimes(1);
+      expect((repo.create as jest.Mock).mock.calls[0][0].Role).toBe('user');
       consoleSpy.mockRestore();
     });
 
-    it('trim 済みのテキストが VOICEVOX に渡される', async () => {
-      const synthesize = jest.fn(async () => new ArrayBuffer(8));
+    it('ユーザー発話の保存に失敗すると 500 PERSISTENCE_FAILED、VOICEVOX は呼ばれない', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const synthesize = jest.fn();
       mockGetClient.mockReturnValueOnce({ synthesize });
-      await POST(buildRequest({ text: '  hello world  ' }));
-      expect(synthesize).toHaveBeenCalledWith('hello world');
+      const repo = makeRepo({
+        create: jest.fn(async () => {
+          throw new Error('dynamodb down');
+        }),
+      });
+      mockGetRepo.mockReturnValue(repo);
+
+      const response = await POST(buildRequest({ text: 'hi' }));
+      expect(response.status).toBe(500);
+      const json = await response.json();
+      expect(json.message).toBe(ECHO_ERROR_MESSAGES.PERSISTENCE_FAILED);
+      expect(synthesize).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('キャラ応答の保存に失敗すると 500 PERSISTENCE_FAILED', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockGetClient.mockReturnValueOnce({
+        synthesize: jest.fn(async () => new ArrayBuffer(4)),
+      });
+      let call = 0;
+      const createFn = jest.fn(async () => {
+        call++;
+        if (call === 1) {
+          return {
+            UserID: 'g1',
+            CharacterID: 'hiyori',
+            MessageID: 'X',
+            Role: 'user' as const,
+            Text: 'hi',
+            CreatedAt: 0,
+            UpdatedAt: 0,
+          };
+        }
+        throw new Error('dynamodb down');
+      });
+      const repo = makeRepo({ create: createFn });
+      mockGetRepo.mockReturnValue(repo);
+
+      const response = await POST(buildRequest({ text: 'hi' }));
+      expect(response.status).toBe(500);
+      const json = await response.json();
+      expect(json.message).toBe(ECHO_ERROR_MESSAGES.PERSISTENCE_FAILED);
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/services/livetalk/web/tests/unit/app/api/messages/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/messages/route.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/messages/route';
+import { MESSAGES_ERROR_MESSAGES } from '@/app/api/messages/constants';
+import { getSession } from '@/lib/server/session';
+import { getMessageRepository } from '@/lib/server/repositories';
+import type { MessageRepository } from '@nagiyu/livetalk-core';
+
+jest.mock('@/lib/server/session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/server/repositories', () => ({ getMessageRepository: jest.fn() }));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetRepo = getMessageRepository as jest.MockedFunction<typeof getMessageRepository>;
+
+const validSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'u@example.com',
+    name: 'U',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+const buildRequest = (search: string = ''): Request =>
+  new Request(`http://localhost/api/messages${search}`, { method: 'GET' });
+
+const makeRepo = (overrides: Partial<MessageRepository> = {}): MessageRepository => {
+  const create: MessageRepository['create'] = jest.fn();
+  const getById: MessageRepository['getById'] = jest.fn(async () => null);
+  const getRecentByTokenBudget: MessageRepository['getRecentByTokenBudget'] = jest.fn(async () => ({
+    messages: [
+      {
+        UserID: 'g1',
+        CharacterID: 'hiyori',
+        MessageID: 'm1',
+        Role: 'user' as const,
+        Text: 'hello',
+        CreatedAt: 1_700_000_000_000,
+        UpdatedAt: 1_700_000_000_000,
+      },
+      {
+        UserID: 'g1',
+        CharacterID: 'hiyori',
+        MessageID: 'm2',
+        Role: 'assistant' as const,
+        Text: 'hi',
+        CreatedAt: 1_700_000_000_001,
+        UpdatedAt: 1_700_000_000_001,
+      },
+    ],
+    totalTokens: 10,
+    truncated: false,
+  }));
+  return { create, getById, getRecentByTokenBudget, ...overrides };
+};
+
+describe('GET /api/messages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRepo.mockReturnValue(makeRepo());
+  });
+
+  it('未認証時は 401', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const response = await GET(buildRequest());
+    expect(response.status).toBe(401);
+  });
+
+  it('permission がない場合は 403', async () => {
+    mockGetSession.mockResolvedValueOnce({
+      ...validSession,
+      user: { ...validSession.user, roles: ['guest'] },
+    });
+    const response = await GET(buildRequest());
+    expect(response.status).toBe(403);
+  });
+
+  describe('認証済み', () => {
+    beforeEach(() => mockGetSession.mockResolvedValue(validSession));
+
+    it('既定で hiyori キャラの直近メッセージを時系列昇順で返す', async () => {
+      const repo = makeRepo();
+      mockGetRepo.mockReturnValue(repo);
+
+      const response = await GET(buildRequest());
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.messages).toEqual([
+        {
+          messageId: 'm1',
+          characterId: 'hiyori',
+          role: 'user',
+          text: 'hello',
+          createdAt: 1_700_000_000_000,
+        },
+        {
+          messageId: 'm2',
+          characterId: 'hiyori',
+          role: 'assistant',
+          text: 'hi',
+          createdAt: 1_700_000_000_001,
+        },
+      ]);
+      expect(json.totalTokens).toBe(10);
+      expect(json.truncated).toBe(false);
+      expect(repo.getRecentByTokenBudget).toHaveBeenCalledWith({
+        userId: 'g1',
+        characterId: 'hiyori',
+        tokenLimit: undefined,
+      });
+    });
+
+    it('characterId クエリで対象キャラを差し替えできる', async () => {
+      const repo = makeRepo();
+      mockGetRepo.mockReturnValue(repo);
+      await GET(buildRequest('?characterId=other'));
+      expect(repo.getRecentByTokenBudget).toHaveBeenCalledWith(
+        expect.objectContaining({ characterId: 'other' })
+      );
+    });
+
+    it('tokenLimit クエリが範囲内なら値が渡る', async () => {
+      const repo = makeRepo();
+      mockGetRepo.mockReturnValue(repo);
+      await GET(buildRequest('?tokenLimit=1000'));
+      expect(repo.getRecentByTokenBudget).toHaveBeenCalledWith(
+        expect.objectContaining({ tokenLimit: 1000 })
+      );
+    });
+
+    it('tokenLimit が極端に小さいと 400 INVALID_REQUEST', async () => {
+      const response = await GET(buildRequest('?tokenLimit=1'));
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.message).toBe(MESSAGES_ERROR_MESSAGES.INVALID_REQUEST);
+    });
+
+    it('tokenLimit が NaN だと 400 INVALID_REQUEST', async () => {
+      const response = await GET(buildRequest('?tokenLimit=abc'));
+      expect(response.status).toBe(400);
+    });
+
+    it('tokenLimit が上限超過だと 400 INVALID_REQUEST', async () => {
+      const response = await GET(buildRequest('?tokenLimit=999999999'));
+      expect(response.status).toBe(400);
+    });
+
+    it('リポジトリエラーは 500 FETCH_FAILED', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockGetRepo.mockReturnValue(
+        makeRepo({
+          getRecentByTokenBudget: jest.fn(async () => {
+            throw new Error('boom');
+          }),
+        })
+      );
+      const response = await GET(buildRequest());
+      expect(response.status).toBe(500);
+      const json = await response.json();
+      expect(json.message).toBe(MESSAGES_ERROR_MESSAGES.FETCH_FAILED);
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/server/repositories.test.ts
+++ b/services/livetalk/web/tests/unit/lib/server/repositories.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment node
+ */
+
+describe('lib/server/repositories', () => {
+  const originalFlag = process.env.USE_IN_MEMORY_DB;
+  const originalTable = process.env.DYNAMODB_TABLE_NAME;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) delete process.env.USE_IN_MEMORY_DB;
+    else process.env.USE_IN_MEMORY_DB = originalFlag;
+    if (originalTable === undefined) delete process.env.DYNAMODB_TABLE_NAME;
+    else process.env.DYNAMODB_TABLE_NAME = originalTable;
+  });
+
+  it('USE_IN_MEMORY_DB=true なら InMemory リポジトリ群をシングルトンで返す', async () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const mod = await import('@/lib/server/repositories');
+    const r1 = mod.getMessageRepository();
+    const r2 = mod.getMessageRepository();
+    expect(r1).toBe(r2);
+
+    const p1 = mod.getProfileRepository();
+    const c1 = mod.getCharacterStateRepository();
+    expect(p1).toBeDefined();
+    expect(c1).toBeDefined();
+  });
+
+  it('InMemory 実装では Message を保存して取得できる（共有 store 検証）', async () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const mod = await import('@/lib/server/repositories');
+    mod.resetRepositoriesForTesting();
+    const repo = mod.getMessageRepository();
+    const saved = await repo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'user',
+      Text: 'hi',
+    });
+    const got = await repo.getById({
+      userId: 'u1',
+      characterId: 'hiyori',
+      messageId: saved.MessageID,
+    });
+    expect(got?.Text).toBe('hi');
+    mod.resetRepositoriesForTesting();
+  });
+
+  it('resetRepositoriesForTesting で次回取得時は別インスタンスになる', async () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const mod = await import('@/lib/server/repositories');
+    const before = mod.getMessageRepository();
+    mod.resetRepositoriesForTesting();
+    const after = mod.getMessageRepository();
+    expect(before).not.toBe(after);
+  });
+
+  it('DynamoDB モード（USE_IN_MEMORY_DB 未設定 + テーブル名指定）でも生成できる', async () => {
+    delete process.env.USE_IN_MEMORY_DB;
+    process.env.DYNAMODB_TABLE_NAME = 'nagiyu-livetalk-test';
+    const mod = await import('@/lib/server/repositories');
+    mod.resetRepositoriesForTesting();
+    expect(() => mod.getMessageRepository()).not.toThrow();
+    expect(() => mod.getProfileRepository()).not.toThrow();
+    expect(() => mod.getCharacterStateRepository()).not.toThrow();
+    mod.resetRepositoriesForTesting();
+  });
+});

--- a/tasks/livetalk/design.md
+++ b/tasks/livetalk/design.md
@@ -231,11 +231,12 @@ data: {}
 
 ```typescript
 type User = {
+    // userId == セッションの googleId をそのまま使う。
+    // 表示名 / メール / Google ID は Auth サービスのセッションから都度取得するため
+    // ここには保持しない（PII を LiveTalk 側に複製しない方針）。
     userId: string;          // googleId
-    displayName: string;
-    email: string;
-    createdAt: string;       // ISO8601
-    lastActiveAt: string;
+    createdAt: string;       // ISO8601、LiveTalk 初回登録時刻
+    lastActiveAt: string;    // LiveTalk 最終アクセス時刻
 };
 
 type CharacterState = {


### PR DESCRIPTION
## 変更の概要

リブトーク Phase 2a。DynamoDB Single Table を新規作成し、会話履歴をユーザーごとに永続化する。直近メッセージ取得は固定 N 件ではなく **「トークン上限ベースの動的取得」**（既定 40K tokens）を採用する。

### 主な変更

**インフラ（CDK）**

- `infra/livetalk/lib/dynamodb-stack.ts`（新規）：`nagiyu-livetalk-{env}` テーブルを作成
  - Single Table（PK / SK のみ、GSI なし）
  - PAY_PER_REQUEST、Point-in-time Recovery、TTL 属性 `TTL`、AWS_MANAGED 暗号化
  - dev は DESTROY、prod は RETAIN
  - テーブル名 / ARN を SSM パラメータ（`/nagiyu/livetalk/{env}/dynamodb/table-{name,arn}`）に出力
- `infra/livetalk/lib/ecs-service-stack.ts`：ECS Task Role に DynamoDB Read/Write 権限を付与し、env var `DYNAMODB_TABLE_NAME` を Next.js コンテナに注入
- `infra/livetalk/bin/livetalk.ts`：DynamoDB Stack を追加、依存関係を ECS Service Stack に宣言
- `infra/common/src/utils/ssm.ts`：`LIVETALK_DYNAMODB_TABLE_NAME` / `LIVETALK_DYNAMODB_TABLE_ARN` を追加

**Core（`services/livetalk/core`）**

- Entity / Mapper / Repository を新規作成
  - Message（1 メッセージ = 1 item、TTL 90 日、ULID 採番）
  - Profile（user 単位、upsert）
  - CharacterState（user × char 単位、upsert）
- DynamoDB 実装 + InMemory 実装（テスト / ローカル用）の二系統
- `lib/token-counter.ts`：`js-tiktoken`（`gpt-4o` 用エンコーダ）ラッパー
- `lib/ulid.ts`：ULID 生成 factory（テスト差し替え可）
- `constants.ts`：`DEFAULT_CHARACTER_ID = 'hiyori'`、`MESSAGE_TTL_SECONDS = 90 日`、`DEFAULT_LLM_CONTEXT_TOKEN_LIMIT = 40_000`
- 新規依存：`@aws-sdk/client-dynamodb`、`@aws-sdk/lib-dynamodb`、`@nagiyu/aws`、`js-tiktoken`、`ulid`

**Web（`services/livetalk/web`）**

- `lib/server/repositories.ts`：`registerDynamoRepositories` を使った factory（`USE_IN_MEMORY_DB=true` で InMemory に切り替え）
- `app/api/echo/route.ts`：
  - 受信時にユーザー発話を DynamoDB に保存
  - VOICEVOX 合成後にキャラ応答も保存
  - 永続化失敗時は 500 を返し UI に伝える
- `app/api/messages/route.ts`（新規）：認証ユーザーの直近メッセージをトークン上限ベースで返す GET エンドポイント

### トークン上限ベース取得の挙動

- DynamoDB に対し `ScanIndexForward=false`（新しい順）でクエリ
- 文字単位でトークン換算（`js-tiktoken`）し、累積が上限を超えた時点で打ち切り
- ただし「最初の 1 件は上限を超えても必ず含める」ことでコンテキスト皆無を回避
- 返却順は時系列昇順（LLM プロンプトにそのまま渡せる形）
- `LLM_CONTEXT_TOKEN_LIMIT` 環境変数で上限を上書き可能
- `/api/messages` のクエリ `tokenLimit` でリクエスト単位の上書きも可能（100〜200K の範囲制限）

## 関連 Issue

- 親: #3185（Phase 2）
- 祖父: #3182（リブトーク 全体）

本 PR では `Closes #` は使用しない（Issue は `integration/3182-livetalk → develop` のマージ後にクローズ）。

## 変更種別

- [x] 新規機能
- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した（TypeScript strict、エラーメッセージは日本語 + 定数化、`@/` パスエイリアスは web のみで使用）
- [x] テストを追加・更新した（テストカバレッジ 80% 以上を確保）
- [x] 関連ドキュメントを更新した（`tasks/livetalk/design.md` の既存ガイダンスに準拠して実装。新規 ADR の追加は不要と判断）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- **core ユニットテスト**：72 件 / 11 ファイル パス、`npm run test:coverage` で 95.16% statements / 80.44% branches / 85.96% funcs / 97.74% lines
  - Mapper の roundtrip + バリデーション
  - InMemory / DynamoDB リポジトリの保存・取得・upsert
  - トークン上限ベース取得の主要ケース：上限以下全件取得、上限超過打ち切り、最初の 1 件強制採用、ユーザー / キャラ分離、hardLimit、ページング、壊れた item のスキップ
  - `tiktoken` ベースのトークン換算、env 上書き、シングルトン挙動
- **web ユニットテスト**：33 件 / 6 ファイル パス、coverage 99.31% lines
  - `/api/echo`：認証・バリデーション・保存→VOICEVOX→保存の正常系・各失敗系
  - `/api/messages`：認証・クエリ検証・正常系・リポジトリエラー
  - リポジトリファクトリの InMemory / DynamoDB 切替
- **infra ユニットテスト**：54 件 / 4 ファイル パス
  - 新規 `dynamodb-stack.test.js`：テーブル名 / Single Table 構成 / PAY_PER_REQUEST / PITR / TTL / 暗号化 / 環境別 RemovalPolicy / SSM 出力 / タグ
  - 既存 `ecs-service-stack.test.js`：DynamoDB env var 注入 + Task Role IAM 権限の検証を追加

## レビューポイント

- **DynamoDB Single Table の SK スキーマ**：`tasks/livetalk/design.md` 3.2 節（Phase 2a 該当部）に準拠したつもりです。Message のみ TTL 90 日、Profile / CharacterState は TTL なし。
- **トークン上限ベース取得のセマンティクス**：
  - 「最初の 1 件は強制的に採用」ロジックを `collected.length > 0` の条件で実装
  - `truncated=true` は「上限到達 or hardLimit 到達」のみ。データを全件取り切ったら `false`
  - 返却順は時系列昇順（LLM プロンプト向け）。UI で「最新 N 件」をスクロール表示するなら呼び出し側で逆順する想定
- **エコー応答の永続化失敗時挙動**：今回は 500 でユーザーに見える形にしました。LLM 統合（Phase 2c）の `/api/chat` に置き換わるまでの暫定挙動です。
- **`fromTableArn` を使った ITable 参照**：CDK は `fromTableAttributes` に tableArn と tableName を同時に渡すとエラーになるため、IAM grant 用には ARN 一本で `fromTableArn` を使い、env var 用にはテーブル名を SSM から直接取り出す形にしました。

## 補足事項

- `ulid` / `js-tiktoken` を新規導入。前者は時系列ソート ID、後者は `gpt-4o` 用の純 JS トークナイザ（WASM 不要、ESM 互換）。
- `services/livetalk/core/tsconfig.json` の `references` に `libs/aws` を追加。
- `services/livetalk/web/jest.config.ts` に `@nagiyu/aws` の moduleNameMapper を追加。
- セーフティイベントの DynamoDB 保管は本 PR の対象外（Phase 2d / #3250 で SafetyEvent テーブルを別途設計）。
- LLM 統合は対象外（Phase 2b / 2c）。今回は エコーレスポンスを `assistant` ロールでそのまま保存する暫定実装。

## 完了条件（Issue #3247）

- [x] CDK 定義で dev に `nagiyu-livetalk-dev` テーブルを作成（実 deploy は人レビュー後）
- [x] エコー時にユーザーメッセージとキャラ応答が DynamoDB に保存される
- [x] 直近メッセージ取得 API でトークン上限ベースの動的取得が動く
- [x] ユーザープロファイル / キャラ状態の Get / Put が動く
- [x] 既存エコー UI が引き続き動作する（テストでバリデーション・ロジック維持を確認）
- [x] ユニットテストでカバレッジ 80% 以上

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH5piFvC2dmJeqzo7ZCr7H)_