### PR TITLE
fix(ci): LiveTalk DynamoDB スタックをデプロイワークフローに追加

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -177,7 +177,7 @@ jobs:
           echo "image-uri=$REPOSITORY_URI:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
   infrastructure-app:
-    name: Deploy ALB and ECS Service Stacks
+    name: Deploy DynamoDB, ALB and ECS Service Stacks
     runs-on: ubuntu-latest
     needs: build
 
@@ -217,7 +217,7 @@ jobs:
             OPENAI_API_KEY,/nagiyu/livetalk/${{ needs.build.outputs.environment }}/openai/api-key
           parse-json-secrets: true
 
-      - name: Deploy ALB and ECS Service Stacks
+      - name: Deploy DynamoDB, ALB and ECS Service Stacks
         env:
           ENVIRONMENT: ${{ needs.build.outputs.environment }}
           STACK_SUFFIX: ${{ needs.build.outputs.stack-suffix }}
@@ -228,14 +228,17 @@ jobs:
           SECRET_VALUE: ${{ env.NEXTAUTH_SECRET }}
           OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
         run: |
+          # DynamoDB Single Table（Phase 2a で追加）。ECS Service とは
+          # deploy 順依存がなく、ALB / Service と同じジョブで一括 deploy する。
           npm run cdk --workspace=@nagiyu/infra-livetalk -- deploy \
+            NagiyuLiveTalkDynamoDB${STACK_SUFFIX} \
             NagiyuLiveTalkAlb${STACK_SUFFIX} \
             NagiyuLiveTalkService${STACK_SUFFIX} \
             --context nextAuthSecret="$SECRET_VALUE" \
             --context openAiApiKey="$OPENAI_API_KEY" \
             --require-approval never
 
-          echo "LiveTalk ALB and ECS Service deployed (environment: $ENVIRONMENT)"
+          echo "LiveTalk DynamoDB, ALB and ECS Service deployed (environment: $ENVIRONMENT)"
 
       - name: Force new ECS service deployment
         env:


### PR DESCRIPTION
## 概要

Phase 2a で CDK に追加された `NagiyuLiveTalkDynamoDB` スタックが、`livetalk-deploy.yml` のデプロイ対象から漏れていた問題を修正する。

## 不具合の現象

dev 環境 (`https://dev-live-talk.nagiyu.com`) で初回アクセスすると同意モーダルが表示され、「利用開始」を押すと「同意の送信に失敗しました」エラーが発生する。

CloudWatch Logs (`/ecs/nagiyu-livetalk-task-dev`):

```
[POST /api/consent] 同意状態の保存に失敗しました
Error [DatabaseError]: データベースエラーが発生しました: Requested resource not found
```

## 根本原因

- CDK 定義 (`infra/livetalk/bin/livetalk.ts`) には `NagiyuLiveTalkDynamoDB${envSuffix}` が含まれている (#3247 / Phase 2a で追加)
- しかし `.github/workflows/livetalk-deploy.yml` のデプロイ対象には含まれていなかった
- AWS 上に DynamoDB Single Table (`nagiyu-livetalk-dynamodb-dev`) が作成されておらず、`/api/consent` および `/api/echo` の DynamoDB アクセスが全て失敗

実際に AWS にデプロイされているスタック (`aws cloudformation list-stacks`)：

| スタック名 | デプロイ済 |
|---|---|
| NagiyuLiveTalkEcrDev | ✅ |
| NagiyuLiveTalkSecretsDev | ✅ |
| NagiyuLiveTalkAlbDev | ✅ |
| **NagiyuLiveTalkDynamoDBDev** | ❌ |
| NagiyuLiveTalkServiceDev | ✅ |
| NagiyuLiveTalkCloudFrontDev | ✅ |

Phase 2a の `/api/messages` も同じ DynamoDB を叩いているが、初回アクセスの consent 取得で確実にエラーが踏まれるようになり、Phase 2e で発覚した。

## 変更内容

`.github/workflows/livetalk-deploy.yml` の `infrastructure-app` ジョブで ALB / ECS Service と同じ `cdk deploy` コマンドに `NagiyuLiveTalkDynamoDB${STACK_SUFFIX}` を追加。

CDK 上 deploy 順依存はない（ECS Service は名前 / ARN を `getDynamoDBTableName` / `getDynamoDBTableArn` ヘルパーで決定論的に組み立てるため、`infra/livetalk/bin/livetalk.ts` 99-102 行目のコメント参照）。

ECS Task の IAM Role は `dynamoTable.grantReadWriteData(taskRole)` で既に読み書き権限が付与されている (`infra/livetalk/lib/ecs-service-stack.ts:297`)。

## テスト計画

- [ ] PR マージ → integration/develop マージ → dev 環境デプロイで `NagiyuLiveTalkDynamoDBDev` スタックが作成されることを確認
- [ ] `aws dynamodb list-tables` で `nagiyu-livetalk-dynamodb-dev` が存在することを確認
- [ ] `https://dev-live-talk.nagiyu.com` で同意モーダルから「利用開始」を押して成功することを確認
- [ ] CloudWatch Logs で "Requested resource not found" エラーが出ないことを確認

## レビューポイント

- DynamoDB スタックを `infrastructure-ecr` ジョブ（ECR / Secrets と同列）ではなく `infrastructure-app` ジョブに置いた判断について。データ層なので前者でもよいが、`build` ジョブを待つ必要がないとはいえ ALB / Service と同じ「アプリ実行時インフラ」として 1 つの cdk deploy にまとめた方が呼び出し回数が減るためこちらにした。

https://claude.ai/code/session_019TacKNBVsSTBfBFbCYLQhR

---
_Generated by [Claude Code](https://claude.ai/code/session_019TacKNBVsSTBfBFbCYLQhR)_