### PR TITLE
[Phase 2f] iOS Safari 音声再生デグレ対応 - AudioContext unlock（Plan A）

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -63,6 +63,7 @@ export default function HomePage() {
   const isPlayingRef = useRef(false);
   const streamDoneRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
 
   useEffect(() => {
     fetch('/api/consent')
@@ -74,6 +75,23 @@ export default function HomePage() {
         // 取得失敗時はモーダルを表示してユーザーに同意を促す
         setConsentPhase('required');
       });
+  }, []);
+
+  // iOS Safari の AudioContext autoplay 制約対策。
+  // user gesture（handleSubmit）の同期スタックで呼ぶことで suspended 状態を解除し、
+  // その後の model.speak() 内部の AudioContext が音声を出力できる状態にする。
+  const ensureAudioContextUnlocked = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    const AudioContextClass =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) return;
+    if (!audioCtxRef.current) {
+      audioCtxRef.current = new AudioContextClass();
+    }
+    if (audioCtxRef.current.state === 'suspended') {
+      await audioCtxRef.current.resume();
+    }
   }, []);
 
   const revokeCurrentAudio = useCallback(() => {
@@ -108,6 +126,9 @@ export default function HomePage() {
 
   const handleSubmit = useCallback(
     async (text: string) => {
+      // user gesture のスタック内で AudioContext を resume する（iOS Safari 対策）
+      await ensureAudioContextUnlocked();
+
       // 前回リクエストをキャンセル
       abortControllerRef.current?.abort();
       const controller = new AbortController();
@@ -199,7 +220,7 @@ export default function HomePage() {
         setPhase('idle');
       }
     },
-    [revokeCurrentAudio, clearAudioQueue, advanceAudioQueue]
+    [ensureAudioContextUnlocked, revokeCurrentAudio, clearAudioQueue, advanceAudioQueue]
   );
 
   const handlePlaybackEnd = useCallback(() => {
@@ -209,7 +230,8 @@ export default function HomePage() {
     advanceAudioQueue();
   }, [revokeCurrentAudio, advanceAudioQueue]);
 
-  const handlePlaybackError = useCallback(() => {
+  const handlePlaybackError = useCallback((error: Error) => {
+    console.error('[LiveTalk] 音声再生エラー', error);
     setErrorMessage('音声再生中にエラーが発生しました。');
     revokeCurrentAudio();
     setAudioUrl(null);

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -230,14 +230,17 @@ export default function HomePage() {
     advanceAudioQueue();
   }, [revokeCurrentAudio, advanceAudioQueue]);
 
-  const handlePlaybackError = useCallback((error: Error) => {
-    console.error('[LiveTalk] 音声再生エラー', error);
-    setErrorMessage('音声再生中にエラーが発生しました。');
-    revokeCurrentAudio();
-    setAudioUrl(null);
-    isPlayingRef.current = false;
-    advanceAudioQueue();
-  }, [revokeCurrentAudio, advanceAudioQueue]);
+  const handlePlaybackError = useCallback(
+    (error: Error) => {
+      console.error('[LiveTalk] 音声再生エラー', error);
+      setErrorMessage('音声再生中にエラーが発生しました。');
+      revokeCurrentAudio();
+      setAudioUrl(null);
+      isPlayingRef.current = false;
+      advanceAudioQueue();
+    },
+    [revokeCurrentAudio, advanceAudioQueue]
+  );
 
   const statusText =
     phase === 'loading' ? '考え中…' : phase === 'streaming' ? '話している' : '待機中';

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -1,0 +1,241 @@
+// jsdom は TextEncoder / TextDecoder / ReadableStream を提供しない場合があるため補完
+import { TextEncoder, TextDecoder } from 'util';
+import { ReadableStream } from 'stream/web';
+Object.assign(global, { TextEncoder, TextDecoder, ReadableStream });
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HomePage from '@/app/page';
+
+// Live2DCanvas の dynamic import をモック（pixi.js / WebGL 依存を排除）
+jest.mock('@/components/Live2DCanvas', () => ({
+  __esModule: true,
+  default: jest.fn(
+    ({
+      onPlaybackEnd,
+      onPlaybackError,
+    }: {
+      audioUrl?: string | null;
+      statusText?: string;
+      onPlaybackEnd?: () => void;
+      onPlaybackError?: (error: Error) => void;
+    }) => (
+      <div data-testid="live2d-canvas">
+        <button data-testid="trigger-playback-end" onClick={onPlaybackEnd}>
+          end
+        </button>
+        <button
+          data-testid="trigger-playback-error"
+          onClick={() => onPlaybackError?.(new Error('再生エラー'))}
+        >
+          error
+        </button>
+      </div>
+    )
+  ),
+  Live2DCanvasFallback: jest.fn(() => <div data-testid="live2d-fallback" />),
+}));
+
+jest.mock('@/components/ConsentModal', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('@/components/SafetyModal', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('@/components/LicenseFooter', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock('@/components/ResponseDisplay', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+// jsdom は URL.createObjectURL / revokeObjectURL 未実装
+Object.defineProperty(global.URL, 'createObjectURL', {
+  writable: true,
+  value: jest.fn(() => 'blob:mock'),
+});
+Object.defineProperty(global.URL, 'revokeObjectURL', {
+  writable: true,
+  value: jest.fn(),
+});
+
+/** /api/consent が同意済みを返す fetch モックを設定する */
+function setupFetchMocks(chatOk = false) {
+  const encoder = new TextEncoder();
+  const chatStream = new ReadableStream({
+    start(controller) {
+      if (chatOk) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+      }
+      controller.close();
+    },
+  });
+
+  global.fetch = jest.fn().mockImplementation((url: string) => {
+    if (url === '/api/consent') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ consented: true }),
+      });
+    }
+    return Promise.resolve({ ok: chatOk, body: chatStream });
+  });
+}
+
+/** window.AudioContext をモック AudioContext クラスで上書きし、cleanup を返す */
+function setupMockAudioContext(state: 'suspended' | 'running') {
+  const mockResume = jest.fn().mockResolvedValue(undefined);
+  const instance = { state, resume: mockResume };
+  const MockAudioContext = jest.fn(() => instance);
+
+  Object.defineProperty(window, 'AudioContext', {
+    writable: true,
+    configurable: true,
+    value: MockAudioContext,
+  });
+
+  return { MockAudioContext, instance, mockResume };
+}
+
+function removeAudioContext() {
+  Object.defineProperty(window, 'AudioContext', {
+    writable: true,
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(window, 'webkitAudioContext', {
+    writable: true,
+    configurable: true,
+    value: undefined,
+  });
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+  removeAudioContext();
+});
+
+/** 同意チェック完了を待ち、有効化された入力欄を返す */
+async function waitForInputEnabled() {
+  await waitFor(() => expect(screen.getByPlaceholderText('メッセージを入力')).toBeEnabled());
+  return screen.getByPlaceholderText('メッセージを入力');
+}
+
+describe('AudioContext unlock（iOS Safari autoplay 制約対策）', () => {
+  it('handleSubmit 時に AudioContext が作成され resume() が呼ばれる（suspended 状態）', async () => {
+    setupFetchMocks();
+    const { MockAudioContext, mockResume } = setupMockAudioContext('suspended');
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'こんにちは');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    expect(MockAudioContext).toHaveBeenCalledTimes(1);
+    expect(mockResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('AudioContext が running 状態のとき resume() は呼ばれない', async () => {
+    setupFetchMocks();
+    const { MockAudioContext, mockResume } = setupMockAudioContext('running');
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'テスト');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    expect(MockAudioContext).toHaveBeenCalledTimes(1);
+    expect(mockResume).not.toHaveBeenCalled();
+  });
+
+  it('2 回目の submit では AudioContext を再生成しない（インスタンスを再利用）', async () => {
+    setupFetchMocks(true); // done イベント付きで phase が idle に戻る
+    const { MockAudioContext, mockResume } = setupMockAudioContext('suspended');
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    // 1 回目
+    await user.type(input, 'テスト1');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    // phase が idle に戻るのを待つ（done イベントで advanceAudioQueue → setPhase('idle')）
+    await waitFor(() => expect(input).toBeEnabled(), { timeout: 5000 });
+
+    // 2 回目
+    await user.type(input, 'テスト2');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    // コンストラクタは 1 回だけ（インスタンスを再利用）
+    expect(MockAudioContext).toHaveBeenCalledTimes(1);
+    // suspended なので 2 回とも resume() が呼ばれる
+    expect(mockResume).toHaveBeenCalledTimes(2);
+  });
+
+  it('window.AudioContext が undefined のとき webkitAudioContext をフォールバックで使う', async () => {
+    setupFetchMocks();
+    const mockResume = jest.fn().mockResolvedValue(undefined);
+    const MockWebkitAudioContext = jest.fn(() => ({ state: 'suspended', resume: mockResume }));
+
+    // AudioContext を未定義にして webkit フォールバックを設定
+    removeAudioContext();
+    Object.defineProperty(window, 'webkitAudioContext', {
+      writable: true,
+      configurable: true,
+      value: MockWebkitAudioContext,
+    });
+
+    const user = userEvent.setup();
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'テスト');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    expect(MockWebkitAudioContext).toHaveBeenCalledTimes(1);
+    expect(mockResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('AudioContext が利用不可の環境でもクラッシュしない', async () => {
+    setupFetchMocks();
+    removeAudioContext(); // AudioContext も webkitAudioContext も未定義
+
+    const user = userEvent.setup();
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'テスト');
+    // エラーが throw されないことを確認
+    await expect(user.click(screen.getByRole('button', { name: '送信' }))).resolves.toBeUndefined();
+  });
+});
+
+describe('handlePlaybackError のデバッグログ', () => {
+  it('onPlaybackError 発火時に console.error でエラーを出力する', async () => {
+    setupFetchMocks();
+    setupMockAudioContext('running');
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    const triggerError = screen.getByTestId('trigger-playback-error');
+    await userEvent.click(triggerError);
+
+    expect(consoleSpy).toHaveBeenCalledWith('[LiveTalk] 音声再生エラー', expect.any(Error));
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## 変更の概要

Issue #3260（Phase 2f）対応。Phase 2c で導入した文単位 VOICEVOX パイプラインにより iOS Safari で音声が再生できなくなったデグレを、Plan A（AudioContext を user gesture で事前 resume）で修正する。

### 変更内容

**`services/livetalk/web/src/app/page.tsx`**
- `audioCtxRef`（`useRef<AudioContext | null>`）を追加
- `ensureAudioContextUnlocked()` を追加：`handleSubmit` の先頭で呼び出し、user gesture のスタック内で AudioContext を作成・resume する
  - 既存 AudioContext があれば再利用（毎回新規生成しない）
  - `state === 'running'` なら no-op（Edge での二重再生デグレ防止）
  - `webkitAudioContext` フォールバック対応
  - AudioContext が利用不可の環境でもクラッシュしない
- `handlePlaybackError` に `console.error('[LiveTalk] 音声再生エラー', error)` を追加（iOS 実機での原因特定用デバッグログ）
- `model.speak()` の呼び出し回数・タイミング・引数は変更なし

**`services/livetalk/web/tests/unit/app/page.test.tsx`**（新規）
- AudioContext unlock の動作を検証するユニットテスト 6 件を追加

## 関連 Issue

#3260（本対応）
#3249（デグレ元：Phase 2c 文単位パイプライン）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（6 件追加、全 56 件パス）
- [ ] 関連ドキュメントを更新した（本修正はドキュメント変更不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した（56/56 pass）
- [x] ビルドエラーがないことを確認した（shared libs 未ビルドによる pre-existing TS エラーを除く）

## テスト内容

`tests/unit/app/page.test.tsx` に以下 6 ケースを追加：

1. `handleSubmit` 時に AudioContext が作成され `resume()` が呼ばれる（suspended 状態）
2. AudioContext が `running` 状態のとき `resume()` は呼ばれない（Edge デグレ防止）
3. 2 回目の submit では AudioContext を再生成しない（インスタンス再利用）
4. `window.AudioContext` が未定義のとき `webkitAudioContext` をフォールバックで使う
5. AudioContext が利用不可の環境でもクラッシュしない
6. `onPlaybackError` 発火時に `console.error` でエラーを出力する

## レビューポイント

- **Edge での二重再生デグレが発生しないこと**を最重点で確認してください
  - `ensureAudioContextUnlocked` は `model.speak()` の呼び出し前に完了するが、speak 自体のタイミングは変更なし
  - `state === 'running'` のケースでは `resume()` を呼ばないため、Edge での既存フローに影響しない
- Plan A の効果は iOS Safari 実機確認が必要です（下記「補足事項」参照）

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

### iOS Safari 実機確認のお願い

Plan A が有効かどうかは iOS Safari 実機でのみ確認できます。以下の 2 点を確認いただけますでしょうか：

**確認環境**
- `https://dev-live-talk.nagiyu.com`
- iOS Safari（PWA standalone モード含む）
- Edge（デスクトップ）でのデグレ確認も合わせてお願いします

**確認手順**
1. チャット画面を開く
2. テキストを入力して送信
3. 音声が再生されるか確認（1 文・複数文の両方）

**確認結果の共有**
- ✅ iOS で音声再生 OK → Plan A で解決、このまま integration → develop PR に進む
- ❌ iOS で引き続き失敗 → iOS の DevTools でコンソールログを確認し、`[LiveTalk] 音声再生エラー` の詳細を教えてください。Plan A+（モンキーパッチ）または Plan B（WAV 結合）への切替を判断します


---
_Generated by [Claude Code](https://claude.ai/code/session_01UNfpwJG5MX7h6dJzrUZWbK)_