### PR TITLE
[Phase 2f / Debug] iOS 実機デバッグ用: 音声再生エラー詳細を画面表示

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -233,7 +233,16 @@ export default function HomePage() {
   const handlePlaybackError = useCallback(
     (error: Error) => {
       console.error('[LiveTalk] 音声再生エラー', error);
-      setErrorMessage('音声再生中にエラーが発生しました。');
+      // iOS Safari 実機デバッグ用に画面にエラー詳細を表示する（#3260 対応中の一時措置、
+      // 解決後は元の汎用メッセージに戻す）。error が Error でない値で渡される可能性に
+      // 備え、name / message を defensive に取り出す。
+      const errorName = (error as { name?: unknown })?.name
+        ? String((error as { name: unknown }).name)
+        : 'Unknown';
+      const errorMessageDetail = (error as { message?: unknown })?.message
+        ? String((error as { message: unknown }).message)
+        : String(error);
+      setErrorMessage(`音声再生中にエラーが発生しました。[${errorName}] ${errorMessageDetail}`);
       revokeCurrentAudio();
       setAudioUrl(null);
       isPlayingRef.current = false;

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -238,4 +238,23 @@ describe('handlePlaybackError のデバッグログ', () => {
     expect(consoleSpy).toHaveBeenCalledWith('[LiveTalk] 音声再生エラー', expect.any(Error));
     consoleSpy.mockRestore();
   });
+
+  it('onPlaybackError 発火時にエラーの name / message を画面に表示する（iOS 実機デバッグ用）', async () => {
+    setupFetchMocks();
+    setupMockAudioContext('running');
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    const triggerError = screen.getByTestId('trigger-playback-error');
+    await userEvent.click(triggerError);
+
+    // mock の Live2DCanvas は `new Error('再生エラー')` を渡すので
+    // 画面に "[Error] 再生エラー" が含まれることを検証
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('[Error]');
+    expect(alert.textContent).toContain('再生エラー');
+    consoleSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## 変更の概要

#3260 Plan A の対応（PR #3261 マージ済み）後、iOS Safari 実機では音声再生が引き続き失敗することが判明。真因特定のため、**iOS 実機デバッグ用にエラー詳細を画面に表示する一時措置**を入れる。

iOS Safari の DevTools コンソールは Mac + USB 接続が必要で、すぐに確認できないため、画面表示が最速。

### 変更内容

**`services/livetalk/web/src/app/page.tsx`**
- `handlePlaybackError` の `setErrorMessage` を `音声再生中にエラーが発生しました。[<error.name>] <error.message>` 形式に変更
- `error` が `Error` インスタンスでない値で渡される可能性に備え、defensive に `name` / `message` を取り出す

**`services/livetalk/web/tests/unit/app/page.test.tsx`**
- 画面表示の検証ケースを 1 件追加（合計 7 件、全 57 件パス）

## 関連 Issue

#3260（本対応中）。本 PR は Plan A 効果なしの後続デバッグ作業。

## 変更種別

- [ ] 新規機能
- [x] バグ修正（デバッグ用一時措置）
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（7 件、全 57 件パス）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した（57/57 pass）
- [x] ビルドエラーがないことを確認した

## テスト内容

`tests/unit/app/page.test.tsx` に以下を追加：

- `onPlaybackError` 発火時にエラーの `name` / `message` を画面に表示する（`[Error] 再生エラー` を含むことを検証）

## レビューポイント

- これは **一時的なデバッグ措置** です。原因特定後は `setErrorMessage('音声再生中にエラーが発生しました。')` の汎用文言に戻す予定
- prod 環境にも露出するが、エラー発生時のみの表示なので user-facing としては許容範囲と判断（短期間）

## スクリーンショット（該当する場合）

UI 変更は「エラー発生時に表示される文字列」のみ。

## 補足事項

### iOS 実機確認のお願い

マージ・dev 反映後、以下を確認してください：

1. iOS Safari で `https://dev-live-talk.nagiyu.com` を開く
2. メッセージ送信して音声再生失敗を再現
3. 画面の赤いエラー表示をスクショまたはテキストでコピーして共有

例：`音声再生中にエラーが発生しました。[NotAllowedError] play() failed because the user didn't interact with the document first.`

この情報があれば Plan A+（モンキーパッチ）か Plan B（WAV 結合）か別アプローチかの判断ができます。


---
_Generated by [Claude Code](https://claude.ai/code/session_01UNfpwJG5MX7h6dJzrUZWbK)_