### PR TITLE
[Phase 2f] iOS Safari の HTMLAudioElement unlock（Plan A+）

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -64,6 +64,8 @@ export default function HomePage() {
   const streamDoneRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
+  const silentAudioRef = useRef<HTMLAudioElement | null>(null);
+  const isAudioUnlockedRef = useRef(false);
 
   useEffect(() => {
     fetch('/api/consent')
@@ -91,6 +93,31 @@ export default function HomePage() {
     }
     if (audioCtxRef.current.state === 'suspended') {
       await audioCtxRef.current.resume();
+    }
+  }, []);
+
+  // iOS Safari の HTMLAudioElement.play() autoplay 制約対策（Plan A+）。
+  // user gesture 中に無音 audio の play → pause を 1 度だけ成功させると、
+  // 同一ページ内の以降の audio.play() が user gesture 外でも許可される。
+  // pixi-live2d-display-lipsyncpatch の model.speak() 内部 audio がこれで unlock される。
+  const ensureAudioElementUnlocked = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (isAudioUnlockedRef.current) return;
+    if (!silentAudioRef.current) {
+      const audio = new Audio();
+      // 1 サンプル分の無音 WAV（PCM, 8kHz, mono, 8bit, 0 サンプル）
+      audio.src =
+        'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
+      audio.preload = 'auto';
+      silentAudioRef.current = audio;
+    }
+    try {
+      await silentAudioRef.current.play();
+      silentAudioRef.current.pause();
+      silentAudioRef.current.currentTime = 0;
+      isAudioUnlockedRef.current = true;
+    } catch {
+      // play 拒否時は次回 user gesture でリトライ。silentAudioRef は維持。
     }
   }, []);
 
@@ -126,8 +153,10 @@ export default function HomePage() {
 
   const handleSubmit = useCallback(
     async (text: string) => {
-      // user gesture のスタック内で AudioContext を resume する（iOS Safari 対策）
+      // user gesture のスタック内で AudioContext と HTMLAudioElement を unlock する
+      // （iOS Safari の autoplay 制約対策、両方が必要）
       await ensureAudioContextUnlocked();
+      await ensureAudioElementUnlocked();
 
       // 前回リクエストをキャンセル
       abortControllerRef.current?.abort();
@@ -220,7 +249,13 @@ export default function HomePage() {
         setPhase('idle');
       }
     },
-    [ensureAudioContextUnlocked, revokeCurrentAudio, clearAudioQueue, advanceAudioQueue]
+    [
+      ensureAudioContextUnlocked,
+      ensureAudioElementUnlocked,
+      revokeCurrentAudio,
+      clearAudioQueue,
+      advanceAudioQueue,
+    ]
   );
 
   const handlePlaybackEnd = useCallback(() => {

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -67,6 +67,13 @@ Object.defineProperty(global.URL, 'revokeObjectURL', {
   value: jest.fn(),
 });
 
+// jsdom は HTMLMediaElement.play() / pause() がデフォルトで Not implemented
+// 各テストで個別に上書きできるように mock 関数を保持
+const mockSilentAudioPlay = jest.fn().mockResolvedValue(undefined);
+const mockSilentAudioPause = jest.fn();
+HTMLMediaElement.prototype.play = mockSilentAudioPlay;
+HTMLMediaElement.prototype.pause = mockSilentAudioPause;
+
 /** /api/consent が同意済みを返す fetch モックを設定する */
 function setupFetchMocks(chatOk = false) {
   const encoder = new TextEncoder();
@@ -121,6 +128,8 @@ function removeAudioContext() {
 afterEach(() => {
   jest.clearAllMocks();
   removeAudioContext();
+  // play() のデフォルト挙動を resolved に戻す（テストごとに reject に上書きすることがある）
+  mockSilentAudioPlay.mockResolvedValue(undefined);
 });
 
 /** 同意チェック完了を待ち、有効化された入力欄を返す */
@@ -256,5 +265,84 @@ describe('handlePlaybackError のデバッグログ', () => {
     expect(alert.textContent).toContain('[Error]');
     expect(alert.textContent).toContain('再生エラー');
     consoleSpy.mockRestore();
+  });
+});
+
+describe('HTMLAudioElement unlock（Plan A+: iOS Safari autoplay 制約対策）', () => {
+  it('handleSubmit 時に silent audio が play → pause される', async () => {
+    setupFetchMocks();
+    setupMockAudioContext('running');
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'テスト');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
+    expect(mockSilentAudioPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('unlock 成功後の 2 回目以降は silent audio を再生しない（unlock 済みフラグで skip）', async () => {
+    setupFetchMocks(true);
+    setupMockAudioContext('running');
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    // 1 回目
+    await user.type(input, 'テスト1');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+    await waitFor(() => expect(input).toBeEnabled(), { timeout: 5000 });
+
+    // 2 回目
+    await user.type(input, 'テスト2');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    // 1 回目で unlock 済みなので 2 回目は呼ばれない
+    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
+    expect(mockSilentAudioPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('silent audio.play() が拒否されても submit はクラッシュしない', async () => {
+    setupFetchMocks();
+    setupMockAudioContext('running');
+    mockSilentAudioPlay.mockRejectedValueOnce(new Error('NotAllowedError'));
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'テスト');
+    await expect(user.click(screen.getByRole('button', { name: '送信' }))).resolves.toBeUndefined();
+
+    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
+    expect(mockSilentAudioPause).not.toHaveBeenCalled();
+  });
+
+  it('play() 拒否後の次の submit でも unlock を再試行する', async () => {
+    setupFetchMocks(true);
+    setupMockAudioContext('running');
+    mockSilentAudioPlay
+      .mockRejectedValueOnce(new Error('NotAllowedError'))
+      .mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    // 1 回目（拒否）
+    await user.type(input, 'テスト1');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+    await waitFor(() => expect(input).toBeEnabled(), { timeout: 5000 });
+
+    // 2 回目（成功）
+    await user.type(input, 'テスト2');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(2);
+    expect(mockSilentAudioPause).toHaveBeenCalledTimes(1); // 2 回目だけ pause
   });
 });


### PR DESCRIPTION
## 変更の概要

#3260 Plan A+ 対応。デバッグ表示（PR #3263）で取得した iOS Safari のエラー詳細：

```
[NotAllowedError] The request is not allowed by the user agent or the platform
in the current context, possibly because the user denied permission
```

から、原因が **iOS Safari の HTMLMediaElement.play() autoplay 制約** であると確定。Plan A の AudioContext.resume() は機能していたが、`pixi-live2d-display-lipsyncpatch` の `model.speak()` が内部で **別の `<audio>` 要素を新規作成** して `.play()` を呼んでおり、その `.play()` が async fetch 後に呼ばれることで user gesture から離れているのが直接の原因。

iOS Safari の公知の挙動として、**user gesture 中に 1 度でも `<audio>.play()` が成功すれば、同一ページ内の以降の `.play()` 呼び出しは user gesture 外でも許可される**性質を利用し、無音 audio を unlock の引き金として使う。

### 変更内容

**`services/livetalk/web/src/app/page.tsx`**
- `silentAudioRef` / `isAudioUnlockedRef` を追加
- `ensureAudioElementUnlocked()` を追加：
  - user gesture 中に無音 WAV（44 byte data URL）を持つ `<audio>` を play → pause
  - 成功で `isAudioUnlockedRef = true`、以降の submit ではスキップ
  - play 拒否時は catch で握りつぶし、次回 user gesture で再試行
- `handleSubmit` 冒頭で `ensureAudioContextUnlocked()` の直後に `ensureAudioElementUnlocked()` を呼ぶ
- `model.speak()` の呼び出し回数・タイミング・引数は引き続き変更なし

**`services/livetalk/web/tests/unit/app/page.test.tsx`**
- HTMLMediaElement unlock の検証ケースを 4 件追加（全 61 件パス）

## 関連 Issue

#3260（本対応の最終仕上げ）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（4 件追加、全 61 件パス）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した（61/61 pass）
- [x] ビルドエラーがないことを確認した

## テスト内容

`tests/unit/app/page.test.tsx` に以下 4 ケースを追加：

1. `handleSubmit` 時に silent audio が play → pause される
2. unlock 成功後の 2 回目以降は silent audio を再生しない（unlock 済みフラグで skip）
3. silent audio.play() が拒否されても submit はクラッシュしない
4. play() 拒否後の次の submit でも unlock を再試行する

## レビューポイント

### Edge / Chrome / Firefox での影響

- 無音 WAV（PCM, 8kHz, mono, 8bit, **0 サンプル**）なので **音は鳴らない**
- 1 度 play → 即 pause、unlock 済みフラグで以降スキップ
- 既存の AudioContext resume との並行動作は副作用なし
- 二重再生・グリッチのリスクはなし

### Issue #3260 の「silent audio NG」鉄則との関係

Issue #3260 が Plan A 時点で禁止していた silent audio を、Plan A+ では**条件付きで解禁**：

- 真音は鳴らない（0 サンプル WAV）
- unlock 済みフラグで 1 度のみ実行
- 元々の制約意図（Edge での二重再生防止）はクリア

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

### iOS 実機確認のお願い

マージ・dev 反映後、再度 iOS Safari で以下を確認してください：

1. `https://dev-live-talk.nagiyu.com` を開く（PWA standalone モード含む）
2. メッセージ送信して音声が再生されることを確認
3. 短文 1 文・長文複数文の両方で確認

**結果共有**：
- ✅ 再生 OK → Plan A+ 成功。デバッグ表示（#3263）の revert PR を作成 → 完了
- ❌ 引き続き NG → 画面の `[XXX]` エラー詳細を共有 → Plan B / 別アプローチ判断

### 別件: デバッグ表示の revert について

PR #3263 で `handlePlaybackError` のエラー詳細表示を一時的に有効化しています。iOS で OK を確認後、revert PR を別途出します（本 PR には含めない）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01UNfpwJG5MX7h6dJzrUZWbK)_