### PR TITLE
[Phase 2f / hotfix] silent audio unlock を fire-and-forget 化（iOS 送信 stall 修正）

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -97,10 +97,14 @@ export default function HomePage() {
   }, []);
 
   // iOS Safari の HTMLAudioElement.play() autoplay 制約対策（Plan A+）。
-  // user gesture 中に無音 audio の play → pause を 1 度だけ成功させると、
-  // 同一ページ内の以降の audio.play() が user gesture 外でも許可される。
-  // pixi-live2d-display-lipsyncpatch の model.speak() 内部 audio がこれで unlock される。
-  const ensureAudioElementUnlocked = useCallback(async () => {
+  // user gesture 中に無音 audio の play() を 1 度だけ呼ぶと、同一ページ内の以降の
+  // audio.play() が user gesture 外でも許可される（pixi-live2d-display-lipsyncpatch の
+  // model.speak() 内部 audio がこれで unlock される）。
+  //
+  // 重要: await しない。iOS Safari は 0 サンプル無音 WAV の play() Promise が
+  // resolve しない場合があり、await すると handleSubmit が stall して送信処理が
+  // 進まなくなる。unlock 効果は play() を「呼んだ」時点で発生するので fire-and-forget で OK。
+  const ensureAudioElementUnlocked = useCallback(() => {
     if (typeof window === 'undefined') return;
     if (isAudioUnlockedRef.current) return;
     if (!silentAudioRef.current) {
@@ -111,13 +115,19 @@ export default function HomePage() {
       audio.preload = 'auto';
       silentAudioRef.current = audio;
     }
-    try {
-      await silentAudioRef.current.play();
-      silentAudioRef.current.pause();
-      silentAudioRef.current.currentTime = 0;
-      isAudioUnlockedRef.current = true;
-    } catch {
-      // play 拒否時は次回 user gesture でリトライ。silentAudioRef は維持。
+    const playPromise = silentAudioRef.current.play();
+    if (playPromise && typeof playPromise.then === 'function') {
+      playPromise
+        .then(() => {
+          silentAudioRef.current?.pause();
+          if (silentAudioRef.current) {
+            silentAudioRef.current.currentTime = 0;
+          }
+          isAudioUnlockedRef.current = true;
+        })
+        .catch(() => {
+          // play 拒否時は次回 user gesture でリトライ。silentAudioRef は維持。
+        });
     }
   }, []);
 
@@ -153,10 +163,12 @@ export default function HomePage() {
 
   const handleSubmit = useCallback(
     async (text: string) => {
-      // user gesture のスタック内で AudioContext と HTMLAudioElement を unlock する
-      // （iOS Safari の autoplay 制約対策、両方が必要）
+      // user gesture の同期スタック内で HTMLAudioElement の unlock を発火する。
+      // await の前に呼ぶことで iOS Safari の user gesture context を確実に保持する。
+      ensureAudioElementUnlocked();
+      // AudioContext の resume は await が必要だが Edge/Chrome では即時 resolve、
+      // iOS Safari でも安全に完了する。
       await ensureAudioContextUnlocked();
-      await ensureAudioElementUnlocked();
 
       // 前回リクエストをキャンセル
       abortControllerRef.current?.abort();

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -269,7 +269,7 @@ describe('handlePlaybackError のデバッグログ', () => {
 });
 
 describe('HTMLAudioElement unlock（Plan A+: iOS Safari autoplay 制約対策）', () => {
-  it('handleSubmit 時に silent audio が play → pause される', async () => {
+  it('handleSubmit 時に silent audio が同期的に play される', async () => {
     setupFetchMocks();
     setupMockAudioContext('running');
     const user = userEvent.setup();
@@ -281,7 +281,8 @@ describe('HTMLAudioElement unlock（Plan A+: iOS Safari autoplay 制約対策）
     await user.click(screen.getByRole('button', { name: '送信' }));
 
     expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
-    expect(mockSilentAudioPause).toHaveBeenCalledTimes(1);
+    // play() resolve 後の microtask で pause が呼ばれる
+    await waitFor(() => expect(mockSilentAudioPause).toHaveBeenCalledTimes(1));
   });
 
   it('unlock 成功後の 2 回目以降は silent audio を再生しない（unlock 済みフラグで skip）', async () => {
@@ -295,6 +296,7 @@ describe('HTMLAudioElement unlock（Plan A+: iOS Safari autoplay 制約対策）
     // 1 回目
     await user.type(input, 'テスト1');
     await user.click(screen.getByRole('button', { name: '送信' }));
+    await waitFor(() => expect(mockSilentAudioPause).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(input).toBeEnabled(), { timeout: 5000 });
 
     // 2 回目
@@ -343,6 +345,30 @@ describe('HTMLAudioElement unlock（Plan A+: iOS Safari autoplay 制約対策）
     await user.click(screen.getByRole('button', { name: '送信' }));
 
     expect(mockSilentAudioPlay).toHaveBeenCalledTimes(2);
-    expect(mockSilentAudioPause).toHaveBeenCalledTimes(1); // 2 回目だけ pause
+    await waitFor(() => expect(mockSilentAudioPause).toHaveBeenCalledTimes(1)); // 2 回目だけ pause
+  });
+
+  it('silent audio.play() の Promise が pending のままでも handleSubmit が stall しない', async () => {
+    // iOS Safari で観測された問題のリグレッション防止:
+    // 無音 WAV に対する play() Promise が resolve しない環境でも、
+    // handleSubmit は次の処理（fetch / setPhase）に進む必要がある
+    setupFetchMocks();
+    setupMockAudioContext('running');
+    // play() を永久に pending のままにする
+    mockSilentAudioPlay.mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'テスト');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    // play() は呼ばれるが await しない → fetch まで到達する
+    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/chat',
+      expect.objectContaining({ method: 'POST' })
+    );
   });
 });


### PR DESCRIPTION
## 変更の概要

PR #3264（Plan A+）マージ後、iOS Safari で**送信ボタンが反応しないリグレッション**が発生したため、緊急 hotfix。

### 原因

`ensureAudioElementUnlocked()` 内で `await silentAudio.play()` していたため、iOS Safari で **0 サンプル無音 WAV の `play()` Promise が resolve しない** ケースに該当すると、`handleSubmit` が最初の `await` で永久に stall。結果として：

- 送信ボタン押下 → handleSubmit 開始
- → `await ensureAudioElementUnlocked()` で永久 hang
- → `setPhase('loading')` も実行されず、UI 上は完全に無反応

Edge では `play()` が即時 resolve するため発症せず。

### 修正

1. **`ensureAudioElementUnlocked` を非 async 化**、`play()` Promise を `.then().catch()` で受けて `await` しない（fire-and-forget）
2. unlock 効果は `play()` を「呼んだ」時点で iOS が判定するため、完了を待つ必要なし
3. `handleSubmit` 冒頭では `ensureAudioContextUnlocked()` の `await` より前に `ensureAudioElementUnlocked()` を同期的に呼び、user gesture context を保持
4. リグレッション防止テスト追加：`play()` Promise が永久 pending でも `handleSubmit` が `fetch` まで到達することを検証

## 関連 Issue

#3260（Plan A+ 後の hotfix）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（12 件、全 65 件パス）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

更新したケース：
- `handleSubmit` 時に silent audio が同期的に play される（pause は microtask 後）
- unlock 成功後の 2 回目以降は再生しない（フラグ skip）
- play() 拒否時もクラッシュしない
- play() 拒否後の次の submit で unlock 再試行

**追加した最重要テスト**：
- ✨ **silent audio.play() の Promise が pending のままでも handleSubmit が stall しない**（iOS リグレッション防止）

## レビューポイント

- Edge 既存挙動への影響なし：`play()` が即時 resolve するため `.then()` が即時実行され、これまでと同様 unlock 済みフラグが立つ
- `handleSubmit` の処理順：`ensureAudioElementUnlocked()`（同期）→ `await ensureAudioContextUnlocked()` → fetch、と user gesture からの距離を最小化
- 1 サンプル WAV を使い続けているのは Edge での副作用が無いことを確認済みのため。iOS で問題が再発する場合は次の PR で WAV を差し替え可能

## 補足事項

### iOS 実機確認のお願い

マージ・dev 反映後、再度確認してください：

1. iOS Safari で `https://dev-live-talk.nagiyu.com` を開く
2. メッセージ送信して **送信ボタンが反応する** ことを確認（loading 状態に遷移するか）
3. 音声が再生されるか確認

**結果共有**：
- ✅ 送信反応 OK & 音声再生 OK → Plan A+ 最終形で解決
- ⚠️ 送信反応 OK だが音声 NG → 画面の `[XXX] YYY` エラー詳細を共有 → Plan B 検討
- ❌ 送信反応 NG → 別原因。さらに調査


---
_Generated by [Claude Code](https://claude.ai/code/session_01UNfpwJG5MX7h6dJzrUZWbK)_