### PR TITLE
[Phase 2f] iOS Safari の HTMLAudioElement 制約を Web Audio API で回避（Plan C）

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -31,41 +31,43 @@ type ChatStreamEvent =
   | { type: 'done' }
   | { type: 'error'; message: string };
 
-function base64ToBlob(base64: string, mimeType: string): Blob {
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
   const binaryString = atob(base64);
   const bytes = new Uint8Array(binaryString.length);
   for (let i = 0; i < binaryString.length; i++) {
     bytes[i] = binaryString.charCodeAt(i);
   }
-  return new Blob([bytes], { type: mimeType });
+  return bytes.buffer;
 }
 
 /**
- * Phase 2c のチャット画面。
+ * Phase 2c のチャット画面（Phase 2f で Web Audio 再生に切替）。
  *
  * - LLM 応答を NDJSON ストリームで受信し、テキストを逐次表示
- * - 文単位の音声（base64 WAV）を受け取り、キューで順番に再生
- * - Live2D の lipsync は既存 model.speak() を流用
+ * - 文単位の音声（base64 WAV）を AudioBuffer に decode して順番に再生
+ * - iOS Safari 対策として AudioContext を user gesture で resume し、
+ *   Live2DCanvas に AudioBuffer + AudioContext を渡して Web Audio で再生する
+ *   （HTMLAudioElement の autoplay 制約を回避）
  */
 export default function HomePage() {
   const [consentPhase, setConsentPhase] = useState<ConsentPhase>('checking');
   const [phase, setPhase] = useState<ChatPhase>('idle');
   const [userText, setUserText] = useState<string | null>(null);
   const [responseText, setResponseText] = useState<string | null>(null);
-  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [audioBuffer, setAudioBuffer] = useState<AudioBuffer | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const [safetyOpen, setSafetyOpen] = useState(false);
   const [safetyResources, setSafetyResources] = useState<SafetyResource[]>([]);
 
-  const audioUrlRef = useRef<string | null>(null);
-  const audioQueueRef = useRef<string[]>([]);
+  const audioQueueRef = useRef<AudioBuffer[]>([]);
   const isPlayingRef = useRef(false);
   const streamDoneRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+  // AudioContext は子コンポーネント（Live2DCanvas）に prop で渡すため state で持つ。
+  // 同期アクセス用に ref も併用する（callback 内で最新値を読むため）。
+  const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
-  const silentAudioRef = useRef<HTMLAudioElement | null>(null);
-  const isAudioUnlockedRef = useRef(false);
 
   useEffect(() => {
     fetch('/api/consent')
@@ -79,9 +81,11 @@ export default function HomePage() {
       });
   }, []);
 
-  // iOS Safari の AudioContext autoplay 制約対策。
-  // user gesture（handleSubmit）の同期スタックで呼ぶことで suspended 状態を解除し、
-  // その後の model.speak() 内部の AudioContext が音声を出力できる状態にする。
+  // iOS Safari の Web Audio autoplay 制約対策。
+  // user gesture（handleSubmit）の同期スタックで AudioContext を作成・resume することで、
+  // 以降の AudioBufferSourceNode.start() が transient activation token を消費せず
+  // いつでも再生可能になる。HTMLAudioElement の per-element 制約は別系統で、
+  // この対策では効かないため、再生は Web Audio API のみで完結させる（Live2DCanvas 参照）。
   const ensureAudioContextUnlocked = useCallback(async () => {
     if (typeof window === 'undefined') return;
     const AudioContextClass =
@@ -89,59 +93,17 @@ export default function HomePage() {
       (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
     if (!AudioContextClass) return;
     if (!audioCtxRef.current) {
-      audioCtxRef.current = new AudioContextClass();
+      const ctx = new AudioContextClass();
+      audioCtxRef.current = ctx;
+      // 子コンポーネント（Live2DCanvas）に prop で渡すため state も更新
+      setAudioContext(ctx);
     }
     if (audioCtxRef.current.state === 'suspended') {
       await audioCtxRef.current.resume();
     }
   }, []);
 
-  // iOS Safari の HTMLAudioElement.play() autoplay 制約対策（Plan A+）。
-  // user gesture 中に無音 audio の play() を 1 度だけ呼ぶと、同一ページ内の以降の
-  // audio.play() が user gesture 外でも許可される（pixi-live2d-display-lipsyncpatch の
-  // model.speak() 内部 audio がこれで unlock される）。
-  //
-  // 重要: await しない。iOS Safari は 0 サンプル無音 WAV の play() Promise が
-  // resolve しない場合があり、await すると handleSubmit が stall して送信処理が
-  // 進まなくなる。unlock 効果は play() を「呼んだ」時点で発生するので fire-and-forget で OK。
-  const ensureAudioElementUnlocked = useCallback(() => {
-    if (typeof window === 'undefined') return;
-    if (isAudioUnlockedRef.current) return;
-    if (!silentAudioRef.current) {
-      const audio = new Audio();
-      // 1 サンプル分の無音 WAV（PCM, 8kHz, mono, 8bit, 0 サンプル）
-      audio.src =
-        'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
-      audio.preload = 'auto';
-      silentAudioRef.current = audio;
-    }
-    const playPromise = silentAudioRef.current.play();
-    if (playPromise && typeof playPromise.then === 'function') {
-      playPromise
-        .then(() => {
-          silentAudioRef.current?.pause();
-          if (silentAudioRef.current) {
-            silentAudioRef.current.currentTime = 0;
-          }
-          isAudioUnlockedRef.current = true;
-        })
-        .catch(() => {
-          // play 拒否時は次回 user gesture でリトライ。silentAudioRef は維持。
-        });
-    }
-  }, []);
-
-  const revokeCurrentAudio = useCallback(() => {
-    if (audioUrlRef.current) {
-      URL.revokeObjectURL(audioUrlRef.current);
-      audioUrlRef.current = null;
-    }
-  }, []);
-
   const clearAudioQueue = useCallback(() => {
-    for (const url of audioQueueRef.current) {
-      URL.revokeObjectURL(url);
-    }
     audioQueueRef.current = [];
     isPlayingRef.current = false;
     streamDoneRef.current = false;
@@ -151,11 +113,10 @@ export default function HomePage() {
   const advanceAudioQueue = useCallback(() => {
     if (isPlayingRef.current) return;
 
-    const nextUrl = audioQueueRef.current.shift();
-    if (nextUrl) {
+    const nextBuffer = audioQueueRef.current.shift();
+    if (nextBuffer) {
       isPlayingRef.current = true;
-      audioUrlRef.current = nextUrl;
-      setAudioUrl(nextUrl);
+      setAudioBuffer(nextBuffer);
     } else if (streamDoneRef.current) {
       setPhase('idle');
     }
@@ -163,12 +124,9 @@ export default function HomePage() {
 
   const handleSubmit = useCallback(
     async (text: string) => {
-      // user gesture の同期スタック内で HTMLAudioElement の unlock を発火する。
-      // await の前に呼ぶことで iOS Safari の user gesture context を確実に保持する。
-      ensureAudioElementUnlocked();
-      // AudioContext の resume は await が必要だが Edge/Chrome では即時 resolve、
-      // iOS Safari でも安全に完了する。
+      // user gesture の同期スタック内で AudioContext を resume する（iOS Safari 対策）
       await ensureAudioContextUnlocked();
+      const audioCtx = audioCtxRef.current;
 
       // 前回リクエストをキャンセル
       abortControllerRef.current?.abort();
@@ -179,8 +137,7 @@ export default function HomePage() {
       setResponseText('');
       setErrorMessage(null);
       setPhase('loading');
-      revokeCurrentAudio();
-      setAudioUrl(null);
+      setAudioBuffer(null);
       clearAudioQueue();
 
       try {
@@ -203,14 +160,22 @@ export default function HomePage() {
         const decoder = new TextDecoder();
         let lineBuffer = '';
 
-        const handleEvent = (event: ChatStreamEvent) => {
+        const handleEvent = async (event: ChatStreamEvent) => {
           if (event.type === 'text') {
             setResponseText((prev) => (prev ?? '') + event.delta);
           } else if (event.type === 'sentence' && event.audio) {
-            const blob = base64ToBlob(event.audio, 'audio/wav');
-            const url = URL.createObjectURL(blob);
-            audioQueueRef.current.push(url);
-            advanceAudioQueue();
+            if (!audioCtx) {
+              // AudioContext が無いブラウザ（極めて稀）: 音声をスキップしてテキストだけ表示
+              return;
+            }
+            try {
+              const arrayBuffer = base64ToArrayBuffer(event.audio);
+              const decoded = await audioCtx.decodeAudioData(arrayBuffer);
+              audioQueueRef.current.push(decoded);
+              advanceAudioQueue();
+            } catch (err) {
+              console.error('[LiveTalk] 音声 decode に失敗しました', err);
+            }
           } else if (event.type === 'safety') {
             if (event.trigger === 'output_moderation' && event.replacementText) {
               setResponseText(event.replacementText);
@@ -239,7 +204,7 @@ export default function HomePage() {
             const trimmed = line.trim();
             if (!trimmed) continue;
             try {
-              handleEvent(JSON.parse(trimmed) as ChatStreamEvent);
+              await handleEvent(JSON.parse(trimmed) as ChatStreamEvent);
             } catch {
               // malformed line はスキップ
             }
@@ -249,7 +214,7 @@ export default function HomePage() {
         // ストリーム終端の残余行
         if (lineBuffer.trim()) {
           try {
-            handleEvent(JSON.parse(lineBuffer.trim()) as ChatStreamEvent);
+            await handleEvent(JSON.parse(lineBuffer.trim()) as ChatStreamEvent);
           } catch {
             // skip
           }
@@ -261,21 +226,14 @@ export default function HomePage() {
         setPhase('idle');
       }
     },
-    [
-      ensureAudioContextUnlocked,
-      ensureAudioElementUnlocked,
-      revokeCurrentAudio,
-      clearAudioQueue,
-      advanceAudioQueue,
-    ]
+    [ensureAudioContextUnlocked, clearAudioQueue, advanceAudioQueue]
   );
 
   const handlePlaybackEnd = useCallback(() => {
-    revokeCurrentAudio();
-    setAudioUrl(null);
+    setAudioBuffer(null);
     isPlayingRef.current = false;
     advanceAudioQueue();
-  }, [revokeCurrentAudio, advanceAudioQueue]);
+  }, [advanceAudioQueue]);
 
   const handlePlaybackError = useCallback(
     (error: Error) => {
@@ -290,12 +248,11 @@ export default function HomePage() {
         ? String((error as { message: unknown }).message)
         : String(error);
       setErrorMessage(`音声再生中にエラーが発生しました。[${errorName}] ${errorMessageDetail}`);
-      revokeCurrentAudio();
-      setAudioUrl(null);
+      setAudioBuffer(null);
       isPlayingRef.current = false;
       advanceAudioQueue();
     },
-    [revokeCurrentAudio, advanceAudioQueue]
+    [advanceAudioQueue]
   );
 
   const statusText =
@@ -323,7 +280,8 @@ export default function HomePage() {
       >
         <Box sx={{ flex: '0 1 60%', minHeight: 240, mb: 1 }}>
           <Live2DCanvas
-            audioUrl={audioUrl}
+            audioBuffer={audioBuffer}
+            audioContext={audioContext}
             statusText={statusText}
             onPlaybackEnd={handlePlaybackEnd}
             onPlaybackError={handlePlaybackError}

--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -50,8 +50,19 @@ function layoutModel(model: Live2DModelInstance, w: number, h: number): void {
 }
 
 export interface Live2DCanvasProps {
-  /** 再生対象の音声 URL。null または undefined のときは再生しない。 */
-  audioUrl?: string | null;
+  /**
+   * 再生対象の AudioBuffer。null または undefined のときは再生しない。
+   *
+   * iOS Safari の HTMLAudioElement autoplay 制約（transient activation token を
+   * play() ごとに消費する仕様）を回避するため、HTMLAudio + model.speak() ではなく
+   * Web Audio API の AudioBufferSourceNode を直接使う。
+   */
+  audioBuffer?: AudioBuffer | null;
+  /**
+   * 再生に使う AudioContext。親側で user gesture 中に resume 済みである前提。
+   * audioBuffer が指定されているのに audioContext が null の場合は再生しない。
+   */
+  audioContext?: AudioContext | null;
   statusText?: string;
   onPlaybackEnd?: () => void;
   onPlaybackError?: (error: Error) => void;
@@ -66,11 +77,18 @@ export interface Live2DCanvasProps {
  * PixiJS v7 と pixi-live2d-display-lipsyncpatch は browser API を直接使うため
  * SSR 不可。next/dynamic + ssr:false で呼び出し元がラップする。
  *
- * audioUrl を受け取ると model.speak() を呼び、ライブラリ内部の AudioContext +
- * AnalyserNode で再生 + リップシンクをモデルの update サイクル内で同期駆動する。
+ * audioBuffer + audioContext を受け取ると、Web Audio API（AudioBufferSourceNode +
+ * AnalyserNode）で再生し、AnalyserNode を motionManager.currentAnalyzer に差し込んで
+ * ライブラリの既存リップシンク駆動ループ（ParamMouthOpenY を毎フレーム更新する）を
+ * そのまま活用する。
+ *
+ * iOS Safari の HTMLAudioElement.play() autoplay 制約を回避するために model.speak() は
+ * 使わない。AudioContext を user gesture 中に resume してさえいれば、Web Audio 経由の
+ * playback は transient activation token を消費しないため何回でも再生できる。
  */
 export default function Live2DCanvas({
-  audioUrl,
+  audioBuffer,
+  audioContext,
   statusText,
   onPlaybackEnd,
   onPlaybackError,
@@ -181,37 +199,81 @@ export default function Live2DCanvas({
     };
   }, []);
 
-  // audioUrl を受け取ったら model.speak() で再生 + リップシンク。
-  // model.speak は内部で AudioContext / AnalyserNode を構築し、
-  // ライブラリの update サイクル内で LipSync パラメータを更新する。
+  // audioBuffer + audioContext を受け取ったら Web Audio で再生し、AnalyserNode を
+  // モデルの motionManager に差し込むことで、ライブラリ既存のリップシンク駆動ループ
+  // （毎フレーム ParamMouthOpenY を更新）をそのまま活用する。
   useEffect(() => {
     const model = modelRef.current;
-    if (!model || !modelReady || !audioUrl) return;
+    if (!model || !modelReady || !audioBuffer || !audioContext) return;
 
     let cancelled = false;
-    model
-      .speak(audioUrl, {
-        volume: 1.0,
-        crossOrigin: 'anonymous',
-        onFinish: () => {
-          if (!cancelled) onPlaybackEndRef.current?.();
-        },
-        onError: (e) => {
-          if (!cancelled) onPlaybackErrorRef.current?.(e);
-        },
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          const error = err instanceof Error ? err : new Error(String(err));
-          onPlaybackErrorRef.current?.(error);
-        }
-      });
+    let source: AudioBufferSourceNode | null = null;
+    let analyser: AnalyserNode | null = null;
+
+    // 型情報がない internal API を扱うための narrowing
+    const motionManager = (
+      model.internalModel as unknown as {
+        motionManager: {
+          currentAudio?: { ended: boolean } | undefined;
+          currentAnalyzer?: AnalyserNode | undefined;
+          currentContext?: AudioContext | undefined;
+        };
+      }
+    ).motionManager;
+
+    try {
+      source = audioContext.createBufferSource();
+      source.buffer = audioBuffer;
+
+      analyser = audioContext.createAnalyser();
+      // SoundManager.addAnalyzer と同じ設定（ライブラリの analyze 関数が前提とする値）
+      analyser.fftSize = 256;
+      analyser.minDecibels = -90;
+      analyser.maxDecibels = -10;
+      analyser.smoothingTimeConstant = 0.85;
+
+      source.connect(analyser);
+      analyser.connect(audioContext.destination);
+
+      // ライブラリ内部のリップシンク駆動ループに自前 AnalyserNode を hijack 注入。
+      // updateParameters 内で `if (this.lipSync && motionManager.currentAudio)` を
+      // 通過させるため、currentAudio には truthy なオブジェクトを置く。
+      motionManager.currentAudio = { ended: false };
+      motionManager.currentAnalyzer = analyser;
+      motionManager.currentContext = audioContext;
+
+      source.onended = () => {
+        if (cancelled) return;
+        motionManager.currentAudio = undefined;
+        motionManager.currentAnalyzer = undefined;
+        motionManager.currentContext = undefined;
+        onPlaybackEndRef.current?.();
+      };
+
+      source.start(0);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      onPlaybackErrorRef.current?.(error);
+    }
 
     return () => {
       cancelled = true;
-      model.stopSpeaking();
+      try {
+        source?.stop();
+      } catch {
+        // 既に停止済み・未開始など。無視。
+      }
+      source?.disconnect();
+      analyser?.disconnect();
+      // 自前で差し込んだ analyser だった場合のみクリア（並走更新で別 useEffect 由来の
+      // analyser に置き換わっていたら触らない）
+      if (motionManager.currentAnalyzer === analyser) {
+        motionManager.currentAudio = undefined;
+        motionManager.currentAnalyzer = undefined;
+        motionManager.currentContext = undefined;
+      }
     };
-  }, [audioUrl, modelReady]);
+  }, [audioBuffer, audioContext, modelReady]);
 
   return (
     <Box

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -16,7 +16,8 @@ jest.mock('@/components/Live2DCanvas', () => ({
       onPlaybackEnd,
       onPlaybackError,
     }: {
-      audioUrl?: string | null;
+      audioBuffer?: AudioBuffer | null;
+      audioContext?: AudioContext | null;
       statusText?: string;
       onPlaybackEnd?: () => void;
       onPlaybackError?: (error: Error) => void;
@@ -57,29 +58,24 @@ jest.mock('@/components/ResponseDisplay', () => ({
   default: jest.fn(() => null),
 }));
 
-// jsdom は URL.createObjectURL / revokeObjectURL 未実装
-Object.defineProperty(global.URL, 'createObjectURL', {
-  writable: true,
-  value: jest.fn(() => 'blob:mock'),
-});
-Object.defineProperty(global.URL, 'revokeObjectURL', {
-  writable: true,
-  value: jest.fn(),
-});
-
-// jsdom は HTMLMediaElement.play() / pause() がデフォルトで Not implemented
-// 各テストで個別に上書きできるように mock 関数を保持
-const mockSilentAudioPlay = jest.fn().mockResolvedValue(undefined);
-const mockSilentAudioPause = jest.fn();
-HTMLMediaElement.prototype.play = mockSilentAudioPlay;
-HTMLMediaElement.prototype.pause = mockSilentAudioPause;
-
 /** /api/consent が同意済みを返す fetch モックを設定する */
-function setupFetchMocks(chatOk = false) {
+function setupFetchMocks(chatOk = false, sentenceAudio?: string) {
   const encoder = new TextEncoder();
   const chatStream = new ReadableStream({
     start(controller) {
       if (chatOk) {
+        if (sentenceAudio) {
+          controller.enqueue(
+            encoder.encode(
+              JSON.stringify({
+                type: 'sentence',
+                index: 0,
+                text: 'こんにちは',
+                audio: sentenceAudio,
+              }) + '\n'
+            )
+          );
+        }
         controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
       }
       controller.close();
@@ -98,9 +94,10 @@ function setupFetchMocks(chatOk = false) {
 }
 
 /** window.AudioContext をモック AudioContext クラスで上書きし、cleanup を返す */
-function setupMockAudioContext(state: 'suspended' | 'running') {
+function setupMockAudioContext(state: 'suspended' | 'running' = 'suspended') {
   const mockResume = jest.fn().mockResolvedValue(undefined);
-  const instance = { state, resume: mockResume };
+  const mockDecodeAudioData = jest.fn().mockResolvedValue({} as AudioBuffer);
+  const instance = { state, resume: mockResume, decodeAudioData: mockDecodeAudioData };
   const MockAudioContext = jest.fn(() => instance);
 
   Object.defineProperty(window, 'AudioContext', {
@@ -109,7 +106,7 @@ function setupMockAudioContext(state: 'suspended' | 'running') {
     value: MockAudioContext,
   });
 
-  return { MockAudioContext, instance, mockResume };
+  return { MockAudioContext, instance, mockResume, mockDecodeAudioData };
 }
 
 function removeAudioContext() {
@@ -128,8 +125,6 @@ function removeAudioContext() {
 afterEach(() => {
   jest.clearAllMocks();
   removeAudioContext();
-  // play() のデフォルト挙動を resolved に戻す（テストごとに reject に上書きすることがある）
-  mockSilentAudioPlay.mockResolvedValue(undefined);
 });
 
 /** 同意チェック完了を待ち、有効化された入力欄を返す */
@@ -170,7 +165,7 @@ describe('AudioContext unlock（iOS Safari autoplay 制約対策）', () => {
   });
 
   it('2 回目の submit では AudioContext を再生成しない（インスタンスを再利用）', async () => {
-    setupFetchMocks(true); // done イベント付きで phase が idle に戻る
+    setupFetchMocks(true);
     const { MockAudioContext, mockResume } = setupMockAudioContext('suspended');
     const user = userEvent.setup();
 
@@ -180,26 +175,26 @@ describe('AudioContext unlock（iOS Safari autoplay 制約対策）', () => {
     // 1 回目
     await user.type(input, 'テスト1');
     await user.click(screen.getByRole('button', { name: '送信' }));
-
-    // phase が idle に戻るのを待つ（done イベントで advanceAudioQueue → setPhase('idle')）
     await waitFor(() => expect(input).toBeEnabled(), { timeout: 5000 });
 
     // 2 回目
     await user.type(input, 'テスト2');
     await user.click(screen.getByRole('button', { name: '送信' }));
 
-    // コンストラクタは 1 回だけ（インスタンスを再利用）
     expect(MockAudioContext).toHaveBeenCalledTimes(1);
-    // suspended なので 2 回とも resume() が呼ばれる
     expect(mockResume).toHaveBeenCalledTimes(2);
   });
 
   it('window.AudioContext が undefined のとき webkitAudioContext をフォールバックで使う', async () => {
     setupFetchMocks();
     const mockResume = jest.fn().mockResolvedValue(undefined);
-    const MockWebkitAudioContext = jest.fn(() => ({ state: 'suspended', resume: mockResume }));
+    const mockDecodeAudioData = jest.fn().mockResolvedValue({} as AudioBuffer);
+    const MockWebkitAudioContext = jest.fn(() => ({
+      state: 'suspended',
+      resume: mockResume,
+      decodeAudioData: mockDecodeAudioData,
+    }));
 
-    // AudioContext を未定義にして webkit フォールバックを設定
     removeAudioContext();
     Object.defineProperty(window, 'webkitAudioContext', {
       writable: true,
@@ -220,19 +215,58 @@ describe('AudioContext unlock（iOS Safari autoplay 制約対策）', () => {
 
   it('AudioContext が利用不可の環境でもクラッシュしない', async () => {
     setupFetchMocks();
-    removeAudioContext(); // AudioContext も webkitAudioContext も未定義
+    removeAudioContext();
 
     const user = userEvent.setup();
     render(<HomePage />);
     const input = await waitForInputEnabled();
 
     await user.type(input, 'テスト');
-    // エラーが throw されないことを確認
     await expect(user.click(screen.getByRole('button', { name: '送信' }))).resolves.toBeUndefined();
   });
 });
 
-describe('handlePlaybackError のデバッグログ', () => {
+describe('音声 decode と queue 管理', () => {
+  it('sentence event を受け取ったら decodeAudioData が呼ばれる', async () => {
+    // 短い base64 文字列を sentence audio として送る
+    const base64Audio = 'AAAAAA=='; // 任意の base64
+    setupFetchMocks(true, base64Audio);
+    const { mockDecodeAudioData } = setupMockAudioContext('running');
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'テスト');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    await waitFor(() => expect(mockDecodeAudioData).toHaveBeenCalledTimes(1));
+  });
+
+  it('decodeAudioData が失敗してもクラッシュしない（テキストは出る）', async () => {
+    const base64Audio = 'AAAAAA==';
+    setupFetchMocks(true, base64Audio);
+    const { mockDecodeAudioData } = setupMockAudioContext('running');
+    mockDecodeAudioData.mockRejectedValueOnce(new Error('decode failure'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'テスト');
+    await expect(user.click(screen.getByRole('button', { name: '送信' }))).resolves.toBeUndefined();
+
+    await waitFor(() => expect(mockDecodeAudioData).toHaveBeenCalledTimes(1));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[LiveTalk] 音声 decode に失敗しました',
+      expect.any(Error)
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('handlePlaybackError のデバッグログ・画面表示', () => {
   it('onPlaybackError 発火時に console.error でエラーを出力する', async () => {
     setupFetchMocks();
     setupMockAudioContext('running');
@@ -259,116 +293,9 @@ describe('handlePlaybackError のデバッグログ', () => {
     const triggerError = screen.getByTestId('trigger-playback-error');
     await userEvent.click(triggerError);
 
-    // mock の Live2DCanvas は `new Error('再生エラー')` を渡すので
-    // 画面に "[Error] 再生エラー" が含まれることを検証
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toContain('[Error]');
     expect(alert.textContent).toContain('再生エラー');
     consoleSpy.mockRestore();
-  });
-});
-
-describe('HTMLAudioElement unlock（Plan A+: iOS Safari autoplay 制約対策）', () => {
-  it('handleSubmit 時に silent audio が同期的に play される', async () => {
-    setupFetchMocks();
-    setupMockAudioContext('running');
-    const user = userEvent.setup();
-
-    render(<HomePage />);
-    const input = await waitForInputEnabled();
-
-    await user.type(input, 'テスト');
-    await user.click(screen.getByRole('button', { name: '送信' }));
-
-    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
-    // play() resolve 後の microtask で pause が呼ばれる
-    await waitFor(() => expect(mockSilentAudioPause).toHaveBeenCalledTimes(1));
-  });
-
-  it('unlock 成功後の 2 回目以降は silent audio を再生しない（unlock 済みフラグで skip）', async () => {
-    setupFetchMocks(true);
-    setupMockAudioContext('running');
-    const user = userEvent.setup();
-
-    render(<HomePage />);
-    const input = await waitForInputEnabled();
-
-    // 1 回目
-    await user.type(input, 'テスト1');
-    await user.click(screen.getByRole('button', { name: '送信' }));
-    await waitFor(() => expect(mockSilentAudioPause).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(input).toBeEnabled(), { timeout: 5000 });
-
-    // 2 回目
-    await user.type(input, 'テスト2');
-    await user.click(screen.getByRole('button', { name: '送信' }));
-
-    // 1 回目で unlock 済みなので 2 回目は呼ばれない
-    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
-    expect(mockSilentAudioPause).toHaveBeenCalledTimes(1);
-  });
-
-  it('silent audio.play() が拒否されても submit はクラッシュしない', async () => {
-    setupFetchMocks();
-    setupMockAudioContext('running');
-    mockSilentAudioPlay.mockRejectedValueOnce(new Error('NotAllowedError'));
-    const user = userEvent.setup();
-
-    render(<HomePage />);
-    const input = await waitForInputEnabled();
-
-    await user.type(input, 'テスト');
-    await expect(user.click(screen.getByRole('button', { name: '送信' }))).resolves.toBeUndefined();
-
-    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
-    expect(mockSilentAudioPause).not.toHaveBeenCalled();
-  });
-
-  it('play() 拒否後の次の submit でも unlock を再試行する', async () => {
-    setupFetchMocks(true);
-    setupMockAudioContext('running');
-    mockSilentAudioPlay
-      .mockRejectedValueOnce(new Error('NotAllowedError'))
-      .mockResolvedValueOnce(undefined);
-    const user = userEvent.setup();
-
-    render(<HomePage />);
-    const input = await waitForInputEnabled();
-
-    // 1 回目（拒否）
-    await user.type(input, 'テスト1');
-    await user.click(screen.getByRole('button', { name: '送信' }));
-    await waitFor(() => expect(input).toBeEnabled(), { timeout: 5000 });
-
-    // 2 回目（成功）
-    await user.type(input, 'テスト2');
-    await user.click(screen.getByRole('button', { name: '送信' }));
-
-    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(2);
-    await waitFor(() => expect(mockSilentAudioPause).toHaveBeenCalledTimes(1)); // 2 回目だけ pause
-  });
-
-  it('silent audio.play() の Promise が pending のままでも handleSubmit が stall しない', async () => {
-    // iOS Safari で観測された問題のリグレッション防止:
-    // 無音 WAV に対する play() Promise が resolve しない環境でも、
-    // handleSubmit は次の処理（fetch / setPhase）に進む必要がある
-    setupFetchMocks();
-    setupMockAudioContext('running');
-    // play() を永久に pending のままにする
-    mockSilentAudioPlay.mockReturnValue(new Promise(() => {}));
-    const user = userEvent.setup();
-
-    render(<HomePage />);
-    const input = await waitForInputEnabled();
-
-    await user.type(input, 'テスト');
-    await user.click(screen.getByRole('button', { name: '送信' }));
-
-    // play() は呼ばれるが await しない → fetch まで到達する
-    expect(mockSilentAudioPlay).toHaveBeenCalledTimes(1);
-    expect(global.fetch).toHaveBeenCalledWith(
-      '/api/chat',
-      expect.objectContaining({ method: 'POST' })
-    );
   });
 });


### PR DESCRIPTION
## 変更の概要

#3260 Plan C 対応。iOS Safari の `HTMLAudioElement.play()` autoplay 制約は **per-element + transient activation token** という仕様で、Plan A / A+ では根本解消できないことが調査と実機検証で判明（user 観測：連打すると 100% 成功する = activation token 消費仕様）。

このため**再生方式そのものを Web Audio API に切り替え**、`pixi-live2d-display-lipsyncpatch` の `model.speak()` を使わない構成にする。

### 仕様根拠

| API | iOS Safari の制約 |
|---|---|
| `HTMLAudioElement.play()` | **要素ごと**に user gesture 必要、**transient activation token** を消費 |
| `AudioContext.resume()` | 初回 user gesture で 1 度のみ必要 |
| `AudioBufferSourceNode.start()` | AudioContext が running なら **token 不要**、何度でも自由に再生可 |

Plan A の `AudioContext.resume()` を維持し、再生経路だけ Web Audio に変えれば iOS の制約を完全回避できる。

### 実装内容

**`services/livetalk/web/src/components/Live2DCanvas.tsx`**
- prop を `audioUrl: string` から `audioBuffer: AudioBuffer + audioContext: AudioContext` に変更
- `model.speak()` 呼び出しを削除
- 自前で `AudioBufferSourceNode` + `AnalyserNode` を構築し再生
- AnalyserNode を `motionManager.currentAnalyzer` に差し込み、ライブラリの**既存リップシンク駆動ループ**（`ParamMouthOpenY` 更新）をそのまま活用
- AnalyserNode 設定（fftSize/minDecibels/maxDecibels/smoothingTimeConstant）はライブラリの `SoundManager.addAnalyzer` と同値

**`services/livetalk/web/src/app/page.tsx`**
- `audioUrl` ベース → `audioBuffer` ベースに切替
- ストリーミングで受け取った base64 音声を `AudioContext.decodeAudioData()` で AudioBuffer に decode → queue に積む
- `Plan A+` の silent audio unlock 一式（`silentAudioRef`, `isAudioUnlockedRef`, `ensureAudioElementUnlocked`）を削除
- `Plan A`（`AudioContext.resume()`）は維持
- AudioContext を子に渡すため `useState` 化（ESLint react-hooks/refs 対応）

**`services/livetalk/web/tests/unit/app/page.test.tsx`**
- silent audio 関連テストを削除
- `decodeAudioData` モック・呼び出し検証テストを追加
- 全 59 件パス

### ライブラリ内部 API 依存

`model.internalModel.motionManager.currentAnalyzer` 等への直接代入はライブラリの公式 API ではなく**内部実装に依存**します。トレードオフ：

| 項目 | 評価 |
|---|---|
| ライブラリのバージョン | `0.5.0-ls-8` でピン留め済み |
| 上位バージョン互換 | アップデート時に再検証が必要 |
| 互換性確認方法 | ライブラリの `cubism4.js` 内 `SoundManager` / `motionManager` の `currentAudio`/`currentAnalyzer` 構造を確認 |

ライブラリ更新時は `node_modules/pixi-live2d-display-lipsyncpatch/dist/cubism4.js` で `mouthSync()` と `addAnalyzer()` の実装が変わっていないか確認する必要がある（コメントで明記）。

## 関連 Issue

#3260（本対応の本命）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（全 59 件パス）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラー・ESLint エラーがないことを確認した
- [x] Prettier フォーマット適用済み

## テスト内容

`tests/unit/app/page.test.tsx`：

- AudioContext unlock 系（5 件）：resume 呼び出し、再利用、webkitAudioContext fallback、未対応環境
- 音声 decode と queue 管理（2 件）：sentence event で `decodeAudioData` が呼ばれる / decode 失敗時もクラッシュしない
- handlePlaybackError（2 件）：console.error 出力 / 画面エラー表示

## レビューポイント

- **Edge / Chrome / Firefox での既存挙動への影響**：Web Audio に切り替わっても全環境で動作するはず。AudioContext.resume() は維持しているので unlock 周りも変わらず
- **`motionManager.currentAnalyzer` の hijack**：ライブラリの updateParameters ループは `if (this.lipSync && motionManager.currentAudio)` 条件下で `mouthSync()` を呼び、AnalyserNode から音量を読む。我々の AnalyserNode を差し込むだけでこのループがそのまま動く
- **テスト戦略**：jsdom + mock 中心。実 AudioContext は使わない（jsdom 未対応のため）。実機検証で補完する

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

### iOS 実機確認のお願い

マージ・dev 反映後、最終確認お願いします：

1. iOS Safari で `https://dev-live-talk.nagiyu.com` を開く（PWA standalone モード含む）
2. メッセージを送信し、**画面を触らずに**音声が再生されることを確認
3. 短文 1 文・長文複数文の両方で確認
4. **連打しなくても全文の音声が流れること** がゴール

**期待される結果**：
- ✅ 連打なしで全文再生 → Plan C 成功。デバッグ表示 revert と integration → develop PR に進む
- ❌ 引き続き失敗 or 別の挙動 → 画面のエラー詳細を共有 → 別アプローチ検討（実装ミス or 別の制約）


---
_Generated by [Claude Code](https://claude.ai/code/session_01UNfpwJG5MX7h6dJzrUZWbK)_