### PR TITLE
[Phase 2f / revert] iOS 実機デバッグ用の画面エラー詳細表示を元に戻す

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -238,16 +238,7 @@ export default function HomePage() {
   const handlePlaybackError = useCallback(
     (error: Error) => {
       console.error('[LiveTalk] 音声再生エラー', error);
-      // iOS Safari 実機デバッグ用に画面にエラー詳細を表示する（#3260 対応中の一時措置、
-      // 解決後は元の汎用メッセージに戻す）。error が Error でない値で渡される可能性に
-      // 備え、name / message を defensive に取り出す。
-      const errorName = (error as { name?: unknown })?.name
-        ? String((error as { name: unknown }).name)
-        : 'Unknown';
-      const errorMessageDetail = (error as { message?: unknown })?.message
-        ? String((error as { message: unknown }).message)
-        : String(error);
-      setErrorMessage(`音声再生中にエラーが発生しました。[${errorName}] ${errorMessageDetail}`);
+      setErrorMessage('音声再生中にエラーが発生しました。');
       setAudioBuffer(null);
       isPlayingRef.current = false;
       advanceAudioQueue();

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -266,7 +266,7 @@ describe('音声 decode と queue 管理', () => {
   });
 });
 
-describe('handlePlaybackError のデバッグログ・画面表示', () => {
+describe('handlePlaybackError のデバッグログ', () => {
   it('onPlaybackError 発火時に console.error でエラーを出力する', async () => {
     setupFetchMocks();
     setupMockAudioContext('running');
@@ -279,23 +279,6 @@ describe('handlePlaybackError のデバッグログ・画面表示', () => {
     await userEvent.click(triggerError);
 
     expect(consoleSpy).toHaveBeenCalledWith('[LiveTalk] 音声再生エラー', expect.any(Error));
-    consoleSpy.mockRestore();
-  });
-
-  it('onPlaybackError 発火時にエラーの name / message を画面に表示する（iOS 実機デバッグ用）', async () => {
-    setupFetchMocks();
-    setupMockAudioContext('running');
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    render(<HomePage />);
-    await waitForInputEnabled();
-
-    const triggerError = screen.getByTestId('trigger-playback-error');
-    await userEvent.click(triggerError);
-
-    const alert = await screen.findByRole('alert');
-    expect(alert.textContent).toContain('[Error]');
-    expect(alert.textContent).toContain('再生エラー');
     consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## 変更の概要

Plan C（PR #3277）で iOS Safari の音声再生が解消されたため、PR #3263 で一時的に入れていた iOS 実機デバッグ用の **画面エラー詳細表示を元に戻す**。

### 変更内容

**`services/livetalk/web/src/app/page.tsx`**
- `handlePlaybackError` の `setErrorMessage` 引数を `音声再生中にエラーが発生しました。[errorName] errorMessageDetail` の defensive 取り出し版から、元の汎用文言 `音声再生中にエラーが発生しました。` に戻す
- `console.error('[LiveTalk] 音声再生エラー', error)` は今後の運用デバッグ用に**維持**

**`services/livetalk/web/tests/unit/app/page.test.tsx`**
- 画面エラー詳細表示の検証テストを削除
- `console.error` 検証テストは維持
- describe 名を「デバッグログ・画面表示」から「デバッグログ」に更新

## 関連 Issue

#3260（Plan C 後始末、最終 cleanup）

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング（デバッグコードの revert）
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（全 58 件パス）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラー・ESLint エラーがないことを確認した

## テスト内容

- 画面エラー詳細表示テスト 1 件を削除
- 残り 58 件全てパス

## レビューポイント

- 動作の変更は「ユーザー画面に出るエラー文言」だけで、ロジックには影響なし
- `console.error` ログは引き続き出力されるため、運用時のデバッグ性は維持

## スクリーンショット（該当する場合）

UI は「エラー発生時の表示文言」のみ変化（再生エラーの実機状況は既に Plan C で解消済み）。

## 補足事項

### #3260 対応の総括

これで Issue #3260（リブトーク Phase 2f iOS Safari 音声再生デグレ）の一連の対応が完了します：

1. ✅ PR #3261 (Plan A): AudioContext.resume() unlock → 単独では効かず
2. ✅ PR #3263 (debug): エラー詳細を画面表示 → 原因 `NotAllowedError` 確定
3. ✅ PR #3264 (Plan A+): silent audio unlock → 単独では効かず、stall regression 発生
4. ✅ PR #3266 (hotfix): silent audio を fire-and-forget 化 → stall は解消も iOS NG 変わらず
5. ✅ PR #3277 (Plan C): Web Audio API + AnalyserNode hijack → **iOS で連打なし全文再生 OK**
6. ✅ 本 PR: デバッグ表示 revert

本 PR マージ後、`integration/3182-livetalk` → `develop` の PR を作る段階に入れる状況です（事前確認が必要、CLAUDE.md ルール）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01UNfpwJG5MX7h6dJzrUZWbK)_