### PR TITLE
[Feature] [リブトーク Phase 3a] メモリ Tier 基盤 + Repository (#3279)

### DIFF
--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -30,3 +30,24 @@ export const TOKEN_BUDGETED_QUERY_PAGE_SIZE = 50;
  */
 export const LIVETALK_TERMS_VERSION = '1.0.0';
 export const LIVETALK_PRIVACY_VERSION = '1.0.0';
+
+/**
+ * Memory Tier C に付与する DynamoDB TTL（秒）。30 日後に自動削除。
+ */
+export const MEMORY_TIER_C_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * Memory Tier D に付与する DynamoDB TTL（秒）。1 日後に自動削除。
+ */
+export const MEMORY_TIER_D_TTL_SECONDS = 1 * 24 * 60 * 60;
+
+/**
+ * 各 Tier の信頼度スコア推奨初期値。
+ * 実際の決定は usecase 層（Phase 3b）に委ねる。Repository はこの値を参照しない。
+ */
+export const MEMORY_DEFAULT_CONFIDENCE = {
+  A: 1.0,
+  B: 0.8,
+  C: 0.5,
+  D: 0.2,
+} as const;

--- a/services/livetalk/core/src/entities/memory.entity.ts
+++ b/services/livetalk/core/src/entities/memory.entity.ts
@@ -33,14 +33,14 @@ export interface MemoryEntity {
   Confidence: number;
   /** 参照回数 */
   ReferencedCount: number;
-  /** 最終参照日時（ISO8601、未参照の場合は undefined） */
-  LastReferencedAt?: string;
+  /** 最終参照日時（Unix ms、未参照の場合は undefined） */
+  LastReferencedAt?: number;
   /** 埋め込みベクトル（Phase 3b で実値投入、現フェーズでは undefined） */
   Embedding?: number[];
-  /** 作成日時（ISO8601） */
-  CreatedAt: string;
-  /** 更新日時（ISO8601） */
-  UpdatedAt: string;
+  /** 作成日時（Unix ms） */
+  CreatedAt: number;
+  /** 更新日時（Unix ms） */
+  UpdatedAt: number;
 }
 
 /**

--- a/services/livetalk/core/src/entities/memory.entity.ts
+++ b/services/livetalk/core/src/entities/memory.entity.ts
@@ -1,0 +1,69 @@
+/**
+ * メモリ Tier の定義。
+ *
+ * A: 確定（名前・誕生日等の明示確認済み）
+ * B: 嗜好（反復言及・確認済み）
+ * C: 観測（一度言及されただけ）
+ * D: 一時（今の会話限り）
+ */
+export type Tier = 'A' | 'B' | 'C' | 'D';
+
+export const TIERS: readonly Tier[] = ['A', 'B', 'C', 'D'] as const;
+
+/**
+ * ユーザー記憶を表すビジネスオブジェクト。
+ *
+ * DynamoDB 属性は PascalCase（プラットフォーム共通ルール）で統一する。
+ * Embedding は Phase 3b で実値を投入するため、型フィールドのみ定義。
+ */
+export interface MemoryEntity {
+  /** ユーザー識別子（Google ID） */
+  UserID: string;
+  /** キャラクター識別子（例: `hiyori`） */
+  CharacterID: string;
+  /** メモリ ID（ULID） */
+  MemoryID: string;
+  /** 記憶の階層 */
+  Tier: Tier;
+  /** カテゴリ（`name`, `food`, `hobby` 等） */
+  Category: string;
+  /** 記憶の本文 */
+  Content: string;
+  /** 信頼度スコア（0.0〜1.0） */
+  Confidence: number;
+  /** 参照回数 */
+  ReferencedCount: number;
+  /** 最終参照日時（ISO8601、未参照の場合は undefined） */
+  LastReferencedAt?: string;
+  /** 埋め込みベクトル（Phase 3b で実値投入、現フェーズでは undefined） */
+  Embedding?: number[];
+  /** 作成日時（ISO8601） */
+  CreatedAt: string;
+  /** 更新日時（ISO8601） */
+  UpdatedAt: string;
+}
+
+/**
+ * 単一メモリを取得する際のキー。
+ */
+export interface MemoryKey {
+  userId: string;
+  characterId: string;
+  tier: Tier;
+  category: string;
+  memoryId: string;
+}
+
+/**
+ * メモリ作成入力（`MemoryID` / `CreatedAt` / `UpdatedAt` はリポジトリ側で付与）。
+ */
+export type CreateMemoryInput = Omit<MemoryEntity, 'MemoryID' | 'CreatedAt' | 'UpdatedAt'> & {
+  /** 明示的に ULID を指定したい場合のみ渡す（テスト用途） */
+  MemoryID?: string;
+};
+
+/**
+ * メモリ更新入力（Content / Confidence / ReferencedCount / LastReferencedAt / Embedding のみ更新可能）。
+ */
+export type UpdateMemoryInput = Pick<MemoryEntity, 'UserID' | 'CharacterID' | 'MemoryID' | 'Tier' | 'Category'> &
+  Partial<Pick<MemoryEntity, 'Content' | 'Confidence' | 'ReferencedCount' | 'LastReferencedAt' | 'Embedding'>>;

--- a/services/livetalk/core/src/entities/memory.entity.ts
+++ b/services/livetalk/core/src/entities/memory.entity.ts
@@ -65,5 +65,13 @@ export type CreateMemoryInput = Omit<MemoryEntity, 'MemoryID' | 'CreatedAt' | 'U
 /**
  * メモリ更新入力（Content / Confidence / ReferencedCount / LastReferencedAt / Embedding のみ更新可能）。
  */
-export type UpdateMemoryInput = Pick<MemoryEntity, 'UserID' | 'CharacterID' | 'MemoryID' | 'Tier' | 'Category'> &
-  Partial<Pick<MemoryEntity, 'Content' | 'Confidence' | 'ReferencedCount' | 'LastReferencedAt' | 'Embedding'>>;
+export type UpdateMemoryInput = Pick<
+  MemoryEntity,
+  'UserID' | 'CharacterID' | 'MemoryID' | 'Tier' | 'Category'
+> &
+  Partial<
+    Pick<
+      MemoryEntity,
+      'Content' | 'Confidence' | 'ReferencedCount' | 'LastReferencedAt' | 'Embedding'
+    >
+  >;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -15,6 +15,14 @@ export { SentenceBuffer } from './lib/sentence-splitter.js';
 export { runChatUseCase, type ChatEvent, type ChatUseCaseParams } from './usecases/chat-usecase.js';
 
 // Entities
+export type {
+  MemoryEntity,
+  MemoryKey,
+  CreateMemoryInput,
+  UpdateMemoryInput,
+  Tier,
+} from './entities/memory.entity.js';
+export { TIERS } from './entities/memory.entity.js';
 export type { MessageEntity, MessageKey, CreateMessageInput } from './entities/message.entity.js';
 export type {
   SafetyEventEntity,
@@ -35,6 +43,7 @@ export type {
 } from './entities/character-state.entity.js';
 
 // Mappers
+export { MemoryMapper } from './mappers/memory.mapper.js';
 export { MessageMapper } from './mappers/message.mapper.js';
 export { ProfileMapper } from './mappers/profile.mapper.js';
 export { CharacterStateMapper } from './mappers/character-state.mapper.js';
@@ -47,9 +56,14 @@ export {
   buildMessageSKPrefix,
   buildSafetyEventSK,
   buildSafetyEventSKPrefix,
+  buildMemorySK,
+  buildMemoryTierSKPrefix,
+  buildMemoryCategoryInTierSKPrefix,
+  buildMemoryAllTiersSKPrefix,
 } from './mappers/keys.js';
 
 // Repository interfaces
+export type { MemoryRepository } from './repositories/memory.repository.interface.js';
 export type {
   MessageRepository,
   GetRecentByTokenBudgetOptions,
@@ -60,10 +74,12 @@ export type { CharacterStateRepository } from './repositories/character-state.re
 export type { SafetyEventRepository } from './repositories/safety-event.repository.interface.js';
 
 // Repository implementations
+export { DynamoDBMemoryRepository } from './repositories/dynamodb-memory.repository.js';
 export { DynamoDBMessageRepository } from './repositories/dynamodb-message.repository.js';
 export { DynamoDBProfileRepository } from './repositories/dynamodb-profile.repository.js';
 export { DynamoDBCharacterStateRepository } from './repositories/dynamodb-character-state.repository.js';
 export { DynamoDBSafetyEventRepository } from './repositories/dynamodb-safety-event.repository.js';
+export { InMemoryMemoryRepository } from './repositories/in-memory-memory.repository.js';
 export { InMemoryMessageRepository } from './repositories/in-memory-message.repository.js';
 export { InMemoryProfileRepository } from './repositories/in-memory-profile.repository.js';
 export { InMemoryCharacterStateRepository } from './repositories/in-memory-character-state.repository.js';
@@ -84,4 +100,10 @@ export { defaultUlidFactory, type UlidFactory } from './lib/ulid.js';
 // Consent
 export { isConsentValid, type ConsentRequirements } from './lib/consent.js';
 export type { ConsentRecord, AgeVerification, UserConsents } from './entities/profile.entity.js';
-export { LIVETALK_TERMS_VERSION, LIVETALK_PRIVACY_VERSION } from './constants.js';
+export {
+  LIVETALK_TERMS_VERSION,
+  LIVETALK_PRIVACY_VERSION,
+  MEMORY_TIER_C_TTL_SECONDS,
+  MEMORY_TIER_D_TTL_SECONDS,
+  MEMORY_DEFAULT_CONFIDENCE,
+} from './constants.js';

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -40,3 +40,29 @@ export function buildSafetyEventSK(eventId: string): string {
 export function buildSafetyEventSKPrefix(): string {
   return 'SAFETY#';
 }
+
+/**
+ * 全 Tier のメモリ範囲クエリ用 SK プレフィックス。
+ * `begins_with(SK, prefix)` でキャラ単位の全メモリを抽出する。
+ */
+export function buildMemoryAllTiersSKPrefix(characterId: string): string {
+  return `CHAR#${characterId}#MEM#`;
+}
+
+/**
+ * 特定 Tier のメモリ範囲クエリ用 SK プレフィックス。
+ */
+export function buildMemoryTierSKPrefix(characterId: string, tier: string): string {
+  return `CHAR#${characterId}#MEM#${tier}#`;
+}
+
+/**
+ * 特定 Tier + カテゴリのメモリ範囲クエリ用 SK プレフィックス。
+ */
+export function buildMemoryCategoryInTierSKPrefix(characterId: string, tier: string, category: string): string {
+  return `CHAR#${characterId}#MEM#${tier}#${category}#`;
+}
+
+export function buildMemorySK(characterId: string, tier: string, category: string, memoryId: string): string {
+  return `CHAR#${characterId}#MEM#${tier}#${category}#${memoryId}`;
+}

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -59,10 +59,19 @@ export function buildMemoryTierSKPrefix(characterId: string, tier: string): stri
 /**
  * 特定 Tier + カテゴリのメモリ範囲クエリ用 SK プレフィックス。
  */
-export function buildMemoryCategoryInTierSKPrefix(characterId: string, tier: string, category: string): string {
+export function buildMemoryCategoryInTierSKPrefix(
+  characterId: string,
+  tier: string,
+  category: string
+): string {
   return `CHAR#${characterId}#MEM#${tier}#${category}#`;
 }
 
-export function buildMemorySK(characterId: string, tier: string, category: string, memoryId: string): string {
+export function buildMemorySK(
+  characterId: string,
+  tier: string,
+  category: string,
+  memoryId: string
+): string {
   return `CHAR#${characterId}#MEM#${tier}#${category}#${memoryId}`;
 }

--- a/services/livetalk/core/src/mappers/memory.mapper.ts
+++ b/services/livetalk/core/src/mappers/memory.mapper.ts
@@ -1,0 +1,81 @@
+import {
+  validateEnumField,
+  validateNumberField,
+  validateStringField,
+  type DynamoDBItem,
+  type EntityMapper,
+} from '@nagiyu/aws';
+import { TIERS, type MemoryEntity, type MemoryKey, type Tier } from '../entities/memory.entity.js';
+import { buildMemorySK, buildUserPK } from './keys.js';
+
+export class MemoryMapper implements EntityMapper<MemoryEntity, MemoryKey> {
+  public readonly entityType = 'Memory';
+
+  public toItem(entity: MemoryEntity): DynamoDBItem {
+    const { pk, sk } = this.buildKeys({
+      userId: entity.UserID,
+      characterId: entity.CharacterID,
+      tier: entity.Tier,
+      category: entity.Category,
+      memoryId: entity.MemoryID,
+    });
+
+    const item: DynamoDBItem = {
+      PK: pk,
+      SK: sk,
+      Type: this.entityType,
+      UserID: entity.UserID,
+      CharacterID: entity.CharacterID,
+      MemoryID: entity.MemoryID,
+      Tier: entity.Tier,
+      Category: entity.Category,
+      Content: entity.Content,
+      Confidence: entity.Confidence,
+      ReferencedCount: entity.ReferencedCount,
+      CreatedAt: entity.CreatedAt,
+      UpdatedAt: entity.UpdatedAt,
+    };
+
+    if (entity.LastReferencedAt !== undefined) {
+      item.LastReferencedAt = entity.LastReferencedAt;
+    }
+    if (entity.Embedding !== undefined) {
+      item.Embedding = entity.Embedding;
+    }
+
+    return item;
+  }
+
+  public toEntity(item: DynamoDBItem): MemoryEntity {
+    const tier = validateEnumField(item.Tier, 'Tier', TIERS) as Tier;
+
+    const entity: MemoryEntity = {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
+      MemoryID: validateStringField(item.MemoryID, 'MemoryID'),
+      Tier: tier,
+      Category: validateStringField(item.Category, 'Category'),
+      Content: validateStringField(item.Content, 'Content', { allowEmpty: true }),
+      Confidence: validateNumberField(item.Confidence, 'Confidence', { min: 0, max: 1 }),
+      ReferencedCount: validateNumberField(item.ReferencedCount, 'ReferencedCount', { min: 0, integer: true }),
+      CreatedAt: validateStringField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateStringField(item.UpdatedAt, 'UpdatedAt'),
+    };
+
+    if (item.LastReferencedAt !== undefined) {
+      entity.LastReferencedAt = validateStringField(item.LastReferencedAt, 'LastReferencedAt');
+    }
+    if (item.Embedding !== undefined && Array.isArray(item.Embedding)) {
+      entity.Embedding = item.Embedding as number[];
+    }
+
+    return entity;
+  }
+
+  public buildKeys(key: MemoryKey): { pk: string; sk: string } {
+    return {
+      pk: buildUserPK(key.userId),
+      sk: buildMemorySK(key.characterId, key.tier, key.category, key.memoryId),
+    };
+  }
+}

--- a/services/livetalk/core/src/mappers/memory.mapper.ts
+++ b/services/livetalk/core/src/mappers/memory.mapper.ts
@@ -57,7 +57,10 @@ export class MemoryMapper implements EntityMapper<MemoryEntity, MemoryKey> {
       Category: validateStringField(item.Category, 'Category'),
       Content: validateStringField(item.Content, 'Content', { allowEmpty: true }),
       Confidence: validateNumberField(item.Confidence, 'Confidence', { min: 0, max: 1 }),
-      ReferencedCount: validateNumberField(item.ReferencedCount, 'ReferencedCount', { min: 0, integer: true }),
+      ReferencedCount: validateNumberField(item.ReferencedCount, 'ReferencedCount', {
+        min: 0,
+        integer: true,
+      }),
       CreatedAt: validateStringField(item.CreatedAt, 'CreatedAt'),
       UpdatedAt: validateStringField(item.UpdatedAt, 'UpdatedAt'),
     };

--- a/services/livetalk/core/src/mappers/memory.mapper.ts
+++ b/services/livetalk/core/src/mappers/memory.mapper.ts
@@ -2,6 +2,7 @@ import {
   validateEnumField,
   validateNumberField,
   validateStringField,
+  validateTimestampField,
   type DynamoDBItem,
   type EntityMapper,
 } from '@nagiyu/aws';
@@ -61,12 +62,12 @@ export class MemoryMapper implements EntityMapper<MemoryEntity, MemoryKey> {
         min: 0,
         integer: true,
       }),
-      CreatedAt: validateStringField(item.CreatedAt, 'CreatedAt'),
-      UpdatedAt: validateStringField(item.UpdatedAt, 'UpdatedAt'),
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
     };
 
     if (item.LastReferencedAt !== undefined) {
-      entity.LastReferencedAt = validateStringField(item.LastReferencedAt, 'LastReferencedAt');
+      entity.LastReferencedAt = validateTimestampField(item.LastReferencedAt, 'LastReferencedAt');
     }
     if (item.Embedding !== undefined && Array.isArray(item.Embedding)) {
       entity.Embedding = item.Embedding as number[];

--- a/services/livetalk/core/src/repositories/dynamodb-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-memory.repository.ts
@@ -30,26 +30,23 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
   private readonly docClient: DynamoDBDocumentClient;
   private readonly tableName: string;
   private readonly ulidFactory: UlidFactory;
-  private readonly nowIso: () => string;
-  private readonly nowSec: () => number;
+  private readonly nowMs: () => number;
 
   constructor(
     docClient: DynamoDBDocumentClient,
     tableName: string,
     ulidFactory: UlidFactory = defaultUlidFactory,
-    nowIso: () => string = () => new Date().toISOString(),
-    nowSec: () => number = () => Math.floor(Date.now() / 1000)
+    nowMs: () => number = () => Date.now()
   ) {
     this.docClient = docClient;
     this.tableName = tableName;
     this.ulidFactory = ulidFactory;
-    this.nowIso = nowIso;
-    this.nowSec = nowSec;
+    this.nowMs = nowMs;
     this.mapper = new MemoryMapper();
   }
 
   public async put(input: CreateMemoryInput): Promise<MemoryEntity> {
-    const now = this.nowIso();
+    const now = this.nowMs();
     const memoryId = input.MemoryID ?? this.ulidFactory();
 
     const entity: MemoryEntity = {
@@ -62,7 +59,7 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
     const item: DynamoDBItem = { ...this.mapper.toItem(entity) };
     const ttlSec = this.resolveTtlSec(entity.Tier);
     if (ttlSec !== null) {
-      item.TTL = this.nowSec() + ttlSec;
+      item.TTL = Math.floor(now / 1000) + ttlSec;
     }
 
     try {
@@ -128,7 +125,7 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
 
     const setExpressions: string[] = ['#UpdatedAt = :updatedAt'];
     const names: Record<string, string> = { '#UpdatedAt': 'UpdatedAt' };
-    const values: Record<string, unknown> = { ':updatedAt': this.nowIso() };
+    const values: Record<string, unknown> = { ':updatedAt': this.nowMs() };
 
     if (input.Content !== undefined) {
       setExpressions.push('#Content = :content');
@@ -210,13 +207,13 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
       memoryId: memory.MemoryID,
     });
 
-    const now = this.nowIso();
+    const now = this.nowMs();
     const newEntity: MemoryEntity = { ...memory, Tier: toTier, UpdatedAt: now };
     const newItem: DynamoDBItem = { ...this.mapper.toItem(newEntity) };
 
     const ttlSec = this.resolveTtlSec(toTier);
     if (ttlSec !== null) {
-      newItem.TTL = this.nowSec() + ttlSec;
+      newItem.TTL = Math.floor(now / 1000) + ttlSec;
     }
 
     try {

--- a/services/livetalk/core/src/repositories/dynamodb-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-memory.repository.ts
@@ -96,13 +96,21 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
     }
   }
 
-  public async listByTier(userId: string, characterId: string, tier: Tier): Promise<MemoryEntity[]> {
+  public async listByTier(
+    userId: string,
+    characterId: string,
+    tier: Tier
+  ): Promise<MemoryEntity[]> {
     const pk = buildUserPK(userId);
     const prefix = buildMemoryTierSKPrefix(characterId, tier);
     return this.queryByPrefix(pk, prefix);
   }
 
-  public async listByCategory(userId: string, characterId: string, category: string): Promise<MemoryEntity[]> {
+  public async listByCategory(
+    userId: string,
+    characterId: string,
+    category: string
+  ): Promise<MemoryEntity[]> {
     const pk = buildUserPK(userId);
     const prefix = buildMemoryAllTiersSKPrefix(characterId);
     const all = await this.queryByPrefix(pk, prefix);

--- a/services/livetalk/core/src/repositories/dynamodb-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-memory.repository.ts
@@ -1,0 +1,277 @@
+import {
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  TransactWriteCommand,
+  UpdateCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, EntityNotFoundError, type DynamoDBItem } from '@nagiyu/aws';
+import { MEMORY_TIER_C_TTL_SECONDS, MEMORY_TIER_D_TTL_SECONDS } from '../constants.js';
+import type {
+  CreateMemoryInput,
+  MemoryEntity,
+  MemoryKey,
+  Tier,
+  UpdateMemoryInput,
+} from '../entities/memory.entity.js';
+import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+import { MemoryMapper } from '../mappers/memory.mapper.js';
+import {
+  buildMemoryAllTiersSKPrefix,
+  buildMemoryTierSKPrefix,
+  buildUserPK,
+} from '../mappers/keys.js';
+import type { MemoryRepository } from './memory.repository.interface.js';
+
+export class DynamoDBMemoryRepository implements MemoryRepository {
+  private readonly mapper: MemoryMapper;
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly ulidFactory: UlidFactory;
+  private readonly nowIso: () => string;
+  private readonly nowSec: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    ulidFactory: UlidFactory = defaultUlidFactory,
+    nowIso: () => string = () => new Date().toISOString(),
+    nowSec: () => number = () => Math.floor(Date.now() / 1000)
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.ulidFactory = ulidFactory;
+    this.nowIso = nowIso;
+    this.nowSec = nowSec;
+    this.mapper = new MemoryMapper();
+  }
+
+  public async put(input: CreateMemoryInput): Promise<MemoryEntity> {
+    const now = this.nowIso();
+    const memoryId = input.MemoryID ?? this.ulidFactory();
+
+    const entity: MemoryEntity = {
+      ...input,
+      MemoryID: memoryId,
+      CreatedAt: now,
+      UpdatedAt: now,
+    };
+
+    const item: DynamoDBItem = { ...this.mapper.toItem(entity) };
+    const ttlSec = this.resolveTtlSec(entity.Tier);
+    if (ttlSec !== null) {
+      item.TTL = this.nowSec() + ttlSec;
+    }
+
+    try {
+      await this.docClient.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: item,
+        })
+      );
+      return entity;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async get(key: MemoryKey): Promise<MemoryEntity | null> {
+    try {
+      const { pk, sk } = this.mapper.buildKeys(key);
+      const result = await this.docClient.send(
+        new GetCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+        })
+      );
+      if (!result.Item) return null;
+      return this.mapper.toEntity(result.Item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async listByTier(userId: string, characterId: string, tier: Tier): Promise<MemoryEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildMemoryTierSKPrefix(characterId, tier);
+    return this.queryByPrefix(pk, prefix);
+  }
+
+  public async listByCategory(userId: string, characterId: string, category: string): Promise<MemoryEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildMemoryAllTiersSKPrefix(characterId);
+    const all = await this.queryByPrefix(pk, prefix);
+    return all.filter((m) => m.Category === category);
+  }
+
+  public async update(input: UpdateMemoryInput): Promise<MemoryEntity> {
+    const { pk, sk } = this.mapper.buildKeys({
+      userId: input.UserID,
+      characterId: input.CharacterID,
+      tier: input.Tier,
+      category: input.Category,
+      memoryId: input.MemoryID,
+    });
+
+    const setExpressions: string[] = ['#UpdatedAt = :updatedAt'];
+    const names: Record<string, string> = { '#UpdatedAt': 'UpdatedAt' };
+    const values: Record<string, unknown> = { ':updatedAt': this.nowIso() };
+
+    if (input.Content !== undefined) {
+      setExpressions.push('#Content = :content');
+      names['#Content'] = 'Content';
+      values[':content'] = input.Content;
+    }
+    if (input.Confidence !== undefined) {
+      setExpressions.push('#Confidence = :confidence');
+      names['#Confidence'] = 'Confidence';
+      values[':confidence'] = input.Confidence;
+    }
+    if (input.ReferencedCount !== undefined) {
+      setExpressions.push('#ReferencedCount = :referencedCount');
+      names['#ReferencedCount'] = 'ReferencedCount';
+      values[':referencedCount'] = input.ReferencedCount;
+    }
+    if (input.LastReferencedAt !== undefined) {
+      setExpressions.push('#LastReferencedAt = :lastReferencedAt');
+      names['#LastReferencedAt'] = 'LastReferencedAt';
+      values[':lastReferencedAt'] = input.LastReferencedAt;
+    }
+    if (input.Embedding !== undefined) {
+      setExpressions.push('#Embedding = :embedding');
+      names['#Embedding'] = 'Embedding';
+      values[':embedding'] = input.Embedding;
+    }
+
+    try {
+      const result = await this.docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+          UpdateExpression: `SET ${setExpressions.join(', ')}`,
+          ExpressionAttributeNames: names,
+          ExpressionAttributeValues: values,
+          ConditionExpression: 'attribute_exists(PK)',
+          ReturnValues: 'ALL_NEW',
+        })
+      );
+      return this.mapper.toEntity(result.Attributes as unknown as DynamoDBItem);
+    } catch (error) {
+      if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
+        throw new EntityNotFoundError('Memory', `${pk}#${sk}`);
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async delete(key: MemoryKey): Promise<void> {
+    try {
+      const { pk, sk } = this.mapper.buildKeys(key);
+      await this.docClient.send(
+        new DeleteCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+        })
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async promote(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity> {
+    return this.changeTierTransact(memory, toTier);
+  }
+
+  public async demote(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity> {
+    return this.changeTierTransact(memory, toTier);
+  }
+
+  private async changeTierTransact(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity> {
+    const { pk: oldPk, sk: oldSk } = this.mapper.buildKeys({
+      userId: memory.UserID,
+      characterId: memory.CharacterID,
+      tier: memory.Tier,
+      category: memory.Category,
+      memoryId: memory.MemoryID,
+    });
+
+    const now = this.nowIso();
+    const newEntity: MemoryEntity = { ...memory, Tier: toTier, UpdatedAt: now };
+    const newItem: DynamoDBItem = { ...this.mapper.toItem(newEntity) };
+
+    const ttlSec = this.resolveTtlSec(toTier);
+    if (ttlSec !== null) {
+      newItem.TTL = this.nowSec() + ttlSec;
+    }
+
+    try {
+      await this.docClient.send(
+        new TransactWriteCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: newItem,
+              },
+            },
+            {
+              Delete: {
+                TableName: this.tableName,
+                Key: { PK: oldPk, SK: oldSk },
+              },
+            },
+          ],
+        })
+      );
+      return newEntity;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  private async queryByPrefix(pk: string, skPrefix: string): Promise<MemoryEntity[]> {
+    const results: MemoryEntity[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: { ':pk': pk, ':prefix': skPrefix },
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        results.push(this.mapper.toEntity(raw as unknown as DynamoDBItem));
+      }
+
+      if (!result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return results;
+  }
+
+  private resolveTtlSec(tier: Tier): number | null {
+    if (tier === 'C') return MEMORY_TIER_C_TTL_SECONDS;
+    if (tier === 'D') return MEMORY_TIER_D_TTL_SECONDS;
+    return null;
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-memory.repository.ts
@@ -20,21 +20,21 @@ export class InMemoryMemoryRepository implements MemoryRepository {
   private readonly mapper: MemoryMapper;
   private readonly store: InMemorySingleTableStore;
   private readonly ulidFactory: UlidFactory;
-  private readonly nowIso: () => string;
+  private readonly nowMs: () => number;
 
   constructor(
     store: InMemorySingleTableStore,
     ulidFactory: UlidFactory = defaultUlidFactory,
-    nowIso: () => string = () => new Date().toISOString()
+    nowMs: () => number = () => Date.now()
   ) {
     this.store = store;
     this.ulidFactory = ulidFactory;
-    this.nowIso = nowIso;
+    this.nowMs = nowMs;
     this.mapper = new MemoryMapper();
   }
 
   public async put(input: CreateMemoryInput): Promise<MemoryEntity> {
-    const now = this.nowIso();
+    const now = this.nowMs();
     const memoryId = input.MemoryID ?? this.ulidFactory();
 
     const entity: MemoryEntity = {
@@ -49,7 +49,7 @@ export class InMemoryMemoryRepository implements MemoryRepository {
 
     const ttlSec = this.resolveTtlSec(entity.Tier);
     if (ttlSec !== null) {
-      item.TTL = Math.floor(Date.now() / 1000) + ttlSec;
+      item.TTL = Math.floor(this.nowMs() / 1000) + ttlSec;
     }
 
     this.store.put(item);
@@ -123,7 +123,7 @@ export class InMemoryMemoryRepository implements MemoryRepository {
       ...(input.ReferencedCount !== undefined && { ReferencedCount: input.ReferencedCount }),
       ...(input.LastReferencedAt !== undefined && { LastReferencedAt: input.LastReferencedAt }),
       ...(input.Embedding !== undefined && { Embedding: input.Embedding }),
-      UpdatedAt: this.nowIso(),
+      UpdatedAt: this.nowMs(),
     };
     this.store.put(this.mapper.toItem(updated));
     return updated;
@@ -152,7 +152,7 @@ export class InMemoryMemoryRepository implements MemoryRepository {
       memoryId: memory.MemoryID,
     });
 
-    const now = this.nowIso();
+    const now = this.nowMs();
     const newEntity: MemoryEntity = { ...memory, Tier: toTier, UpdatedAt: now };
     const newItem: DynamoDBItem = { ...this.mapper.toItem(newEntity) };
 

--- a/services/livetalk/core/src/repositories/in-memory-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-memory.repository.ts
@@ -63,7 +63,11 @@ export class InMemoryMemoryRepository implements MemoryRepository {
     return this.mapper.toEntity(item);
   }
 
-  public async listByTier(userId: string, characterId: string, tier: Tier): Promise<MemoryEntity[]> {
+  public async listByTier(
+    userId: string,
+    characterId: string,
+    tier: Tier
+  ): Promise<MemoryEntity[]> {
     const pk = buildUserPK(userId);
     const prefix = buildMemoryTierSKPrefix(characterId, tier);
     const { items } = this.store.query(
@@ -73,7 +77,11 @@ export class InMemoryMemoryRepository implements MemoryRepository {
     return items.map((item) => this.mapper.toEntity(item));
   }
 
-  public async listByCategory(userId: string, characterId: string, category: string): Promise<MemoryEntity[]> {
+  public async listByCategory(
+    userId: string,
+    characterId: string,
+    category: string
+  ): Promise<MemoryEntity[]> {
     const pk = buildUserPK(userId);
     const allPrefix = buildMemoryAllTiersSKPrefix(characterId);
     const { items } = this.store.query(

--- a/services/livetalk/core/src/repositories/in-memory-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-memory.repository.ts
@@ -1,0 +1,166 @@
+import { InMemorySingleTableStore, type DynamoDBItem } from '@nagiyu/aws';
+import { MEMORY_TIER_C_TTL_SECONDS, MEMORY_TIER_D_TTL_SECONDS } from '../constants.js';
+import type {
+  CreateMemoryInput,
+  MemoryEntity,
+  MemoryKey,
+  Tier,
+  UpdateMemoryInput,
+} from '../entities/memory.entity.js';
+import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+import { MemoryMapper } from '../mappers/memory.mapper.js';
+import {
+  buildMemoryAllTiersSKPrefix,
+  buildMemoryTierSKPrefix,
+  buildUserPK,
+} from '../mappers/keys.js';
+import type { MemoryRepository } from './memory.repository.interface.js';
+
+export class InMemoryMemoryRepository implements MemoryRepository {
+  private readonly mapper: MemoryMapper;
+  private readonly store: InMemorySingleTableStore;
+  private readonly ulidFactory: UlidFactory;
+  private readonly nowIso: () => string;
+
+  constructor(
+    store: InMemorySingleTableStore,
+    ulidFactory: UlidFactory = defaultUlidFactory,
+    nowIso: () => string = () => new Date().toISOString()
+  ) {
+    this.store = store;
+    this.ulidFactory = ulidFactory;
+    this.nowIso = nowIso;
+    this.mapper = new MemoryMapper();
+  }
+
+  public async put(input: CreateMemoryInput): Promise<MemoryEntity> {
+    const now = this.nowIso();
+    const memoryId = input.MemoryID ?? this.ulidFactory();
+
+    const entity: MemoryEntity = {
+      ...input,
+      MemoryID: memoryId,
+      CreatedAt: now,
+      UpdatedAt: now,
+    };
+
+    const baseItem = this.mapper.toItem(entity);
+    const item: DynamoDBItem = { ...baseItem };
+
+    const ttlSec = this.resolveTtlSec(entity.Tier);
+    if (ttlSec !== null) {
+      item.TTL = Math.floor(Date.now() / 1000) + ttlSec;
+    }
+
+    this.store.put(item);
+    return entity;
+  }
+
+  public async get(key: MemoryKey): Promise<MemoryEntity | null> {
+    const { pk, sk } = this.mapper.buildKeys(key);
+    const item = this.store.get(pk, sk);
+    if (!item) return null;
+    return this.mapper.toEntity(item);
+  }
+
+  public async listByTier(userId: string, characterId: string, tier: Tier): Promise<MemoryEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildMemoryTierSKPrefix(characterId, tier);
+    const { items } = this.store.query(
+      { pk, sk: { operator: 'begins_with', value: prefix } },
+      { limit: Number.MAX_SAFE_INTEGER }
+    );
+    return items.map((item) => this.mapper.toEntity(item));
+  }
+
+  public async listByCategory(userId: string, characterId: string, category: string): Promise<MemoryEntity[]> {
+    const pk = buildUserPK(userId);
+    const allPrefix = buildMemoryAllTiersSKPrefix(characterId);
+    const { items } = this.store.query(
+      { pk, sk: { operator: 'begins_with', value: allPrefix } },
+      { limit: Number.MAX_SAFE_INTEGER }
+    );
+    const result: MemoryEntity[] = [];
+    for (const item of items) {
+      let entity: MemoryEntity;
+      try {
+        entity = this.mapper.toEntity(item);
+      } catch {
+        continue;
+      }
+      if (entity.Category === category) {
+        result.push(entity);
+      }
+    }
+    return result;
+  }
+
+  public async update(input: UpdateMemoryInput): Promise<MemoryEntity> {
+    const { pk, sk } = this.mapper.buildKeys({
+      userId: input.UserID,
+      characterId: input.CharacterID,
+      tier: input.Tier,
+      category: input.Category,
+      memoryId: input.MemoryID,
+    });
+    const existing = this.store.get(pk, sk);
+    if (!existing) {
+      throw new Error(`メモリが見つかりません: ${pk}#${sk}`);
+    }
+    const current = this.mapper.toEntity(existing);
+    const updated: MemoryEntity = {
+      ...current,
+      ...(input.Content !== undefined && { Content: input.Content }),
+      ...(input.Confidence !== undefined && { Confidence: input.Confidence }),
+      ...(input.ReferencedCount !== undefined && { ReferencedCount: input.ReferencedCount }),
+      ...(input.LastReferencedAt !== undefined && { LastReferencedAt: input.LastReferencedAt }),
+      ...(input.Embedding !== undefined && { Embedding: input.Embedding }),
+      UpdatedAt: this.nowIso(),
+    };
+    this.store.put(this.mapper.toItem(updated));
+    return updated;
+  }
+
+  public async delete(key: MemoryKey): Promise<void> {
+    const { pk, sk } = this.mapper.buildKeys(key);
+    this.store.delete(pk, sk);
+  }
+
+  public async promote(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity> {
+    return this.changeTier(memory, toTier);
+  }
+
+  public async demote(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity> {
+    return this.changeTier(memory, toTier);
+  }
+
+  private changeTier(memory: MemoryEntity, toTier: Tier): MemoryEntity {
+    const oldPk = buildUserPK(memory.UserID);
+    const { sk: oldSk } = this.mapper.buildKeys({
+      userId: memory.UserID,
+      characterId: memory.CharacterID,
+      tier: memory.Tier,
+      category: memory.Category,
+      memoryId: memory.MemoryID,
+    });
+
+    const now = this.nowIso();
+    const newEntity: MemoryEntity = { ...memory, Tier: toTier, UpdatedAt: now };
+    const newItem: DynamoDBItem = { ...this.mapper.toItem(newEntity) };
+
+    const ttlSec = this.resolveTtlSec(toTier);
+    if (ttlSec !== null) {
+      newItem.TTL = Math.floor(Date.now() / 1000) + ttlSec;
+    }
+
+    this.store.put(newItem);
+    this.store.delete(oldPk, oldSk);
+    return newEntity;
+  }
+
+  private resolveTtlSec(tier: Tier): number | null {
+    if (tier === 'C') return MEMORY_TIER_C_TTL_SECONDS;
+    if (tier === 'D') return MEMORY_TIER_D_TTL_SECONDS;
+    return null;
+  }
+}

--- a/services/livetalk/core/src/repositories/memory.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/memory.repository.interface.ts
@@ -1,0 +1,44 @@
+import type { CreateMemoryInput, MemoryEntity, MemoryKey, Tier, UpdateMemoryInput } from '../entities/memory.entity.js';
+
+export interface MemoryRepository {
+  /**
+   * メモリを保存する。`MemoryID` 未指定時は ULID を自動採番する。
+   * TTL（Tier C: 30 日 / Tier D: 1 日）はリポジトリ側で自動付与する。
+   */
+  put(memory: CreateMemoryInput): Promise<MemoryEntity>;
+
+  /**
+   * 単一メモリを取得する。
+   */
+  get(key: MemoryKey): Promise<MemoryEntity | null>;
+
+  /**
+   * 指定 Tier のメモリを全件取得する。
+   */
+  listByTier(userId: string, characterId: string, tier: Tier): Promise<MemoryEntity[]>;
+
+  /**
+   * 指定カテゴリのメモリを Tier 横断で全件取得する。
+   */
+  listByCategory(userId: string, characterId: string, category: string): Promise<MemoryEntity[]>;
+
+  /**
+   * メモリの可変フィールドを更新する。
+   */
+  update(memory: UpdateMemoryInput): Promise<MemoryEntity>;
+
+  /**
+   * メモリを削除する。
+   */
+  delete(key: MemoryKey): Promise<void>;
+
+  /**
+   * メモリを上位 Tier に昇格する（SK 変更を伴う delete + put のトランザクション）。
+   */
+  promote(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity>;
+
+  /**
+   * メモリを下位 Tier に降格する（SK 変更を伴う delete + put のトランザクション）。
+   */
+  demote(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity>;
+}

--- a/services/livetalk/core/src/repositories/memory.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/memory.repository.interface.ts
@@ -1,4 +1,10 @@
-import type { CreateMemoryInput, MemoryEntity, MemoryKey, Tier, UpdateMemoryInput } from '../entities/memory.entity.js';
+import type {
+  CreateMemoryInput,
+  MemoryEntity,
+  MemoryKey,
+  Tier,
+  UpdateMemoryInput,
+} from '../entities/memory.entity.js';
 
 export interface MemoryRepository {
   /**

--- a/services/livetalk/core/tests/unit/mappers/memory.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/memory.mapper.test.ts
@@ -1,0 +1,151 @@
+import { InvalidEntityDataError } from '@nagiyu/aws';
+import { MemoryMapper } from '../../../src/mappers/memory.mapper.js';
+import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
+
+const baseEntity: MemoryEntity = {
+  UserID: 'user1',
+  CharacterID: 'hiyori',
+  MemoryID: 'MEM-001',
+  Tier: 'B',
+  Category: 'food',
+  Content: 'コーヒーが好き',
+  Confidence: 0.8,
+  ReferencedCount: 3,
+  CreatedAt: '2026-01-01T00:00:00.000Z',
+  UpdatedAt: '2026-01-02T00:00:00.000Z',
+};
+
+describe('MemoryMapper', () => {
+  let mapper: MemoryMapper;
+
+  beforeEach(() => {
+    mapper = new MemoryMapper();
+  });
+
+  describe('toItem', () => {
+    it('エンティティを DynamoDB Item に変換する', () => {
+      const item = mapper.toItem(baseEntity);
+      expect(item.PK).toBe('USER#user1');
+      expect(item.SK).toBe('CHAR#hiyori#MEM#B#food#MEM-001');
+      expect(item.Type).toBe('Memory');
+      expect(item.UserID).toBe('user1');
+      expect(item.CharacterID).toBe('hiyori');
+      expect(item.MemoryID).toBe('MEM-001');
+      expect(item.Tier).toBe('B');
+      expect(item.Category).toBe('food');
+      expect(item.Content).toBe('コーヒーが好き');
+      expect(item.Confidence).toBe(0.8);
+      expect(item.ReferencedCount).toBe(3);
+      expect(item.CreatedAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(item.UpdatedAt).toBe('2026-01-02T00:00:00.000Z');
+    });
+
+    it('LastReferencedAt / Embedding が undefined の場合は Item に含めない', () => {
+      const item = mapper.toItem(baseEntity);
+      expect(item.LastReferencedAt).toBeUndefined();
+      expect(item.Embedding).toBeUndefined();
+    });
+
+    it('LastReferencedAt / Embedding が設定されている場合は Item に含める', () => {
+      const entity: MemoryEntity = {
+        ...baseEntity,
+        LastReferencedAt: '2026-01-03T00:00:00.000Z',
+        Embedding: [0.1, 0.2, 0.3],
+      };
+      const item = mapper.toItem(entity);
+      expect(item.LastReferencedAt).toBe('2026-01-03T00:00:00.000Z');
+      expect(item.Embedding).toEqual([0.1, 0.2, 0.3]);
+    });
+
+    it('全 Tier の SK を正しく組み立てる', () => {
+      const tiers = ['A', 'B', 'C', 'D'] as const;
+      for (const tier of tiers) {
+        const entity: MemoryEntity = { ...baseEntity, Tier: tier };
+        const item = mapper.toItem(entity);
+        expect(item.SK).toBe(`CHAR#hiyori#MEM#${tier}#food#MEM-001`);
+      }
+    });
+  });
+
+  describe('toEntity', () => {
+    it('DynamoDB Item をエンティティに変換する', () => {
+      const item = {
+        PK: 'USER#user1',
+        SK: 'CHAR#hiyori#MEM#B#food#MEM-001',
+        Type: 'Memory',
+        UserID: 'user1',
+        CharacterID: 'hiyori',
+        MemoryID: 'MEM-001',
+        Tier: 'B',
+        Category: 'food',
+        Content: 'コーヒーが好き',
+        Confidence: 0.8,
+        ReferencedCount: 3,
+        CreatedAt: '2026-01-01T00:00:00.000Z',
+        UpdatedAt: '2026-01-02T00:00:00.000Z',
+      };
+      const entity = mapper.toEntity(item);
+      expect(entity.UserID).toBe('user1');
+      expect(entity.Tier).toBe('B');
+      expect(entity.Confidence).toBe(0.8);
+      expect(entity.LastReferencedAt).toBeUndefined();
+      expect(entity.Embedding).toBeUndefined();
+    });
+
+    it('不正な Tier は InvalidEntityDataError を投げる', () => {
+      const item = { ...mapper.toItem(baseEntity), Tier: 'Z' };
+      expect(() => mapper.toEntity(item)).toThrow(InvalidEntityDataError);
+    });
+
+    it('Confidence が 0 未満は InvalidEntityDataError を投げる', () => {
+      const item = { ...mapper.toItem(baseEntity), Confidence: -0.1 };
+      expect(() => mapper.toEntity(item)).toThrow(InvalidEntityDataError);
+    });
+
+    it('Confidence が 1 超は InvalidEntityDataError を投げる', () => {
+      const item = { ...mapper.toItem(baseEntity), Confidence: 1.1 };
+      expect(() => mapper.toEntity(item)).toThrow(InvalidEntityDataError);
+    });
+
+    it('LastReferencedAt が存在する場合はエンティティに含める', () => {
+      const item = {
+        ...mapper.toItem(baseEntity),
+        LastReferencedAt: '2026-01-03T00:00:00.000Z',
+      };
+      const entity = mapper.toEntity(item);
+      expect(entity.LastReferencedAt).toBe('2026-01-03T00:00:00.000Z');
+    });
+
+    it('Embedding が存在する場合はエンティティに含める', () => {
+      const item = { ...mapper.toItem(baseEntity), Embedding: [0.1, 0.2] };
+      const entity = mapper.toEntity(item);
+      expect(entity.Embedding).toEqual([0.1, 0.2]);
+    });
+  });
+
+  describe('buildKeys', () => {
+    it('PK / SK を正しく組み立てる', () => {
+      const { pk, sk } = mapper.buildKeys({
+        userId: 'user1',
+        characterId: 'hiyori',
+        tier: 'A',
+        category: 'name',
+        memoryId: 'MEM-001',
+      });
+      expect(pk).toBe('USER#user1');
+      expect(sk).toBe('CHAR#hiyori#MEM#A#name#MEM-001');
+    });
+  });
+
+  describe('toItem → toEntity ラウンドトリップ', () => {
+    it('Embedding 付きエンティティも往復変換できる', () => {
+      const entity: MemoryEntity = {
+        ...baseEntity,
+        LastReferencedAt: '2026-01-03T00:00:00.000Z',
+        Embedding: [0.5, 0.6],
+      };
+      const roundTripped = mapper.toEntity(mapper.toItem(entity));
+      expect(roundTripped).toEqual(entity);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/mappers/memory.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/memory.mapper.test.ts
@@ -11,8 +11,8 @@ const baseEntity: MemoryEntity = {
   Content: 'コーヒーが好き',
   Confidence: 0.8,
   ReferencedCount: 3,
-  CreatedAt: '2026-01-01T00:00:00.000Z',
-  UpdatedAt: '2026-01-02T00:00:00.000Z',
+  CreatedAt: 1_750_000_000_000,
+  UpdatedAt: 1_750_086_400_000,
 };
 
 describe('MemoryMapper', () => {
@@ -36,8 +36,8 @@ describe('MemoryMapper', () => {
       expect(item.Content).toBe('コーヒーが好き');
       expect(item.Confidence).toBe(0.8);
       expect(item.ReferencedCount).toBe(3);
-      expect(item.CreatedAt).toBe('2026-01-01T00:00:00.000Z');
-      expect(item.UpdatedAt).toBe('2026-01-02T00:00:00.000Z');
+      expect(item.CreatedAt).toBe(1_750_000_000_000);
+      expect(item.UpdatedAt).toBe(1_750_086_400_000);
     });
 
     it('LastReferencedAt / Embedding が undefined の場合は Item に含めない', () => {
@@ -49,11 +49,11 @@ describe('MemoryMapper', () => {
     it('LastReferencedAt / Embedding が設定されている場合は Item に含める', () => {
       const entity: MemoryEntity = {
         ...baseEntity,
-        LastReferencedAt: '2026-01-03T00:00:00.000Z',
+        LastReferencedAt: 1_750_172_800_000,
         Embedding: [0.1, 0.2, 0.3],
       };
       const item = mapper.toItem(entity);
-      expect(item.LastReferencedAt).toBe('2026-01-03T00:00:00.000Z');
+      expect(item.LastReferencedAt).toBe(1_750_172_800_000);
       expect(item.Embedding).toEqual([0.1, 0.2, 0.3]);
     });
 
@@ -81,8 +81,8 @@ describe('MemoryMapper', () => {
         Content: 'コーヒーが好き',
         Confidence: 0.8,
         ReferencedCount: 3,
-        CreatedAt: '2026-01-01T00:00:00.000Z',
-        UpdatedAt: '2026-01-02T00:00:00.000Z',
+        CreatedAt: 1_750_000_000_000,
+        UpdatedAt: 1_750_086_400_000,
       };
       const entity = mapper.toEntity(item);
       expect(entity.UserID).toBe('user1');
@@ -110,10 +110,10 @@ describe('MemoryMapper', () => {
     it('LastReferencedAt が存在する場合はエンティティに含める', () => {
       const item = {
         ...mapper.toItem(baseEntity),
-        LastReferencedAt: '2026-01-03T00:00:00.000Z',
+        LastReferencedAt: 1_750_172_800_000,
       };
       const entity = mapper.toEntity(item);
-      expect(entity.LastReferencedAt).toBe('2026-01-03T00:00:00.000Z');
+      expect(entity.LastReferencedAt).toBe(1_750_172_800_000);
     });
 
     it('Embedding が存在する場合はエンティティに含める', () => {
@@ -141,7 +141,7 @@ describe('MemoryMapper', () => {
     it('Embedding 付きエンティティも往復変換できる', () => {
       const entity: MemoryEntity = {
         ...baseEntity,
-        LastReferencedAt: '2026-01-03T00:00:00.000Z',
+        LastReferencedAt: 1_750_172_800_000,
         Embedding: [0.5, 0.6],
       };
       const roundTripped = mapper.toEntity(mapper.toItem(entity));

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-memory.repository.test.ts
@@ -14,6 +14,10 @@ import type { CreateMemoryInput, MemoryEntity } from '../../../src/entities/memo
 type SendHandler = (command: unknown) => Promise<unknown>;
 const makeClient = (handler: SendHandler) => ({ send: handler });
 
+const fixedNow = 1_750_000_000_000;
+const tableName = 'nagiyu-livetalk-dev';
+const ulidFactory = () => 'MEM-001';
+
 const baseInput: CreateMemoryInput = {
   UserID: 'u1',
   CharacterID: 'hiyori',
@@ -36,14 +40,9 @@ const baseItem = {
   Content: 'コーヒーが好き',
   Confidence: 0.8,
   ReferencedCount: 0,
-  CreatedAt: '2026-01-01T00:00:00.000Z',
-  UpdatedAt: '2026-01-01T00:00:00.000Z',
+  CreatedAt: fixedNow,
+  UpdatedAt: fixedNow,
 };
-
-const tableName = 'nagiyu-livetalk-dev';
-const fixedNow = '2026-01-01T00:00:00.000Z';
-const fixedNowSec = 1_750_000_000;
-const ulidFactory = () => 'MEM-001';
 
 describe('DynamoDBMemoryRepository', () => {
   describe('put', () => {
@@ -57,8 +56,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
 
       const entity = await repo.put(baseInput);
@@ -81,8 +79,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await repo.put({ ...baseInput, Tier: 'B' });
       const input = (sent[0] as PutCommand).input;
@@ -99,12 +96,11 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await repo.put({ ...baseInput, Tier: 'C' });
       const input = (sent[0] as PutCommand).input;
-      expect(input.Item?.TTL).toBe(fixedNowSec + MEMORY_TIER_C_TTL_SECONDS);
+      expect(input.Item?.TTL).toBe(Math.floor(fixedNow / 1000) + MEMORY_TIER_C_TTL_SECONDS);
     });
 
     it('Tier D には 1 日後の TTL を付与する', async () => {
@@ -117,12 +113,11 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await repo.put({ ...baseInput, Tier: 'D' });
       const input = (sent[0] as PutCommand).input;
-      expect(input.Item?.TTL).toBe(fixedNowSec + MEMORY_TIER_D_TTL_SECONDS);
+      expect(input.Item?.TTL).toBe(Math.floor(fixedNow / 1000) + MEMORY_TIER_D_TTL_SECONDS);
     });
 
     it('DynamoDB エラーは DatabaseError でラップする', async () => {
@@ -133,8 +128,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await expect(repo.put(baseInput)).rejects.toBeInstanceOf(DatabaseError);
     });
@@ -158,8 +152,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       const result = await repo.get({
         userId: 'u1',
@@ -180,8 +173,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       const result = await repo.get({
         userId: 'u1',
@@ -201,8 +193,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await expect(
         repo.get({
@@ -227,8 +218,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       const result = await repo.listByTier('u1', 'hiyori', 'B');
       expect(result).toHaveLength(1);
@@ -249,8 +239,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await repo.listByTier('u1', 'hiyori', 'B');
       expect(call).toBe(2);
@@ -272,8 +261,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       const result = await repo.listByCategory('u1', 'hiyori', 'food');
       expect(result).toHaveLength(1);
@@ -292,8 +280,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await expect(
         repo.update({
@@ -317,8 +304,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       const result = await repo.update({
         UserID: 'u1',
@@ -345,8 +331,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await repo.delete({
         userId: 'u1',
@@ -368,8 +353,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await expect(
         repo.delete({
@@ -393,8 +377,8 @@ describe('DynamoDBMemoryRepository', () => {
       Content: 'コーヒーが好き',
       Confidence: 0.5,
       ReferencedCount: 1,
-      CreatedAt: '2026-01-01T00:00:00.000Z',
-      UpdatedAt: '2026-01-01T00:00:00.000Z',
+      CreatedAt: fixedNow,
+      UpdatedAt: fixedNow,
     };
 
     it('promote は TransactWriteCommand で Put(新SK) + Delete(旧SK) を送る', async () => {
@@ -407,8 +391,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       const result = await repo.promote(savedEntity, 'B');
       expect(result.Tier).toBe('B');
@@ -429,8 +412,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       const tierAEntity: MemoryEntity = { ...savedEntity, Tier: 'A' };
       const result = await repo.demote(tierAEntity, 'C');
@@ -448,8 +430,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await repo.promote(savedEntity, 'B');
       const input = (sent[0] as TransactWriteCommand).input;
@@ -466,12 +447,13 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await repo.demote(savedEntity, 'D');
       const input = (sent[0] as TransactWriteCommand).input;
-      expect(input.TransactItems?.[0].Put?.Item?.TTL).toBe(fixedNowSec + MEMORY_TIER_D_TTL_SECONDS);
+      expect(input.TransactItems?.[0].Put?.Item?.TTL).toBe(
+        Math.floor(fixedNow / 1000) + MEMORY_TIER_D_TTL_SECONDS
+      );
     });
 
     it('TransactWrite エラーは DatabaseError でラップする', async () => {
@@ -482,8 +464,7 @@ describe('DynamoDBMemoryRepository', () => {
         client as never,
         tableName,
         ulidFactory,
-        () => fixedNow,
-        () => fixedNowSec
+        () => fixedNow
       );
       await expect(repo.promote(savedEntity, 'A')).rejects.toBeInstanceOf(DatabaseError);
     });

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-memory.repository.test.ts
@@ -49,9 +49,16 @@ describe('DynamoDBMemoryRepository', () => {
   describe('put', () => {
     it('PutCommand を送り MemoryID / CreatedAt を付与する', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
 
       const entity = await repo.put(baseInput);
@@ -66,9 +73,16 @@ describe('DynamoDBMemoryRepository', () => {
 
     it('Tier B には TTL を付与しない', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await repo.put({ ...baseInput, Tier: 'B' });
       const input = (sent[0] as PutCommand).input;
@@ -77,9 +91,16 @@ describe('DynamoDBMemoryRepository', () => {
 
     it('Tier C には 30 日後の TTL を付与する', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await repo.put({ ...baseInput, Tier: 'C' });
       const input = (sent[0] as PutCommand).input;
@@ -88,9 +109,16 @@ describe('DynamoDBMemoryRepository', () => {
 
     it('Tier D には 1 日後の TTL を付与する', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await repo.put({ ...baseInput, Tier: 'D' });
       const input = (sent[0] as PutCommand).input;
@@ -98,9 +126,15 @@ describe('DynamoDBMemoryRepository', () => {
     });
 
     it('DynamoDB エラーは DatabaseError でラップする', async () => {
-      const client = makeClient(async () => { throw new Error('boom'); });
+      const client = makeClient(async () => {
+        throw new Error('boom');
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await expect(repo.put(baseInput)).rejects.toBeInstanceOf(DatabaseError);
     });
@@ -116,12 +150,23 @@ describe('DynamoDBMemoryRepository', () => {
   describe('get', () => {
     it('GetCommand を送り Item があれば Entity を返す', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return { Item: baseItem }; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Item: baseItem };
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       const result = await repo.get({
-        userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'MEM-001',
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B',
+        category: 'food',
+        memoryId: 'MEM-001',
       });
       expect(result?.Content).toBe('コーヒーが好き');
       expect(sent[0]).toBeInstanceOf(GetCommand);
@@ -132,21 +177,41 @@ describe('DynamoDBMemoryRepository', () => {
     it('Item がなければ null を返す', async () => {
       const client = makeClient(async () => ({ Item: undefined }));
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       const result = await repo.get({
-        userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'missing',
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B',
+        category: 'food',
+        memoryId: 'missing',
       });
       expect(result).toBeNull();
     });
 
     it('DynamoDB エラーは DatabaseError でラップする', async () => {
-      const client = makeClient(async () => { throw new Error('network'); });
+      const client = makeClient(async () => {
+        throw new Error('network');
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await expect(
-        repo.get({ userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'x' })
+        repo.get({
+          userId: 'u1',
+          characterId: 'hiyori',
+          tier: 'B',
+          category: 'food',
+          memoryId: 'x',
+        })
       ).rejects.toBeInstanceOf(DatabaseError);
     });
   });
@@ -154,9 +219,16 @@ describe('DynamoDBMemoryRepository', () => {
   describe('listByTier', () => {
     it('QueryCommand で begins_with による Tier 絞り込みを行う', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return { Items: [baseItem] }; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Items: [baseItem] };
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       const result = await repo.listByTier('u1', 'hiyori', 'B');
       expect(result).toHaveLength(1);
@@ -174,7 +246,11 @@ describe('DynamoDBMemoryRepository', () => {
         return { Items: [] };
       });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await repo.listByTier('u1', 'hiyori', 'B');
       expect(call).toBe(2);
@@ -193,7 +269,11 @@ describe('DynamoDBMemoryRepository', () => {
       };
       const client = makeClient(async () => ({ Items: [foodItem, hobbyItem] }));
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       const result = await repo.listByCategory('u1', 'hiyori', 'food');
       expect(result).toHaveLength(1);
@@ -205,12 +285,24 @@ describe('DynamoDBMemoryRepository', () => {
     it('UpdateCommand を送り ConditionalCheckFailedException を EntityNotFoundError に変換する', async () => {
       const error = new Error('failed');
       error.name = 'ConditionalCheckFailedException';
-      const client = makeClient(async () => { throw error; });
+      const client = makeClient(async () => {
+        throw error;
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await expect(
-        repo.update({ UserID: 'u1', CharacterID: 'hiyori', Tier: 'B', Category: 'food', MemoryID: 'MEM-001' })
+        repo.update({
+          UserID: 'u1',
+          CharacterID: 'hiyori',
+          Tier: 'B',
+          Category: 'food',
+          MemoryID: 'MEM-001',
+        })
       ).rejects.toBeInstanceOf(EntityNotFoundError);
     });
 
@@ -222,11 +314,20 @@ describe('DynamoDBMemoryRepository', () => {
         return { Attributes: updatedItem };
       });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       const result = await repo.update({
-        UserID: 'u1', CharacterID: 'hiyori', Tier: 'B', Category: 'food', MemoryID: 'MEM-001',
-        Content: '緑茶も好き', Confidence: 0.9,
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Tier: 'B',
+        Category: 'food',
+        MemoryID: 'MEM-001',
+        Content: '緑茶も好き',
+        Confidence: 0.9,
       });
       expect(result.Content).toBe('緑茶も好き');
       expect(sent[0]).toBeInstanceOf(UpdateCommand);
@@ -236,23 +337,48 @@ describe('DynamoDBMemoryRepository', () => {
   describe('delete', () => {
     it('DeleteCommand を送る', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
-      await repo.delete({ userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'MEM-001' });
+      await repo.delete({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B',
+        category: 'food',
+        memoryId: 'MEM-001',
+      });
       expect(sent[0]).toBeInstanceOf(DeleteCommand);
       const input = (sent[0] as DeleteCommand).input;
       expect(input.Key).toEqual({ PK: 'USER#u1', SK: 'CHAR#hiyori#MEM#B#food#MEM-001' });
     });
 
     it('DynamoDB エラーは DatabaseError でラップする', async () => {
-      const client = makeClient(async () => { throw new Error('boom'); });
+      const client = makeClient(async () => {
+        throw new Error('boom');
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await expect(
-        repo.delete({ userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'x' })
+        repo.delete({
+          userId: 'u1',
+          characterId: 'hiyori',
+          tier: 'B',
+          category: 'food',
+          memoryId: 'x',
+        })
       ).rejects.toBeInstanceOf(DatabaseError);
     });
   });
@@ -273,9 +399,16 @@ describe('DynamoDBMemoryRepository', () => {
 
     it('promote は TransactWriteCommand で Put(新SK) + Delete(旧SK) を送る', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       const result = await repo.promote(savedEntity, 'B');
       expect(result.Tier).toBe('B');
@@ -288,9 +421,16 @@ describe('DynamoDBMemoryRepository', () => {
 
     it('demote は TransactWriteCommand で Put(新SK) + Delete(旧SK) を送る', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       const tierAEntity: MemoryEntity = { ...savedEntity, Tier: 'A' };
       const result = await repo.demote(tierAEntity, 'C');
@@ -300,9 +440,16 @@ describe('DynamoDBMemoryRepository', () => {
 
     it('B へ昇格すると TTL なし', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await repo.promote(savedEntity, 'B');
       const input = (sent[0] as TransactWriteCommand).input;
@@ -311,9 +458,16 @@ describe('DynamoDBMemoryRepository', () => {
 
     it('D へ降格すると TTL あり', async () => {
       const sent: unknown[] = [];
-      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await repo.demote(savedEntity, 'D');
       const input = (sent[0] as TransactWriteCommand).input;
@@ -321,9 +475,15 @@ describe('DynamoDBMemoryRepository', () => {
     });
 
     it('TransactWrite エラーは DatabaseError でラップする', async () => {
-      const client = makeClient(async () => { throw new Error('transact error'); });
+      const client = makeClient(async () => {
+        throw new Error('transact error');
+      });
       const repo = new DynamoDBMemoryRepository(
-        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+        client as never,
+        tableName,
+        ulidFactory,
+        () => fixedNow,
+        () => fixedNowSec
       );
       await expect(repo.promote(savedEntity, 'A')).rejects.toBeInstanceOf(DatabaseError);
     });

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-memory.repository.test.ts
@@ -1,0 +1,331 @@
+import {
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  TransactWriteCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, EntityNotFoundError } from '@nagiyu/aws';
+import { DynamoDBMemoryRepository } from '../../../src/repositories/dynamodb-memory.repository.js';
+import { MEMORY_TIER_C_TTL_SECONDS, MEMORY_TIER_D_TTL_SECONDS } from '../../../src/constants.js';
+import type { CreateMemoryInput, MemoryEntity } from '../../../src/entities/memory.entity.js';
+
+type SendHandler = (command: unknown) => Promise<unknown>;
+const makeClient = (handler: SendHandler) => ({ send: handler });
+
+const baseInput: CreateMemoryInput = {
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  Tier: 'B',
+  Category: 'food',
+  Content: 'コーヒーが好き',
+  Confidence: 0.8,
+  ReferencedCount: 0,
+};
+
+const baseItem = {
+  PK: 'USER#u1',
+  SK: 'CHAR#hiyori#MEM#B#food#MEM-001',
+  Type: 'Memory',
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  MemoryID: 'MEM-001',
+  Tier: 'B',
+  Category: 'food',
+  Content: 'コーヒーが好き',
+  Confidence: 0.8,
+  ReferencedCount: 0,
+  CreatedAt: '2026-01-01T00:00:00.000Z',
+  UpdatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const tableName = 'nagiyu-livetalk-dev';
+const fixedNow = '2026-01-01T00:00:00.000Z';
+const fixedNowSec = 1_750_000_000;
+const ulidFactory = () => 'MEM-001';
+
+describe('DynamoDBMemoryRepository', () => {
+  describe('put', () => {
+    it('PutCommand を送り MemoryID / CreatedAt を付与する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+
+      const entity = await repo.put(baseInput);
+      expect(entity.MemoryID).toBe('MEM-001');
+      expect(entity.CreatedAt).toBe(fixedNow);
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toBeInstanceOf(PutCommand);
+      const input = (sent[0] as PutCommand).input;
+      expect(input.Item?.PK).toBe('USER#u1');
+      expect(input.Item?.SK).toBe('CHAR#hiyori#MEM#B#food#MEM-001');
+    });
+
+    it('Tier B には TTL を付与しない', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await repo.put({ ...baseInput, Tier: 'B' });
+      const input = (sent[0] as PutCommand).input;
+      expect(input.Item?.TTL).toBeUndefined();
+    });
+
+    it('Tier C には 30 日後の TTL を付与する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await repo.put({ ...baseInput, Tier: 'C' });
+      const input = (sent[0] as PutCommand).input;
+      expect(input.Item?.TTL).toBe(fixedNowSec + MEMORY_TIER_C_TTL_SECONDS);
+    });
+
+    it('Tier D には 1 日後の TTL を付与する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await repo.put({ ...baseInput, Tier: 'D' });
+      const input = (sent[0] as PutCommand).input;
+      expect(input.Item?.TTL).toBe(fixedNowSec + MEMORY_TIER_D_TTL_SECONDS);
+    });
+
+    it('DynamoDB エラーは DatabaseError でラップする', async () => {
+      const client = makeClient(async () => { throw new Error('boom'); });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await expect(repo.put(baseInput)).rejects.toBeInstanceOf(DatabaseError);
+    });
+
+    it('デフォルトコンストラクタで動作する', async () => {
+      const client = makeClient(async () => ({}));
+      const repo = new DynamoDBMemoryRepository(client as never, tableName);
+      const entity = await repo.put(baseInput);
+      expect(entity.MemoryID).toMatch(/^[0-9A-Z]{26}$/);
+    });
+  });
+
+  describe('get', () => {
+    it('GetCommand を送り Item があれば Entity を返す', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return { Item: baseItem }; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      const result = await repo.get({
+        userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'MEM-001',
+      });
+      expect(result?.Content).toBe('コーヒーが好き');
+      expect(sent[0]).toBeInstanceOf(GetCommand);
+      const input = (sent[0] as GetCommand).input;
+      expect(input.Key).toEqual({ PK: 'USER#u1', SK: 'CHAR#hiyori#MEM#B#food#MEM-001' });
+    });
+
+    it('Item がなければ null を返す', async () => {
+      const client = makeClient(async () => ({ Item: undefined }));
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      const result = await repo.get({
+        userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'missing',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('DynamoDB エラーは DatabaseError でラップする', async () => {
+      const client = makeClient(async () => { throw new Error('network'); });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await expect(
+        repo.get({ userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'x' })
+      ).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
+  describe('listByTier', () => {
+    it('QueryCommand で begins_with による Tier 絞り込みを行う', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return { Items: [baseItem] }; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      const result = await repo.listByTier('u1', 'hiyori', 'B');
+      expect(result).toHaveLength(1);
+      expect(sent[0]).toBeInstanceOf(QueryCommand);
+      const input = (sent[0] as QueryCommand).input;
+      expect(input.ExpressionAttributeValues?.[':pk']).toBe('USER#u1');
+      expect(input.ExpressionAttributeValues?.[':prefix']).toBe('CHAR#hiyori#MEM#B#');
+    });
+
+    it('LastEvaluatedKey がある間はページング継続する', async () => {
+      let call = 0;
+      const client = makeClient(async () => {
+        call++;
+        if (call === 1) return { Items: [baseItem], LastEvaluatedKey: { PK: 'x', SK: 'y' } };
+        return { Items: [] };
+      });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await repo.listByTier('u1', 'hiyori', 'B');
+      expect(call).toBe(2);
+    });
+  });
+
+  describe('listByCategory', () => {
+    it('全 Tier を QueryCommand で取得し Category でフィルタする', async () => {
+      const foodItem = { ...baseItem };
+      const hobbyItem = {
+        ...baseItem,
+        SK: 'CHAR#hiyori#MEM#B#hobby#MEM-002',
+        MemoryID: 'MEM-002',
+        Category: 'hobby',
+        Content: '読書',
+      };
+      const client = makeClient(async () => ({ Items: [foodItem, hobbyItem] }));
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      const result = await repo.listByCategory('u1', 'hiyori', 'food');
+      expect(result).toHaveLength(1);
+      expect(result[0].Category).toBe('food');
+    });
+  });
+
+  describe('update', () => {
+    it('UpdateCommand を送り ConditionalCheckFailedException を EntityNotFoundError に変換する', async () => {
+      const error = new Error('failed');
+      error.name = 'ConditionalCheckFailedException';
+      const client = makeClient(async () => { throw error; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await expect(
+        repo.update({ UserID: 'u1', CharacterID: 'hiyori', Tier: 'B', Category: 'food', MemoryID: 'MEM-001' })
+      ).rejects.toBeInstanceOf(EntityNotFoundError);
+    });
+
+    it('UpdateCommand を送り更新後のエンティティを返す', async () => {
+      const updatedItem = { ...baseItem, Content: '緑茶も好き', Confidence: 0.9 };
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Attributes: updatedItem };
+      });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      const result = await repo.update({
+        UserID: 'u1', CharacterID: 'hiyori', Tier: 'B', Category: 'food', MemoryID: 'MEM-001',
+        Content: '緑茶も好き', Confidence: 0.9,
+      });
+      expect(result.Content).toBe('緑茶も好き');
+      expect(sent[0]).toBeInstanceOf(UpdateCommand);
+    });
+  });
+
+  describe('delete', () => {
+    it('DeleteCommand を送る', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await repo.delete({ userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'MEM-001' });
+      expect(sent[0]).toBeInstanceOf(DeleteCommand);
+      const input = (sent[0] as DeleteCommand).input;
+      expect(input.Key).toEqual({ PK: 'USER#u1', SK: 'CHAR#hiyori#MEM#B#food#MEM-001' });
+    });
+
+    it('DynamoDB エラーは DatabaseError でラップする', async () => {
+      const client = makeClient(async () => { throw new Error('boom'); });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await expect(
+        repo.delete({ userId: 'u1', characterId: 'hiyori', tier: 'B', category: 'food', memoryId: 'x' })
+      ).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
+  describe('promote / demote', () => {
+    const savedEntity: MemoryEntity = {
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      MemoryID: 'MEM-001',
+      Tier: 'C',
+      Category: 'food',
+      Content: 'コーヒーが好き',
+      Confidence: 0.5,
+      ReferencedCount: 1,
+      CreatedAt: '2026-01-01T00:00:00.000Z',
+      UpdatedAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    it('promote は TransactWriteCommand で Put(新SK) + Delete(旧SK) を送る', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      const result = await repo.promote(savedEntity, 'B');
+      expect(result.Tier).toBe('B');
+      expect(sent[0]).toBeInstanceOf(TransactWriteCommand);
+      const input = (sent[0] as TransactWriteCommand).input;
+      expect(input.TransactItems).toHaveLength(2);
+      expect(input.TransactItems?.[0].Put?.Item?.SK).toBe('CHAR#hiyori#MEM#B#food#MEM-001');
+      expect(input.TransactItems?.[1].Delete?.Key?.SK).toBe('CHAR#hiyori#MEM#C#food#MEM-001');
+    });
+
+    it('demote は TransactWriteCommand で Put(新SK) + Delete(旧SK) を送る', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      const tierAEntity: MemoryEntity = { ...savedEntity, Tier: 'A' };
+      const result = await repo.demote(tierAEntity, 'C');
+      expect(result.Tier).toBe('C');
+      expect(sent[0]).toBeInstanceOf(TransactWriteCommand);
+    });
+
+    it('B へ昇格すると TTL なし', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await repo.promote(savedEntity, 'B');
+      const input = (sent[0] as TransactWriteCommand).input;
+      expect(input.TransactItems?.[0].Put?.Item?.TTL).toBeUndefined();
+    });
+
+    it('D へ降格すると TTL あり', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => { sent.push(cmd); return {}; });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await repo.demote(savedEntity, 'D');
+      const input = (sent[0] as TransactWriteCommand).input;
+      expect(input.TransactItems?.[0].Put?.Item?.TTL).toBe(fixedNowSec + MEMORY_TIER_D_TTL_SECONDS);
+    });
+
+    it('TransactWrite エラーは DatabaseError でラップする', async () => {
+      const client = makeClient(async () => { throw new Error('transact error'); });
+      const repo = new DynamoDBMemoryRepository(
+        client as never, tableName, ulidFactory, () => fixedNow, () => fixedNowSec
+      );
+      await expect(repo.promote(savedEntity, 'A')).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/in-memory-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-memory.repository.test.ts
@@ -16,7 +16,7 @@ const baseInput: CreateMemoryInput = {
 describe('InMemoryMemoryRepository', () => {
   let store: InMemorySingleTableStore;
   let repo: InMemoryMemoryRepository;
-  const fixedNow = '2026-01-01T00:00:00.000Z';
+  const fixedNow = 1_750_000_000_000;
   let callCount = 0;
 
   beforeEach(() => {
@@ -52,26 +52,21 @@ describe('InMemoryMemoryRepository', () => {
     });
 
     it('Tier C には 30 日後の TTL を Unix 秒で付与する', async () => {
-      const before = Math.floor(Date.now() / 1000);
       await repo.put({ ...baseInput, Tier: 'C' });
       const items = Array.from(
         (store as unknown as { store: Map<string, Record<string, unknown>> }).store.values()
       );
       const ttl = items[0].TTL as number;
-      expect(ttl).toBeGreaterThanOrEqual(before + MEMORY_TIER_C_TTL_SECONDS);
-      expect(ttl).toBeLessThanOrEqual(
-        Math.floor(Date.now() / 1000) + MEMORY_TIER_C_TTL_SECONDS + 5
-      );
+      expect(ttl).toBe(Math.floor(fixedNow / 1000) + MEMORY_TIER_C_TTL_SECONDS);
     });
 
     it('Tier D には 1 日後の TTL を Unix 秒で付与する', async () => {
-      const before = Math.floor(Date.now() / 1000);
       await repo.put({ ...baseInput, Tier: 'D' });
       const items = Array.from(
         (store as unknown as { store: Map<string, Record<string, unknown>> }).store.values()
       );
       const ttl = items[0].TTL as number;
-      expect(ttl).toBeGreaterThanOrEqual(before + MEMORY_TIER_D_TTL_SECONDS);
+      expect(ttl).toBe(Math.floor(fixedNow / 1000) + MEMORY_TIER_D_TTL_SECONDS);
     });
   });
 

--- a/services/livetalk/core/tests/unit/repositories/in-memory-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-memory.repository.test.ts
@@ -1,0 +1,267 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryMemoryRepository } from '../../../src/repositories/in-memory-memory.repository.js';
+import { MEMORY_TIER_C_TTL_SECONDS, MEMORY_TIER_D_TTL_SECONDS } from '../../../src/constants.js';
+import type { CreateMemoryInput, MemoryEntity } from '../../../src/entities/memory.entity.js';
+
+const baseInput: CreateMemoryInput = {
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  Tier: 'B',
+  Category: 'food',
+  Content: 'コーヒーが好き',
+  Confidence: 0.8,
+  ReferencedCount: 0,
+};
+
+describe('InMemoryMemoryRepository', () => {
+  let store: InMemorySingleTableStore;
+  let repo: InMemoryMemoryRepository;
+  const fixedNow = '2026-01-01T00:00:00.000Z';
+  let callCount = 0;
+
+  beforeEach(() => {
+    store = new InMemorySingleTableStore();
+    callCount = 0;
+    const ulidFactory = () => `MEM-${String(++callCount).padStart(3, '0')}`;
+    repo = new InMemoryMemoryRepository(store, ulidFactory, () => fixedNow);
+  });
+
+  describe('put', () => {
+    it('メモリを保存し MemoryID / CreatedAt / UpdatedAt を付与する', async () => {
+      const entity = await repo.put(baseInput);
+      expect(entity.MemoryID).toBe('MEM-001');
+      expect(entity.CreatedAt).toBe(fixedNow);
+      expect(entity.UpdatedAt).toBe(fixedNow);
+      expect(entity.Tier).toBe('B');
+    });
+
+    it('明示的な MemoryID を尊重する', async () => {
+      const entity = await repo.put({ ...baseInput, MemoryID: 'explicit-id' });
+      expect(entity.MemoryID).toBe('explicit-id');
+    });
+
+    it('Tier A/B には TTL を付与しない', async () => {
+      await repo.put({ ...baseInput, Tier: 'A' });
+      await repo.put({ ...baseInput, Tier: 'B' });
+      const items = Array.from(
+        (store as unknown as { store: Map<string, Record<string, unknown>> }).store.values()
+      );
+      for (const item of items) {
+        expect(item.TTL).toBeUndefined();
+      }
+    });
+
+    it('Tier C には 30 日後の TTL を Unix 秒で付与する', async () => {
+      const before = Math.floor(Date.now() / 1000);
+      await repo.put({ ...baseInput, Tier: 'C' });
+      const items = Array.from(
+        (store as unknown as { store: Map<string, Record<string, unknown>> }).store.values()
+      );
+      const ttl = items[0].TTL as number;
+      expect(ttl).toBeGreaterThanOrEqual(before + MEMORY_TIER_C_TTL_SECONDS);
+      expect(ttl).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + MEMORY_TIER_C_TTL_SECONDS + 5);
+    });
+
+    it('Tier D には 1 日後の TTL を Unix 秒で付与する', async () => {
+      const before = Math.floor(Date.now() / 1000);
+      await repo.put({ ...baseInput, Tier: 'D' });
+      const items = Array.from(
+        (store as unknown as { store: Map<string, Record<string, unknown>> }).store.values()
+      );
+      const ttl = items[0].TTL as number;
+      expect(ttl).toBeGreaterThanOrEqual(before + MEMORY_TIER_D_TTL_SECONDS);
+    });
+  });
+
+  describe('get', () => {
+    it('保存したメモリを取得できる', async () => {
+      const saved = await repo.put(baseInput);
+      const found = await repo.get({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B',
+        category: 'food',
+        memoryId: saved.MemoryID,
+      });
+      expect(found).not.toBeNull();
+      expect(found?.Content).toBe('コーヒーが好き');
+    });
+
+    it('存在しないキーは null を返す', async () => {
+      const found = await repo.get({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'A',
+        category: 'name',
+        memoryId: 'missing',
+      });
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('listByTier', () => {
+    it('指定 Tier のメモリのみを返す', async () => {
+      await repo.put({ ...baseInput, Tier: 'A', Category: 'name', Content: '名前' });
+      await repo.put({ ...baseInput, Tier: 'B', Category: 'food', Content: 'コーヒー' });
+      await repo.put({ ...baseInput, Tier: 'B', Category: 'hobby', Content: '読書' });
+
+      const result = await repo.listByTier('u1', 'hiyori', 'B');
+      expect(result).toHaveLength(2);
+      expect(result.every((m) => m.Tier === 'B')).toBe(true);
+    });
+
+    it('別ユーザー / 別キャラのメモリは混入しない', async () => {
+      await repo.put({ ...baseInput, Tier: 'A' });
+      await repo.put({ ...baseInput, UserID: 'u2', Tier: 'A' });
+      await repo.put({ ...baseInput, CharacterID: 'other', Tier: 'A' });
+
+      const result = await repo.listByTier('u1', 'hiyori', 'A');
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('listByCategory', () => {
+    it('指定カテゴリのメモリを Tier 横断で返す', async () => {
+      await repo.put({ ...baseInput, Tier: 'A', Category: 'food', Content: 'お米' });
+      await repo.put({ ...baseInput, Tier: 'B', Category: 'food', Content: 'コーヒー' });
+      await repo.put({ ...baseInput, Tier: 'C', Category: 'hobby', Content: '読書' });
+
+      const result = await repo.listByCategory('u1', 'hiyori', 'food');
+      expect(result).toHaveLength(2);
+      expect(result.every((m) => m.Category === 'food')).toBe(true);
+    });
+
+    it('存在しないカテゴリは空配列', async () => {
+      await repo.put(baseInput);
+      const result = await repo.listByCategory('u1', 'hiyori', 'nonexistent');
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('update', () => {
+    it('Content / Confidence / ReferencedCount / UpdatedAt を更新できる', async () => {
+      const saved = await repo.put(baseInput);
+      const updated = await repo.update({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Tier: 'B',
+        Category: 'food',
+        MemoryID: saved.MemoryID,
+        Content: '緑茶も好き',
+        Confidence: 0.9,
+        ReferencedCount: 1,
+      });
+      expect(updated.Content).toBe('緑茶も好き');
+      expect(updated.Confidence).toBe(0.9);
+      expect(updated.ReferencedCount).toBe(1);
+      expect(updated.UpdatedAt).toBe(fixedNow);
+    });
+
+    it('存在しないメモリの更新はエラーを投げる', async () => {
+      await expect(
+        repo.update({
+          UserID: 'u1',
+          CharacterID: 'hiyori',
+          Tier: 'B',
+          Category: 'food',
+          MemoryID: 'missing',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('delete', () => {
+    it('メモリを削除できる', async () => {
+      const saved = await repo.put(baseInput);
+      await repo.delete({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B',
+        category: 'food',
+        memoryId: saved.MemoryID,
+      });
+      const found = await repo.get({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B',
+        category: 'food',
+        memoryId: saved.MemoryID,
+      });
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('promote / demote', () => {
+    it('promote は新 Tier で取得でき、旧 Tier では取得できなくなる', async () => {
+      const saved = await repo.put({ ...baseInput, Tier: 'C' });
+      const promoted = await repo.promote(saved, 'B');
+
+      expect(promoted.Tier).toBe('B');
+
+      const newFound = await repo.get({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B',
+        category: 'food',
+        memoryId: saved.MemoryID,
+      });
+      expect(newFound).not.toBeNull();
+
+      const oldFound = await repo.get({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'C',
+        category: 'food',
+        memoryId: saved.MemoryID,
+      });
+      expect(oldFound).toBeNull();
+    });
+
+    it('demote は新 Tier で取得でき、旧 Tier では取得できなくなる', async () => {
+      const saved = await repo.put({ ...baseInput, Tier: 'A' });
+      const demoted = await repo.demote(saved, 'C');
+
+      expect(demoted.Tier).toBe('C');
+
+      const newFound = await repo.get({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'C',
+        category: 'food',
+        memoryId: saved.MemoryID,
+      });
+      expect(newFound).not.toBeNull();
+
+      const oldFound = await repo.get({
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'A',
+        category: 'food',
+        memoryId: saved.MemoryID,
+      });
+      expect(oldFound).toBeNull();
+    });
+
+    it('D へ demote すると TTL が付与される', async () => {
+      const saved = await repo.put({ ...baseInput, Tier: 'B' });
+      await repo.demote(saved, 'D');
+
+      const item = store.get(
+        `USER#u1`,
+        `CHAR#hiyori#MEM#D#food#${saved.MemoryID}`
+      );
+      expect(item?.TTL).toBeDefined();
+    });
+
+    it('A へ promote すると TTL がない', async () => {
+      const saved = await repo.put({ ...baseInput, Tier: 'C' });
+      const promoted = await repo.promote(saved, 'A');
+
+      const item = store.get(
+        `USER#u1`,
+        `CHAR#hiyori#MEM#A#food#${promoted.MemoryID}`
+      );
+      expect(item?.TTL).toBeUndefined();
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/in-memory-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-memory.repository.test.ts
@@ -1,7 +1,7 @@
 import { InMemorySingleTableStore } from '@nagiyu/aws';
 import { InMemoryMemoryRepository } from '../../../src/repositories/in-memory-memory.repository.js';
 import { MEMORY_TIER_C_TTL_SECONDS, MEMORY_TIER_D_TTL_SECONDS } from '../../../src/constants.js';
-import type { CreateMemoryInput, MemoryEntity } from '../../../src/entities/memory.entity.js';
+import type { CreateMemoryInput } from '../../../src/entities/memory.entity.js';
 
 const baseInput: CreateMemoryInput = {
   UserID: 'u1',
@@ -59,7 +59,9 @@ describe('InMemoryMemoryRepository', () => {
       );
       const ttl = items[0].TTL as number;
       expect(ttl).toBeGreaterThanOrEqual(before + MEMORY_TIER_C_TTL_SECONDS);
-      expect(ttl).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + MEMORY_TIER_C_TTL_SECONDS + 5);
+      expect(ttl).toBeLessThanOrEqual(
+        Math.floor(Date.now() / 1000) + MEMORY_TIER_C_TTL_SECONDS + 5
+      );
     });
 
     it('Tier D には 1 日後の TTL を Unix 秒で付与する', async () => {
@@ -246,10 +248,7 @@ describe('InMemoryMemoryRepository', () => {
       const saved = await repo.put({ ...baseInput, Tier: 'B' });
       await repo.demote(saved, 'D');
 
-      const item = store.get(
-        `USER#u1`,
-        `CHAR#hiyori#MEM#D#food#${saved.MemoryID}`
-      );
+      const item = store.get(`USER#u1`, `CHAR#hiyori#MEM#D#food#${saved.MemoryID}`);
       expect(item?.TTL).toBeDefined();
     });
 
@@ -257,10 +256,7 @@ describe('InMemoryMemoryRepository', () => {
       const saved = await repo.put({ ...baseInput, Tier: 'C' });
       const promoted = await repo.promote(saved, 'A');
 
-      const item = store.get(
-        `USER#u1`,
-        `CHAR#hiyori#MEM#A#food#${promoted.MemoryID}`
-      );
+      const item = store.get(`USER#u1`, `CHAR#hiyori#MEM#A#food#${promoted.MemoryID}`);
       expect(item?.TTL).toBeUndefined();
     });
   });

--- a/services/livetalk/web/src/lib/server/repositories.ts
+++ b/services/livetalk/web/src/lib/server/repositories.ts
@@ -10,20 +10,24 @@
 import { InMemorySingleTableStore, registerDynamoRepositories } from '@nagiyu/aws';
 import type {
   CharacterStateRepository,
+  MemoryRepository,
   MessageRepository,
   ProfileRepository,
 } from '@nagiyu/livetalk-core';
 import {
   DynamoDBCharacterStateRepository,
+  DynamoDBMemoryRepository,
   DynamoDBMessageRepository,
   DynamoDBProfileRepository,
   InMemoryCharacterStateRepository,
+  InMemoryMemoryRepository,
   InMemoryMessageRepository,
   InMemoryProfileRepository,
 } from '@nagiyu/livetalk-core';
 
 const registry = registerDynamoRepositories<
   {
+    memory: MemoryRepository;
     message: MessageRepository;
     profile: ProfileRepository;
     characterState: CharacterStateRepository;
@@ -31,6 +35,11 @@ const registry = registerDynamoRepositories<
   InMemorySingleTableStore
 >(
   {
+    memory: {
+      createInMemoryRepository: (store) => new InMemoryMemoryRepository(store),
+      createDynamoDBRepository: ({ docClient, tableName }) =>
+        new DynamoDBMemoryRepository(docClient, tableName),
+    },
     message: {
       createInMemoryRepository: (store) => new InMemoryMessageRepository(store),
       createDynamoDBRepository: ({ docClient, tableName }) =>
@@ -52,6 +61,10 @@ const registry = registerDynamoRepositories<
     createSharedStore: () => new InMemorySingleTableStore(),
   }
 );
+
+export function getMemoryRepository(): MemoryRepository {
+  return registry.memory.createRepository();
+}
 
 export function getMessageRepository(): MessageRepository {
   return registry.message.createRepository();

--- a/tasks/livetalk/design.md
+++ b/tasks/livetalk/design.md
@@ -373,7 +373,7 @@ type SafetyEvent = {
 | Memory (Tier A) | `CHAR#<charId>#MEM#A#<category>#<id>` | なし |
 | Memory (Tier B) | `CHAR#<charId>#MEM#B#<category>#<id>` | なし |
 | Memory (Tier C) | `CHAR#<charId>#MEM#C#<category>#<id>` | 30 日 |
-| Memory (Tier D) | `CHAR#<charId>#MEM#D#<id>` | 1 日 |
+| Memory (Tier D) | `CHAR#<charId>#MEM#D#<category>#<id>` | 1 日 |
 | Message | `CHAR#<charId>#MSG#<ulid>` | 90 日 |
 | Knowledge | `CHAR#<charId>#KNOWLEDGE#<ulid>` | なし |
 | Note | `CHAR#<charId>#NOTE#<ulid>` | なし |


### PR DESCRIPTION
## 変更の概要

Issue #3279（Phase 3a）の実装。メモリ階層（Tier A/B/C/D）と信頼度スコアの基盤を追加し、Phase 3 の後続サブ Issue（retrieval / 圧縮要約 / 編集 UI / 親密度）が乗る Repository 層を整備した。

## 関連 Issue

#3279（Phase 3a メモリ Tier 基盤 + Repository）
Parent: #3186（Phase 3）

## 変更種別

- [x] 新機能

## 実装内容

### 新規ファイル

| ファイル | 内容 |
|---|---|
| `core/src/entities/memory.entity.ts` | `MemoryEntity` / `Tier` / `CreateMemoryInput` / `UpdateMemoryInput` |
| `core/src/mappers/memory.mapper.ts` | `MemoryMapper`（toItem / toEntity / buildKeys） |
| `core/src/repositories/memory.repository.interface.ts` | `MemoryRepository` インターフェース |
| `core/src/repositories/in-memory-memory.repository.ts` | テスト・ローカル用 InMemory 実装 |
| `core/src/repositories/dynamodb-memory.repository.ts` | DynamoDB 実装（promote/demote は TransactWriteCommand） |
| `tests/unit/mappers/memory.mapper.test.ts` | Mapper テスト |
| `tests/unit/repositories/in-memory-memory.repository.test.ts` | InMemory テスト |
| `tests/unit/repositories/dynamodb-memory.repository.test.ts` | DynamoDB テスト |

### 修正ファイル

| ファイル | 変更内容 |
|---|---|
| `core/src/constants.ts` | `MEMORY_TIER_C_TTL_SECONDS` / `MEMORY_TIER_D_TTL_SECONDS` / `MEMORY_DEFAULT_CONFIDENCE` を追加 |
| `core/src/mappers/keys.ts` | Memory SK ビルダー関数を追加 |
| `core/src/index.ts` | Memory 関連を全て re-export |
| `web/src/lib/server/repositories.ts` | `MemoryRepository` を registry に登録、`getMemoryRepository()` を export |
| `tasks/livetalk/design.md` | Tier D の SK パターンを `MEM#D#<category>#<id>` に修正（Issue #3279 方針に統一） |

### DynamoDB SK パターン（全 Tier 統一）

```
PK: USER#<userId>
SK: CHAR#<charId>#MEM#<tier>#<category>#<id>
例: CHAR#hiyori#MEM#A#name#01J...
    CHAR#hiyori#MEM#D#temp#01J...
```

### TTL

| Tier | TTL |
|---|---|
| A / B | なし（永続） |
| C | 30 日 |
| D | 1 日 |

### 昇格・降格

SK が変わるため `TransactWriteCommand`（Put 新SK + Delete 旧SK）で原子化。

## 実装チェックリスト

- [x] `Memory` エンティティ + Repository が定義されている
- [x] DynamoDB に Memory が put / get / update / delete できる
- [x] Tier 別の listByTier が動く
- [x] カテゴリ横断の listByCategory が動く
- [x] 昇格・降格が動く（SK 変更を伴う TransactWriteItems）
- [x] TTL が Tier C/D に正しく設定される
- [x] embedding フィールドを先に確保（実値は Phase 3b）
- [x] ユニットテスト全 309 件通過
- [x] カバレッジ: Stmts 96% / Branch 82% / Funcs 94%（閾値 80% クリア）

## テスト内容

- `memory.mapper.test.ts`: toItem / toEntity / buildKeys / バリデーションエラー / ラウンドトリップ
- `in-memory-memory.repository.test.ts`: put / get / listByTier / listByCategory / update / delete / promote / demote / TTL
- `dynamodb-memory.repository.test.ts`: 各コマンドの送信内容 / TransactWriteCommand の構造 / エラーハンドリング / TTL

## レビューポイント

- **design.md 修正**: Tier D の SK に category を含む形に変更。Issue #3279 の Repository インターフェース（全 Tier で category 引数を取る）との整合性を優先した。
- **listByCategory の実装方式**: 全 Tier の SK prefix でクエリ後、Category 属性で client-side フィルタ。件数増加時の対応は Phase 3b 以降で判断。
- **confidence 初期値**: `MEMORY_DEFAULT_CONFIDENCE` 定数として定義のみ。実際の付与ロジックは Phase 3b の usecase 層に委任。

https://claude.ai/code/session_01A8rYkNv9b8Di6P1u7NSqGY

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8rYkNv9b8Di6P1u7NSqGY)_