### PR TITLE
[リブトーク Phase 3b] メモリ retrieval + chat-usecase 統合（embedding ベース）

### DIFF
--- a/services/livetalk/core/src/characters/prompt-builder.ts
+++ b/services/livetalk/core/src/characters/prompt-builder.ts
@@ -1,6 +1,7 @@
 import type { CharacterDefinition } from './types.js';
 import type { MessageEntity } from '../entities/message.entity.js';
 import type { ChatMessage } from '../llm-client/types.js';
+import type { RetrievedMemory } from '../memory/types.js';
 
 export type TimeOfDay = '朝' | '昼' | '夜';
 
@@ -11,13 +12,17 @@ export function getTimeOfDay(date: Date): TimeOfDay {
   return '夜';
 }
 
-export function buildSystemPrompt(character: CharacterDefinition, now: Date): string {
+export function buildSystemPrompt(
+  character: CharacterDefinition,
+  now: Date,
+  retrievedMemories: RetrievedMemory[] = []
+): string {
   const { personality, displayName } = character;
   const timeOfDay = getTimeOfDay(now);
   const likesList = personality.preferences.likes.join('、');
   const dislikesList = personality.preferences.dislikes.join('、');
 
-  return `${personality.basePrompt}
+  const base = `${personality.basePrompt}
 
 名前: ${displayName}
 口調: ${personality.speechStyle}
@@ -29,6 +34,17 @@ export function buildSystemPrompt(character: CharacterDefinition, now: Date): st
 - 質問攻めにしない。まず自分の気持ちや体験を話し、相手が自然に話したくなる流れを作る
 - 返答は短く（1〜3 文程度）、テンポよく続ける
 - セーフティ対応は後続ロジックで処理されるため、ここでは扱わない`.trim();
+
+  if (retrievedMemories.length === 0) return base;
+
+  const memoriesSection = retrievedMemories
+    .map((r) => `- ${r.memory.Content}`)
+    .join('\n');
+
+  return `${base}
+
+あなたが覚えていること：
+${memoriesSection}`;
 }
 
 /**
@@ -43,9 +59,10 @@ export function buildChatMessages(
   character: CharacterDefinition,
   now: Date,
   history: MessageEntity[],
-  userText: string
+  userText: string,
+  retrievedMemories: RetrievedMemory[] = []
 ): ChatMessage[] {
-  const systemPrompt = buildSystemPrompt(character, now);
+  const systemPrompt = buildSystemPrompt(character, now, retrievedMemories);
   const messages: ChatMessage[] = [{ role: 'system', content: systemPrompt }];
 
   for (const msg of history) {

--- a/services/livetalk/core/src/characters/prompt-builder.ts
+++ b/services/livetalk/core/src/characters/prompt-builder.ts
@@ -37,9 +37,7 @@ export function buildSystemPrompt(
 
   if (retrievedMemories.length === 0) return base;
 
-  const memoriesSection = retrievedMemories
-    .map((r) => `- ${r.memory.Content}`)
-    .join('\n');
+  const memoriesSection = retrievedMemories.map((r) => `- ${r.memory.Content}`).join('\n');
 
   return `${base}
 

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -42,6 +42,22 @@ export const MEMORY_TIER_C_TTL_SECONDS = 30 * 24 * 60 * 60;
 export const MEMORY_TIER_D_TTL_SECONDS = 1 * 24 * 60 * 60;
 
 /**
+ * Memory cooldown 判定閾値（ミリ秒）。
+ * 同じ Memory を直近 30 分以内に参照済みの場合は retrieve 対象外にする。
+ */
+export const MEMORY_COOLDOWN_MS = 30 * 60 * 1000;
+
+/**
+ * Tier B retrieve の既定上限件数。
+ */
+export const MEMORY_MAX_TIER_B = 5;
+
+/**
+ * 1 LLM 呼び出し単位で同カテゴリの Tier B Memory を注入できる最大件数。
+ */
+export const MEMORY_CATEGORY_CAP = 1;
+
+/**
  * 各 Tier の信頼度スコア推奨初期値。
  * 実際の決定は usecase 層（Phase 3b）に委ねる。Repository はこの値を参照しない。
  */

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -2,6 +2,10 @@ export * from './voicevox/index.js';
 export * from './llm-client/index.js';
 export * from './constants.js';
 
+// Memory retrieval
+export { cosineSimilarity, MemoryRetriever } from './memory/index.js';
+export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './memory/index.js';
+
 // Safety
 export * from './safety/index.js';
 
@@ -74,6 +78,7 @@ export type { CharacterStateRepository } from './repositories/character-state.re
 export type { SafetyEventRepository } from './repositories/safety-event.repository.interface.js';
 
 // Repository implementations
+export { EmbeddingMemoryRepository } from './repositories/embedding-memory.repository.js';
 export { DynamoDBMemoryRepository } from './repositories/dynamodb-memory.repository.js';
 export { DynamoDBMessageRepository } from './repositories/dynamodb-message.repository.js';
 export { DynamoDBProfileRepository } from './repositories/dynamodb-profile.repository.js';

--- a/services/livetalk/core/src/llm-client/factory.ts
+++ b/services/livetalk/core/src/llm-client/factory.ts
@@ -1,5 +1,10 @@
-import { OpenAIClient, type OpenAIClientOptions } from './openai-client.js';
-import type { ILLMClient, PurposeModelMap } from './types.js';
+import {
+  OpenAIClient,
+  OpenAIEmbeddingClient,
+  type OpenAIClientOptions,
+  type OpenAIEmbeddingClientOptions,
+} from './openai-client.js';
+import type { IEmbeddingClient, ILLMClient, PurposeModelMap } from './types.js';
 
 export const FACTORY_ERROR_MESSAGES = {
   MISSING_API_KEY: 'OpenAI API キーが指定されていません',
@@ -14,6 +19,10 @@ export interface ProviderSecretConfig {
 
 export interface CreateLLMClientOptions {
   /** OpenAI 用設定 */
+  openai?: ProviderSecretConfig;
+}
+
+export interface CreateEmbeddingClientOptions {
   openai?: ProviderSecretConfig;
 }
 
@@ -33,7 +42,13 @@ export function createLLMClient(options: CreateLLMClientOptions = {}): ILLMClien
   return new OpenAIClient(clientOptions);
 }
 
-function resolveApiKey(options: CreateLLMClientOptions): string {
+export function createEmbeddingClient(options: CreateEmbeddingClientOptions = {}): IEmbeddingClient {
+  const apiKey = resolveApiKey(options);
+  const clientOptions: OpenAIEmbeddingClientOptions = { apiKey };
+  return new OpenAIEmbeddingClient(clientOptions);
+}
+
+function resolveApiKey(options: CreateLLMClientOptions | CreateEmbeddingClientOptions): string {
   if (options.openai?.apiKey) {
     return options.openai.apiKey;
   }

--- a/services/livetalk/core/src/llm-client/factory.ts
+++ b/services/livetalk/core/src/llm-client/factory.ts
@@ -42,7 +42,9 @@ export function createLLMClient(options: CreateLLMClientOptions = {}): ILLMClien
   return new OpenAIClient(clientOptions);
 }
 
-export function createEmbeddingClient(options: CreateEmbeddingClientOptions = {}): IEmbeddingClient {
+export function createEmbeddingClient(
+  options: CreateEmbeddingClientOptions = {}
+): IEmbeddingClient {
   const apiKey = resolveApiKey(options);
   const clientOptions: OpenAIEmbeddingClientOptions = { apiKey };
   return new OpenAIEmbeddingClient(clientOptions);

--- a/services/livetalk/core/src/llm-client/index.ts
+++ b/services/livetalk/core/src/llm-client/index.ts
@@ -13,6 +13,7 @@ export type {
   ChatMessage,
   ChatOptions,
   ChatPurpose,
+  IEmbeddingClient,
   ILLMClient,
   PurposeModelMap,
 } from './types.js';
@@ -25,8 +26,17 @@ export {
 } from './openai-client.js';
 
 export {
+  OpenAIEmbeddingClient,
+  OPENAI_EMBEDDING_MODEL,
+  OPENAI_EMBEDDING_ERROR_MESSAGES,
+  type OpenAIEmbeddingClientOptions,
+} from './openai-client.js';
+
+export {
   createLLMClient,
+  createEmbeddingClient,
   FACTORY_ERROR_MESSAGES,
   type CreateLLMClientOptions,
+  type CreateEmbeddingClientOptions,
   type ProviderSecretConfig,
 } from './factory.js';

--- a/services/livetalk/core/src/llm-client/openai-client.ts
+++ b/services/livetalk/core/src/llm-client/openai-client.ts
@@ -5,7 +5,7 @@ import type {
   ResponseStreamEvent,
 } from 'openai/resources/responses/responses';
 import type { Stream } from 'openai/streaming';
-import type { ChatMessage, ChatOptions, ILLMClient, PurposeModelMap } from './types.js';
+import type { ChatMessage, ChatOptions, IEmbeddingClient, ILLMClient, PurposeModelMap } from './types.js';
 
 /**
  * OpenAI 実装の用途別既定モデル（GPT-5 系）。
@@ -111,4 +111,52 @@ export class OpenAIClient implements ILLMClient {
 
 function toEasyInputMessage(msg: ChatMessage): EasyInputMessage {
   return { role: msg.role, content: msg.content, type: 'message' };
+}
+
+/** OpenAI embedding API で使用するモデル。軽量・高速・低コスト。 */
+export const OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
+
+export const OPENAI_EMBEDDING_ERROR_MESSAGES = {
+  EMPTY_API_KEY: 'OpenAI API キーが指定されていません',
+  EMPTY_TEXT: 'テキストが空です',
+} as const;
+
+export interface OpenAIEmbeddingClientOptions {
+  apiKey?: string;
+  model?: string;
+  client?: OpenAI;
+}
+
+/**
+ * OpenAI Embeddings API を {@link IEmbeddingClient} 形にラップする実装。
+ *
+ * `text-embedding-3-small`（1536 次元）を既定として使用する。
+ */
+export class OpenAIEmbeddingClient implements IEmbeddingClient {
+  private readonly client: OpenAI;
+  private readonly model: string;
+
+  constructor(options: OpenAIEmbeddingClientOptions = {}) {
+    if (options.client) {
+      this.client = options.client;
+    } else {
+      if (!options.apiKey) {
+        throw new Error(OPENAI_EMBEDDING_ERROR_MESSAGES.EMPTY_API_KEY);
+      }
+      this.client = new OpenAI({ apiKey: options.apiKey, maxRetries: 0 });
+    }
+    this.model = options.model ?? OPENAI_EMBEDDING_MODEL;
+  }
+
+  public async embed(text: string): Promise<number[]> {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      throw new Error(OPENAI_EMBEDDING_ERROR_MESSAGES.EMPTY_TEXT);
+    }
+    const response = await this.client.embeddings.create({
+      model: this.model,
+      input: trimmed,
+    });
+    return response.data[0].embedding;
+  }
 }

--- a/services/livetalk/core/src/llm-client/openai-client.ts
+++ b/services/livetalk/core/src/llm-client/openai-client.ts
@@ -5,7 +5,13 @@ import type {
   ResponseStreamEvent,
 } from 'openai/resources/responses/responses';
 import type { Stream } from 'openai/streaming';
-import type { ChatMessage, ChatOptions, IEmbeddingClient, ILLMClient, PurposeModelMap } from './types.js';
+import type {
+  ChatMessage,
+  ChatOptions,
+  IEmbeddingClient,
+  ILLMClient,
+  PurposeModelMap,
+} from './types.js';
 
 /**
  * OpenAI 実装の用途別既定モデル（GPT-5 系）。

--- a/services/livetalk/core/src/llm-client/types.ts
+++ b/services/livetalk/core/src/llm-client/types.ts
@@ -58,3 +58,12 @@ export interface ILLMClient {
  * 用途別モデルマップ。Provider 実装側で既定値を持ち、コンストラクタで上書き可能。
  */
 export type PurposeModelMap = Record<ChatPurpose, string>;
+
+/**
+ * Embedding クライアントの抽象インターフェース。
+ *
+ * テキストを数値ベクトルに変換する。retrieval などの類似度計算に使う。
+ */
+export interface IEmbeddingClient {
+  embed(text: string): Promise<number[]>;
+}

--- a/services/livetalk/core/src/memory/embedding.ts
+++ b/services/livetalk/core/src/memory/embedding.ts
@@ -1,0 +1,28 @@
+/**
+ * ベクトル演算ユーティリティ。外部ライブラリ不要の自前実装。
+ */
+
+/**
+ * 2 つのベクトルの cosine similarity を返す（-1.0 〜 1.0）。
+ *
+ * - 長さが異なる場合は 0 を返す
+ * - どちらかがゼロベクトルの場合は 0 を返す
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  if (denom === 0) return 0;
+
+  return dot / denom;
+}

--- a/services/livetalk/core/src/memory/index.ts
+++ b/services/livetalk/core/src/memory/index.ts
@@ -1,0 +1,3 @@
+export { cosineSimilarity } from './embedding.js';
+export { MemoryRetriever } from './retrieval.js';
+export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './types.js';

--- a/services/livetalk/core/src/memory/retrieval.ts
+++ b/services/livetalk/core/src/memory/retrieval.ts
@@ -15,11 +15,19 @@ import type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './types
  *   6. 降順ソート → 上位 maxTierB 件を返す
  */
 export class MemoryRetriever implements IMemoryRetriever {
+  private readonly memoryRepository: MemoryRepository;
+  private readonly embeddingClient: IEmbeddingClient;
+  private readonly nowMs: () => number;
+
   constructor(
-    private readonly memoryRepository: MemoryRepository,
-    private readonly embeddingClient: IEmbeddingClient,
-    private readonly nowMs: () => number = () => Date.now()
-  ) {}
+    memoryRepository: MemoryRepository,
+    embeddingClient: IEmbeddingClient,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.memoryRepository = memoryRepository;
+    this.embeddingClient = embeddingClient;
+    this.nowMs = nowMs;
+  }
 
   public async retrieve(
     userId: string,
@@ -53,10 +61,7 @@ export class MemoryRetriever implements IMemoryRetriever {
       if (!memory.Embedding || memory.Embedding.length === 0) continue;
 
       // 4. cooldown 適用
-      if (
-        memory.LastReferencedAt !== undefined &&
-        now - memory.LastReferencedAt < cooldownMs
-      ) {
+      if (memory.LastReferencedAt !== undefined && now - memory.LastReferencedAt < cooldownMs) {
         continue;
       }
 

--- a/services/livetalk/core/src/memory/retrieval.ts
+++ b/services/livetalk/core/src/memory/retrieval.ts
@@ -1,0 +1,86 @@
+import type { IEmbeddingClient } from '../llm-client/types.js';
+import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
+import { cosineSimilarity } from './embedding.js';
+import type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './types.js';
+
+/**
+ * embedding ベースの Memory retriever。
+ *
+ * フロー:
+ *   1. ユーザー入力の embedding を生成（失敗時は Tier A のみ返す）
+ *   2. Tier A 全件取得（無条件で注入）
+ *   3. Tier B 全件取得 → cosine similarity 計算
+ *   4. cooldown 適用（直近 cooldownMs 以内に参照済みを除外）
+ *   5. カテゴリキャップ適用（同カテゴリは categoryCapPerConversation 件まで）
+ *   6. 降順ソート → 上位 maxTierB 件を返す
+ */
+export class MemoryRetriever implements IMemoryRetriever {
+  constructor(
+    private readonly memoryRepository: MemoryRepository,
+    private readonly embeddingClient: IEmbeddingClient,
+    private readonly nowMs: () => number = () => Date.now()
+  ) {}
+
+  public async retrieve(
+    userId: string,
+    characterId: string,
+    options: RetrieveOptions
+  ): Promise<RetrievedMemory[]> {
+    const { userInput, maxTierB, cooldownMs, categoryCapPerConversation } = options;
+
+    // 1. Tier A 全件（無条件）
+    const tierAMemories = await this.memoryRepository.listByTier(userId, characterId, 'A');
+    const tierAResults: RetrievedMemory[] = tierAMemories.map((memory) => ({
+      memory,
+      similarity: 1.0,
+    }));
+
+    // 2. ユーザー入力の embedding 生成（失敗時は Tier A のみ）
+    let queryEmbedding: number[];
+    try {
+      queryEmbedding = await this.embeddingClient.embed(userInput);
+    } catch {
+      return tierAResults;
+    }
+
+    // 3. Tier B 全件取得 + cosine similarity 計算
+    const tierBMemories = await this.memoryRepository.listByTier(userId, characterId, 'B');
+    const now = this.nowMs();
+
+    const tierBCandidates: RetrievedMemory[] = [];
+    for (const memory of tierBMemories) {
+      // embedding が未生成の Memory はスキップ
+      if (!memory.Embedding || memory.Embedding.length === 0) continue;
+
+      // 4. cooldown 適用
+      if (
+        memory.LastReferencedAt !== undefined &&
+        now - memory.LastReferencedAt < cooldownMs
+      ) {
+        continue;
+      }
+
+      const similarity = cosineSimilarity(queryEmbedding, memory.Embedding);
+      tierBCandidates.push({ memory, similarity });
+    }
+
+    // 5. カテゴリキャップ適用（降順ソート後に先着順で制限）
+    tierBCandidates.sort((a, b) => b.similarity - a.similarity);
+
+    const categoryCount = new Map<string, number>();
+    const tierBResults: RetrievedMemory[] = [];
+
+    for (const candidate of tierBCandidates) {
+      if (tierBResults.length >= maxTierB) break;
+
+      const cat = candidate.memory.Category;
+      const count = categoryCount.get(cat) ?? 0;
+      if (count >= categoryCapPerConversation) continue;
+
+      categoryCount.set(cat, count + 1);
+      tierBResults.push(candidate);
+    }
+
+    return [...tierAResults, ...tierBResults];
+  }
+}

--- a/services/livetalk/core/src/memory/types.ts
+++ b/services/livetalk/core/src/memory/types.ts
@@ -14,5 +14,9 @@ export interface RetrievedMemory {
 }
 
 export interface IMemoryRetriever {
-  retrieve(userId: string, characterId: string, options: RetrieveOptions): Promise<RetrievedMemory[]>;
+  retrieve(
+    userId: string,
+    characterId: string,
+    options: RetrieveOptions
+  ): Promise<RetrievedMemory[]>;
 }

--- a/services/livetalk/core/src/memory/types.ts
+++ b/services/livetalk/core/src/memory/types.ts
@@ -1,0 +1,18 @@
+import type { MemoryEntity } from '../entities/memory.entity.js';
+
+export interface RetrieveOptions {
+  userInput: string;
+  maxTierB: number;
+  cooldownMs: number;
+  categoryCapPerConversation: number;
+}
+
+export interface RetrievedMemory {
+  memory: MemoryEntity;
+  /** Tier A は 1.0 固定、Tier B は cosine similarity */
+  similarity: number;
+}
+
+export interface IMemoryRetriever {
+  retrieve(userId: string, characterId: string, options: RetrieveOptions): Promise<RetrievedMemory[]>;
+}

--- a/services/livetalk/core/src/repositories/embedding-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/embedding-memory.repository.ts
@@ -16,10 +16,13 @@ import type { MemoryRepository } from './memory.repository.interface.js';
  * 生成に失敗した場合は embedding なしで保存を継続する（fail-warn）。
  */
 export class EmbeddingMemoryRepository implements MemoryRepository {
-  constructor(
-    private readonly inner: MemoryRepository,
-    private readonly embeddingClient: IEmbeddingClient
-  ) {}
+  private readonly inner: MemoryRepository;
+  private readonly embeddingClient: IEmbeddingClient;
+
+  constructor(inner: MemoryRepository, embeddingClient: IEmbeddingClient) {
+    this.inner = inner;
+    this.embeddingClient = embeddingClient;
+  }
 
   public async put(input: CreateMemoryInput): Promise<MemoryEntity> {
     const embedding = await this.generateEmbedding(input.Content);
@@ -68,9 +71,12 @@ export class EmbeddingMemoryRepository implements MemoryRepository {
     try {
       return await this.embeddingClient.embed(text);
     } catch (err) {
-      logger.warn('[EmbeddingMemoryRepository] embedding 生成に失敗しました（embedding なしで保存）', {
-        err,
-      });
+      logger.warn(
+        '[EmbeddingMemoryRepository] embedding 生成に失敗しました（embedding なしで保存）',
+        {
+          err,
+        }
+      );
       return undefined;
     }
   }

--- a/services/livetalk/core/src/repositories/embedding-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/embedding-memory.repository.ts
@@ -1,0 +1,77 @@
+import { logger } from '@nagiyu/common';
+import type { IEmbeddingClient } from '../llm-client/types.js';
+import type {
+  CreateMemoryInput,
+  MemoryEntity,
+  MemoryKey,
+  Tier,
+  UpdateMemoryInput,
+} from '../entities/memory.entity.js';
+import type { MemoryRepository } from './memory.repository.interface.js';
+
+/**
+ * MemoryRepository の Decorator。
+ *
+ * `put` / `promote` 時に embedding を自動生成して保存する。
+ * 生成に失敗した場合は embedding なしで保存を継続する（fail-warn）。
+ */
+export class EmbeddingMemoryRepository implements MemoryRepository {
+  constructor(
+    private readonly inner: MemoryRepository,
+    private readonly embeddingClient: IEmbeddingClient
+  ) {}
+
+  public async put(input: CreateMemoryInput): Promise<MemoryEntity> {
+    const embedding = await this.generateEmbedding(input.Content);
+    return this.inner.put({ ...input, Embedding: embedding ?? input.Embedding });
+  }
+
+  public async get(key: MemoryKey): Promise<MemoryEntity | null> {
+    return this.inner.get(key);
+  }
+
+  public async listByTier(
+    userId: string,
+    characterId: string,
+    tier: Tier
+  ): Promise<MemoryEntity[]> {
+    return this.inner.listByTier(userId, characterId, tier);
+  }
+
+  public async listByCategory(
+    userId: string,
+    characterId: string,
+    category: string
+  ): Promise<MemoryEntity[]> {
+    return this.inner.listByCategory(userId, characterId, category);
+  }
+
+  public async update(input: UpdateMemoryInput): Promise<MemoryEntity> {
+    return this.inner.update(input);
+  }
+
+  public async delete(key: MemoryKey): Promise<void> {
+    return this.inner.delete(key);
+  }
+
+  public async promote(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity> {
+    const embedding = await this.generateEmbedding(memory.Content);
+    const target = embedding ? { ...memory, Embedding: embedding } : memory;
+    return this.inner.promote(target, toTier);
+  }
+
+  public async demote(memory: MemoryEntity, toTier: Tier): Promise<MemoryEntity> {
+    return this.inner.demote(memory, toTier);
+  }
+
+  private async generateEmbedding(text: string): Promise<number[] | undefined> {
+    try {
+      return await this.embeddingClient.embed(text);
+    } catch (err) {
+      logger.warn('[EmbeddingMemoryRepository] embedding 生成に失敗しました（embedding なしで保存）', {
+        err,
+      });
+      return undefined;
+    }
+  }
+}

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -1,16 +1,23 @@
 import { logger } from '@nagiyu/common';
 import type { ILLMClient } from '../llm-client/types.js';
 import type { IVoiceClient } from '../voicevox/types.js';
+import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
 import type { MessageRepository } from '../repositories/message.repository.interface.js';
 import type { SafetyEventRepository } from '../repositories/safety-event.repository.interface.js';
 import type { CharacterDefinition } from '../characters/types.js';
 import { buildChatMessages } from '../characters/prompt-builder.js';
 import { SentenceBuffer } from '../lib/sentence-splitter.js';
-import { DEFAULT_CHARACTER_ID } from '../constants.js';
+import {
+  DEFAULT_CHARACTER_ID,
+  MEMORY_CATEGORY_CAP,
+  MEMORY_COOLDOWN_MS,
+  MEMORY_MAX_TIER_B,
+} from '../constants.js';
 import { detectSafetyRisk } from '../safety/detector.js';
 import { buildModerationReplacementMessage, buildSafetyMessage } from '../safety/templates.js';
 import { SAFETY_RESOURCES } from '../safety/resources.js';
 import type { IModerationClient, SafetyResource } from '../safety/types.js';
+import type { IMemoryRetriever, RetrievedMemory } from '../memory/types.js';
 
 /**
  * /api/chat ストリーミングレスポンスの各イベント型。
@@ -45,6 +52,10 @@ export interface ChatUseCaseParams {
   safetyEventRepository?: SafetyEventRepository;
   /** Moderation クライアント。未指定時は応答後チェックをスキップする */
   moderationClient?: IModerationClient;
+  /** Memory retriever。未指定時はメモリ注入をスキップする */
+  memoryRetriever?: IMemoryRetriever;
+  /** memoryRetriever が指定された場合に使う Memory リポジトリ */
+  memoryRepository?: MemoryRepository;
 }
 
 type SynthesisResult = { index: number; text: string; audio: string | null };
@@ -147,6 +158,8 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     messageRepository,
     safetyEventRepository,
     moderationClient,
+    memoryRetriever,
+    memoryRepository,
   } = params;
 
   // 1. 直近会話履歴取得
@@ -206,8 +219,23 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     return;
   }
 
-  // 4. LLM ストリーミング（通常フロー）
-  const chatMessages = buildChatMessages(character, new Date(), history, userText);
+  // 4. Memory retrieve（fail-warn: エラー時は空配列で継続）
+  let retrievedMemories: RetrievedMemory[] = [];
+  if (memoryRetriever) {
+    try {
+      retrievedMemories = await memoryRetriever.retrieve(userId, characterId, {
+        userInput: userText,
+        maxTierB: MEMORY_MAX_TIER_B,
+        cooldownMs: MEMORY_COOLDOWN_MS,
+        categoryCapPerConversation: MEMORY_CATEGORY_CAP,
+      });
+    } catch (err) {
+      logger.warn('[chat-usecase] Memory retrieve に失敗しました（メモリなしで継続）', { err });
+    }
+  }
+
+  // 5. LLM ストリーミング（通常フロー）
+  const chatMessages = buildChatMessages(character, new Date(), history, userText, retrievedMemories);
   const sentenceBuffer = new SentenceBuffer();
   let fullResponseText = '';
   const pendingSynthesis: Array<Promise<SynthesisResult>> = [];
@@ -217,7 +245,7 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     yield { type: 'text', delta };
     fullResponseText += delta;
 
-    // 5. 文区切りで VOICEVOX を非同期起動
+    // 6. 文区切りで VOICEVOX を非同期起動
     for (const sentence of sentenceBuffer.push(delta)) {
       const idx = sentenceIndex++;
       pendingSynthesis.push(
@@ -242,7 +270,7 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     }
   }
 
-  // 6. Moderation API チェック（fail-warn: エラー時は通常応答を通す）
+  // 8. Moderation API チェック（fail-warn: エラー時は通常応答を通す）
   if (moderationClient && fullResponseText.trim()) {
     try {
       const modResult = await moderationClient.check(fullResponseText);
@@ -282,10 +310,10 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     }
   }
 
-  // 8. done
+  // 9. done
   yield { type: 'done' };
 
-  // 9. アシスタントメッセージを保存
+  // 10. アシスタントメッセージを保存
   const assistantText = fullResponseText.trim();
   if (assistantText) {
     try {
@@ -298,5 +326,27 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     } catch (err) {
       logger.error('[chat-usecase] アシスタントメッセージの保存に失敗しました', { err });
     }
+  }
+
+  // 11. 参照済み Memory の referencedCount / lastReferencedAt を更新（fire-and-forget）
+  if (memoryRepository && retrievedMemories.length > 0) {
+    const now = Date.now();
+    void Promise.all(
+      retrievedMemories.map((r) =>
+        memoryRepository
+          .update({
+            UserID: r.memory.UserID,
+            CharacterID: r.memory.CharacterID,
+            Tier: r.memory.Tier,
+            Category: r.memory.Category,
+            MemoryID: r.memory.MemoryID,
+            ReferencedCount: r.memory.ReferencedCount + 1,
+            LastReferencedAt: now,
+          })
+          .catch((err) => {
+            logger.warn('[chat-usecase] Memory 参照情報の更新に失敗しました', { err });
+          })
+      )
+    );
   }
 }

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -235,7 +235,13 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
   }
 
   // 5. LLM ストリーミング（通常フロー）
-  const chatMessages = buildChatMessages(character, new Date(), history, userText, retrievedMemories);
+  const chatMessages = buildChatMessages(
+    character,
+    new Date(),
+    history,
+    userText,
+    retrievedMemories
+  );
   const sentenceBuffer = new SentenceBuffer();
   let fullResponseText = '';
   const pendingSynthesis: Array<Promise<SynthesisResult>> = [];

--- a/services/livetalk/core/tests/unit/characters/prompt-builder.test.ts
+++ b/services/livetalk/core/tests/unit/characters/prompt-builder.test.ts
@@ -5,6 +5,8 @@ import {
 } from '../../../src/characters/prompt-builder.js';
 import { hiyori } from '../../../src/characters/hiyori.js';
 import type { MessageEntity } from '../../../src/entities/message.entity.js';
+import type { RetrievedMemory } from '../../../src/memory/types.js';
+import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
 
 const makeMsg = (role: 'user' | 'assistant', text: string, id = 'id1'): MessageEntity => ({
   UserID: 'u1',
@@ -68,6 +70,51 @@ describe('buildSystemPrompt', () => {
   });
 });
 
+function makeRetrievedMemory(content: string, tier: 'A' | 'B' = 'B'): RetrievedMemory {
+  const memory: MemoryEntity = {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    MemoryID: 'mem-001',
+    Tier: tier,
+    Category: 'food',
+    Content: content,
+    Confidence: 0.8,
+    ReferencedCount: 0,
+    CreatedAt: 1_700_000_000_000,
+    UpdatedAt: 1_700_000_000_000,
+  };
+  return { memory, similarity: tier === 'A' ? 1.0 : 0.9 };
+}
+
+describe('buildSystemPrompt（retrievedMemories）', () => {
+  it('retrievedMemories が空の場合は「あなたが覚えていること」セクションがない', () => {
+    const prompt = buildSystemPrompt(hiyori, new Date(), []);
+    expect(prompt).not.toContain('あなたが覚えていること');
+  });
+
+  it('retrievedMemories が未指定の場合もセクションがない', () => {
+    const prompt = buildSystemPrompt(hiyori, new Date());
+    expect(prompt).not.toContain('あなたが覚えていること');
+  });
+
+  it('retrievedMemories がある場合はセクションが追加される', () => {
+    const memories = [makeRetrievedMemory('コーヒーが好き', 'B')];
+    const prompt = buildSystemPrompt(hiyori, new Date(), memories);
+    expect(prompt).toContain('あなたが覚えていること');
+    expect(prompt).toContain('- コーヒーが好き');
+  });
+
+  it('複数の記憶が列挙される', () => {
+    const memories = [
+      makeRetrievedMemory('名前は田中', 'A'),
+      makeRetrievedMemory('コーヒーが好き', 'B'),
+    ];
+    const prompt = buildSystemPrompt(hiyori, new Date(), memories);
+    expect(prompt).toContain('- 名前は田中');
+    expect(prompt).toContain('- コーヒーが好き');
+  });
+});
+
 describe('buildChatMessages', () => {
   it('system + history + current user message の順で返す', () => {
     const history = [
@@ -100,5 +147,17 @@ describe('buildChatMessages', () => {
     const history = [makeMsg('user', 'test')];
     const messages = buildChatMessages(hiyori, new Date(), history, 'reply');
     expect(messages.some((m) => m.content === 'test')).toBe(true);
+  });
+
+  it('retrievedMemories が渡されると system prompt に記憶セクションが注入される', () => {
+    const memories = [makeRetrievedMemory('コーヒーが好き', 'B')];
+    const messages = buildChatMessages(hiyori, new Date(), [], 'おはよう', memories);
+    expect(messages[0].content).toContain('あなたが覚えていること');
+    expect(messages[0].content).toContain('- コーヒーが好き');
+  });
+
+  it('retrievedMemories が空の場合は記憶セクションなし', () => {
+    const messages = buildChatMessages(hiyori, new Date(), [], 'こんにちは', []);
+    expect(messages[0].content).not.toContain('あなたが覚えていること');
   });
 });

--- a/services/livetalk/core/tests/unit/llm-client/openai-embedding-client.test.ts
+++ b/services/livetalk/core/tests/unit/llm-client/openai-embedding-client.test.ts
@@ -1,0 +1,72 @@
+import OpenAI from 'openai';
+import {
+  OpenAIEmbeddingClient,
+  OPENAI_EMBEDDING_MODEL,
+  OPENAI_EMBEDDING_ERROR_MESSAGES,
+} from '../../../src/llm-client/openai-client.js';
+
+function makeMockOpenAI(): { client: OpenAI; create: jest.Mock } {
+  const create = jest.fn();
+  const client = {
+    embeddings: { create },
+  } as unknown as OpenAI;
+  return { client, create };
+}
+
+describe('OpenAIEmbeddingClient', () => {
+  describe('constructor', () => {
+    it('client 注入のみで生成できる', () => {
+      const { client } = makeMockOpenAI();
+      expect(() => new OpenAIEmbeddingClient({ client })).not.toThrow();
+    });
+
+    it('apiKey も client も無ければエラーを投げる', () => {
+      expect(() => new OpenAIEmbeddingClient({})).toThrow(
+        OPENAI_EMBEDDING_ERROR_MESSAGES.EMPTY_API_KEY
+      );
+    });
+  });
+
+  describe('embed', () => {
+    it('テキストを送ると embedding ベクトルを返す', async () => {
+      const { client, create } = makeMockOpenAI();
+      const mockVec = Array.from({ length: 3 }, (_, i) => i * 0.1);
+      create.mockResolvedValue({ data: [{ embedding: mockVec }] });
+
+      const cli = new OpenAIEmbeddingClient({ client });
+      const result = await cli.embed('コーヒーが好き');
+
+      expect(result).toEqual(mockVec);
+      const args = create.mock.calls[0][0];
+      expect(args.model).toBe(OPENAI_EMBEDDING_MODEL);
+      expect(args.input).toBe('コーヒーが好き');
+    });
+
+    it('model 上書きが反映される', async () => {
+      const { client, create } = makeMockOpenAI();
+      create.mockResolvedValue({ data: [{ embedding: [0.1] }] });
+
+      const cli = new OpenAIEmbeddingClient({ client, model: 'text-embedding-custom' });
+      await cli.embed('test');
+
+      expect(create.mock.calls[0][0].model).toBe('text-embedding-custom');
+    });
+
+    it('空文字を渡すと EMPTY_TEXT エラーを投げる', async () => {
+      const { client } = makeMockOpenAI();
+      const cli = new OpenAIEmbeddingClient({ client });
+
+      await expect(cli.embed('  ')).rejects.toThrow(OPENAI_EMBEDDING_ERROR_MESSAGES.EMPTY_TEXT);
+    });
+
+    it('前後の空白はトリムして送る', async () => {
+      const { client, create } = makeMockOpenAI();
+      create.mockResolvedValue({ data: [{ embedding: [0.5] }] });
+
+      const cli = new OpenAIEmbeddingClient({ client });
+      await cli.embed('  テスト  ');
+
+      expect(create.mock.calls[0][0].input).toBe('テスト');
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/memory/embedding.test.ts
+++ b/services/livetalk/core/tests/unit/memory/embedding.test.ts
@@ -1,0 +1,40 @@
+import { cosineSimilarity } from '../../../src/memory/embedding.js';
+
+describe('cosineSimilarity', () => {
+  it('同一ベクトルは 1.0 を返す', () => {
+    const v = [1, 2, 3];
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1.0);
+  });
+
+  it('直交ベクトルは 0 を返す', () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+  });
+
+  it('逆方向ベクトルは -1.0 を返す', () => {
+    expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(-1.0);
+  });
+
+  it('長さが異なるベクトルは 0 を返す', () => {
+    expect(cosineSimilarity([1, 2], [1, 2, 3])).toBe(0);
+  });
+
+  it('空ベクトルは 0 を返す', () => {
+    expect(cosineSimilarity([], [])).toBe(0);
+  });
+
+  it('ゼロベクトルは 0 を返す', () => {
+    expect(cosineSimilarity([0, 0], [1, 2])).toBe(0);
+  });
+
+  it('正規化されていないベクトルでも正しく計算する', () => {
+    const a = [3, 0];
+    const b = [0, 5];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0);
+  });
+
+  it('類似したベクトルは高いスコアを返す', () => {
+    const a = [1, 0.9];
+    const b = [0.9, 1];
+    expect(cosineSimilarity(a, b)).toBeGreaterThan(0.9);
+  });
+});

--- a/services/livetalk/core/tests/unit/memory/retrieval.test.ts
+++ b/services/livetalk/core/tests/unit/memory/retrieval.test.ts
@@ -27,10 +27,7 @@ function makeMemory(
   };
 }
 
-function makeMemoryRepo(
-  tierA: MemoryEntity[] = [],
-  tierB: MemoryEntity[] = []
-): MemoryRepository {
+function makeMemoryRepo(tierA: MemoryEntity[] = [], tierB: MemoryEntity[] = []): MemoryRepository {
   return {
     listByTier: jest.fn(async (_userId, _charId, tier) => {
       if (tier === 'A') return tierA;
@@ -102,9 +99,24 @@ describe('MemoryRetriever', () => {
   describe('Tier B 取得', () => {
     it('embedding のある Tier B を cosine similarity で上位 N 件返す', async () => {
       const tierB = [
-        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
-        makeMemory({ MemoryID: 'b2', Content: 'スポーツ好き', Category: 'hobby', Embedding: VEC_SPORTS }),
-        makeMemory({ MemoryID: 'b3', Content: '音楽好き', Category: 'hobby2', Embedding: VEC_MUSIC }),
+        makeMemory({
+          MemoryID: 'b1',
+          Content: 'コーヒー好き',
+          Category: 'food',
+          Embedding: VEC_COFFEE,
+        }),
+        makeMemory({
+          MemoryID: 'b2',
+          Content: 'スポーツ好き',
+          Category: 'hobby',
+          Embedding: VEC_SPORTS,
+        }),
+        makeMemory({
+          MemoryID: 'b3',
+          Content: '音楽好き',
+          Category: 'hobby2',
+          Embedding: VEC_MUSIC,
+        }),
       ];
       const retriever = new MemoryRetriever(
         makeMemoryRepo([], tierB),
@@ -121,7 +133,12 @@ describe('MemoryRetriever', () => {
     it('embedding が未設定の Memory はスキップされる', async () => {
       const tierB = [
         makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food' }),
-        makeMemory({ MemoryID: 'b2', Content: 'スポーツ好き', Category: 'hobby', Embedding: VEC_SPORTS }),
+        makeMemory({
+          MemoryID: 'b2',
+          Content: 'スポーツ好き',
+          Category: 'hobby',
+          Embedding: VEC_SPORTS,
+        }),
       ];
       const retriever = new MemoryRetriever(
         makeMemoryRepo([], tierB),
@@ -189,7 +206,12 @@ describe('MemoryRetriever', () => {
 
     it('LastReferencedAt が未設定の Memory は cooldown 除外されない', async () => {
       const tierB = [
-        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+        makeMemory({
+          MemoryID: 'b1',
+          Content: 'コーヒー好き',
+          Category: 'food',
+          Embedding: VEC_COFFEE,
+        }),
       ];
       const retriever = new MemoryRetriever(
         makeMemoryRepo([], tierB),
@@ -205,9 +227,24 @@ describe('MemoryRetriever', () => {
   describe('カテゴリキャップ', () => {
     it('同カテゴリから categoryCapPerConversation 件を超えて返さない', async () => {
       const tierB = [
-        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
-        makeMemory({ MemoryID: 'b2', Content: '紅茶も好き', Category: 'food', Embedding: [0.9, 0.1, 0] }),
-        makeMemory({ MemoryID: 'b3', Content: 'スポーツ好き', Category: 'hobby', Embedding: VEC_SPORTS }),
+        makeMemory({
+          MemoryID: 'b1',
+          Content: 'コーヒー好き',
+          Category: 'food',
+          Embedding: VEC_COFFEE,
+        }),
+        makeMemory({
+          MemoryID: 'b2',
+          Content: '紅茶も好き',
+          Category: 'food',
+          Embedding: [0.9, 0.1, 0],
+        }),
+        makeMemory({
+          MemoryID: 'b3',
+          Content: 'スポーツ好き',
+          Category: 'hobby',
+          Embedding: VEC_SPORTS,
+        }),
       ];
       const retriever = new MemoryRetriever(
         makeMemoryRepo([], tierB),
@@ -215,16 +252,34 @@ describe('MemoryRetriever', () => {
         () => FIXED_NOW
       );
 
-      const result = await retriever.retrieve('u1', 'hiyori', { ...defaultOptions, categoryCapPerConversation: 1 });
+      const result = await retriever.retrieve('u1', 'hiyori', {
+        ...defaultOptions,
+        categoryCapPerConversation: 1,
+      });
       const food = result.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
       expect(food).toHaveLength(1);
     });
 
     it('categoryCapPerConversation=2 なら同カテゴリ 2 件まで返す', async () => {
       const tierB = [
-        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
-        makeMemory({ MemoryID: 'b2', Content: '緑茶も好き', Category: 'food', Embedding: [0.9, 0.1, 0] }),
-        makeMemory({ MemoryID: 'b3', Content: '麦茶も', Category: 'food', Embedding: [0.8, 0.2, 0] }),
+        makeMemory({
+          MemoryID: 'b1',
+          Content: 'コーヒー好き',
+          Category: 'food',
+          Embedding: VEC_COFFEE,
+        }),
+        makeMemory({
+          MemoryID: 'b2',
+          Content: '緑茶も好き',
+          Category: 'food',
+          Embedding: [0.9, 0.1, 0],
+        }),
+        makeMemory({
+          MemoryID: 'b3',
+          Content: '麦茶も',
+          Category: 'food',
+          Embedding: [0.8, 0.2, 0],
+        }),
       ];
       const retriever = new MemoryRetriever(
         makeMemoryRepo([], tierB),
@@ -232,7 +287,11 @@ describe('MemoryRetriever', () => {
         () => FIXED_NOW
       );
 
-      const result = await retriever.retrieve('u1', 'hiyori', { ...defaultOptions, categoryCapPerConversation: 2, maxTierB: 10 });
+      const result = await retriever.retrieve('u1', 'hiyori', {
+        ...defaultOptions,
+        categoryCapPerConversation: 2,
+        maxTierB: 10,
+      });
       const food = result.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
       expect(food).toHaveLength(2);
     });
@@ -244,10 +303,17 @@ describe('MemoryRetriever', () => {
         makeMemory({ MemoryID: 'a1', Content: '名前は田中', Category: 'name', Tier: 'A' }),
       ];
       const tierB = [
-        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+        makeMemory({
+          MemoryID: 'b1',
+          Content: 'コーヒー好き',
+          Category: 'food',
+          Embedding: VEC_COFFEE,
+        }),
       ];
       const failingEmbedding: IEmbeddingClient = {
-        embed: jest.fn(async () => { throw new Error('API 障害'); }),
+        embed: jest.fn(async () => {
+          throw new Error('API 障害');
+        }),
       };
       const retriever = new MemoryRetriever(
         makeMemoryRepo(tierA, tierB),
@@ -267,7 +333,12 @@ describe('MemoryRetriever', () => {
         makeMemory({ MemoryID: 'a1', Content: '名前は田中', Category: 'name', Tier: 'A' }),
       ];
       const tierB = [
-        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+        makeMemory({
+          MemoryID: 'b1',
+          Content: 'コーヒー好き',
+          Category: 'food',
+          Embedding: VEC_COFFEE,
+        }),
       ];
       const retriever = new MemoryRetriever(
         makeMemoryRepo(tierA, tierB),

--- a/services/livetalk/core/tests/unit/memory/retrieval.test.ts
+++ b/services/livetalk/core/tests/unit/memory/retrieval.test.ts
@@ -1,0 +1,283 @@
+import { MemoryRetriever } from '../../../src/memory/retrieval.js';
+import type { IEmbeddingClient } from '../../../src/llm-client/types.js';
+import type { MemoryRepository } from '../../../src/repositories/memory.repository.interface.js';
+import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
+
+// 1536 次元で互いに直交する単純なテスト用ベクトル
+const VEC_COFFEE = [1, 0, 0];
+const VEC_SPORTS = [0, 1, 0];
+const VEC_MUSIC = [0, 0, 1];
+const VEC_QUERY_COFFEE = [0.99, 0.01, 0]; // coffee に近い
+
+const FIXED_NOW = 1_750_000_000_000;
+const COOLDOWN_MS = 30 * 60 * 1000; // 30 分
+
+function makeMemory(
+  override: Partial<MemoryEntity> & { MemoryID: string; Content: string; Category: string }
+): MemoryEntity {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    Tier: 'B',
+    Confidence: 0.8,
+    ReferencedCount: 0,
+    CreatedAt: FIXED_NOW - 10000,
+    UpdatedAt: FIXED_NOW - 10000,
+    ...override,
+  };
+}
+
+function makeMemoryRepo(
+  tierA: MemoryEntity[] = [],
+  tierB: MemoryEntity[] = []
+): MemoryRepository {
+  return {
+    listByTier: jest.fn(async (_userId, _charId, tier) => {
+      if (tier === 'A') return tierA;
+      if (tier === 'B') return tierB;
+      return [];
+    }),
+    put: jest.fn(),
+    get: jest.fn(),
+    listByCategory: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    promote: jest.fn(),
+    demote: jest.fn(),
+  } as unknown as MemoryRepository;
+}
+
+function makeEmbeddingClient(vec: number[]): IEmbeddingClient {
+  return { embed: jest.fn(async () => vec) };
+}
+
+const defaultOptions = {
+  userInput: 'コーヒー飲んだ',
+  maxTierB: 5,
+  cooldownMs: COOLDOWN_MS,
+  categoryCapPerConversation: 1,
+};
+
+describe('MemoryRetriever', () => {
+  describe('Tier A 取得', () => {
+    it('Tier A は無条件で全件返す', async () => {
+      const tierA = [
+        makeMemory({ MemoryID: 'a1', Content: '名前は田中', Category: 'name', Tier: 'A' }),
+        makeMemory({ MemoryID: 'a2', Content: '誕生日は3月', Category: 'birthday', Tier: 'A' }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo(tierA),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
+      const tierAResults = result.filter((r) => r.memory.Tier === 'A');
+      expect(tierAResults).toHaveLength(2);
+      expect(tierAResults.every((r) => r.similarity === 1.0)).toBe(true);
+    });
+
+    it('Tier A は cooldown の影響を受けない', async () => {
+      const recent = FIXED_NOW - 1000;
+      const tierA = [
+        makeMemory({
+          MemoryID: 'a1',
+          Content: '名前は田中',
+          Category: 'name',
+          Tier: 'A',
+          LastReferencedAt: recent,
+        }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo(tierA),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
+      expect(result.filter((r) => r.memory.Tier === 'A')).toHaveLength(1);
+    });
+  });
+
+  describe('Tier B 取得', () => {
+    it('embedding のある Tier B を cosine similarity で上位 N 件返す', async () => {
+      const tierB = [
+        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+        makeMemory({ MemoryID: 'b2', Content: 'スポーツ好き', Category: 'hobby', Embedding: VEC_SPORTS }),
+        makeMemory({ MemoryID: 'b3', Content: '音楽好き', Category: 'hobby2', Embedding: VEC_MUSIC }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo([], tierB),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', { ...defaultOptions, maxTierB: 2 });
+      const tierBResults = result.filter((r) => r.memory.Tier === 'B');
+      expect(tierBResults).toHaveLength(2);
+      expect(tierBResults[0].memory.Content).toBe('コーヒー好き');
+    });
+
+    it('embedding が未設定の Memory はスキップされる', async () => {
+      const tierB = [
+        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food' }),
+        makeMemory({ MemoryID: 'b2', Content: 'スポーツ好き', Category: 'hobby', Embedding: VEC_SPORTS }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo([], tierB),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
+      const tierBResults = result.filter((r) => r.memory.Tier === 'B');
+      expect(tierBResults).toHaveLength(1);
+      expect(tierBResults[0].memory.Content).toBe('スポーツ好き');
+    });
+  });
+
+  describe('cooldown 除外', () => {
+    it('直近 cooldownMs 以内に参照された Tier B Memory は除外される', async () => {
+      const recentRef = FIXED_NOW - COOLDOWN_MS + 1000;
+      const tierB = [
+        makeMemory({
+          MemoryID: 'b1',
+          Content: 'コーヒー好き',
+          Category: 'food',
+          Embedding: VEC_COFFEE,
+          LastReferencedAt: recentRef,
+        }),
+        makeMemory({
+          MemoryID: 'b2',
+          Content: 'スポーツ好き',
+          Category: 'hobby',
+          Embedding: VEC_SPORTS,
+        }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo([], tierB),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
+      const tierBResults = result.filter((r) => r.memory.Tier === 'B');
+      expect(tierBResults).toHaveLength(1);
+      expect(tierBResults[0].memory.Content).toBe('スポーツ好き');
+    });
+
+    it('cooldownMs を過ぎた Memory は除外されない', async () => {
+      const oldRef = FIXED_NOW - COOLDOWN_MS - 1000;
+      const tierB = [
+        makeMemory({
+          MemoryID: 'b1',
+          Content: 'コーヒー好き',
+          Category: 'food',
+          Embedding: VEC_COFFEE,
+          LastReferencedAt: oldRef,
+        }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo([], tierB),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
+      expect(result.filter((r) => r.memory.Tier === 'B')).toHaveLength(1);
+    });
+
+    it('LastReferencedAt が未設定の Memory は cooldown 除外されない', async () => {
+      const tierB = [
+        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo([], tierB),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
+      expect(result.filter((r) => r.memory.Tier === 'B')).toHaveLength(1);
+    });
+  });
+
+  describe('カテゴリキャップ', () => {
+    it('同カテゴリから categoryCapPerConversation 件を超えて返さない', async () => {
+      const tierB = [
+        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+        makeMemory({ MemoryID: 'b2', Content: '紅茶も好き', Category: 'food', Embedding: [0.9, 0.1, 0] }),
+        makeMemory({ MemoryID: 'b3', Content: 'スポーツ好き', Category: 'hobby', Embedding: VEC_SPORTS }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo([], tierB),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', { ...defaultOptions, categoryCapPerConversation: 1 });
+      const food = result.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
+      expect(food).toHaveLength(1);
+    });
+
+    it('categoryCapPerConversation=2 なら同カテゴリ 2 件まで返す', async () => {
+      const tierB = [
+        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+        makeMemory({ MemoryID: 'b2', Content: '緑茶も好き', Category: 'food', Embedding: [0.9, 0.1, 0] }),
+        makeMemory({ MemoryID: 'b3', Content: '麦茶も', Category: 'food', Embedding: [0.8, 0.2, 0] }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo([], tierB),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', { ...defaultOptions, categoryCapPerConversation: 2, maxTierB: 10 });
+      const food = result.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
+      expect(food).toHaveLength(2);
+    });
+  });
+
+  describe('embedding 生成失敗時のフォールバック', () => {
+    it('embedding 生成に失敗した場合は Tier A のみ返す', async () => {
+      const tierA = [
+        makeMemory({ MemoryID: 'a1', Content: '名前は田中', Category: 'name', Tier: 'A' }),
+      ];
+      const tierB = [
+        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+      ];
+      const failingEmbedding: IEmbeddingClient = {
+        embed: jest.fn(async () => { throw new Error('API 障害'); }),
+      };
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo(tierA, tierB),
+        failingEmbedding,
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
+      expect(result).toHaveLength(1);
+      expect(result[0].memory.Tier).toBe('A');
+    });
+  });
+
+  describe('統合（Tier A + B の混在）', () => {
+    it('Tier A と Tier B が両方返る', async () => {
+      const tierA = [
+        makeMemory({ MemoryID: 'a1', Content: '名前は田中', Category: 'name', Tier: 'A' }),
+      ];
+      const tierB = [
+        makeMemory({ MemoryID: 'b1', Content: 'コーヒー好き', Category: 'food', Embedding: VEC_COFFEE }),
+      ];
+      const retriever = new MemoryRetriever(
+        makeMemoryRepo(tierA, tierB),
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        () => FIXED_NOW
+      );
+
+      const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
+      expect(result.some((r) => r.memory.Tier === 'A')).toBe(true);
+      expect(result.some((r) => r.memory.Tier === 'B')).toBe(true);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/embedding-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/embedding-memory.repository.test.ts
@@ -57,7 +57,9 @@ describe('EmbeddingMemoryRepository', () => {
     it('embedding 生成失敗時は embedding なしで inner.put を呼ぶ（fail-warn）', async () => {
       const inner = makeInner();
       const failingClient: IEmbeddingClient = {
-        embed: jest.fn(async () => { throw new Error('API 障害'); }),
+        embed: jest.fn(async () => {
+          throw new Error('API 障害');
+        }),
       };
       const repo = new EmbeddingMemoryRepository(inner, failingClient);
 
@@ -99,7 +101,9 @@ describe('EmbeddingMemoryRepository', () => {
       const entityWithEmbedding = { ...savedEntity, Embedding: [0.5, 0.5] };
       const inner = makeInner();
       const failingClient: IEmbeddingClient = {
-        embed: jest.fn(async () => { throw new Error('API 障害'); }),
+        embed: jest.fn(async () => {
+          throw new Error('API 障害');
+        }),
       };
       const repo = new EmbeddingMemoryRepository(inner, failingClient);
 
@@ -128,7 +132,13 @@ describe('EmbeddingMemoryRepository', () => {
     it('get は inner に委譲する', async () => {
       const inner = makeInner();
       const repo = new EmbeddingMemoryRepository(inner, makeEmbeddingClient());
-      const key = { userId: 'u1', characterId: 'hiyori', tier: 'B' as const, category: 'food', memoryId: 'mem-001' };
+      const key = {
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B' as const,
+        category: 'food',
+        memoryId: 'mem-001',
+      };
       await repo.get(key);
       expect(inner.get).toHaveBeenCalledWith(key);
     });
@@ -143,7 +153,14 @@ describe('EmbeddingMemoryRepository', () => {
     it('update は inner に委譲する', async () => {
       const inner = makeInner();
       const repo = new EmbeddingMemoryRepository(inner, makeEmbeddingClient());
-      const input = { UserID: 'u1', CharacterID: 'hiyori', Tier: 'B' as const, Category: 'food', MemoryID: 'mem-001', Content: '更新' };
+      const input = {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Tier: 'B' as const,
+        Category: 'food',
+        MemoryID: 'mem-001',
+        Content: '更新',
+      };
       await repo.update(input);
       expect(inner.update).toHaveBeenCalledWith(input);
     });
@@ -151,7 +168,13 @@ describe('EmbeddingMemoryRepository', () => {
     it('delete は inner に委譲する', async () => {
       const inner = makeInner();
       const repo = new EmbeddingMemoryRepository(inner, makeEmbeddingClient());
-      const key = { userId: 'u1', characterId: 'hiyori', tier: 'B' as const, category: 'food', memoryId: 'mem-001' };
+      const key = {
+        userId: 'u1',
+        characterId: 'hiyori',
+        tier: 'B' as const,
+        category: 'food',
+        memoryId: 'mem-001',
+      };
       await repo.delete(key);
       expect(inner.delete).toHaveBeenCalledWith(key);
     });

--- a/services/livetalk/core/tests/unit/repositories/embedding-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/embedding-memory.repository.test.ts
@@ -1,0 +1,159 @@
+import { EmbeddingMemoryRepository } from '../../../src/repositories/embedding-memory.repository.js';
+import type { IEmbeddingClient } from '../../../src/llm-client/types.js';
+import type { MemoryRepository } from '../../../src/repositories/memory.repository.interface.js';
+import type { CreateMemoryInput, MemoryEntity } from '../../../src/entities/memory.entity.js';
+
+const MOCK_EMBEDDING = [0.1, 0.2, 0.3];
+
+const baseInput: CreateMemoryInput = {
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  Tier: 'B',
+  Category: 'food',
+  Content: 'コーヒーが好き',
+  Confidence: 0.8,
+  ReferencedCount: 0,
+};
+
+const savedEntity: MemoryEntity = {
+  ...baseInput,
+  MemoryID: 'mem-001',
+  CreatedAt: 1_750_000_000_000,
+  UpdatedAt: 1_750_000_000_000,
+};
+
+function makeInner(): MemoryRepository {
+  return {
+    put: jest.fn(async () => savedEntity),
+    get: jest.fn(async () => null),
+    listByTier: jest.fn(async () => []),
+    listByCategory: jest.fn(async () => []),
+    update: jest.fn(async () => savedEntity),
+    delete: jest.fn(async () => undefined),
+    promote: jest.fn(async () => savedEntity),
+    demote: jest.fn(async () => savedEntity),
+  } as unknown as MemoryRepository;
+}
+
+function makeEmbeddingClient(vec: number[] = MOCK_EMBEDDING): IEmbeddingClient {
+  return { embed: jest.fn(async () => vec) };
+}
+
+describe('EmbeddingMemoryRepository', () => {
+  describe('put', () => {
+    it('embedding を生成して inner.put に渡す', async () => {
+      const inner = makeInner();
+      const embeddingClient = makeEmbeddingClient();
+      const repo = new EmbeddingMemoryRepository(inner, embeddingClient);
+
+      await repo.put(baseInput);
+
+      expect(embeddingClient.embed).toHaveBeenCalledWith(baseInput.Content);
+      expect(inner.put).toHaveBeenCalledWith(
+        expect.objectContaining({ Embedding: MOCK_EMBEDDING })
+      );
+    });
+
+    it('embedding 生成失敗時は embedding なしで inner.put を呼ぶ（fail-warn）', async () => {
+      const inner = makeInner();
+      const failingClient: IEmbeddingClient = {
+        embed: jest.fn(async () => { throw new Error('API 障害'); }),
+      };
+      const repo = new EmbeddingMemoryRepository(inner, failingClient);
+
+      await expect(repo.put(baseInput)).resolves.not.toThrow();
+      expect(inner.put).toHaveBeenCalledWith(
+        expect.not.objectContaining({ Embedding: MOCK_EMBEDDING })
+      );
+    });
+
+    it('入力に既存 Embedding があっても生成した embedding で上書きする', async () => {
+      const inner = makeInner();
+      const embeddingClient = makeEmbeddingClient([0.9, 0.8, 0.7]);
+      const repo = new EmbeddingMemoryRepository(inner, embeddingClient);
+
+      await repo.put({ ...baseInput, Embedding: [0.0, 0.0, 0.0] });
+
+      expect(inner.put).toHaveBeenCalledWith(
+        expect.objectContaining({ Embedding: [0.9, 0.8, 0.7] })
+      );
+    });
+  });
+
+  describe('promote', () => {
+    it('promote 時に embedding を再生成する', async () => {
+      const inner = makeInner();
+      const embeddingClient = makeEmbeddingClient();
+      const repo = new EmbeddingMemoryRepository(inner, embeddingClient);
+
+      await repo.promote(savedEntity, 'A');
+
+      expect(embeddingClient.embed).toHaveBeenCalledWith(savedEntity.Content);
+      expect(inner.promote).toHaveBeenCalledWith(
+        expect.objectContaining({ Embedding: MOCK_EMBEDDING }),
+        'A'
+      );
+    });
+
+    it('embedding 生成失敗時は既存 embedding のまま promote する', async () => {
+      const entityWithEmbedding = { ...savedEntity, Embedding: [0.5, 0.5] };
+      const inner = makeInner();
+      const failingClient: IEmbeddingClient = {
+        embed: jest.fn(async () => { throw new Error('API 障害'); }),
+      };
+      const repo = new EmbeddingMemoryRepository(inner, failingClient);
+
+      await expect(repo.promote(entityWithEmbedding, 'A')).resolves.not.toThrow();
+      expect(inner.promote).toHaveBeenCalledWith(
+        expect.objectContaining({ Embedding: [0.5, 0.5] }),
+        'A'
+      );
+    });
+  });
+
+  describe('demote', () => {
+    it('demote は embedding 再生成なしに inner.demote を呼ぶ', async () => {
+      const inner = makeInner();
+      const embeddingClient = makeEmbeddingClient();
+      const repo = new EmbeddingMemoryRepository(inner, embeddingClient);
+
+      await repo.demote(savedEntity, 'C');
+
+      expect(embeddingClient.embed).not.toHaveBeenCalled();
+      expect(inner.demote).toHaveBeenCalledWith(savedEntity, 'C');
+    });
+  });
+
+  describe('委譲メソッド', () => {
+    it('get は inner に委譲する', async () => {
+      const inner = makeInner();
+      const repo = new EmbeddingMemoryRepository(inner, makeEmbeddingClient());
+      const key = { userId: 'u1', characterId: 'hiyori', tier: 'B' as const, category: 'food', memoryId: 'mem-001' };
+      await repo.get(key);
+      expect(inner.get).toHaveBeenCalledWith(key);
+    });
+
+    it('listByTier は inner に委譲する', async () => {
+      const inner = makeInner();
+      const repo = new EmbeddingMemoryRepository(inner, makeEmbeddingClient());
+      await repo.listByTier('u1', 'hiyori', 'B');
+      expect(inner.listByTier).toHaveBeenCalledWith('u1', 'hiyori', 'B');
+    });
+
+    it('update は inner に委譲する', async () => {
+      const inner = makeInner();
+      const repo = new EmbeddingMemoryRepository(inner, makeEmbeddingClient());
+      const input = { UserID: 'u1', CharacterID: 'hiyori', Tier: 'B' as const, Category: 'food', MemoryID: 'mem-001', Content: '更新' };
+      await repo.update(input);
+      expect(inner.update).toHaveBeenCalledWith(input);
+    });
+
+    it('delete は inner に委譲する', async () => {
+      const inner = makeInner();
+      const repo = new EmbeddingMemoryRepository(inner, makeEmbeddingClient());
+      const key = { userId: 'u1', characterId: 'hiyori', tier: 'B' as const, category: 'food', memoryId: 'mem-001' };
+      await repo.delete(key);
+      expect(inner.delete).toHaveBeenCalledWith(key);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -126,18 +126,21 @@ function makeMemoryRepo(): MemoryRepository {
     get: jest.fn(async () => null),
     listByTier: jest.fn(async () => []),
     listByCategory: jest.fn(async () => []),
-    update: jest.fn(async (input) => ({
-      UserID: input.UserID,
-      CharacterID: input.CharacterID,
-      MemoryID: input.MemoryID,
-      Tier: input.Tier,
-      Category: input.Category,
-      Content: 'x',
-      Confidence: 0.8,
-      ReferencedCount: input.ReferencedCount ?? 0,
-      CreatedAt: 0,
-      UpdatedAt: 0,
-    } as MemoryEntity)),
+    update: jest.fn(
+      async (input) =>
+        ({
+          UserID: input.UserID,
+          CharacterID: input.CharacterID,
+          MemoryID: input.MemoryID,
+          Tier: input.Tier,
+          Category: input.Category,
+          Content: 'x',
+          Confidence: 0.8,
+          ReferencedCount: input.ReferencedCount ?? 0,
+          CreatedAt: 0,
+          UpdatedAt: 0,
+        }) as MemoryEntity
+    ),
     delete: jest.fn(),
     promote: jest.fn(),
     demote: jest.fn(),
@@ -687,7 +690,11 @@ describe('runChatUseCase', () => {
         })
       );
 
-      expect(retriever.retrieve).toHaveBeenCalledWith('u1', 'hiyori', expect.objectContaining({ userInput: 'こんにちは' }));
+      expect(retriever.retrieve).toHaveBeenCalledWith(
+        'u1',
+        'hiyori',
+        expect.objectContaining({ userInput: 'こんにちは' })
+      );
     });
 
     it('memoryRetriever 未指定の場合は retrieve が呼ばれない', async () => {
@@ -733,7 +740,9 @@ describe('runChatUseCase', () => {
 
     it('retrieve 失敗時は memory なしで通常応答を継続する（fail-warn）', async () => {
       const failingRetriever: IMemoryRetriever = {
-        retrieve: jest.fn(async () => { throw new Error('retrieve 失敗'); }),
+        retrieve: jest.fn(async () => {
+          throw new Error('retrieve 失敗');
+        }),
       };
       const llm = makeLLMClient(['ok。']);
       const voice = makeVoiceClient();

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -2,11 +2,14 @@ import { runChatUseCase, type ChatEvent } from '../../../src/usecases/chat-useca
 import { hiyori } from '../../../src/characters/hiyori.js';
 import type { ILLMClient } from '../../../src/llm-client/types.js';
 import type { IVoiceClient } from '../../../src/voicevox/types.js';
+import type { MemoryRepository } from '../../../src/repositories/memory.repository.interface.js';
 import type { MessageRepository } from '../../../src/repositories/message.repository.interface.js';
 import type { SafetyEventRepository } from '../../../src/repositories/safety-event.repository.interface.js';
 import type { MessageEntity } from '../../../src/entities/message.entity.js';
+import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
 import type { SafetyEventEntity } from '../../../src/entities/safety-event.entity.js';
 import type { IModerationClient, ModerationResult } from '../../../src/safety/types.js';
+import type { IMemoryRetriever, RetrievedMemory } from '../../../src/memory/types.js';
 
 // ── ヘルパー ──────────────────────────────────────────────────────────────
 
@@ -109,6 +112,36 @@ function makeModerationClient(
       })
     ),
   };
+}
+
+function makeMemoryRetriever(memories: RetrievedMemory[] = []): IMemoryRetriever {
+  return {
+    retrieve: jest.fn(async () => memories),
+  };
+}
+
+function makeMemoryRepo(): MemoryRepository {
+  return {
+    put: jest.fn(),
+    get: jest.fn(async () => null),
+    listByTier: jest.fn(async () => []),
+    listByCategory: jest.fn(async () => []),
+    update: jest.fn(async (input) => ({
+      UserID: input.UserID,
+      CharacterID: input.CharacterID,
+      MemoryID: input.MemoryID,
+      Tier: input.Tier,
+      Category: input.Category,
+      Content: 'x',
+      Confidence: 0.8,
+      ReferencedCount: input.ReferencedCount ?? 0,
+      CreatedAt: 0,
+      UpdatedAt: 0,
+    } as MemoryEntity)),
+    delete: jest.fn(),
+    promote: jest.fn(),
+    demote: jest.fn(),
+  } as unknown as MemoryRepository;
 }
 
 // ── テスト本体 ──────────────────────────────────────────────────────────────
@@ -615,6 +648,153 @@ describe('runChatUseCase', () => {
             voiceClient: voice,
             messageRepository: repo,
             safetyEventRepository: safetyRepo,
+          })
+        )
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('Memory retrieval 統合', () => {
+    function makeRetrievedMemory(content: string): RetrievedMemory {
+      const memory: MemoryEntity = {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        MemoryID: 'mem-001',
+        Tier: 'B',
+        Category: 'food',
+        Content: content,
+        Confidence: 0.8,
+        ReferencedCount: 2,
+        CreatedAt: 0,
+        UpdatedAt: 0,
+      };
+      return { memory, similarity: 0.9 };
+    }
+
+    it('memoryRetriever が指定されると retrieve が呼ばれる', async () => {
+      const llm = makeLLMClient(['ok。']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const retriever = makeMemoryRetriever();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRetriever: retriever,
+        })
+      );
+
+      expect(retriever.retrieve).toHaveBeenCalledWith('u1', 'hiyori', expect.objectContaining({ userInput: 'こんにちは' }));
+    });
+
+    it('memoryRetriever 未指定の場合は retrieve が呼ばれない', async () => {
+      const llm = makeLLMClient(['ok。']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const retriever = makeMemoryRetriever();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          // memoryRetriever なし
+        })
+      );
+
+      expect(retriever.retrieve).not.toHaveBeenCalled();
+    });
+
+    it('retrieve 結果が system prompt に注入される（LLM に渡されるメッセージで確認）', async () => {
+      const retrieved = [makeRetrievedMemory('コーヒーが好き')];
+      const llm = makeLLMClient(['ok。']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRetriever: makeMemoryRetriever(retrieved),
+        })
+      );
+
+      const chatStreamMock = llm.chatStream as jest.Mock;
+      const passedMessages = chatStreamMock.mock.calls[0][0];
+      expect(passedMessages[0].content).toContain('あなたが覚えていること');
+      expect(passedMessages[0].content).toContain('- コーヒーが好き');
+    });
+
+    it('retrieve 失敗時は memory なしで通常応答を継続する（fail-warn）', async () => {
+      const failingRetriever: IMemoryRetriever = {
+        retrieve: jest.fn(async () => { throw new Error('retrieve 失敗'); }),
+      };
+      const llm = makeLLMClient(['ok。']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRetriever: failingRetriever,
+        })
+      );
+
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+    });
+
+    it('retrieve された Memory の referencedCount が更新される（fire-and-forget）', async () => {
+      const retrieved = [makeRetrievedMemory('コーヒーが好き')];
+      const llm = makeLLMClient(['ok。']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const memRepo = makeMemoryRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRetriever: makeMemoryRetriever(retrieved),
+          memoryRepository: memRepo,
+        })
+      );
+
+      // fire-and-forget のため少し待つ
+      await new Promise((r) => setTimeout(r, 10));
+      expect(memRepo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MemoryID: 'mem-001',
+          ReferencedCount: 3,
+        })
+      );
+    });
+
+    it('memoryRepository 未指定の場合は referencedCount 更新がスキップされる', async () => {
+      const retrieved = [makeRetrievedMemory('コーヒーが好き')];
+      const llm = makeLLMClient(['ok。']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await expect(
+        collectEvents(
+          runChatUseCase({
+            ...baseParams,
+            llmClient: llm,
+            voiceClient: voice,
+            messageRepository: repo,
+            memoryRetriever: makeMemoryRetriever(retrieved),
+            // memoryRepository なし
           })
         )
       ).resolves.not.toThrow();

--- a/services/livetalk/web/src/app/api/chat/route.ts
+++ b/services/livetalk/web/src/app/api/chat/route.ts
@@ -4,8 +4,9 @@ import { DEFAULT_CHARACTER_ID, hiyori, runChatUseCase } from '@nagiyu/livetalk-c
 import { getSession } from '@/lib/server/session';
 import { getLLMClient } from '@/lib/server/llm';
 import { getVoicevoxClient } from '@/lib/server/voicevox';
-import { getMessageRepository } from '@/lib/server/repositories';
+import { getMemoryRepository, getMessageRepository } from '@/lib/server/repositories';
 import { getModerationClient, getSafetyEventRepository } from '@/lib/server/safety';
+import { getMemoryRetriever } from '@/lib/server/memory-retriever';
 import { CHAT_ERROR_MESSAGES, CHAT_MAX_TEXT_LENGTH } from './constants';
 
 interface ChatRequest {
@@ -89,6 +90,8 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
           messageRepository: getMessageRepository(),
           safetyEventRepository: getSafetyEventRepository(),
           moderationClient: getModerationClient(),
+          memoryRetriever: getMemoryRetriever(),
+          memoryRepository: getMemoryRepository(),
         });
 
         for await (const event of eventGenerator) {

--- a/services/livetalk/web/src/lib/server/embedding.ts
+++ b/services/livetalk/web/src/lib/server/embedding.ts
@@ -1,0 +1,15 @@
+import { createEmbeddingClient } from '@nagiyu/livetalk-core';
+import type { IEmbeddingClient } from '@nagiyu/livetalk-core';
+
+let cachedClient: IEmbeddingClient | null = null;
+
+export function getEmbeddingClient(): IEmbeddingClient {
+  if (!cachedClient) {
+    cachedClient = createEmbeddingClient();
+  }
+  return cachedClient;
+}
+
+export function setEmbeddingClientForTesting(client: IEmbeddingClient | null): void {
+  cachedClient = client;
+}

--- a/services/livetalk/web/src/lib/server/memory-retriever.ts
+++ b/services/livetalk/web/src/lib/server/memory-retriever.ts
@@ -1,0 +1,17 @@
+import { MemoryRetriever } from '@nagiyu/livetalk-core';
+import type { IMemoryRetriever } from '@nagiyu/livetalk-core';
+import { getEmbeddingClient } from './embedding';
+import { getMemoryRepository } from './repositories';
+
+let cachedRetriever: IMemoryRetriever | null = null;
+
+export function getMemoryRetriever(): IMemoryRetriever {
+  if (!cachedRetriever) {
+    cachedRetriever = new MemoryRetriever(getMemoryRepository(), getEmbeddingClient());
+  }
+  return cachedRetriever;
+}
+
+export function setMemoryRetrieverForTesting(retriever: IMemoryRetriever | null): void {
+  cachedRetriever = retriever;
+}

--- a/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
@@ -11,10 +11,16 @@ import { getMessageRepository } from '@/lib/server/repositories';
 jest.mock('@/lib/server/session', () => ({ getSession: jest.fn() }));
 jest.mock('@/lib/server/llm', () => ({ getLLMClient: jest.fn() }));
 jest.mock('@/lib/server/voicevox', () => ({ getVoicevoxClient: jest.fn() }));
-jest.mock('@/lib/server/repositories', () => ({ getMessageRepository: jest.fn() }));
+jest.mock('@/lib/server/repositories', () => ({
+  getMessageRepository: jest.fn(),
+  getMemoryRepository: jest.fn().mockReturnValue({}),
+}));
 jest.mock('@/lib/server/safety', () => ({
   getSafetyEventRepository: jest.fn().mockReturnValue({}),
   getModerationClient: jest.fn().mockReturnValue({}),
+}));
+jest.mock('@/lib/server/memory-retriever', () => ({
+  getMemoryRetriever: jest.fn().mockReturnValue({}),
 }));
 
 // runChatUseCase をモック化して依存 I/O を切り離す


### PR DESCRIPTION
## 変更の概要

Issue #3280 の実装。Phase 3a で構築した Memory 基盤の上に、embedding ベースの関連度判定・retrieval ロジックを実装し、`chat-usecase` に統合した。

**主な変更:**
- `text-embedding-3-small` による embedding 生成パイプライン
- `EmbeddingMemoryRepository`（Decorator）: `put` / `promote` 時に embedding を自動生成
- `MemoryRetriever`: Tier A 全件 + Tier B cosine similarity 上位 N 件を返す retrieval ロジック
  - cooldown: 直近 30 分以内に参照済みの Memory は除外
  - カテゴリキャップ: Tier B は同カテゴリ 1 件まで（1 LLM 呼び出し単位）
- `prompt-builder.ts` に「あなたが覚えていること：」セクション追加
- `chat-usecase.ts` に retriever 統合 + `referencedCount` / `lastReferencedAt` の fire-and-forget 更新
- Web 層に `getEmbeddingClient` / `getMemoryRetriever` シングルトン追加

## 関連 Issue

関連: #3280（Phase 3b）
Parent: #3186（Phase 3）

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ 95.8%）
- [x] 関連ドキュメントを更新した
- [x] ローカルでテストが全て通ることを確認した（356 件全パス）
- [x] ビルドエラーがないことを確認した

## テスト内容

新規テストスイート（5 件追加）:

- `tests/unit/memory/embedding.test.ts` — `cosineSimilarity` の境界値（同一/直交/逆方向/長さ不一致/ゼロベクトル等）
- `tests/unit/memory/retrieval.test.ts` — Tier A 全件、Tier B 上位 N、cooldown 除外、カテゴリキャップ、embedding なし Memory のスキップ、embedding 生成失敗時の Tier A フォールバック
- `tests/unit/repositories/embedding-memory.repository.test.ts` — Decorator が put/promote 時に embedding を呼ぶ、生成失敗時の fail-warn 継続
- `tests/unit/llm-client/openai-embedding-client.test.ts` — SDK モック、model 指定、空文字エラー
- 既存テスト更新: `prompt-builder.test.ts`、`chat-usecase.test.ts` に retrieval 関連ケース追加

## レビューポイント

- `cooldown` の判定を「直近 N ターン」でなく**経過時間（30 分）**にした理由: 人間の感覚に近く、会話を長時間放置してから再開したときに同じ記憶が再浮上するのが自然なため
- `EmbeddingMemoryRepository` を Decorator にした理由: Repository 層を純粋な I/O に保ち、既存テストへの影響をゼロにするため
- `chat-usecase.ts` の retrieve 失敗と referencedCount 更新失敗はどちらも fail-warn（ログのみ）として通常応答を優先する設計

## 補足事項

- 既存 Memory（embedding なし）のバックフィルはこのフェーズのスコープ外。新規 put 以降のみ embedding を持つ
- Tier C / D は retrieve 対象外（Issue 設計通り）
- デフォルト値: `maxTierB=5` / `cooldownMs=30分` / `categoryCapPerConversation=1` は定数化済み（`constants.ts`）

---
_Generated by [Claude Code](https://claude.ai/code/session_014XUnrrHW7qH3cuGBKQUW4m)_