### PR TITLE
feat(stock-tracker): TradingView タイムアウト原因切り分け用ログ計装

### DIFF
--- a/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
+++ b/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
@@ -119,6 +119,14 @@ export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
             'application-autoscaling:Describe*',
             // STS (自分の identity 確認用)
             'sts:GetCallerIdentity',
+            // X-Ray (タイムアウト原因の DNS/TCP/TLS 内訳確認用)
+            'xray:GetTraceSummaries',
+            'xray:BatchGetTraces',
+            'xray:GetServiceGraph',
+            'xray:GetTraceGraph',
+            'xray:GetGroups',
+            'xray:GetGroup',
+            'xray:ListTagsForResource',
           ],
           resources: ['*'],
         }),

--- a/services/stock-tracker/batch/src/minute.ts
+++ b/services/stock-tracker/batch/src/minute.ts
@@ -255,6 +255,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     logger.info('1分間隔バッチ処理が正常に完了しました', {
       eventId: event.id,
       statistics: stats,
+      sessionId: session.getSessionId(),
     });
 
     return {

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -14,7 +14,7 @@ import * as tradingHoursChecker from '@nagiyu/stock-tracker-core';
 import type { Alert, Exchange } from '@nagiyu/stock-tracker-core';
 
 // TradingViewSession モックインスタンス（beforeEach で再生成）
-let mockSession: { getCurrentPrice: jest.Mock; close: jest.Mock };
+let mockSession: { getCurrentPrice: jest.Mock; close: jest.Mock; getSessionId: jest.Mock };
 
 // モックの設定
 jest.mock('@nagiyu/aws');
@@ -78,6 +78,7 @@ describe('minute batch handler', () => {
     mockSession = {
       getCurrentPrice: jest.fn(),
       close: jest.fn().mockResolvedValue(undefined),
+      getSessionId: jest.fn().mockReturnValue('test-session-id'),
     };
 
     // Mock DynamoDB Document Client

--- a/services/stock-tracker/core/src/services/tradingview-client.ts
+++ b/services/stock-tracker/core/src/services/tradingview-client.ts
@@ -11,9 +11,17 @@
  * - リソース管理: chart.delete() と client.end() を必ず実行
  */
 
+import { randomUUID } from 'crypto';
 import * as TradingView from '@mathieuc/tradingview';
 import type { TimeFrame } from '@mathieuc/tradingview';
+import { logger } from '@nagiyu/common';
 import type { ChartDataPoint } from '../types.js';
+
+// Node.js 内部 API の型定義（診断用）
+type NodeProcessInternal = NodeJS.Process & {
+  _getActiveHandles?: () => unknown[];
+  _getActiveRequests?: () => unknown[];
+};
 
 /**
  * TradingView API エラーメッセージ定数
@@ -162,9 +170,18 @@ export async function getCurrentPrice(
  */
 export class TradingViewSession {
   private readonly client: TradingView.Client;
+  private readonly sessionId: string;
+  private chartSeq: number;
 
   constructor() {
     this.client = new TradingView.Client();
+    this.sessionId = randomUUID();
+    this.chartSeq = 0;
+  }
+
+  /** invocation 間でセッションを識別するための ID */
+  public getSessionId(): string {
+    return this.sessionId;
   }
 
   /**
@@ -185,6 +202,11 @@ export class TradingViewSession {
       throw new Error(TRADINGVIEW_ERROR_MESSAGES.INVALID_TICKER);
     }
 
+    const callAt = Date.now();
+    const seq = ++this.chartSeq;
+    let firstUpdateAt: number | undefined;
+    let firstErrorAt: number | undefined;
+
     const chart = new this.client.Session.Chart();
 
     try {
@@ -194,6 +216,22 @@ export class TradingViewSession {
         const timeoutId = setTimeout(() => {
           if (!resolved) {
             resolved = true;
+            const mem = process.memoryUsage();
+            const proc = process as NodeProcessInternal;
+            logger.warn('TradingView API タイムアウト (共有セッション)', {
+              sessionId: this.sessionId,
+              seq,
+              tickerId,
+              timeoutMs: timeout,
+              elapsedMs: Date.now() - callAt,
+              firstUpdateAt,
+              firstErrorAt,
+              activeHandles: proc._getActiveHandles?.()?.length ?? null,
+              activeRequests: proc._getActiveRequests?.()?.length ?? null,
+              heapUsedMB: Math.round(mem.heapUsed / 1024 / 1024),
+              heapTotalMB: Math.round(mem.heapTotal / 1024 / 1024),
+              rssMB: Math.round(mem.rss / 1024 / 1024),
+            });
             reject(new Error(TRADINGVIEW_ERROR_MESSAGES.TIMEOUT));
           }
         }, timeout);
@@ -201,21 +239,43 @@ export class TradingViewSession {
         chart.setMarket(tickerId, { timeframe: '1', session });
 
         chart.onUpdate(() => {
+          if (firstUpdateAt === undefined) {
+            firstUpdateAt = Date.now();
+          }
           if (!resolved && chart.periods && chart.periods.length > 0) {
             const currentPrice = chart.periods[0]?.close;
             if (currentPrice !== undefined && currentPrice !== null) {
               resolved = true;
               clearTimeout(timeoutId);
+              logger.debug('TradingView 現在価格取得完了', {
+                sessionId: this.sessionId,
+                seq,
+                tickerId,
+                firstUpdateElapsedMs: firstUpdateAt - callAt,
+                totalElapsedMs: Date.now() - callAt,
+              });
               resolve(currentPrice);
             }
           }
         });
 
         chart.onError((error: Error) => {
+          if (firstErrorAt === undefined) {
+            firstErrorAt = Date.now();
+          }
           if (!resolved) {
             resolved = true;
             clearTimeout(timeoutId);
             const errorMessage = error.message || '';
+            logger.warn('TradingView API エラー (共有セッション)', {
+              sessionId: this.sessionId,
+              seq,
+              tickerId,
+              elapsedMs: Date.now() - callAt,
+              firstUpdateAt,
+              firstErrorAt,
+              errorMessage,
+            });
             if (errorMessage.includes('rate') || errorMessage.includes('limit')) {
               reject(new Error(TRADINGVIEW_ERROR_MESSAGES.RATE_LIMIT));
             } else {

--- a/services/stock-tracker/core/tests/unit/services/tradingview-client.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/tradingview-client.test.ts
@@ -12,6 +12,24 @@ import {
   TRADINGVIEW_ERROR_MESSAGES,
 } from '../../../src/services/tradingview-client';
 
+// logger のモック
+jest.mock('@nagiyu/common', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// モック済み logger への参照
+const mockLogger = jest.requireMock('@nagiyu/common').logger as {
+  debug: jest.Mock;
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+};
+
 /**
  * TradingView ライブラリのモック
  *
@@ -58,6 +76,7 @@ describe('TradingView Client', () => {
     // モックオブジェクトの初期化
     onUpdateCallback = null;
     onErrorCallback = null;
+    jest.clearAllMocks();
 
     mockChart = {
       setMarket: jest.fn(),
@@ -531,6 +550,125 @@ describe('TradingView Client', () => {
 
         const session = new TradingViewSession();
         await expect(session.close()).resolves.toBeUndefined();
+      });
+    });
+
+    describe('getSessionId()', () => {
+      test('UUID 形式の文字列を返す', () => {
+        const session = new TradingViewSession();
+        const id = session.getSessionId();
+        expect(typeof id).toBe('string');
+        expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+      });
+
+      test('セッションごとに異なる ID が生成される', () => {
+        const session1 = new TradingViewSession();
+        const session2 = new TradingViewSession();
+        expect(session1.getSessionId()).not.toBe(session2.getSessionId());
+      });
+    });
+
+    describe('ログ計装', () => {
+      test('タイムアウト時に logger.warn が sessionId / seq / firstUpdateAt を含む詳細ログを出力する', async () => {
+        const session = new TradingViewSession();
+
+        await expect(session.getCurrentPrice('NSDQ:AAPL', { timeout: 50 })).rejects.toThrow(
+          TRADINGVIEW_ERROR_MESSAGES.TIMEOUT
+        );
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'TradingView API タイムアウト (共有セッション)',
+          expect.objectContaining({
+            sessionId: session.getSessionId(),
+            seq: 1,
+            tickerId: 'NSDQ:AAPL',
+            timeoutMs: 50,
+            firstUpdateAt: undefined,
+          })
+        );
+      });
+
+      test('タイムアウト前に onUpdate が呼ばれた場合、firstUpdateAt がタイムスタンプとして記録される', async () => {
+        const session = new TradingViewSession();
+
+        const pricePromise = session.getCurrentPrice('NSDQ:AAPL', { timeout: 50 });
+
+        // onUpdate を発火させるが close を解決しない（periods が空）
+        mockChart.periods = [];
+        if (onUpdateCallback) {
+          onUpdateCallback();
+        }
+
+        await expect(pricePromise).rejects.toThrow(TRADINGVIEW_ERROR_MESSAGES.TIMEOUT);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'TradingView API タイムアウト (共有セッション)',
+          expect.objectContaining({
+            firstUpdateAt: expect.any(Number),
+          })
+        );
+      });
+
+      test('正常取得時に logger.debug が呼ばれる', async () => {
+        mockChart.periods = [{ close: 150.5 }];
+        const session = new TradingViewSession();
+
+        const pricePromise = session.getCurrentPrice('NSDQ:AAPL');
+        if (onUpdateCallback) {
+          onUpdateCallback();
+        }
+        await pricePromise;
+
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          'TradingView 現在価格取得完了',
+          expect.objectContaining({
+            sessionId: session.getSessionId(),
+            seq: 1,
+            tickerId: 'NSDQ:AAPL',
+          })
+        );
+      });
+
+      test('接続エラー時に logger.warn が sessionId / errorMessage を含む詳細ログを出力する', async () => {
+        const session = new TradingViewSession();
+
+        const pricePromise = session.getCurrentPrice('NSDQ:AAPL');
+        if (onErrorCallback) {
+          onErrorCallback(new Error('Connection failed'));
+        }
+
+        await expect(pricePromise).rejects.toThrow(
+          `${TRADINGVIEW_ERROR_MESSAGES.CONNECTION_ERROR}: Connection failed`
+        );
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'TradingView API エラー (共有セッション)',
+          expect.objectContaining({
+            sessionId: session.getSessionId(),
+            seq: 1,
+            tickerId: 'NSDQ:AAPL',
+            errorMessage: 'Connection failed',
+          })
+        );
+      });
+
+      test('seq は呼び出しごとにインクリメントされる', async () => {
+        mockChart.periods = [{ close: 100.0 }];
+        const session = new TradingViewSession();
+
+        const p1 = session.getCurrentPrice('NSDQ:AAPL');
+        if (onUpdateCallback) onUpdateCallback();
+        await p1;
+
+        const p2 = session.getCurrentPrice('NYSE:TSLA');
+        if (onUpdateCallback) onUpdateCallback();
+        await p2;
+
+        const debugCalls = mockLogger.debug.mock.calls;
+        const seqs = debugCalls
+          .filter((c: unknown[]) => c[0] === 'TradingView 現在価格取得完了')
+          .map((c: unknown[]) => (c[1] as { seq: number }).seq);
+        expect(seqs).toEqual([1, 2]);
       });
     });
   });


### PR DESCRIPTION
## 変更の概要

Issue #3288 のログ計装実装。TradingView API タイムアウトの原因切り分けに必要な診断情報をログに追加する。

**追加した診断情報**

| フィールド | 目的 |
|---|---|
| `sessionId` | コンテナ内の invocation 間でセッションを識別し、問題のある共有セッションを特定 |
| `seq` | セッション内の何回目の `getCurrentPrice` 呼び出しか（蓄積障害の検出） |
| `firstUpdateAt` | `onUpdate` が初めて呼ばれた時刻（`undefined` → WS レベルで詰まっている） |
| `firstErrorAt` | `onError` が初めて呼ばれた時刻 |
| `activeHandles` / `activeRequests` | Node.js プロセス内の zombie ソケット / タイマー数 |
| `heapUsedMB` / `heapTotalMB` / `rssMB` | タイムアウト時のメモリ状態 |

**ログ出力タイミング**

- タイムアウト時: `logger.warn('TradingView API タイムアウト (共有セッション)', {...})`
- 接続エラー時: `logger.warn('TradingView API エラー (共有セッション)', {...})`
- 正常完了時: `logger.debug('TradingView 現在価格取得完了', {...})`

**その他**
- `minute.ts` の完了ログに `sessionId` を追加（どの invocation がどのセッションを持っていたか）
- IAM Claude readonly ポリシーに X-Ray 読み取り権限 7 アクションを追加

## 関連 Issue

<!-- integration → develop の PR でのみ Closes # を使用する -->
#3288

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した（816 tests passed）
- [x] ビルドエラーがないことを確認した

## テスト内容

- `TradingViewSession.getSessionId()` が UUID を返すこと
- タイムアウト時に `logger.warn` が `sessionId` / `seq` / `firstUpdateAt` / `activeHandles` を含むこと
- `onUpdate` 発火後にタイムアウトした場合 `firstUpdateAt` が数値として記録されること
- 正常取得時に `logger.debug` が呼ばれること
- 接続エラー時に `logger.warn` が `errorMessage` を含むこと
- `seq` が呼び出しごとにインクリメントされること
- `minute.ts`: `mockSession` に `getSessionId()` を追加し既存15テストが継続してパスすること

## レビューポイント

- `tradingview-client.ts` に `logger` を import した。core パッケージはもともと `@nagiyu/common` を依存として持つため循環依存は発生していないが、念のため確認をお願いしたい
- `process._getActiveHandles` / `process._getActiveRequests` は Node.js の内部 API（型定義なし）。`NodeProcessInternal` 型で安全に optional chain している
- `firstUpdateAt` は `undefined` のまま warn ログに出力するケースがある（CloudWatch Insights で `IS NULL` フィルタが使える想定）

## スクリーンショット（該当する場合）

なし（ログ計装のみ）

## 補足事項

本 PR のスコープは診断ログの追加のみ。実際のタイムアウト対策（セッション再生成、接続リセット等）は別 Issue で対応する予定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkdFCxzBaqqBbgR1JQvL4e)_