### PR TITLE
feat(stock-tracker): container kill 戦略を実装 (#3288)

### DIFF
--- a/services/stock-tracker/batch/src/minute.ts
+++ b/services/stock-tracker/batch/src/minute.ts
@@ -210,6 +210,13 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
   const timeBudgetMs = parseInt(process.env.MINUTE_BATCH_TIME_BUDGET_MS ?? '30000', 10);
   const isBudgetExceeded = (): boolean => Date.now() - startTime > timeBudgetMs;
 
+  // container kill 閾値: invocation 内エラー数がこの値以上になると process.exit(1) で container を廃棄する
+  const containerKillThreshold = parseInt(
+    process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD ?? '2',
+    10
+  );
+  let shouldKillContainer = false;
+
   // invocation スコープで 1 つの TradingView WebSocket 接続を共有する
   const session = new TradingViewSession();
 
@@ -248,6 +255,17 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       logger.warn('時間予算超過のためアラートをスキップしました', {
         skippedCount,
         elapsedMs: Date.now() - startTime,
+      });
+    }
+
+    // broken container 検出: invocation 内エラー数が閾値以上なら container を廃棄する
+    // finally ブロックで session.close() 後に process.exit(1) を呼ぶ
+    if (stats.errors >= containerKillThreshold) {
+      shouldKillContainer = true;
+      logger.warn('連続タイムアウト発生のため container を破棄します', {
+        errors: stats.errors,
+        threshold: containerKillThreshold,
+        sessionId: session.getSessionId(),
       });
     }
 
@@ -290,5 +308,8 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     };
   } finally {
     await session.close();
+    if (shouldKillContainer) {
+      process.exit(1);
+    }
   }
 }

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -886,4 +886,53 @@ describe('minute batch handler', () => {
       expect(body.statistics.skippedTimeBudget).toBe(0);
     });
   });
+
+  describe('container kill 戦略', () => {
+    let exitSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // process.exit をモックして実際にプロセスが終了しないようにする
+      exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((() => undefined) as () => never);
+      process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD = '1';
+    });
+
+    afterEach(() => {
+      exitSpy.mockRestore();
+      delete process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD;
+    });
+
+    it('errors が閾値以上の場合、session.close() 後に process.exit(1) を呼ぶ', async () => {
+      // Arrange: 閾値 1 に対して errors = 1 になるケース（TradingView API タイムアウト）
+      const alert = makeAlert();
+      mockAlertRepo.getByFrequency.mockResolvedValue({ items: [alert] });
+      mockExchangeRepo.getById.mockResolvedValue(mockExchange);
+      (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
+      mockSession.getCurrentPrice.mockRejectedValue(new Error('TradingView API タイムアウト'));
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
+
+      // Act
+      await handler(mockEvent);
+
+      // Assert: session.close() が先に呼ばれ、その後 process.exit(1) が呼ばれる
+      expect(mockSession.close).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const closeOrder = mockSession.close.mock.invocationCallOrder[0];
+      const exitOrder = exitSpy.mock.invocationCallOrder[0];
+      expect(closeOrder).toBeLessThan(exitOrder);
+    });
+
+    it('errors が閾値未満の場合、process.exit を呼ばない', async () => {
+      // Arrange: 閾値 1 に対して errors = 0 になるケース（Enabled=false はエラー扱いしない）
+      const alert = makeAlert({ Enabled: false });
+      mockAlertRepo.getByFrequency.mockResolvedValue({ items: [alert] });
+
+      // Act
+      await handler(mockEvent);
+
+      // Assert
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -892,9 +892,7 @@ describe('minute batch handler', () => {
 
     beforeEach(() => {
       // process.exit をモックして実際にプロセスが終了しないようにする
-      exitSpy = jest
-        .spyOn(process, 'exit')
-        .mockImplementation((() => undefined) as () => never);
+      exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
       process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD = '1';
     });
 


### PR DESCRIPTION
## 変更の概要

PR #3289 のログ計装データから、障害が Lambda container 単位の outbound NAT パス破損であることが確定。broken container を自動排除するための「container kill 戦略」を実装する。

**根本原因（PR #3289 計装データより）:**
- `firstUpdateAt: undefined`（100% のタイムアウトで onUpdate が一度も発火しない）
- `activeHandles: 2`, heap ~25-31MB → Node.js プロセス自体は正常
- container ごとに broken/正常が完全に分かれる（100〜140分継続）

**対策:**
1 invocation 内のエラー数が閾値以上になった場合、`process.exit(1)` で container を強制終了。Lambda は次回 invocation で新しい container をスポーンするため、broken な outbound パスを持つ container が排除される。

## 関連 Issue

Issue #3288

## 変更種別

- [x] 新機能

## 実装チェックリスト

- [x] `minute.ts`: `MINUTE_BATCH_CONTAINER_KILL_THRESHOLD` 環境変数（デフォルト: `2`）で閾値を制御
- [x] `finally` ブロック内で `session.close()` 後に `process.exit(1)` を呼び、WebSocket 後処理を保証
- [x] テスト: `process.exit` をモックし、`close()` → `exit(1)` の呼び出し順を検証
- [x] テスト: errors < threshold の場合は `process.exit` が呼ばれないことを検証

## テスト内容

```
Tests: 17 passed, 17 total
```

新規追加テスト（`container kill 戦略` describe ブロック）:
- `errors が閾値以上の場合、session.close() 後に process.exit(1) を呼ぶ`
- `errors が閾値未満の場合、process.exit を呼ばない`

## レビューポイント

- `finally` ブロックで `session.close()` の後に `process.exit(1)` を置く構造が、セッション後処理の保証と container 廃棄の両立を実現している点
- デフォルト閾値 `2`（1 invocation 内で 2 アラートがタイムアウト → container 廃棄）が適切かどうか
  - 閾値が低すぎると健全な container でも誤廃棄のリスクがある
  - 現状では MINUTE_LEVEL アラート数は数件程度なので `2` で十分と判断


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkdFCxzBaqqBbgR1JQvL4e)_