### PR TITLE
fix(stock-tracker): container kill 閾値のデフォルトを 1 に変更 (#3288)

### DIFF
--- a/services/stock-tracker/batch/src/minute.ts
+++ b/services/stock-tracker/batch/src/minute.ts
@@ -211,8 +211,10 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
   const isBudgetExceeded = (): boolean => Date.now() - startTime > timeBudgetMs;
 
   // container kill 閾値: invocation 内エラー数がこの値以上になると process.exit(1) で container を廃棄する
+  // 観測（PR #3290 デプロイ後）: broken container でも 1 invocation あたり errors は最大 1 のため、閾値 1 で kill する。
+  // 誤検知コストは Lambda cold start のみで運用影響ゼロ。broken container 居座りによる通知欠落の方が深刻。
   const containerKillThreshold = parseInt(
-    process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD ?? '2',
+    process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD ?? '1',
     10
   );
   let shouldKillContainer = false;

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -69,10 +69,14 @@ describe('minute batch handler', () => {
   let mockAlertRepo: jest.Mocked<DynamoDBAlertRepository>;
   let mockExchangeRepo: jest.Mocked<ExchangeRepository>;
   let mockEvent: ScheduledEvent;
+  let exitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // モックのリセット
     jest.clearAllMocks();
+
+    // process.exit をモックして、container kill 発火時にテストプロセスが終了するのを防ぐ
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
 
     // TradingViewSession モックを再生成
     mockSession = {
@@ -128,6 +132,7 @@ describe('minute batch handler', () => {
   afterEach(() => {
     delete process.env.VAPID_PUBLIC_KEY;
     delete process.env.VAPID_PRIVATE_KEY;
+    exitSpy.mockRestore();
   });
 
   describe('正常系: アラート条件達成時に通知を送信', () => {
@@ -888,16 +893,11 @@ describe('minute batch handler', () => {
   });
 
   describe('container kill 戦略', () => {
-    let exitSpy: jest.SpyInstance;
-
     beforeEach(() => {
-      // process.exit をモックして実際にプロセスが終了しないようにする
-      exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
       process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD = '1';
     });
 
     afterEach(() => {
-      exitSpy.mockRestore();
       delete process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD;
     });
 
@@ -931,6 +931,23 @@ describe('minute batch handler', () => {
 
       // Assert
       expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('閾値環境変数が未設定の場合、デフォルト 1 で発火する', async () => {
+      // Arrange: 環境変数を未設定（デフォルト値 1 で動作することを検証）
+      delete process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD;
+      const alert = makeAlert();
+      mockAlertRepo.getByFrequency.mockResolvedValue({ items: [alert] });
+      mockExchangeRepo.getById.mockResolvedValue(mockExchange);
+      (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
+      mockSession.getCurrentPrice.mockRejectedValue(new Error('TradingView API タイムアウト'));
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
+
+      // Act
+      await handler(mockEvent);
+
+      // Assert: errors=1 でデフォルト閾値 1 に到達 → process.exit(1) 発火
+      expect(exitSpy).toHaveBeenCalledWith(1);
     });
   });
 });


### PR DESCRIPTION
## 変更の概要

PR #3290 のデプロイ後観測結果に基づき、container kill 閾値のデフォルトを `2` → `1` に変更する。

### 観測結果（デプロイ後 ~50 分）

| 環境 | タイムアウト | invocation 内 errors 最大 | kill 発火 |
|---|---|---|---|
| prod | 0 件 / 54 invocations | 0 | 0 |
| dev | 16 件（1 container に集中） | **1** | 0 |

broken container でも 3 アラート中 1 つのみが timeout する確率的挙動のため、閾値 `2` では到達不可能。閾値 `1` に下げて broken container を素早く排除する。

### トレードオフ

| | 閾値 2 | 閾値 1 |
|---|---|---|
| 発火確率 | 観測上ゼロ | 16% / invocation |
| 平均 broken 居座り時間 | ∞ | **~6 分** |
| 誤検知コスト | - | Lambda cold start のみ |

CDK とコードで値が乖離するリスクを避けるため、CDK の環境変数指定ではなくコード側のデフォルト値を変更する方針とした。

## 関連 Issue

Issue #3288

## 変更種別

- [x] バグ修正

## 実装チェックリスト

- [x] `minute.ts`: `MINUTE_BATCH_CONTAINER_KILL_THRESHOLD` のデフォルト値を `'2'` → `'1'` に変更
- [x] 観測結果のコメントをコード内に記述
- [x] テスト: デフォルト値変更により既存 errors テストで `process.exit` が呼ばれるため、グローバルに `process.exit` モック化
- [x] テスト: 環境変数未設定時にデフォルト 1 で発火することを検証

## テスト内容

```
Tests: 18 passed, 18 total
```

## レビューポイント

- 閾値 1 は誤検知（一過性 TCP 瞬断）でも kill するが、Lambda cold start のみのコストで運用影響なしと判断
- `process.exit` のグローバルモック化が他テストに影響しないか


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkdFCxzBaqqBbgR1JQvL4e)_