### PR TITLE
feat(stock-tracker): TradingView タイムアウト調査と container kill 戦略 (#3288)

### DIFF
--- a/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
+++ b/infra/shared/lib/iam/iam-claude-readonly-policy-stack.ts
@@ -119,6 +119,14 @@ export class IamClaudeReadonlyPolicyStack extends cdk.Stack {
             'application-autoscaling:Describe*',
             // STS (自分の identity 確認用)
             'sts:GetCallerIdentity',
+            // X-Ray (タイムアウト原因の DNS/TCP/TLS 内訳確認用)
+            'xray:GetTraceSummaries',
+            'xray:BatchGetTraces',
+            'xray:GetServiceGraph',
+            'xray:GetTraceGraph',
+            'xray:GetGroups',
+            'xray:GetGroup',
+            'xray:ListTagsForResource',
           ],
           resources: ['*'],
         }),

--- a/services/stock-tracker/batch/src/minute.ts
+++ b/services/stock-tracker/batch/src/minute.ts
@@ -211,8 +211,10 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
   const isBudgetExceeded = (): boolean => Date.now() - startTime > timeBudgetMs;
 
   // container kill 閾値: invocation 内エラー数がこの値以上になると process.exit(1) で container を廃棄する
+  // 観測（PR #3290 デプロイ後）: broken container でも 1 invocation あたり errors は最大 1 のため、閾値 1 で kill する。
+  // 誤検知コストは Lambda cold start のみで運用影響ゼロ。broken container 居座りによる通知欠落の方が深刻。
   const containerKillThreshold = parseInt(
-    process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD ?? '2',
+    process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD ?? '1',
     10
   );
   let shouldKillContainer = false;

--- a/services/stock-tracker/batch/src/minute.ts
+++ b/services/stock-tracker/batch/src/minute.ts
@@ -255,6 +255,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     logger.info('1分間隔バッチ処理が正常に完了しました', {
       eventId: event.id,
       statistics: stats,
+      sessionId: session.getSessionId(),
     });
 
     return {

--- a/services/stock-tracker/batch/src/minute.ts
+++ b/services/stock-tracker/batch/src/minute.ts
@@ -210,6 +210,13 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
   const timeBudgetMs = parseInt(process.env.MINUTE_BATCH_TIME_BUDGET_MS ?? '30000', 10);
   const isBudgetExceeded = (): boolean => Date.now() - startTime > timeBudgetMs;
 
+  // container kill 閾値: invocation 内エラー数がこの値以上になると process.exit(1) で container を廃棄する
+  const containerKillThreshold = parseInt(
+    process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD ?? '2',
+    10
+  );
+  let shouldKillContainer = false;
+
   // invocation スコープで 1 つの TradingView WebSocket 接続を共有する
   const session = new TradingViewSession();
 
@@ -248,6 +255,17 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       logger.warn('時間予算超過のためアラートをスキップしました', {
         skippedCount,
         elapsedMs: Date.now() - startTime,
+      });
+    }
+
+    // broken container 検出: invocation 内エラー数が閾値以上なら container を廃棄する
+    // finally ブロックで session.close() 後に process.exit(1) を呼ぶ
+    if (stats.errors >= containerKillThreshold) {
+      shouldKillContainer = true;
+      logger.warn('連続タイムアウト発生のため container を破棄します', {
+        errors: stats.errors,
+        threshold: containerKillThreshold,
+        sessionId: session.getSessionId(),
       });
     }
 
@@ -290,5 +308,8 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     };
   } finally {
     await session.close();
+    if (shouldKillContainer) {
+      process.exit(1);
+    }
   }
 }

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -886,4 +886,53 @@ describe('minute batch handler', () => {
       expect(body.statistics.skippedTimeBudget).toBe(0);
     });
   });
+
+  describe('container kill 戦略', () => {
+    let exitSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // process.exit をモックして実際にプロセスが終了しないようにする
+      exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((() => undefined) as () => never);
+      process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD = '1';
+    });
+
+    afterEach(() => {
+      exitSpy.mockRestore();
+      delete process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD;
+    });
+
+    it('errors が閾値以上の場合、session.close() 後に process.exit(1) を呼ぶ', async () => {
+      // Arrange: 閾値 1 に対して errors = 1 になるケース（TradingView API タイムアウト）
+      const alert = makeAlert();
+      mockAlertRepo.getByFrequency.mockResolvedValue({ items: [alert] });
+      mockExchangeRepo.getById.mockResolvedValue(mockExchange);
+      (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
+      mockSession.getCurrentPrice.mockRejectedValue(new Error('TradingView API タイムアウト'));
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
+
+      // Act
+      await handler(mockEvent);
+
+      // Assert: session.close() が先に呼ばれ、その後 process.exit(1) が呼ばれる
+      expect(mockSession.close).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const closeOrder = mockSession.close.mock.invocationCallOrder[0];
+      const exitOrder = exitSpy.mock.invocationCallOrder[0];
+      expect(closeOrder).toBeLessThan(exitOrder);
+    });
+
+    it('errors が閾値未満の場合、process.exit を呼ばない', async () => {
+      // Arrange: 閾値 1 に対して errors = 0 になるケース（Enabled=false はエラー扱いしない）
+      const alert = makeAlert({ Enabled: false });
+      mockAlertRepo.getByFrequency.mockResolvedValue({ items: [alert] });
+
+      // Act
+      await handler(mockEvent);
+
+      // Assert
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -14,7 +14,7 @@ import * as tradingHoursChecker from '@nagiyu/stock-tracker-core';
 import type { Alert, Exchange } from '@nagiyu/stock-tracker-core';
 
 // TradingViewSession モックインスタンス（beforeEach で再生成）
-let mockSession: { getCurrentPrice: jest.Mock; close: jest.Mock };
+let mockSession: { getCurrentPrice: jest.Mock; close: jest.Mock; getSessionId: jest.Mock };
 
 // モックの設定
 jest.mock('@nagiyu/aws');
@@ -78,6 +78,7 @@ describe('minute batch handler', () => {
     mockSession = {
       getCurrentPrice: jest.fn(),
       close: jest.fn().mockResolvedValue(undefined),
+      getSessionId: jest.fn().mockReturnValue('test-session-id'),
     };
 
     // Mock DynamoDB Document Client

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -892,9 +892,7 @@ describe('minute batch handler', () => {
 
     beforeEach(() => {
       // process.exit をモックして実際にプロセスが終了しないようにする
-      exitSpy = jest
-        .spyOn(process, 'exit')
-        .mockImplementation((() => undefined) as () => never);
+      exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
       process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD = '1';
     });
 

--- a/services/stock-tracker/batch/tests/unit/minute.test.ts
+++ b/services/stock-tracker/batch/tests/unit/minute.test.ts
@@ -69,10 +69,14 @@ describe('minute batch handler', () => {
   let mockAlertRepo: jest.Mocked<DynamoDBAlertRepository>;
   let mockExchangeRepo: jest.Mocked<ExchangeRepository>;
   let mockEvent: ScheduledEvent;
+  let exitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     // モックのリセット
     jest.clearAllMocks();
+
+    // process.exit をモックして、container kill 発火時にテストプロセスが終了するのを防ぐ
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
 
     // TradingViewSession モックを再生成
     mockSession = {
@@ -128,6 +132,7 @@ describe('minute batch handler', () => {
   afterEach(() => {
     delete process.env.VAPID_PUBLIC_KEY;
     delete process.env.VAPID_PRIVATE_KEY;
+    exitSpy.mockRestore();
   });
 
   describe('正常系: アラート条件達成時に通知を送信', () => {
@@ -888,16 +893,11 @@ describe('minute batch handler', () => {
   });
 
   describe('container kill 戦略', () => {
-    let exitSpy: jest.SpyInstance;
-
     beforeEach(() => {
-      // process.exit をモックして実際にプロセスが終了しないようにする
-      exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as () => never);
       process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD = '1';
     });
 
     afterEach(() => {
-      exitSpy.mockRestore();
       delete process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD;
     });
 
@@ -931,6 +931,23 @@ describe('minute batch handler', () => {
 
       // Assert
       expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('閾値環境変数が未設定の場合、デフォルト 1 で発火する', async () => {
+      // Arrange: 環境変数を未設定（デフォルト値 1 で動作することを検証）
+      delete process.env.MINUTE_BATCH_CONTAINER_KILL_THRESHOLD;
+      const alert = makeAlert();
+      mockAlertRepo.getByFrequency.mockResolvedValue({ items: [alert] });
+      mockExchangeRepo.getById.mockResolvedValue(mockExchange);
+      (tradingHoursChecker.isTradingHours as jest.Mock).mockReturnValue(true);
+      mockSession.getCurrentPrice.mockRejectedValue(new Error('TradingView API タイムアウト'));
+      (awsClients.reportErrorEvent as jest.Mock).mockResolvedValue(null);
+
+      // Act
+      await handler(mockEvent);
+
+      // Assert: errors=1 でデフォルト閾値 1 に到達 → process.exit(1) 発火
+      expect(exitSpy).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/services/stock-tracker/core/src/services/tradingview-client.ts
+++ b/services/stock-tracker/core/src/services/tradingview-client.ts
@@ -11,9 +11,17 @@
  * - リソース管理: chart.delete() と client.end() を必ず実行
  */
 
+import { randomUUID } from 'crypto';
 import * as TradingView from '@mathieuc/tradingview';
 import type { TimeFrame } from '@mathieuc/tradingview';
+import { logger } from '@nagiyu/common';
 import type { ChartDataPoint } from '../types.js';
+
+// Node.js 内部 API の型定義（診断用）
+type NodeProcessInternal = NodeJS.Process & {
+  _getActiveHandles?: () => unknown[];
+  _getActiveRequests?: () => unknown[];
+};
 
 /**
  * TradingView API エラーメッセージ定数
@@ -162,9 +170,18 @@ export async function getCurrentPrice(
  */
 export class TradingViewSession {
   private readonly client: TradingView.Client;
+  private readonly sessionId: string;
+  private chartSeq: number;
 
   constructor() {
     this.client = new TradingView.Client();
+    this.sessionId = randomUUID();
+    this.chartSeq = 0;
+  }
+
+  /** invocation 間でセッションを識別するための ID */
+  public getSessionId(): string {
+    return this.sessionId;
   }
 
   /**
@@ -185,6 +202,11 @@ export class TradingViewSession {
       throw new Error(TRADINGVIEW_ERROR_MESSAGES.INVALID_TICKER);
     }
 
+    const callAt = Date.now();
+    const seq = ++this.chartSeq;
+    let firstUpdateAt: number | undefined;
+    let firstErrorAt: number | undefined;
+
     const chart = new this.client.Session.Chart();
 
     try {
@@ -194,6 +216,22 @@ export class TradingViewSession {
         const timeoutId = setTimeout(() => {
           if (!resolved) {
             resolved = true;
+            const mem = process.memoryUsage();
+            const proc = process as NodeProcessInternal;
+            logger.warn('TradingView API タイムアウト (共有セッション)', {
+              sessionId: this.sessionId,
+              seq,
+              tickerId,
+              timeoutMs: timeout,
+              elapsedMs: Date.now() - callAt,
+              firstUpdateAt,
+              firstErrorAt,
+              activeHandles: proc._getActiveHandles?.()?.length ?? null,
+              activeRequests: proc._getActiveRequests?.()?.length ?? null,
+              heapUsedMB: Math.round(mem.heapUsed / 1024 / 1024),
+              heapTotalMB: Math.round(mem.heapTotal / 1024 / 1024),
+              rssMB: Math.round(mem.rss / 1024 / 1024),
+            });
             reject(new Error(TRADINGVIEW_ERROR_MESSAGES.TIMEOUT));
           }
         }, timeout);
@@ -201,21 +239,43 @@ export class TradingViewSession {
         chart.setMarket(tickerId, { timeframe: '1', session });
 
         chart.onUpdate(() => {
+          if (firstUpdateAt === undefined) {
+            firstUpdateAt = Date.now();
+          }
           if (!resolved && chart.periods && chart.periods.length > 0) {
             const currentPrice = chart.periods[0]?.close;
             if (currentPrice !== undefined && currentPrice !== null) {
               resolved = true;
               clearTimeout(timeoutId);
+              logger.debug('TradingView 現在価格取得完了', {
+                sessionId: this.sessionId,
+                seq,
+                tickerId,
+                firstUpdateElapsedMs: firstUpdateAt - callAt,
+                totalElapsedMs: Date.now() - callAt,
+              });
               resolve(currentPrice);
             }
           }
         });
 
         chart.onError((error: Error) => {
+          if (firstErrorAt === undefined) {
+            firstErrorAt = Date.now();
+          }
           if (!resolved) {
             resolved = true;
             clearTimeout(timeoutId);
             const errorMessage = error.message || '';
+            logger.warn('TradingView API エラー (共有セッション)', {
+              sessionId: this.sessionId,
+              seq,
+              tickerId,
+              elapsedMs: Date.now() - callAt,
+              firstUpdateAt,
+              firstErrorAt,
+              errorMessage,
+            });
             if (errorMessage.includes('rate') || errorMessage.includes('limit')) {
               reject(new Error(TRADINGVIEW_ERROR_MESSAGES.RATE_LIMIT));
             } else {

--- a/services/stock-tracker/core/tests/unit/services/tradingview-client.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/tradingview-client.test.ts
@@ -12,6 +12,24 @@ import {
   TRADINGVIEW_ERROR_MESSAGES,
 } from '../../../src/services/tradingview-client';
 
+// logger のモック
+jest.mock('@nagiyu/common', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// モック済み logger への参照
+const mockLogger = jest.requireMock('@nagiyu/common').logger as {
+  debug: jest.Mock;
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+};
+
 /**
  * TradingView ライブラリのモック
  *
@@ -58,6 +76,7 @@ describe('TradingView Client', () => {
     // モックオブジェクトの初期化
     onUpdateCallback = null;
     onErrorCallback = null;
+    jest.clearAllMocks();
 
     mockChart = {
       setMarket: jest.fn(),
@@ -531,6 +550,125 @@ describe('TradingView Client', () => {
 
         const session = new TradingViewSession();
         await expect(session.close()).resolves.toBeUndefined();
+      });
+    });
+
+    describe('getSessionId()', () => {
+      test('UUID 形式の文字列を返す', () => {
+        const session = new TradingViewSession();
+        const id = session.getSessionId();
+        expect(typeof id).toBe('string');
+        expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+      });
+
+      test('セッションごとに異なる ID が生成される', () => {
+        const session1 = new TradingViewSession();
+        const session2 = new TradingViewSession();
+        expect(session1.getSessionId()).not.toBe(session2.getSessionId());
+      });
+    });
+
+    describe('ログ計装', () => {
+      test('タイムアウト時に logger.warn が sessionId / seq / firstUpdateAt を含む詳細ログを出力する', async () => {
+        const session = new TradingViewSession();
+
+        await expect(session.getCurrentPrice('NSDQ:AAPL', { timeout: 50 })).rejects.toThrow(
+          TRADINGVIEW_ERROR_MESSAGES.TIMEOUT
+        );
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'TradingView API タイムアウト (共有セッション)',
+          expect.objectContaining({
+            sessionId: session.getSessionId(),
+            seq: 1,
+            tickerId: 'NSDQ:AAPL',
+            timeoutMs: 50,
+            firstUpdateAt: undefined,
+          })
+        );
+      });
+
+      test('タイムアウト前に onUpdate が呼ばれた場合、firstUpdateAt がタイムスタンプとして記録される', async () => {
+        const session = new TradingViewSession();
+
+        const pricePromise = session.getCurrentPrice('NSDQ:AAPL', { timeout: 50 });
+
+        // onUpdate を発火させるが close を解決しない（periods が空）
+        mockChart.periods = [];
+        if (onUpdateCallback) {
+          onUpdateCallback();
+        }
+
+        await expect(pricePromise).rejects.toThrow(TRADINGVIEW_ERROR_MESSAGES.TIMEOUT);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'TradingView API タイムアウト (共有セッション)',
+          expect.objectContaining({
+            firstUpdateAt: expect.any(Number),
+          })
+        );
+      });
+
+      test('正常取得時に logger.debug が呼ばれる', async () => {
+        mockChart.periods = [{ close: 150.5 }];
+        const session = new TradingViewSession();
+
+        const pricePromise = session.getCurrentPrice('NSDQ:AAPL');
+        if (onUpdateCallback) {
+          onUpdateCallback();
+        }
+        await pricePromise;
+
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          'TradingView 現在価格取得完了',
+          expect.objectContaining({
+            sessionId: session.getSessionId(),
+            seq: 1,
+            tickerId: 'NSDQ:AAPL',
+          })
+        );
+      });
+
+      test('接続エラー時に logger.warn が sessionId / errorMessage を含む詳細ログを出力する', async () => {
+        const session = new TradingViewSession();
+
+        const pricePromise = session.getCurrentPrice('NSDQ:AAPL');
+        if (onErrorCallback) {
+          onErrorCallback(new Error('Connection failed'));
+        }
+
+        await expect(pricePromise).rejects.toThrow(
+          `${TRADINGVIEW_ERROR_MESSAGES.CONNECTION_ERROR}: Connection failed`
+        );
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'TradingView API エラー (共有セッション)',
+          expect.objectContaining({
+            sessionId: session.getSessionId(),
+            seq: 1,
+            tickerId: 'NSDQ:AAPL',
+            errorMessage: 'Connection failed',
+          })
+        );
+      });
+
+      test('seq は呼び出しごとにインクリメントされる', async () => {
+        mockChart.periods = [{ close: 100.0 }];
+        const session = new TradingViewSession();
+
+        const p1 = session.getCurrentPrice('NSDQ:AAPL');
+        if (onUpdateCallback) onUpdateCallback();
+        await p1;
+
+        const p2 = session.getCurrentPrice('NYSE:TSLA');
+        if (onUpdateCallback) onUpdateCallback();
+        await p2;
+
+        const debugCalls = mockLogger.debug.mock.calls;
+        const seqs = debugCalls
+          .filter((c: unknown[]) => c[0] === 'TradingView 現在価格取得完了')
+          .map((c: unknown[]) => (c[1] as { seq: number }).seq);
+        expect(seqs).toEqual([1, 2]);
       });
     });
   });


### PR DESCRIPTION
## 変更の概要

TradingView API タイムアウト障害の原因調査（ログ計装）と、根本対策としての container kill 戦略を実装する。本 integration ブランチには 3 つの PR がマージ済み。

| PR | 内容 |
|---|---|
| #3289 | TradingView タイムアウト原因切り分け用ログ計装（`sessionId` / `firstUpdateAt` / `activeHandles` 等）+ X-Ray 読み取り権限追加 |
| #3290 | container kill 戦略の実装（`stats.errors >= 閾値` で `process.exit(1)`） |
| #3291 | 観測結果に基づき kill 閾値のデフォルトを `2` → `1` に変更 |

## 原因と対策

**原因（ログ計装により確定）:**
- `firstUpdateAt: undefined`（100% のタイムアウトで onUpdate が一度も発火しない）→ TCP は繋がっているが subscribe レスポンスがサイレントにドロップされる
- container 単位で broken/正常が完全に分かれ、broken state は container 全生存期間（100〜140分）継続
- Node.js プロセス自体は正常（`activeHandles: 2`, heap ~25-31MB）

**対策:**
broken な outbound パスを持つ Lambda container を、1 invocation 内エラー数が閾値（デフォルト 1）以上で `process.exit(1)` により強制排除。Lambda は次回 invocation で新しい container をスポーンする。

## デプロイ後の観測結果

| 環境 | 経過 | invocations | container 数 | タイムアウト | kill 発火 |
|---|---|---|---|---|---|
| dev  | ~9h | 543 | 7 | **0** | 0 |
| prod | ~9h | 542 | 6 | **0** | 0 |

100 分超の long-lived container を含め全て healthy。kill 戦略は保険として機能する状態（現状は発火不要な平和な状態）。

## 関連 Issue

Closes #3288

## 変更種別

- [x] 新機能
- [x] バグ修正

## 実装チェックリスト

- [x] ログ計装（PR #3289）
- [x] container kill 戦略（PR #3290）
- [x] 閾値デフォルト調整（PR #3291）
- [x] 単体テスト追加・更新
- [x] dev / prod デプロイ後の動作確認

## テスト内容

- core: TradingView クライアントのログ計装テスト（PR #3289）
- batch: container kill 戦略テスト（発火順序・閾値・デフォルト値）— 18 tests passed

## レビューポイント

- kill 閾値 1 は一過性 TCP 瞬断でも発火するが、Lambda cold start のみのコストで運用影響なしと判断
- 実環境での実発火実績はまだなし（broken container が未発生のため）。再発時に閾値 1 で平均 ~6 分以内に排除される想定
- 残課題があれば別 Issue で対応する方針


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkdFCxzBaqqBbgR1JQvL4e)_