### PR TITLE
[Feature] [リブトーク Phase 3c] 圧縮要約バッチ（EventBridge + Lambda、日次）

### DIFF
--- a/infra/common/src/utils/ssm.ts
+++ b/infra/common/src/utils/ssm.ts
@@ -32,8 +32,4 @@ export const SSM_PARAMETERS = {
   LIVETALK_CLOUDFRONT_CUSTOM_DOMAIN: (env: Environment) =>
     `/nagiyu/livetalk/${env}/cloudfront/custom-domain`,
   LIVETALK_ASSETS_BUCKET_NAME: (env: Environment) => `/nagiyu/livetalk/${env}/assets/bucket-name`,
-  LIVETALK_BATCH_ECR_REPOSITORY_NAME: (env: Environment) =>
-    `/nagiyu/livetalk/${env}/batch-ecr/repository-name`,
-  LIVETALK_BATCH_ECR_REPOSITORY_URI: (env: Environment) =>
-    `/nagiyu/livetalk/${env}/batch-ecr/repository-uri`,
 } as const;

--- a/infra/common/src/utils/ssm.ts
+++ b/infra/common/src/utils/ssm.ts
@@ -32,4 +32,8 @@ export const SSM_PARAMETERS = {
   LIVETALK_CLOUDFRONT_CUSTOM_DOMAIN: (env: Environment) =>
     `/nagiyu/livetalk/${env}/cloudfront/custom-domain`,
   LIVETALK_ASSETS_BUCKET_NAME: (env: Environment) => `/nagiyu/livetalk/${env}/assets/bucket-name`,
+  LIVETALK_BATCH_ECR_REPOSITORY_NAME: (env: Environment) =>
+    `/nagiyu/livetalk/${env}/batch-ecr/repository-name`,
+  LIVETALK_BATCH_ECR_REPOSITORY_URI: (env: Environment) =>
+    `/nagiyu/livetalk/${env}/batch-ecr/repository-uri`,
 } as const;

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -36,7 +36,7 @@ new LiveTalkEcrStack(app, `NagiyuLiveTalkEcr${envSuffix}`, {
 });
 
 // LiveTalk Batch ECR Repository Stack（Phase 3c / Issue #3281）
-const batchEcrStack = new LiveTalkBatchEcrStack(app, `NagiyuLiveTalkBatchEcr${envSuffix}`, {
+new LiveTalkBatchEcrStack(app, `NagiyuLiveTalkBatchEcr${envSuffix}`, {
   env: stackEnv,
   environment,
   description: `LiveTalk Batch ECR Repository (${environment})`,
@@ -92,17 +92,16 @@ const cloudFrontStack = new LiveTalkCloudFrontStack(app, `NagiyuLiveTalkCloudFro
 // EventBridge 日次トリガー + Lambda + DLQ + IAM
 const openAiApiKey = app.node.tryGetContext('openAiApiKey') || 'PLACEHOLDER_OPENAI_API_KEY';
 
-const batchStack = new LiveTalkBatchStack(app, `NagiyuLiveTalkBatch${envSuffix}`, {
+new LiveTalkBatchStack(app, `NagiyuLiveTalkBatch${envSuffix}`, {
   env: stackEnv,
   environment,
-  batchEcrRepositoryName: batchEcrStack.repository.repositoryName,
   openAiApiKey,
   description: `LiveTalk Batch（圧縮要約 Lambda + EventBridge）(${environment})`,
 });
 
-// Batch stack は Batch ECR stack に依存する（リポジトリ名参照のため）
-batchStack.addDependency(batchEcrStack);
-// Batch stack は DynamoDB stack と同様に決定論的 ARN 参照で deploy 順序不問
+// Batch stack は ECR リポジトリ名を `getEcrRepositoryName('livetalk-batch', env)` で
+// 決定論的に組み立てる（DynamoDB stack と同様に SSM もクロススタック参照も介さない）。
+// このため Batch ECR stack との deploy 順依存は発生しない。
 
 // SSM 経由の参照のため CDK は自動的にスタック間依存を検出できない。
 // 明示的に依存を宣言して deploy 順を保証する。

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -2,11 +2,13 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { LiveTalkEcrStack } from '../lib/ecr-stack';
+import { LiveTalkBatchEcrStack } from '../lib/batch-ecr-stack';
 import { LiveTalkAlbStack } from '../lib/alb-stack';
 import { LiveTalkDynamoDbStack } from '../lib/dynamodb-stack';
 import { LiveTalkEcsServiceStack } from '../lib/ecs-service-stack';
 import { LiveTalkCloudFrontStack } from '../lib/cloudfront-stack';
 import { LiveTalkSecretsStack } from '../lib/secrets-stack';
+import { LiveTalkBatchStack } from '../lib/batch-stack';
 
 const app = new cdk.App();
 
@@ -31,6 +33,13 @@ new LiveTalkEcrStack(app, `NagiyuLiveTalkEcr${envSuffix}`, {
   env: stackEnv,
   environment,
   description: `LiveTalk ECR Repository (${environment})`,
+});
+
+// LiveTalk Batch ECR Repository Stack（Phase 3c / Issue #3281）
+const batchEcrStack = new LiveTalkBatchEcrStack(app, `NagiyuLiveTalkBatchEcr${envSuffix}`, {
+  env: stackEnv,
+  environment,
+  description: `LiveTalk Batch ECR Repository (${environment})`,
 });
 
 // LiveTalk Secrets Stack（Phase 2b / Issue #3248）
@@ -90,6 +99,23 @@ const cloudFrontStack = new LiveTalkCloudFrontStack(
     description: `LiveTalk CloudFront Distribution (${environment})`,
   }
 );
+
+// LiveTalk Batch Stack（Phase 3c / Issue #3281）
+// EventBridge 日次トリガー + Lambda + DLQ + IAM
+const openAiApiKey =
+  app.node.tryGetContext('openAiApiKey') || 'PLACEHOLDER_OPENAI_API_KEY';
+
+const batchStack = new LiveTalkBatchStack(app, `NagiyuLiveTalkBatch${envSuffix}`, {
+  env: stackEnv,
+  environment,
+  batchEcrRepositoryName: batchEcrStack.repository.repositoryName,
+  openAiApiKey,
+  description: `LiveTalk Batch（圧縮要約 Lambda + EventBridge）(${environment})`,
+});
+
+// Batch stack は Batch ECR stack に依存する（リポジトリ名参照のため）
+batchStack.addDependency(batchEcrStack);
+// Batch stack は DynamoDB stack と同様に決定論的 ARN 参照で deploy 順序不問
 
 // SSM 経由の参照のため CDK は自動的にスタック間依存を検出できない。
 // 明示的に依存を宣言して deploy 順を保証する。

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -64,46 +64,33 @@ const albStack = new LiveTalkAlbStack(app, `NagiyuLiveTalkAlb${envSuffix}`, {
 // テーブル名 / ARN は ECS Service Stack 側でも `getDynamoDBTableName('livetalk', env)`
 // / `getDynamoDBTableArn(...)` を呼んで独立に組み立てる（SSM もクロススタック参照も
 // 介さない方針）。両 stack の deploy 順序や export 依存は発生しない。
-const dynamoDbStack = new LiveTalkDynamoDbStack(
-  app,
-  `NagiyuLiveTalkDynamoDB${envSuffix}`,
-  {
-    env: stackEnv,
-    environment,
-    description: `LiveTalk DynamoDB Single Table (${environment})`,
-  }
-);
+const dynamoDbStack = new LiveTalkDynamoDbStack(app, `NagiyuLiveTalkDynamoDB${envSuffix}`, {
+  env: stackEnv,
+  environment,
+  description: `LiveTalk DynamoDB Single Table (${environment})`,
+});
 
 // LiveTalk ECS Service Stack（共通 Cluster に Attach、ALB Target Group へ登録）
-const ecsServiceStack = new LiveTalkEcsServiceStack(
-  app,
-  `NagiyuLiveTalkService${envSuffix}`,
-  {
-    env: stackEnv,
-    environment,
-    appVersion,
-    description: `LiveTalk ECS Service (${environment})`,
-  }
-);
+const ecsServiceStack = new LiveTalkEcsServiceStack(app, `NagiyuLiveTalkService${envSuffix}`, {
+  env: stackEnv,
+  environment,
+  appVersion,
+  description: `LiveTalk ECS Service (${environment})`,
+});
 
 // LiveTalk CloudFront Distribution Stack（Phase 1d）
 // dev / prod ともに登録。Route53 ALIAS レコードは CloudFront stack 内で同時作成する
 // （`infra/ui-storybook` パターン）ため、cross-stack 依存・SSM 順序問題は発生しない。
 // 実際の prod deploy タイミングはブランチ運用（master push）で制御する。
-const cloudFrontStack = new LiveTalkCloudFrontStack(
-  app,
-  `NagiyuLiveTalkCloudFront${envSuffix}`,
-  {
-    env: stackEnv,
-    environment,
-    description: `LiveTalk CloudFront Distribution (${environment})`,
-  }
-);
+const cloudFrontStack = new LiveTalkCloudFrontStack(app, `NagiyuLiveTalkCloudFront${envSuffix}`, {
+  env: stackEnv,
+  environment,
+  description: `LiveTalk CloudFront Distribution (${environment})`,
+});
 
 // LiveTalk Batch Stack（Phase 3c / Issue #3281）
 // EventBridge 日次トリガー + Lambda + DLQ + IAM
-const openAiApiKey =
-  app.node.tryGetContext('openAiApiKey') || 'PLACEHOLDER_OPENAI_API_KEY';
+const openAiApiKey = app.node.tryGetContext('openAiApiKey') || 'PLACEHOLDER_OPENAI_API_KEY';
 
 const batchStack = new LiveTalkBatchStack(app, `NagiyuLiveTalkBatch${envSuffix}`, {
   env: stackEnv,

--- a/infra/livetalk/lib/batch-ecr-stack.ts
+++ b/infra/livetalk/lib/batch-ecr-stack.ts
@@ -1,0 +1,51 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import {
+  EcrStackBase,
+  type EcrStackBaseProps,
+  type Environment,
+  SSM_PARAMETERS,
+} from '@nagiyu/infra-common';
+
+export interface LiveTalkBatchEcrStackProps extends cdk.StackProps {
+  environment: string;
+}
+
+/**
+ * LiveTalk バッチ用 ECR スタック（Phase 3c / Issue #3281）
+ *
+ * - 命名規則: `nagiyu-livetalk-batch-ecr-{env}`
+ * - SSM Parameter に repository-name / repository-uri を格納
+ * - Component: livetalk タグを付与
+ */
+export class LiveTalkBatchEcrStack extends EcrStackBase {
+  constructor(scope: Construct, id: string, props: LiveTalkBatchEcrStackProps) {
+    const { environment, ...stackProps } = props;
+    const ssmEnvironment = environment as Environment;
+
+    const baseProps: EcrStackBaseProps = {
+      ...stackProps,
+      serviceName: 'livetalk-batch',
+      environment: ssmEnvironment,
+    };
+
+    super(scope, id, baseProps);
+
+    cdk.Tags.of(this).add('Component', 'livetalk');
+
+    new ssm.StringParameter(this, 'BatchEcrRepositoryNameParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_BATCH_ECR_REPOSITORY_NAME(ssmEnvironment),
+      stringValue: this.repository.repositoryName,
+      description: 'LiveTalk Batch ECR repository name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'BatchEcrRepositoryUriParam', {
+      parameterName: SSM_PARAMETERS.LIVETALK_BATCH_ECR_REPOSITORY_URI(ssmEnvironment),
+      stringValue: this.repository.repositoryUri,
+      description: 'LiveTalk Batch ECR repository URI',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+  }
+}

--- a/infra/livetalk/lib/batch-ecr-stack.ts
+++ b/infra/livetalk/lib/batch-ecr-stack.ts
@@ -1,12 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
-import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
-import {
-  EcrStackBase,
-  type EcrStackBaseProps,
-  type Environment,
-  SSM_PARAMETERS,
-} from '@nagiyu/infra-common';
+import { EcrStackBase, type EcrStackBaseProps, type Environment } from '@nagiyu/infra-common';
 
 export interface LiveTalkBatchEcrStackProps extends cdk.StackProps {
   environment: string;
@@ -15,8 +9,10 @@ export interface LiveTalkBatchEcrStackProps extends cdk.StackProps {
 /**
  * LiveTalk バッチ用 ECR スタック（Phase 3c / Issue #3281）
  *
- * - 命名規則: `nagiyu-livetalk-batch-ecr-{env}`
- * - SSM Parameter に repository-name / repository-uri を格納
+ * - 命名規則: `nagiyu-livetalk-batch-ecr-{env}`（`getEcrRepositoryName` と一致）
+ * - リポジトリ名は命名規則から決定論的に導出できるため SSM には格納しない。
+ *   参照側（batch-stack）は `getEcrRepositoryName('livetalk-batch', env)` で
+ *   独立に組み立てる（SSM もクロススタック参照も介さない方針）。
  * - Component: livetalk タグを付与
  */
 export class LiveTalkBatchEcrStack extends EcrStackBase {
@@ -33,19 +29,5 @@ export class LiveTalkBatchEcrStack extends EcrStackBase {
     super(scope, id, baseProps);
 
     cdk.Tags.of(this).add('Component', 'livetalk');
-
-    new ssm.StringParameter(this, 'BatchEcrRepositoryNameParam', {
-      parameterName: SSM_PARAMETERS.LIVETALK_BATCH_ECR_REPOSITORY_NAME(ssmEnvironment),
-      stringValue: this.repository.repositoryName,
-      description: 'LiveTalk Batch ECR repository name',
-      tier: ssm.ParameterTier.STANDARD,
-    });
-
-    new ssm.StringParameter(this, 'BatchEcrRepositoryUriParam', {
-      parameterName: SSM_PARAMETERS.LIVETALK_BATCH_ECR_REPOSITORY_URI(ssmEnvironment),
-      stringValue: this.repository.repositoryUri,
-      description: 'LiveTalk Batch ECR repository URI',
-      tier: ssm.ParameterTier.STANDARD,
-    });
   }
 }

--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -8,7 +8,11 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
-import { getDynamoDBTableArn, getDynamoDBTableName, grantErrorEventsWrite } from '@nagiyu/infra-common';
+import {
+  getDynamoDBTableArn,
+  getDynamoDBTableName,
+  grantErrorEventsWrite,
+} from '@nagiyu/infra-common';
 import type { Environment } from '@nagiyu/infra-common';
 
 export interface LiveTalkBatchStackProps extends cdk.StackProps {
@@ -76,9 +80,7 @@ export class LiveTalkBatchStack extends cdk.Stack {
       runtime: lambda.Runtime.FROM_IMAGE,
       code: lambda.Code.fromEcrImage(batchRepository, {
         tagOrDigest: 'latest',
-        cmd: [
-          'services/livetalk/batch/dist/src/handlers/compress-conversations.handler.handler',
-        ],
+        cmd: ['services/livetalk/batch/dist/src/handlers/compress-conversations.handler.handler'],
       }),
       handler: lambda.Handler.FROM_IMAGE,
       role: executionRole,

--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -11,13 +11,13 @@ import { Construct } from 'constructs';
 import {
   getDynamoDBTableArn,
   getDynamoDBTableName,
+  getEcrRepositoryName,
   grantErrorEventsWrite,
 } from '@nagiyu/infra-common';
 import type { Environment } from '@nagiyu/infra-common';
 
 export interface LiveTalkBatchStackProps extends cdk.StackProps {
   environment: Environment;
-  batchEcrRepositoryName: string;
   openAiApiKey: string;
 }
 
@@ -36,9 +36,12 @@ export class LiveTalkBatchStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: LiveTalkBatchStackProps) {
     super(scope, id, props);
 
-    const { environment, batchEcrRepositoryName, openAiApiKey } = props;
+    const { environment, openAiApiKey } = props;
 
     // ECR リポジトリの参照
+    // リポジトリ名は命名規則から決定論的に導出する（SSM もクロススタック参照も
+    // 介さないため、Batch ECR stack との deploy 順依存は発生しない）。
+    const batchEcrRepositoryName = getEcrRepositoryName('livetalk-batch', environment);
     const batchRepository = ecr.Repository.fromRepositoryName(
       this,
       'BatchRepository',

--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -1,0 +1,135 @@
+import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import { Construct } from 'constructs';
+import { getDynamoDBTableArn, getDynamoDBTableName, grantErrorEventsWrite } from '@nagiyu/infra-common';
+import type { Environment } from '@nagiyu/infra-common';
+
+export interface LiveTalkBatchStackProps extends cdk.StackProps {
+  environment: Environment;
+  batchEcrRepositoryName: string;
+  openAiApiKey: string;
+}
+
+/**
+ * LiveTalk バッチ処理スタック（Phase 3c / Issue #3281）
+ *
+ * 日次で全ユーザーの会話を圧縮要約する Lambda を作成する。
+ * - EventBridge: JST 03:00（UTC 18:00）に日次実行
+ * - Lambda: FROM_IMAGE / 512MB / 15 分タイムアウト
+ * - DLQ: 失敗時のデッドレター保持（7 日）
+ * - IAM: DynamoDB 読み書き + CloudWatch Logs
+ */
+export class LiveTalkBatchStack extends cdk.Stack {
+  public readonly batchFunction: lambda.Function;
+
+  constructor(scope: Construct, id: string, props: LiveTalkBatchStackProps) {
+    super(scope, id, props);
+
+    const { environment, batchEcrRepositoryName, openAiApiKey } = props;
+
+    // ECR リポジトリの参照
+    const batchRepository = ecr.Repository.fromRepositoryName(
+      this,
+      'BatchRepository',
+      batchEcrRepositoryName
+    );
+
+    // DynamoDB テーブル
+    const dynamoTableName = getDynamoDBTableName('livetalk', environment);
+    const dynamoTableArn = getDynamoDBTableArn(this.region, this.account, dynamoTableName);
+    const dynamoTable = dynamodb.Table.fromTableArn(this, 'DynamoTable', dynamoTableArn);
+
+    // DLQ（失敗時の保持）
+    const dlq = new sqs.Queue(this, 'BatchDlq', {
+      queueName: `nagiyu-livetalk-batch-dlq-${environment}`,
+      retentionPeriod: cdk.Duration.days(7),
+    });
+
+    // Batch Lambda 実行ロール
+    const executionRole = new iam.Role(this, 'BatchExecutionRole', {
+      roleName: `nagiyu-livetalk-batch-execution-role-${environment}`,
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+      ],
+    });
+
+    // DynamoDB 読み書き権限
+    dynamoTable.grantReadWriteData(executionRole);
+
+    // DLQ 送信権限
+    dlq.grantSendMessages(executionRole);
+
+    // ErrorEvents 書き込み権限
+    grantErrorEventsWrite(this, executionRole, environment);
+
+    // Lambda 関数
+    this.batchFunction = new lambda.Function(this, 'BatchFunction', {
+      functionName: `nagiyu-livetalk-batch-compress-${environment}`,
+      runtime: lambda.Runtime.FROM_IMAGE,
+      code: lambda.Code.fromEcrImage(batchRepository, {
+        tagOrDigest: 'latest',
+        cmd: [
+          'services/livetalk/batch/dist/src/handlers/compress-conversations.handler.handler',
+        ],
+      }),
+      handler: lambda.Handler.FROM_IMAGE,
+      role: executionRole,
+      memorySize: 512,
+      timeout: cdk.Duration.minutes(15),
+      environment: {
+        NODE_ENV: environment,
+        DYNAMODB_TABLE_NAME: dynamoTableName,
+        OPENAI_API_KEY: openAiApiKey,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
+      },
+      deadLetterQueue: dlq,
+      tracing: lambda.Tracing.ACTIVE,
+      logRetention: logs.RetentionDays.ONE_MONTH,
+    });
+
+    // EventBridge: 毎日 JST 03:00（= UTC 18:00 前日）に実行
+    const dailyRule = new events.Rule(this, 'DailyCompressRule', {
+      ruleName: `livetalk-batch-compress-${environment}`,
+      description: 'LiveTalk 圧縮要約バッチ（日次 JST 03:00）',
+      schedule: events.Schedule.cron({
+        minute: '0',
+        hour: '18',
+        day: '*',
+        month: '*',
+        year: '*',
+      }),
+    });
+    dailyRule.addTarget(
+      new targets.LambdaFunction(this.batchFunction, {
+        deadLetterQueue: dlq,
+        maxEventAge: cdk.Duration.hours(2),
+        retryAttempts: 1,
+      })
+    );
+
+    // タグ
+    cdk.Tags.of(this).add('Application', 'nagiyu');
+    cdk.Tags.of(this).add('Service', 'livetalk');
+    cdk.Tags.of(this).add('Environment', environment);
+    cdk.Tags.of(this).add('Component', 'livetalk-batch');
+
+    // CloudFormation Outputs
+    new cdk.CfnOutput(this, 'BatchFunctionArn', {
+      value: this.batchFunction.functionArn,
+      description: 'LiveTalk Batch Lambda Function ARN',
+    });
+
+    new cdk.CfnOutput(this, 'BatchDlqUrl', {
+      value: dlq.queueUrl,
+      description: 'LiveTalk Batch DLQ URL',
+    });
+  }
+}

--- a/infra/livetalk/package.json
+++ b/infra/livetalk/package.json
@@ -22,5 +22,8 @@
   "engines": {
     "node": ">=24.0.0",
     "npm": ">=10.0.0"
+  },
+  "devDependencies": {
+    "ts-jest": "^29.4.11"
   }
 }

--- a/infra/livetalk/tests/unit/batch-ecr-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-ecr-stack.test.js
@@ -1,0 +1,56 @@
+const cdk = require('aws-cdk-lib');
+const { Template, Match } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { LiveTalkBatchEcrStack } = require('../../lib/batch-ecr-stack');
+
+const STACK_ENV = { account: '000000000000', region: 'us-east-1' };
+
+const synth = (environment) => {
+  const app = new cdk.App();
+  const stack = new LiveTalkBatchEcrStack(app, `TestLiveTalkBatchEcr${environment}`, {
+    environment,
+    env: STACK_ENV,
+  });
+  return Template.fromStack(stack);
+};
+
+describe('LiveTalkBatchEcrStack', () => {
+  it('ECR リポジトリを 1 つ作成する', () => {
+    const template = synth('dev');
+    template.resourceCountIs('AWS::ECR::Repository', 1);
+  });
+
+  it('バッチ用リポジトリ名に livetalk-batch が含まれる', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECR::Repository', {
+      RepositoryName: Match.stringLikeRegexp('livetalk-batch'),
+    });
+  });
+
+  it('Component=livetalk タグを付与する', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECR::Repository', {
+      Tags: Match.arrayWith([{ Key: 'Component', Value: 'livetalk' }]),
+    });
+  });
+
+  it('SSM パラメータを 2 つ出力する（name / uri）', () => {
+    const template = synth('dev');
+    template.resourceCountIs('AWS::SSM::Parameter', 2);
+  });
+
+  it('SSM パラメータ名に batch-ecr が含まれる', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: Match.stringLikeRegexp('batch-ecr'),
+    });
+  });
+
+  it('prod でも正しく生成する', () => {
+    const template = synth('prod');
+    template.hasResourceProperties('AWS::ECR::Repository', {
+      RepositoryName: Match.stringLikeRegexp('livetalk-batch'),
+    });
+  });
+});

--- a/infra/livetalk/tests/unit/batch-ecr-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-ecr-stack.test.js
@@ -35,16 +35,9 @@ describe('LiveTalkBatchEcrStack', () => {
     });
   });
 
-  it('SSM パラメータを 2 つ出力する（name / uri）', () => {
+  it('SSM パラメータを作成しない（リポジトリ名は命名規則から導出する）', () => {
     const template = synth('dev');
-    template.resourceCountIs('AWS::SSM::Parameter', 2);
-  });
-
-  it('SSM パラメータ名に batch-ecr が含まれる', () => {
-    const template = synth('dev');
-    template.hasResourceProperties('AWS::SSM::Parameter', {
-      Name: Match.stringLikeRegexp('batch-ecr'),
-    });
+    template.resourceCountIs('AWS::SSM::Parameter', 0);
   });
 
   it('prod でも正しく生成する', () => {

--- a/infra/livetalk/tests/unit/batch-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-stack.test.js
@@ -10,7 +10,6 @@ const synth = (environment = 'dev', overrides = {}) => {
   const app = new cdk.App();
   const stack = new LiveTalkBatchStack(app, `TestLiveTalkBatch${environment}`, {
     environment,
-    batchEcrRepositoryName: `nagiyu-livetalk-batch-${environment}`,
     openAiApiKey: 'PLACEHOLDER_KEY',
     env: STACK_ENV,
     ...overrides,

--- a/infra/livetalk/tests/unit/batch-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-stack.test.js
@@ -1,0 +1,99 @@
+const cdk = require('aws-cdk-lib');
+const { Template, Match } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { LiveTalkBatchStack } = require('../../lib/batch-stack');
+
+const STACK_ENV = { account: '000000000000', region: 'us-east-1' };
+
+const synth = (environment = 'dev', overrides = {}) => {
+  const app = new cdk.App();
+  const stack = new LiveTalkBatchStack(app, `TestLiveTalkBatch${environment}`, {
+    environment,
+    batchEcrRepositoryName: `nagiyu-livetalk-batch-${environment}`,
+    openAiApiKey: 'PLACEHOLDER_KEY',
+    env: STACK_ENV,
+    ...overrides,
+  });
+  return { template: Template.fromStack(stack), stack };
+};
+
+describe('LiveTalkBatchStack', () => {
+  it('バッチ用 Lambda 関数が存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: Match.stringLikeRegexp('livetalk-batch-compress'),
+    });
+  });
+
+  it('Lambda のタイムアウトは 15 分', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Timeout: 900,
+    });
+  });
+
+  it('Lambda のメモリは 512MB', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      MemorySize: 512,
+    });
+  });
+
+  it('Lambda 環境変数に OPENAI_API_KEY が含まれる', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Environment: {
+        Variables: Match.objectLike({
+          OPENAI_API_KEY: 'PLACEHOLDER_KEY',
+        }),
+      },
+    });
+  });
+
+  it('EventBridge ルールを 1 つ作成する', () => {
+    const { template } = synth();
+    template.resourceCountIs('AWS::Events::Rule', 1);
+  });
+
+  it('EventBridge スケジュールは cron(0 18 * * ? *)', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: 'cron(0 18 * * ? *)',
+    });
+  });
+
+  it('SQS DLQ を 1 つ作成する', () => {
+    const { template } = synth();
+    template.resourceCountIs('AWS::SQS::Queue', 1);
+  });
+
+  it('Lambda 実行ロールを作成する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Principal: { Service: 'lambda.amazonaws.com' },
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('BatchFunctionArn を Outputs に出力する', () => {
+    const { template } = synth();
+    template.hasOutput('BatchFunctionArn', Match.anyValue());
+  });
+
+  it('prod 環境でも正しく生成する', () => {
+    const { template } = synth('prod');
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Environment: {
+        Variables: Match.objectLike({
+          NODE_ENV: 'prod',
+        }),
+      },
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,9 @@
         "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0"
       },
+      "devDependencies": {
+        "ts-jest": "^29.4.11"
+      },
       "engines": {
         "node": ">=24.0.0",
         "npm": ">=10.0.0"
@@ -562,6 +565,19 @@
         "node": ">= 6"
       }
     },
+    "infra/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "infra/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -579,6 +595,72 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "infra/node_modules/ts-jest": {
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "infra/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "infra/quick-clip": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14494,6 +14494,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14515,6 +14516,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14536,6 +14538,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14557,6 +14560,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14578,6 +14582,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14599,6 +14604,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14620,6 +14626,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14641,6 +14648,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14662,6 +14670,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14683,6 +14692,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14704,6 +14714,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20049,6 +20060,90 @@
         "js-tiktoken": "^1.0.21",
         "openai": "^6.33.0",
         "ulid": "^3.0.1"
+      },
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "jest": "^30.4.2",
+        "ts-jest": "^29.4.11"
+      }
+    },
+    "services/livetalk/core/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "services/livetalk/core/node_modules/ts-jest": {
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "services/livetalk/core/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "services/livetalk/web": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4612,6 +4612,10 @@
       "resolved": "infra/ui-storybook",
       "link": true
     },
+    "node_modules/@nagiyu/livetalk-batch": {
+      "resolved": "services/livetalk/batch",
+      "link": true
+    },
     "node_modules/@nagiyu/livetalk-core": {
       "resolved": "services/livetalk/core",
       "link": true
@@ -20047,6 +20051,102 @@
       "devDependencies": {
         "@aws-sdk/types": "^3.973.6",
         "@types/uuid": "^10.0.0"
+      }
+    },
+    "services/livetalk/batch": {
+      "name": "@nagiyu/livetalk-batch",
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1024.0",
+        "@aws-sdk/lib-dynamodb": "^3.1024.0",
+        "@nagiyu/aws": "*",
+        "@nagiyu/common": "*",
+        "@nagiyu/livetalk-core": "*",
+        "openai": "^6.33.0"
+      },
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "jest": "^30.4.2",
+        "ts-jest": "^29.4.11"
+      }
+    },
+    "services/livetalk/batch/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "services/livetalk/batch/node_modules/ts-jest": {
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "services/livetalk/batch/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "services/livetalk/core": {

--- a/services/livetalk/batch/Dockerfile
+++ b/services/livetalk/batch/Dockerfile
@@ -1,0 +1,56 @@
+# Multi-stage build for LiveTalk Batch Lambda
+# AWS Lambda 公式 Node.js 24 ベースイメージを使用
+
+# ベースイメージ
+FROM public.ecr.aws/lambda/nodejs:24 AS base
+
+# ビルドステージ
+FROM base AS builder
+WORKDIR /app
+
+# モノレポ全体のpackage.jsonとソースをコピー
+COPY package*.json ./
+COPY configs ./configs/
+COPY libs ./libs/
+COPY services/livetalk ./services/livetalk/
+
+# 依存関係をインストール（ソースコード存在下で実行）
+RUN npm ci
+
+# モノレポのルートからビルド（共通ライブラリも含めて）
+RUN npm run build --workspace=@nagiyu/common
+RUN npm run build --workspace=@nagiyu/aws
+RUN npm run build --workspace=@nagiyu/livetalk-core
+RUN npm run build --workspace=@nagiyu/livetalk-batch
+
+# 実行ステージ
+FROM base AS runner
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+ENV NODE_ENV=production
+
+# モノレポのルートnode_modulesをコピー（依存関係のホイスティングに対応）
+COPY --from=builder /app/node_modules ./node_modules
+
+# 必要なビルド成果物とpackage.jsonをコピー
+COPY --from=builder /app/package*.json ./
+
+# 共通ライブラリ
+COPY --from=builder /app/libs/common/package*.json ./libs/common/
+COPY --from=builder /app/libs/common/dist ./libs/common/dist
+
+# AWS ライブラリ
+COPY --from=builder /app/libs/aws/package*.json ./libs/aws/
+COPY --from=builder /app/libs/aws/dist ./libs/aws/dist
+
+# Core パッケージ
+COPY --from=builder /app/services/livetalk/core/package*.json ./services/livetalk/core/
+COPY --from=builder /app/services/livetalk/core/dist ./services/livetalk/core/dist
+
+# Batch パッケージ
+COPY --from=builder /app/services/livetalk/batch/package*.json ./services/livetalk/batch/
+COPY --from=builder /app/services/livetalk/batch/dist ./services/livetalk/batch/dist
+
+# Lambda ハンドラーを指定
+# CMD は CDK の cmd オプションで上書きされる
+CMD ["services/livetalk/batch/dist/src/handlers/compress-conversations.handler.handler"]

--- a/services/livetalk/batch/eslint.config.mjs
+++ b/services/livetalk/batch/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '../../../configs/eslint.config.base.mjs';
+
+export default baseConfig;

--- a/services/livetalk/batch/jest.config.ts
+++ b/services/livetalk/batch/jest.config.ts
@@ -1,0 +1,39 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@nagiyu/livetalk-core$': '<rootDir>/../core/src/index.ts',
+    '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',
+    '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: {
+          moduleResolution: 'node',
+          esModuleInterop: true,
+        },
+      },
+    ],
+  },
+  testMatch: ['<rootDir>/tests/**/*.test.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  coverageDirectory: 'coverage',
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  modulePathIgnorePatterns: ['<rootDir>/../../package.json'],
+};
+
+export default config;

--- a/services/livetalk/batch/package.json
+++ b/services/livetalk/batch/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@nagiyu/livetalk-batch",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/src/handlers/compress-conversations.handler.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts tests/**/*.ts",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1024.0",
+    "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@nagiyu/aws": "*",
+    "@nagiyu/common": "*",
+    "@nagiyu/livetalk-core": "*",
+    "openai": "^6.33.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.4.2",
+    "ts-jest": "^29.4.11"
+  }
+}

--- a/services/livetalk/batch/src/handlers/compress-conversations.handler.ts
+++ b/services/livetalk/batch/src/handlers/compress-conversations.handler.ts
@@ -1,0 +1,94 @@
+import { logger, toErrorMessage } from '@nagiyu/common';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
+import {
+  DynamoDBMemorySummaryRepository,
+  DynamoDBMessageRepository,
+  DynamoDBMemoryRepository,
+  EmbeddingMemoryRepository,
+  OpenAIClient,
+  OpenAIEmbeddingClient,
+  defaultUlidFactory,
+} from '@nagiyu/livetalk-core';
+import { compressAllConversations } from '../usecases/compress-conversations.usecase.js';
+
+const SERVICE_ID = 'livetalk';
+
+export interface ScheduledEvent {
+  version: string;
+  id: string;
+  'detail-type': string;
+  source: string;
+  account: string;
+  time: string;
+  region: string;
+  resources: string[];
+  detail: Record<string, unknown>;
+}
+
+export interface HandlerResponse {
+  statusCode: number;
+  body: string;
+}
+
+export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
+  logger.info('[compress-conversations] バッチ開始', {
+    eventId: event.id,
+    eventTime: event.time,
+  });
+
+  try {
+    const docClient = getDynamoDBDocumentClient();
+    const tableName = getTableName();
+    const apiKey = process.env.OPENAI_API_KEY ?? '';
+
+    const summaryRepo = new DynamoDBMemorySummaryRepository(docClient, tableName);
+    const messageRepo = new DynamoDBMessageRepository(docClient, tableName, defaultUlidFactory);
+    const innerMemoryRepo = new DynamoDBMemoryRepository(docClient, tableName, defaultUlidFactory);
+    const embeddingClient = new OpenAIEmbeddingClient({ apiKey });
+    const memoryRepo = new EmbeddingMemoryRepository(innerMemoryRepo, embeddingClient);
+    const llmClient = new OpenAIClient({ apiKey });
+
+    const result = await compressAllConversations({
+      docClient,
+      tableName,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    logger.info('[compress-conversations] バッチ完了', {
+      eventId: event.id,
+      ...result,
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: '圧縮要約バッチが正常に完了しました',
+        ...result,
+      }),
+    };
+  } catch (error) {
+    const errorMessage = toErrorMessage(error);
+    logger.error('[compress-conversations] バッチ失敗', {
+      eventId: event.id,
+      error: errorMessage,
+    });
+    await reportErrorEvent({
+      serviceId: SERVICE_ID,
+      severity: 'error',
+      title: '圧縮要約バッチ: 致命的エラー',
+      message: errorMessage,
+      context: { eventId: event.id },
+    });
+
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: '圧縮要約バッチでエラーが発生しました',
+        error: errorMessage,
+      }),
+    };
+  }
+}

--- a/services/livetalk/batch/src/index.ts
+++ b/services/livetalk/batch/src/index.ts
@@ -1,0 +1,6 @@
+export { handler } from './handlers/compress-conversations.handler.js';
+export { compressAllConversations } from './usecases/compress-conversations.usecase.js';
+export type {
+  CompressAllConversationsParams,
+  CompressAllConversationsResult,
+} from './usecases/compress-conversations.usecase.js';

--- a/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
+++ b/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
@@ -6,8 +6,10 @@ import {
   type CompressConversationParams,
 } from '@nagiyu/livetalk-core';
 
-export interface CompressAllConversationsParams
-  extends Omit<CompressConversationParams, 'characterName'> {
+export interface CompressAllConversationsParams extends Omit<
+  CompressConversationParams,
+  'characterName'
+> {
   docClient: DynamoDBDocumentClient;
   tableName: string;
   characterName?: string;

--- a/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
+++ b/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
@@ -1,0 +1,110 @@
+import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { logger, toErrorMessage } from '@nagiyu/common';
+import {
+  DEFAULT_CHARACTER_ID,
+  compressConversation,
+  type CompressConversationParams,
+} from '@nagiyu/livetalk-core';
+
+export interface CompressAllConversationsParams
+  extends Omit<CompressConversationParams, 'characterName'> {
+  docClient: DynamoDBDocumentClient;
+  tableName: string;
+  characterName?: string;
+}
+
+export interface CompressAllConversationsResult {
+  processedUsers: number;
+  skippedUsers: number;
+  failedUsers: number;
+  failedUserIds: string[];
+}
+
+/**
+ * 全アクティブユーザーの会話を圧縮要約する。
+ *
+ * DynamoDB を Scan して Type='Profile' のアイテムを列挙し、
+ * 各ユーザーについて DEFAULT_CHARACTER_ID（hiyori）の会話を圧縮する。
+ */
+export async function compressAllConversations(
+  params: CompressAllConversationsParams
+): Promise<CompressAllConversationsResult> {
+  const {
+    docClient,
+    tableName,
+    llmClient,
+    summaryRepo,
+    messageRepo,
+    memoryRepo,
+    characterName = '桃瀬ひより',
+    now,
+  } = params;
+
+  const userIds = await scanAllUserIds(docClient, tableName);
+
+  logger.info('[compressAllConversations] ユーザー一覧取得完了', {
+    userCount: userIds.length,
+  });
+
+  const result: CompressAllConversationsResult = {
+    processedUsers: 0,
+    skippedUsers: 0,
+    failedUsers: 0,
+    failedUserIds: [],
+  };
+
+  for (const userId of userIds) {
+    try {
+      const before = { ...result };
+      await compressConversation(userId, DEFAULT_CHARACTER_ID, {
+        summaryRepo,
+        messageRepo,
+        memoryRepo,
+        llmClient,
+        characterName,
+        now,
+      });
+      void before;
+      result.processedUsers++;
+    } catch (error) {
+      logger.error('[compressAllConversations] ユーザー処理失敗', {
+        userId,
+        error: toErrorMessage(error),
+      });
+      result.failedUsers++;
+      result.failedUserIds.push(userId);
+    }
+  }
+
+  logger.info('[compressAllConversations] 全ユーザー処理完了', result);
+  return result;
+}
+
+async function scanAllUserIds(
+  docClient: DynamoDBDocumentClient,
+  tableName: string
+): Promise<string[]> {
+  const userIds: string[] = [];
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+  do {
+    const command = new ScanCommand({
+      TableName: tableName,
+      FilterExpression: '#type = :profile',
+      ExpressionAttributeNames: { '#type': 'Type' },
+      ExpressionAttributeValues: { ':profile': 'Profile' },
+      ProjectionExpression: 'UserID',
+      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
+    });
+
+    const response = await docClient.send(command);
+    for (const item of response.Items ?? []) {
+      if (typeof item.UserID === 'string' && item.UserID) {
+        userIds.push(item.UserID);
+      }
+    }
+    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastEvaluatedKey !== undefined);
+
+  return userIds;
+}

--- a/services/livetalk/batch/tests/unit/handlers/compress-conversations.handler.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/compress-conversations.handler.test.ts
@@ -1,0 +1,83 @@
+import type { ScheduledEvent } from '../../../src/handlers/compress-conversations.handler.js';
+
+jest.mock('@nagiyu/aws', () => ({
+  getDynamoDBDocumentClient: jest.fn(() => ({})),
+  getTableName: jest.fn(() => 'test-table'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@nagiyu/livetalk-core', () => ({
+  DynamoDBMemorySummaryRepository: jest.fn(),
+  DynamoDBMessageRepository: jest.fn(),
+  DynamoDBMemoryRepository: jest.fn(),
+  EmbeddingMemoryRepository: jest.fn(),
+  OpenAIClient: jest.fn(),
+  OpenAIEmbeddingClient: jest.fn(),
+  defaultUlidFactory: jest.fn(),
+}));
+
+const mockCompressAll = jest.fn();
+jest.mock('../../../src/usecases/compress-conversations.usecase.js', () => ({
+  compressAllConversations: (...args: unknown[]) => mockCompressAll(...args),
+}));
+
+const makeEvent = (overrides: Partial<ScheduledEvent> = {}): ScheduledEvent => ({
+  version: '0',
+  id: 'event-001',
+  'detail-type': 'Scheduled Event',
+  source: 'aws.events',
+  account: '123456789',
+  time: '2026-05-29T18:00:00Z',
+  region: 'ap-northeast-1',
+  resources: [],
+  detail: {},
+  ...overrides,
+});
+
+describe('compress-conversations handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('正常処理時に 200 を返す', async () => {
+    mockCompressAll.mockResolvedValue({
+      processedUsers: 5,
+      skippedUsers: 0,
+      failedUsers: 0,
+      failedUserIds: [],
+    });
+
+    const { handler } = await import('../../../src/handlers/compress-conversations.handler.js');
+    const response = await handler(makeEvent());
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.processedUsers).toBe(5);
+  });
+
+  it('例外発生時に 500 を返す', async () => {
+    mockCompressAll.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    const { handler } = await import('../../../src/handlers/compress-conversations.handler.js');
+    const response = await handler(makeEvent());
+
+    expect(response.statusCode).toBe(500);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain('DynamoDB 接続エラー');
+  });
+
+  it('例外発生時に reportErrorEvent を呼ぶ', async () => {
+    const { reportErrorEvent } = await import('@nagiyu/aws');
+    mockCompressAll.mockRejectedValue(new Error('fatal'));
+
+    const { handler } = await import('../../../src/handlers/compress-conversations.handler.js');
+    await handler(makeEvent({ id: 'ev-999' }));
+
+    expect(reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'livetalk',
+        severity: 'error',
+      })
+    );
+  });
+});

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -1,0 +1,170 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import {
+  InMemoryMemorySummaryRepository,
+  InMemoryMessageRepository,
+  InMemoryMemoryRepository,
+  type ILLMClient,
+} from '@nagiyu/livetalk-core';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  compressAllConversations,
+  type CompressAllConversationsParams,
+} from '../../../src/usecases/compress-conversations.usecase.js';
+
+const fixedNow = 1_750_000_000_000;
+let tick = fixedNow;
+
+const makeLLMClient = (): ILLMClient & { summarizeCalls: number } => {
+  let summarizeCalls = 0;
+  return {
+    async *chatStream() { yield ''; },
+    async chatComplete() { return ''; },
+    async summarize() {
+      summarizeCalls++;
+      return { mergedSummary: '要約', newMemoryCandidates: [] };
+    },
+    get summarizeCalls() { return summarizeCalls; },
+  };
+};
+
+const makeRepos = () => {
+  const store = new InMemorySingleTableStore();
+  tick = fixedNow;
+  const nowMs = () => tick;
+  const ulidFactory = () => `ULID-${tick++}`;
+  return {
+    summaryRepo: new InMemoryMemorySummaryRepository(store, nowMs),
+    messageRepo: new InMemoryMessageRepository(store, ulidFactory, nowMs),
+    memoryRepo: new InMemoryMemoryRepository(store, ulidFactory, nowMs),
+  };
+};
+
+const makeDocClientMock = (userIds: string[]): DynamoDBDocumentClient => {
+  const items = userIds.map((id) => ({ UserID: id }));
+  return {
+    send: async () => ({ Items: items }),
+  } as unknown as DynamoDBDocumentClient;
+};
+
+const makeParams = (
+  overrides: Partial<CompressAllConversationsParams> = {}
+): CompressAllConversationsParams => {
+  const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+  return {
+    docClient: makeDocClientMock([]),
+    tableName: 'test-table',
+    summaryRepo,
+    messageRepo,
+    memoryRepo,
+    llmClient: makeLLMClient(),
+    ...overrides,
+  };
+};
+
+describe('compressAllConversations', () => {
+  it('ユーザーが 0 件のとき LLM を呼ばない', async () => {
+    const llmClient = makeLLMClient();
+    const result = await compressAllConversations(makeParams({ llmClient }));
+    expect(llmClient.summarizeCalls).toBe(0);
+    expect(result.processedUsers).toBe(0);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('メッセージのないユーザーは処理をスキップする（LLM 呼び出しなし）', async () => {
+    const llmClient = makeLLMClient();
+    const docClient = makeDocClientMock(['u1', 'u2']);
+    const result = await compressAllConversations(makeParams({ llmClient, docClient }));
+    expect(llmClient.summarizeCalls).toBe(0);
+    expect(result.processedUsers).toBe(2);
+  });
+
+  it('メッセージのあるユーザー分だけ LLM を呼ぶ', async () => {
+    const llmClient = makeLLMClient();
+    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
+
+    const docClient = makeDocClientMock(['u1', 'u2']);
+    const result = await compressAllConversations({
+      docClient,
+      tableName: 'test',
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    expect(llmClient.summarizeCalls).toBe(1);
+    expect(result.processedUsers).toBe(2);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('1 ユーザーが失敗しても他のユーザーを継続処理する', async () => {
+    let callCount = 0;
+    const errorClient: ILLMClient = {
+      async *chatStream() { yield ''; },
+      async chatComplete() { return ''; },
+      async summarize() {
+        callCount++;
+        if (callCount === 1) throw new Error('LLM 失敗');
+        return { mergedSummary: '要約', newMemoryCandidates: [] };
+      },
+    };
+
+    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hi' });
+    tick++;
+    await messageRepo.create({ UserID: 'u2', CharacterID: 'hiyori', Role: 'user', Text: 'hi2' });
+
+    const docClient = makeDocClientMock(['u1', 'u2']);
+    const result = await compressAllConversations({
+      docClient,
+      tableName: 'test',
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient: errorClient,
+    });
+
+    expect(result.failedUsers).toBe(1);
+    expect(result.failedUserIds).toContain('u1');
+    expect(result.processedUsers).toBe(1);
+  });
+
+  it('DynamoDB Scan が複数ページに渡るとき全ユーザーを処理する', async () => {
+    const llmClient = makeLLMClient();
+    let pageCount = 0;
+    const pagedDocClient = {
+      send: async () => {
+        pageCount++;
+        if (pageCount === 1) {
+          return {
+            Items: [{ UserID: 'u1' }],
+            LastEvaluatedKey: { PK: 'USER#u1' },
+          };
+        }
+        return { Items: [{ UserID: 'u2' }] };
+      },
+    } as unknown as DynamoDBDocumentClient;
+
+    const result = await compressAllConversations(
+      makeParams({ llmClient, docClient: pagedDocClient })
+    );
+
+    expect(result.processedUsers).toBe(2);
+    expect(pageCount).toBe(2);
+  });
+
+  it('UserID が空や型違いのアイテムを無視する', async () => {
+    const llmClient = makeLLMClient();
+    const docClient = {
+      send: async () => ({
+        Items: [{ UserID: '' }, { UserID: 123 }, { UserID: 'valid-user' }],
+      }),
+    } as unknown as DynamoDBDocumentClient;
+
+    const result = await compressAllConversations(makeParams({ llmClient, docClient }));
+    expect(result.processedUsers).toBe(1);
+  });
+});

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -17,13 +17,19 @@ let tick = fixedNow;
 const makeLLMClient = (): ILLMClient & { summarizeCalls: number } => {
   let summarizeCalls = 0;
   return {
-    async *chatStream() { yield ''; },
-    async chatComplete() { return ''; },
+    async *chatStream() {
+      yield '';
+    },
+    async chatComplete() {
+      return '';
+    },
     async summarize() {
       summarizeCalls++;
       return { mergedSummary: '要約', newMemoryCandidates: [] };
     },
-    get summarizeCalls() { return summarizeCalls; },
+    get summarizeCalls() {
+      return summarizeCalls;
+    },
   };
 };
 
@@ -102,8 +108,12 @@ describe('compressAllConversations', () => {
   it('1 ユーザーが失敗しても他のユーザーを継続処理する', async () => {
     let callCount = 0;
     const errorClient: ILLMClient = {
-      async *chatStream() { yield ''; },
-      async chatComplete() { return ''; },
+      async *chatStream() {
+        yield '';
+      },
+      async chatComplete() {
+        return '';
+      },
       async summarize() {
         callCount++;
         if (callCount === 1) throw new Error('LLM 失敗');

--- a/services/livetalk/batch/tsconfig.json
+++ b/services/livetalk/batch/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../configs/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/services/livetalk/core/package.json
+++ b/services/livetalk/core/package.json
@@ -22,5 +22,10 @@
     "js-tiktoken": "^1.0.21",
     "openai": "^6.33.0",
     "ulid": "^3.0.1"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.4.2",
+    "ts-jest": "^29.4.11"
   }
 }

--- a/services/livetalk/core/src/characters/prompt-builder.ts
+++ b/services/livetalk/core/src/characters/prompt-builder.ts
@@ -15,7 +15,8 @@ export function getTimeOfDay(date: Date): TimeOfDay {
 export function buildSystemPrompt(
   character: CharacterDefinition,
   now: Date,
-  retrievedMemories: RetrievedMemory[] = []
+  retrievedMemories: RetrievedMemory[] = [],
+  summaryText?: string
 ): string {
   const { personality, displayName } = character;
   const timeOfDay = getTimeOfDay(now);
@@ -35,14 +36,23 @@ export function buildSystemPrompt(
 - 返答は短く（1〜3 文程度）、テンポよく続ける
 - セーフティ対応は後続ロジックで処理されるため、ここでは扱わない`.trim();
 
-  if (retrievedMemories.length === 0) return base;
+  const hasSummary = summaryText && summaryText.trim().length > 0;
+  const hasMemories = retrievedMemories.length > 0;
 
-  const memoriesSection = retrievedMemories.map((r) => `- ${r.memory.Content}`).join('\n');
+  if (!hasSummary && !hasMemories) return base;
 
-  return `${base}
+  const sections: string[] = [base];
 
-あなたが覚えていること：
-${memoriesSection}`;
+  if (hasSummary) {
+    sections.push(`あなたがこれまでに知ったこと：\n${summaryText!.trim()}`);
+  }
+
+  if (hasMemories) {
+    const memoriesSection = retrievedMemories.map((r) => `- ${r.memory.Content}`).join('\n');
+    sections.push(`あなたが覚えていること：\n${memoriesSection}`);
+  }
+
+  return sections.join('\n\n');
 }
 
 /**
@@ -58,9 +68,10 @@ export function buildChatMessages(
   now: Date,
   history: MessageEntity[],
   userText: string,
-  retrievedMemories: RetrievedMemory[] = []
+  retrievedMemories: RetrievedMemory[] = [],
+  summaryText?: string
 ): ChatMessage[] {
-  const systemPrompt = buildSystemPrompt(character, now, retrievedMemories);
+  const systemPrompt = buildSystemPrompt(character, now, retrievedMemories, summaryText);
   const messages: ChatMessage[] = [{ role: 'system', content: systemPrompt }];
 
   for (const msg of history) {

--- a/services/livetalk/core/src/entities/memory-summary.entity.ts
+++ b/services/livetalk/core/src/entities/memory-summary.entity.ts
@@ -1,0 +1,15 @@
+export interface MemorySummaryEntity {
+  UserID: string;
+  CharacterID: string;
+  SummaryText: string;
+  LastCompressedAt: number;
+  CreatedAt: number;
+  UpdatedAt: number;
+}
+
+export interface MemorySummaryKey {
+  userId: string;
+  characterId: string;
+}
+
+export type CreateMemorySummaryInput = Omit<MemorySummaryEntity, 'CreatedAt' | 'UpdatedAt'>;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -29,6 +29,11 @@ export type {
 export { TIERS } from './entities/memory.entity.js';
 export type { MessageEntity, MessageKey, CreateMessageInput } from './entities/message.entity.js';
 export type {
+  MemorySummaryEntity,
+  MemorySummaryKey,
+  CreateMemorySummaryInput,
+} from './entities/memory-summary.entity.js';
+export type {
   SafetyEventEntity,
   SafetyEventKey,
   CreateSafetyEventInput,
@@ -48,6 +53,7 @@ export type {
 
 // Mappers
 export { MemoryMapper } from './mappers/memory.mapper.js';
+export { MemorySummaryMapper } from './mappers/memory-summary.mapper.js';
 export { MessageMapper } from './mappers/message.mapper.js';
 export { ProfileMapper } from './mappers/profile.mapper.js';
 export { CharacterStateMapper } from './mappers/character-state.mapper.js';
@@ -64,10 +70,12 @@ export {
   buildMemoryTierSKPrefix,
   buildMemoryCategoryInTierSKPrefix,
   buildMemoryAllTiersSKPrefix,
+  buildMemorySummarySK,
 } from './mappers/keys.js';
 
 // Repository interfaces
 export type { MemoryRepository } from './repositories/memory.repository.interface.js';
+export type { MemorySummaryRepository } from './repositories/memory-summary.repository.interface.js';
 export type {
   MessageRepository,
   GetRecentByTokenBudgetOptions,
@@ -80,11 +88,13 @@ export type { SafetyEventRepository } from './repositories/safety-event.reposito
 // Repository implementations
 export { EmbeddingMemoryRepository } from './repositories/embedding-memory.repository.js';
 export { DynamoDBMemoryRepository } from './repositories/dynamodb-memory.repository.js';
+export { DynamoDBMemorySummaryRepository } from './repositories/dynamodb-memory-summary.repository.js';
 export { DynamoDBMessageRepository } from './repositories/dynamodb-message.repository.js';
 export { DynamoDBProfileRepository } from './repositories/dynamodb-profile.repository.js';
 export { DynamoDBCharacterStateRepository } from './repositories/dynamodb-character-state.repository.js';
 export { DynamoDBSafetyEventRepository } from './repositories/dynamodb-safety-event.repository.js';
 export { InMemoryMemoryRepository } from './repositories/in-memory-memory.repository.js';
+export { InMemoryMemorySummaryRepository } from './repositories/in-memory-memory-summary.repository.js';
 export { InMemoryMessageRepository } from './repositories/in-memory-message.repository.js';
 export { InMemoryProfileRepository } from './repositories/in-memory-profile.repository.js';
 export { InMemoryCharacterStateRepository } from './repositories/in-memory-character-state.repository.js';

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -19,6 +19,12 @@ export { SentenceBuffer } from './lib/sentence-splitter.js';
 // Chat usecase
 export { runChatUseCase, type ChatEvent, type ChatUseCaseParams } from './usecases/chat-usecase.js';
 
+// Compress conversation usecase
+export {
+  compressConversation,
+  type CompressConversationParams,
+} from './usecases/compress-conversation.usecase.js';
+
 // Entities
 export type {
   MemoryEntity,

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './voicevox/index.js';
 export * from './llm-client/index.js';
+export type { SummarizeInput, SummarizeResult, MemoryCandidate } from './llm-client/types.js';
 export * from './constants.js';
 
 // Memory retrieval

--- a/services/livetalk/core/src/llm-client/index.ts
+++ b/services/livetalk/core/src/llm-client/index.ts
@@ -22,6 +22,7 @@ export {
   OpenAIClient,
   OPENAI_DEFAULT_MODELS,
   OPENAI_ERROR_MESSAGES,
+  parseSummarizeResult,
   type OpenAIClientOptions,
 } from './openai-client.js';
 

--- a/services/livetalk/core/src/llm-client/openai-client.ts
+++ b/services/livetalk/core/src/llm-client/openai-client.ts
@@ -129,10 +129,9 @@ ${messagesSection}
   ]
 }`;
 
-    const rawText = await this.chatComplete(
-      [{ role: 'user', content: prompt }],
-      { purpose: 'summarize' }
-    );
+    const rawText = await this.chatComplete([{ role: 'user', content: prompt }], {
+      purpose: 'summarize',
+    });
 
     return parseSummarizeResult(rawText);
   }
@@ -160,21 +159,20 @@ export function parseSummarizeResult(rawText: string): SummarizeResult {
   let json: Record<string, unknown>;
   try {
     // LLM が ```json ... ``` で囲む場合を考慮して、コードブロックを除去する
-    const cleaned = rawText.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const cleaned = rawText
+      .replace(/^```(?:json)?\s*/i, '')
+      .replace(/\s*```$/i, '')
+      .trim();
     json = JSON.parse(cleaned) as Record<string, unknown>;
   } catch {
     return { mergedSummary: rawText.trim(), newMemoryCandidates: [] };
   }
 
-  const mergedSummary =
-    typeof json.mergedSummary === 'string' ? json.mergedSummary : '';
+  const mergedSummary = typeof json.mergedSummary === 'string' ? json.mergedSummary : '';
 
   const candidates = Array.isArray(json.newMemoryCandidates) ? json.newMemoryCandidates : [];
   const newMemoryCandidates: MemoryCandidate[] = candidates
-    .filter(
-      (c): c is Record<string, unknown> =>
-        typeof c === 'object' && c !== null
-    )
+    .filter((c): c is Record<string, unknown> => typeof c === 'object' && c !== null)
     .map((c) => ({
       category: typeof c.category === 'string' ? c.category : 'general',
       content: typeof c.content === 'string' ? c.content : '',

--- a/services/livetalk/core/src/llm-client/openai-client.ts
+++ b/services/livetalk/core/src/llm-client/openai-client.ts
@@ -10,7 +10,10 @@ import type {
   ChatOptions,
   IEmbeddingClient,
   ILLMClient,
+  MemoryCandidate,
   PurposeModelMap,
+  SummarizeInput,
+  SummarizeResult,
 } from './types.js';
 
 /**
@@ -100,6 +103,40 @@ export class OpenAIClient implements ILLMClient {
     return response.output_text ?? '';
   }
 
+  public async summarize(input: SummarizeInput): Promise<SummarizeResult> {
+    const { existingSummary, newMessages, characterName } = input;
+
+    const existingSection = existingSummary
+      ? `既存の要約：\n${existingSummary}`
+      : '既存の要約：なし';
+
+    const messagesSection = newMessages
+      .map((m) => `${m.role === 'user' ? 'ユーザー' : characterName}: ${m.text}`)
+      .join('\n');
+
+    const prompt = `以下は ${characterName} とユーザーとの会話です。
+
+${existingSection}
+
+新しい会話：
+${messagesSection}
+
+以下の JSON を返してください（余分なテキストなし）：
+{
+  "mergedSummary": "既存と新規をマージした最新要約（日本語）",
+  "newMemoryCandidates": [
+    { "category": "カテゴリ名", "content": "記憶の内容（日本語）" }
+  ]
+}`;
+
+    const rawText = await this.chatComplete(
+      [{ role: 'user', content: prompt }],
+      { purpose: 'summarize' }
+    );
+
+    return parseSummarizeResult(rawText);
+  }
+
   private assertMessages(messages: ChatMessage[]): void {
     if (messages.length === 0) {
       throw new Error(OPENAI_ERROR_MESSAGES.EMPTY_MESSAGES);
@@ -117,6 +154,34 @@ export class OpenAIClient implements ILLMClient {
 
 function toEasyInputMessage(msg: ChatMessage): EasyInputMessage {
   return { role: msg.role, content: msg.content, type: 'message' };
+}
+
+export function parseSummarizeResult(rawText: string): SummarizeResult {
+  let json: Record<string, unknown>;
+  try {
+    // LLM が ```json ... ``` で囲む場合を考慮して、コードブロックを除去する
+    const cleaned = rawText.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    json = JSON.parse(cleaned) as Record<string, unknown>;
+  } catch {
+    return { mergedSummary: rawText.trim(), newMemoryCandidates: [] };
+  }
+
+  const mergedSummary =
+    typeof json.mergedSummary === 'string' ? json.mergedSummary : '';
+
+  const candidates = Array.isArray(json.newMemoryCandidates) ? json.newMemoryCandidates : [];
+  const newMemoryCandidates: MemoryCandidate[] = candidates
+    .filter(
+      (c): c is Record<string, unknown> =>
+        typeof c === 'object' && c !== null
+    )
+    .map((c) => ({
+      category: typeof c.category === 'string' ? c.category : 'general',
+      content: typeof c.content === 'string' ? c.content : '',
+    }))
+    .filter((c) => c.content.length > 0);
+
+  return { mergedSummary, newMemoryCandidates };
 }
 
 /** OpenAI embedding API で使用するモデル。軽量・高速・低コスト。 */

--- a/services/livetalk/core/src/llm-client/types.ts
+++ b/services/livetalk/core/src/llm-client/types.ts
@@ -45,6 +45,7 @@ export interface ChatOptions {
  *
  * - `chatStream`: ストリーミング応答。`AsyncIterable<string>` でテキスト delta を逐次返す
  * - `chatComplete`: 一括応答。完成したテキストを返す
+ * - `summarize`: 会話圧縮要約。既存要約と新着メッセージをマージして新要約 + 記憶候補を返す
  *
  * ネットワークエラー・rate limit 等は Error として throw される（Provider のエラーをそのまま伝播）。
  * リトライは呼び出し側の責務。
@@ -52,12 +53,38 @@ export interface ChatOptions {
 export interface ILLMClient {
   chatStream(messages: ChatMessage[], options?: ChatOptions): AsyncIterable<string>;
   chatComplete(messages: ChatMessage[], options?: ChatOptions): Promise<string>;
+  summarize(input: SummarizeInput): Promise<SummarizeResult>;
 }
 
 /**
  * 用途別モデルマップ。Provider 実装側で既定値を持ち、コンストラクタで上書き可能。
  */
 export type PurposeModelMap = Record<ChatPurpose, string>;
+
+/**
+ * `ILLMClient.summarize` の入力。
+ */
+export interface SummarizeInput {
+  existingSummary: string | undefined;
+  newMessages: Array<{ role: 'user' | 'assistant'; text: string }>;
+  characterName: string;
+}
+
+/**
+ * 抽出された新規記憶候補（Tier C として保存される）。
+ */
+export interface MemoryCandidate {
+  category: string;
+  content: string;
+}
+
+/**
+ * `ILLMClient.summarize` の出力。
+ */
+export interface SummarizeResult {
+  mergedSummary: string;
+  newMemoryCandidates: MemoryCandidate[];
+}
 
 /**
  * Embedding クライアントの抽象インターフェース。

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -75,3 +75,7 @@ export function buildMemorySK(
 ): string {
   return `CHAR#${characterId}#MEM#${tier}#${category}#${memoryId}`;
 }
+
+export function buildMemorySummarySK(characterId: string): string {
+  return `CHAR#${characterId}#MEMORY#SUMMARY`;
+}

--- a/services/livetalk/core/src/mappers/memory-summary.mapper.ts
+++ b/services/livetalk/core/src/mappers/memory-summary.mapper.ts
@@ -1,0 +1,53 @@
+import {
+  validateStringField,
+  validateTimestampField,
+  type DynamoDBItem,
+  type EntityMapper,
+} from '@nagiyu/aws';
+import type {
+  MemorySummaryEntity,
+  MemorySummaryKey,
+} from '../entities/memory-summary.entity.js';
+import { buildMemorySummarySK, buildUserPK } from './keys.js';
+
+export class MemorySummaryMapper
+  implements EntityMapper<MemorySummaryEntity, MemorySummaryKey>
+{
+  public readonly entityType = 'MemorySummary';
+
+  public toItem(entity: MemorySummaryEntity): DynamoDBItem {
+    const { pk, sk } = this.buildKeys({
+      userId: entity.UserID,
+      characterId: entity.CharacterID,
+    });
+    return {
+      PK: pk,
+      SK: sk,
+      Type: this.entityType,
+      UserID: entity.UserID,
+      CharacterID: entity.CharacterID,
+      SummaryText: entity.SummaryText,
+      LastCompressedAt: entity.LastCompressedAt,
+      CreatedAt: entity.CreatedAt,
+      UpdatedAt: entity.UpdatedAt,
+    };
+  }
+
+  public toEntity(item: DynamoDBItem): MemorySummaryEntity {
+    return {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
+      SummaryText: validateStringField(item.SummaryText, 'SummaryText', { allowEmpty: true }),
+      LastCompressedAt: validateTimestampField(item.LastCompressedAt, 'LastCompressedAt'),
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
+    };
+  }
+
+  public buildKeys(key: MemorySummaryKey): { pk: string; sk: string } {
+    return {
+      pk: buildUserPK(key.userId),
+      sk: buildMemorySummarySK(key.characterId),
+    };
+  }
+}

--- a/services/livetalk/core/src/mappers/memory-summary.mapper.ts
+++ b/services/livetalk/core/src/mappers/memory-summary.mapper.ts
@@ -4,15 +4,10 @@ import {
   type DynamoDBItem,
   type EntityMapper,
 } from '@nagiyu/aws';
-import type {
-  MemorySummaryEntity,
-  MemorySummaryKey,
-} from '../entities/memory-summary.entity.js';
+import type { MemorySummaryEntity, MemorySummaryKey } from '../entities/memory-summary.entity.js';
 import { buildMemorySummarySK, buildUserPK } from './keys.js';
 
-export class MemorySummaryMapper
-  implements EntityMapper<MemorySummaryEntity, MemorySummaryKey>
-{
+export class MemorySummaryMapper implements EntityMapper<MemorySummaryEntity, MemorySummaryKey> {
   public readonly entityType = 'MemorySummary';
 
   public toItem(entity: MemorySummaryEntity): DynamoDBItem {

--- a/services/livetalk/core/src/repositories/dynamodb-memory-summary.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-memory-summary.repository.ts
@@ -1,0 +1,88 @@
+import {
+  GetCommand,
+  UpdateCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
+import type {
+  CreateMemorySummaryInput,
+  MemorySummaryEntity,
+} from '../entities/memory-summary.entity.js';
+import { MemorySummaryMapper } from '../mappers/memory-summary.mapper.js';
+import { buildMemorySummarySK, buildUserPK } from '../mappers/keys.js';
+import type { MemorySummaryRepository } from './memory-summary.repository.interface.js';
+
+export class DynamoDBMemorySummaryRepository implements MemorySummaryRepository {
+  private readonly mapper: MemorySummaryMapper;
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly nowMs: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.nowMs = nowMs;
+    this.mapper = new MemorySummaryMapper();
+  }
+
+  public async get(userId: string, characterId: string): Promise<MemorySummaryEntity | null> {
+    try {
+      const pk = buildUserPK(userId);
+      const sk = buildMemorySummarySK(characterId);
+      const result = await this.docClient.send(
+        new GetCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+        })
+      );
+      if (!result.Item) return null;
+      return this.mapper.toEntity(result.Item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async put(input: CreateMemorySummaryInput): Promise<MemorySummaryEntity> {
+    const now = this.nowMs();
+    const pk = buildUserPK(input.UserID);
+    const sk = buildMemorySummarySK(input.CharacterID);
+
+    try {
+      const result = await this.docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+          UpdateExpression: [
+            'SET #type = :type',
+            'UserID = :userId',
+            'CharacterID = :characterId',
+            'SummaryText = :summaryText',
+            'LastCompressedAt = :lastCompressedAt',
+            'UpdatedAt = :updatedAt',
+            'CreatedAt = if_not_exists(CreatedAt, :createdAt)',
+          ].join(', '),
+          ExpressionAttributeNames: { '#type': 'Type' },
+          ExpressionAttributeValues: {
+            ':type': this.mapper.entityType,
+            ':userId': input.UserID,
+            ':characterId': input.CharacterID,
+            ':summaryText': input.SummaryText,
+            ':lastCompressedAt': input.LastCompressedAt,
+            ':updatedAt': now,
+            ':createdAt': now,
+          },
+          ReturnValues: 'ALL_NEW',
+        })
+      );
+      return this.mapper.toEntity(result.Attributes as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+}

--- a/services/livetalk/core/src/repositories/dynamodb-memory-summary.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-memory-summary.repository.ts
@@ -1,8 +1,4 @@
-import {
-  GetCommand,
-  UpdateCommand,
-  type DynamoDBDocumentClient,
-} from '@aws-sdk/lib-dynamodb';
+import { GetCommand, UpdateCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
 import type {
   CreateMemorySummaryInput,

--- a/services/livetalk/core/src/repositories/dynamodb-message.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-message.repository.ts
@@ -96,6 +96,58 @@ export class DynamoDBMessageRepository implements MessageRepository {
     }
   }
 
+  public async listSince(
+    userId: string,
+    characterId: string,
+    sinceMs: number
+  ): Promise<MessageEntity[]> {
+    const pk = buildUserPK(userId);
+    const skPrefix = buildMessageSKPrefix(characterId);
+    const results: MessageEntity[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            FilterExpression: sinceMs > 0 ? 'CreatedAt > :sinceMs' : undefined,
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: {
+              ':pk': pk,
+              ':prefix': skPrefix,
+              ...(sinceMs > 0 && { ':sinceMs': sinceMs }),
+            },
+            ScanIndexForward: true,
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        try {
+          results.push(this.mapper.toEntity(raw as unknown as DynamoDBItem));
+        } catch (error) {
+          logger.warn('無効なメッセージデータをスキップしました', {
+            pk: (raw as Record<string, unknown>).PK,
+            sk: (raw as Record<string, unknown>).SK,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      if (!result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return results;
+  }
+
   public async getRecentByTokenBudget(
     options: GetRecentByTokenBudgetOptions
   ): Promise<RecentMessagesResult> {

--- a/services/livetalk/core/src/repositories/in-memory-memory-summary.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-memory-summary.repository.ts
@@ -11,10 +11,7 @@ export class InMemoryMemorySummaryRepository implements MemorySummaryRepository 
   private readonly store: InMemorySingleTableStore;
   private readonly nowMs: () => number;
 
-  constructor(
-    store: InMemorySingleTableStore,
-    nowMs: () => number = () => Date.now()
-  ) {
+  constructor(store: InMemorySingleTableStore, nowMs: () => number = () => Date.now()) {
     this.store = store;
     this.nowMs = nowMs;
     this.mapper = new MemorySummaryMapper();

--- a/services/livetalk/core/src/repositories/in-memory-memory-summary.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-memory-summary.repository.ts
@@ -1,0 +1,47 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import type {
+  CreateMemorySummaryInput,
+  MemorySummaryEntity,
+} from '../entities/memory-summary.entity.js';
+import { MemorySummaryMapper } from '../mappers/memory-summary.mapper.js';
+import type { MemorySummaryRepository } from './memory-summary.repository.interface.js';
+
+export class InMemoryMemorySummaryRepository implements MemorySummaryRepository {
+  private readonly mapper: MemorySummaryMapper;
+  private readonly store: InMemorySingleTableStore;
+  private readonly nowMs: () => number;
+
+  constructor(
+    store: InMemorySingleTableStore,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.store = store;
+    this.nowMs = nowMs;
+    this.mapper = new MemorySummaryMapper();
+  }
+
+  public async get(userId: string, characterId: string): Promise<MemorySummaryEntity | null> {
+    const { pk, sk } = this.mapper.buildKeys({ userId, characterId });
+    const item = this.store.get(pk, sk);
+    if (!item) return null;
+    return this.mapper.toEntity(item);
+  }
+
+  public async put(input: CreateMemorySummaryInput): Promise<MemorySummaryEntity> {
+    const now = this.nowMs();
+    const { pk, sk } = this.mapper.buildKeys({
+      userId: input.UserID,
+      characterId: input.CharacterID,
+    });
+    const existing = this.store.get(pk, sk);
+    const createdAt = existing ? (existing.CreatedAt as number) : now;
+
+    const entity: MemorySummaryEntity = {
+      ...input,
+      CreatedAt: createdAt,
+      UpdatedAt: now,
+    };
+    this.store.put(this.mapper.toItem(entity));
+    return entity;
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-message.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-message.repository.ts
@@ -60,6 +60,24 @@ export class InMemoryMessageRepository implements MessageRepository {
     return this.mapper.toEntity(item);
   }
 
+  public async listSince(
+    userId: string,
+    characterId: string,
+    sinceMs: number
+  ): Promise<MessageEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildMessageSKPrefix(characterId);
+
+    const { items } = this.store.query(
+      { pk, sk: { operator: 'begins_with', value: prefix } },
+      { limit: Number.MAX_SAFE_INTEGER }
+    );
+
+    const filtered = sinceMs > 0 ? items.filter((i) => (i.CreatedAt as number) > sinceMs) : items;
+    const sorted = [...filtered].sort((a, b) => (a.SK < b.SK ? -1 : a.SK > b.SK ? 1 : 0));
+    return sorted.map((i) => this.mapper.toEntity(i));
+  }
+
   public async getRecentByTokenBudget(
     options: GetRecentByTokenBudgetOptions
   ): Promise<RecentMessagesResult> {

--- a/services/livetalk/core/src/repositories/memory-summary.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/memory-summary.repository.interface.ts
@@ -1,0 +1,9 @@
+import type {
+  CreateMemorySummaryInput,
+  MemorySummaryEntity,
+} from '../entities/memory-summary.entity.js';
+
+export interface MemorySummaryRepository {
+  get(userId: string, characterId: string): Promise<MemorySummaryEntity | null>;
+  put(input: CreateMemorySummaryInput): Promise<MemorySummaryEntity>;
+}

--- a/services/livetalk/core/src/repositories/message.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/message.repository.interface.ts
@@ -42,6 +42,7 @@ export interface RecentMessagesResult {
  * 会話メッセージのリポジトリ。
  *
  * Phase 2a では「保存」と「トークン上限ベースの直近取得」のみを公開する。
+ * Phase 3c で `listSince` を追加（圧縮要約バッチ用）。
  * 単発取得・削除等は今後の Phase で必要になった時点で追加する。
  */
 export interface MessageRepository {
@@ -61,4 +62,11 @@ export interface MessageRepository {
    * 返す配列は時系列昇順（古い順）に並び替えてある。
    */
   getRecentByTokenBudget(options: GetRecentByTokenBudgetOptions): Promise<RecentMessagesResult>;
+
+  /**
+   * 指定日時以降（`sinceMs` 以降、exclusive）のメッセージを時系列昇順で全件返す。
+   * `sinceMs` が 0 の場合は全件を返す。
+   * 圧縮要約バッチが前回圧縮後のメッセージのみを処理するために使用する。
+   */
+  listSince(userId: string, characterId: string, sinceMs: number): Promise<MessageEntity[]>;
 }

--- a/services/livetalk/core/src/usecases/compress-conversation.usecase.ts
+++ b/services/livetalk/core/src/usecases/compress-conversation.usecase.ts
@@ -1,0 +1,88 @@
+import { logger } from '@nagiyu/common';
+import { MEMORY_DEFAULT_CONFIDENCE } from '../constants.js';
+import type { MemorySummaryRepository } from '../repositories/memory-summary.repository.interface.js';
+import type { MessageRepository } from '../repositories/message.repository.interface.js';
+import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
+import type { ILLMClient } from '../llm-client/types.js';
+
+export interface CompressConversationParams {
+  summaryRepo: MemorySummaryRepository;
+  messageRepo: MessageRepository;
+  memoryRepo: MemoryRepository;
+  llmClient: ILLMClient;
+  characterName: string;
+  now?: () => number;
+}
+
+/**
+ * 1 ユーザー × 1 キャラの会話を圧縮要約する。
+ *
+ * 処理フロー：
+ * 1. MEMORY#SUMMARY の最終圧縮時刻を取得
+ * 2. lastCompressedAt 以降のメッセージを listSince で取得
+ * 3. メッセージが 0 件なら何もしない（return）
+ * 4. LLM で要約 + 新規記憶候補抽出
+ * 5. MEMORY#SUMMARY を更新（既存 + 新規をマージした要約）
+ * 6. 新規記憶候補を Tier C として保存（embedding・TTL はリポジトリ任せ）
+ */
+export async function compressConversation(
+  userId: string,
+  characterId: string,
+  params: CompressConversationParams
+): Promise<void> {
+  const {
+    summaryRepo,
+    messageRepo,
+    memoryRepo,
+    llmClient,
+    characterName,
+    now = () => Date.now(),
+  } = params;
+
+  const summary = await summaryRepo.get(userId, characterId);
+  const lastCompressedAt = summary?.LastCompressedAt ?? 0;
+
+  const messages = await messageRepo.listSince(userId, characterId, lastCompressedAt);
+
+  if (messages.length === 0) {
+    logger.info('[compressConversation] スキップ（新着メッセージなし）', { userId, characterId });
+    return;
+  }
+
+  logger.info('[compressConversation] 圧縮開始', {
+    userId,
+    characterId,
+    messageCount: messages.length,
+  });
+
+  const result = await llmClient.summarize({
+    existingSummary: summary?.SummaryText,
+    newMessages: messages.map((m) => ({ role: m.Role, text: m.Text })),
+    characterName,
+  });
+
+  await summaryRepo.put({
+    UserID: userId,
+    CharacterID: characterId,
+    SummaryText: result.mergedSummary,
+    LastCompressedAt: now(),
+  });
+
+  for (const candidate of result.newMemoryCandidates) {
+    await memoryRepo.put({
+      UserID: userId,
+      CharacterID: characterId,
+      Tier: 'C',
+      Category: candidate.category,
+      Content: candidate.content,
+      Confidence: MEMORY_DEFAULT_CONFIDENCE.C,
+      ReferencedCount: 0,
+    });
+  }
+
+  logger.info('[compressConversation] 圧縮完了', {
+    userId,
+    characterId,
+    candidateCount: result.newMemoryCandidates.length,
+  });
+}

--- a/services/livetalk/core/tests/unit/characters/prompt-builder.test.ts
+++ b/services/livetalk/core/tests/unit/characters/prompt-builder.test.ts
@@ -160,4 +160,26 @@ describe('buildChatMessages', () => {
     const messages = buildChatMessages(hiyori, new Date(), [], 'こんにちは', []);
     expect(messages[0].content).not.toContain('あなたが覚えていること');
   });
+
+  it('summaryText が渡されると system prompt に圧縮要約セクションが注入される', () => {
+    const messages = buildChatMessages(hiyori, new Date(), [], 'hi', [], 'コーヒーとケーキが好き');
+    expect(messages[0].content).toContain('あなたがこれまでに知ったこと');
+    expect(messages[0].content).toContain('コーヒーとケーキが好き');
+  });
+
+  it('summaryText が空文字の場合は圧縮要約セクションを挿入しない', () => {
+    const messages = buildChatMessages(hiyori, new Date(), [], 'hi', [], '');
+    expect(messages[0].content).not.toContain('あなたがこれまでに知ったこと');
+  });
+
+  it('summaryText と retrievedMemories の両方がある場合、要約が先に来る', () => {
+    const memories = [makeRetrievedMemory('ケーキが好き', 'B')];
+    const messages = buildChatMessages(hiyori, new Date(), [], 'hi', memories, '長期要約テキスト');
+    const content = messages[0].content;
+    const summaryIdx = content.indexOf('あなたがこれまでに知ったこと');
+    const memoriesIdx = content.indexOf('あなたが覚えていること');
+    expect(summaryIdx).toBeGreaterThan(-1);
+    expect(memoriesIdx).toBeGreaterThan(-1);
+    expect(summaryIdx).toBeLessThan(memoriesIdx);
+  });
 });

--- a/services/livetalk/core/tests/unit/llm-client/openai-client.test.ts
+++ b/services/livetalk/core/tests/unit/llm-client/openai-client.test.ts
@@ -3,8 +3,9 @@ import {
   OpenAIClient,
   OPENAI_DEFAULT_MODELS,
   OPENAI_ERROR_MESSAGES,
+  parseSummarizeResult,
 } from '../../../src/llm-client/openai-client.js';
-import type { ChatMessage } from '../../../src/llm-client/types.js';
+import type { ChatMessage, SummarizeInput } from '../../../src/llm-client/types.js';
 
 function makeStreamEvents(deltas: Array<string | null>): AsyncIterable<unknown> {
   return {
@@ -192,5 +193,102 @@ describe('OpenAIClient', () => {
 
       await expect(livetalk.chatComplete([])).rejects.toThrow(OPENAI_ERROR_MESSAGES.EMPTY_MESSAGES);
     });
+  });
+
+  describe('summarize', () => {
+    const baseInput: SummarizeInput = {
+      existingSummary: 'コーヒーが好き',
+      newMessages: [
+        { role: 'user', text: 'ケーキも好きだよ' },
+        { role: 'assistant', text: 'そうなんだね！' },
+      ],
+      characterName: 'ひより',
+    };
+
+    it('chatComplete を purpose=summarize で呼び出す', async () => {
+      const { client, create } = makeMockOpenAI();
+      create.mockResolvedValue({ output_text: '{"mergedSummary":"テスト","newMemoryCandidates":[]}' });
+      const livetalk = new OpenAIClient({ client });
+      await livetalk.summarize(baseInput);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({ model: OPENAI_DEFAULT_MODELS.summarize })
+      );
+    });
+
+    it('JSON レスポンスを SummarizeResult に変換する', async () => {
+      const { client, create } = makeMockOpenAI();
+      create.mockResolvedValue({
+        output_text: JSON.stringify({
+          mergedSummary: 'コーヒーとケーキが好き',
+          newMemoryCandidates: [{ category: 'food', content: 'ケーキが好き' }],
+        }),
+      });
+      const livetalk = new OpenAIClient({ client });
+      const result = await livetalk.summarize(baseInput);
+      expect(result.mergedSummary).toBe('コーヒーとケーキが好き');
+      expect(result.newMemoryCandidates).toHaveLength(1);
+      expect(result.newMemoryCandidates[0].category).toBe('food');
+    });
+
+    it('existingSummary が undefined のとき「既存の要約：なし」をプロンプトに含める', async () => {
+      const { client, create } = makeMockOpenAI();
+      create.mockResolvedValue({ output_text: '{"mergedSummary":"","newMemoryCandidates":[]}' });
+      const livetalk = new OpenAIClient({ client });
+      await livetalk.summarize({ ...baseInput, existingSummary: undefined });
+      const calledMessages = (create.mock.calls[0] as [{ input: Array<{ content: string }> }])[0].input;
+      expect(calledMessages[0].content).toContain('既存の要約：なし');
+    });
+  });
+});
+
+describe('parseSummarizeResult', () => {
+  it('正常な JSON をパースする', () => {
+    const raw = JSON.stringify({
+      mergedSummary: 'まとめ',
+      newMemoryCandidates: [{ category: 'hobby', content: '映画好き' }],
+    });
+    const result = parseSummarizeResult(raw);
+    expect(result.mergedSummary).toBe('まとめ');
+    expect(result.newMemoryCandidates).toHaveLength(1);
+  });
+
+  it('```json コードブロックを除去してパースする', () => {
+    const raw = '```json\n{"mergedSummary":"テスト","newMemoryCandidates":[]}\n```';
+    const result = parseSummarizeResult(raw);
+    expect(result.mergedSummary).toBe('テスト');
+  });
+
+  it('JSON パース失敗時は rawText を mergedSummary に、candidates を空配列にする', () => {
+    const result = parseSummarizeResult('これは JSON ではない');
+    expect(result.mergedSummary).toBe('これは JSON ではない');
+    expect(result.newMemoryCandidates).toEqual([]);
+  });
+
+  it('newMemoryCandidates が配列でない場合は空配列にする', () => {
+    const raw = JSON.stringify({ mergedSummary: 'ok', newMemoryCandidates: 'bad' });
+    const result = parseSummarizeResult(raw);
+    expect(result.newMemoryCandidates).toEqual([]);
+  });
+
+  it('content が空の候補は除外する', () => {
+    const raw = JSON.stringify({
+      mergedSummary: 'ok',
+      newMemoryCandidates: [
+        { category: 'a', content: '' },
+        { category: 'b', content: '有効' },
+      ],
+    });
+    const result = parseSummarizeResult(raw);
+    expect(result.newMemoryCandidates).toHaveLength(1);
+    expect(result.newMemoryCandidates[0].content).toBe('有効');
+  });
+
+  it('category が文字列でない場合は "general" にフォールバックする', () => {
+    const raw = JSON.stringify({
+      mergedSummary: 'ok',
+      newMemoryCandidates: [{ category: 123, content: 'test' }],
+    });
+    const result = parseSummarizeResult(raw);
+    expect(result.newMemoryCandidates[0].category).toBe('general');
   });
 });

--- a/services/livetalk/core/tests/unit/llm-client/openai-client.test.ts
+++ b/services/livetalk/core/tests/unit/llm-client/openai-client.test.ts
@@ -207,7 +207,9 @@ describe('OpenAIClient', () => {
 
     it('chatComplete を purpose=summarize で呼び出す', async () => {
       const { client, create } = makeMockOpenAI();
-      create.mockResolvedValue({ output_text: '{"mergedSummary":"テスト","newMemoryCandidates":[]}' });
+      create.mockResolvedValue({
+        output_text: '{"mergedSummary":"テスト","newMemoryCandidates":[]}',
+      });
       const livetalk = new OpenAIClient({ client });
       await livetalk.summarize(baseInput);
       expect(create).toHaveBeenCalledWith(
@@ -235,7 +237,8 @@ describe('OpenAIClient', () => {
       create.mockResolvedValue({ output_text: '{"mergedSummary":"","newMemoryCandidates":[]}' });
       const livetalk = new OpenAIClient({ client });
       await livetalk.summarize({ ...baseInput, existingSummary: undefined });
-      const calledMessages = (create.mock.calls[0] as [{ input: Array<{ content: string }> }])[0].input;
+      const calledMessages = (create.mock.calls[0] as [{ input: Array<{ content: string }> }])[0]
+        .input;
       expect(calledMessages[0].content).toContain('既存の要約：なし');
     });
   });

--- a/services/livetalk/core/tests/unit/mappers/memory-summary.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/memory-summary.mapper.test.ts
@@ -1,0 +1,57 @@
+import { MemorySummaryMapper } from '../../../src/mappers/memory-summary.mapper.js';
+
+const mapper = new MemorySummaryMapper();
+
+const entity = {
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  SummaryText: 'コーヒーが好きな人',
+  LastCompressedAt: 1_750_000_000_000,
+  CreatedAt: 1_749_000_000_000,
+  UpdatedAt: 1_750_000_000_000,
+};
+
+const item = {
+  PK: 'USER#u1',
+  SK: 'CHAR#hiyori#MEMORY#SUMMARY',
+  Type: 'MemorySummary',
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  SummaryText: 'コーヒーが好きな人',
+  LastCompressedAt: 1_750_000_000_000,
+  CreatedAt: 1_749_000_000_000,
+  UpdatedAt: 1_750_000_000_000,
+};
+
+describe('MemorySummaryMapper', () => {
+  describe('buildKeys', () => {
+    it('正しい PK / SK を生成する', () => {
+      const { pk, sk } = mapper.buildKeys({ userId: 'u1', characterId: 'hiyori' });
+      expect(pk).toBe('USER#u1');
+      expect(sk).toBe('CHAR#hiyori#MEMORY#SUMMARY');
+    });
+  });
+
+  describe('toItem', () => {
+    it('エンティティを DynamoDB アイテムに変換する', () => {
+      expect(mapper.toItem(entity)).toEqual(item);
+    });
+  });
+
+  describe('toEntity', () => {
+    it('DynamoDB アイテムをエンティティに変換する', () => {
+      expect(mapper.toEntity(item)).toEqual(entity);
+    });
+
+    it('SummaryText が空文字でも変換できる', () => {
+      const emptyItem = { ...item, SummaryText: '' };
+      const result = mapper.toEntity(emptyItem);
+      expect(result.SummaryText).toBe('');
+    });
+
+    it('必須フィールドが欠損していると例外を投げる', () => {
+      const badItem = { ...item, UserID: undefined };
+      expect(() => mapper.toEntity(badItem)).toThrow();
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-memory-summary.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-memory-summary.repository.test.ts
@@ -1,0 +1,124 @@
+import { GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError } from '@nagiyu/aws';
+import { DynamoDBMemorySummaryRepository } from '../../../src/repositories/dynamodb-memory-summary.repository.js';
+import type { CreateMemorySummaryInput } from '../../../src/entities/memory-summary.entity.js';
+
+type SendHandler = (command: unknown) => Promise<unknown>;
+const makeClient = (handler: SendHandler) => ({ send: handler });
+
+const fixedNow = 1_750_000_000_000;
+const tableName = 'nagiyu-livetalk-dev';
+
+const baseInput: CreateMemorySummaryInput = {
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  SummaryText: 'コーヒーが好きな人',
+  LastCompressedAt: fixedNow,
+};
+
+const mockAttributes = {
+  PK: 'USER#u1',
+  SK: 'CHAR#hiyori#MEMORY#SUMMARY',
+  Type: 'MemorySummary',
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  SummaryText: 'コーヒーが好きな人',
+  LastCompressedAt: fixedNow,
+  CreatedAt: fixedNow,
+  UpdatedAt: fixedNow,
+};
+
+describe('DynamoDBMemorySummaryRepository', () => {
+  describe('get', () => {
+    it('Item がない場合は null を返す', async () => {
+      const client = makeClient(async () => ({ Item: undefined }));
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      expect(await repo.get('u1', 'hiyori')).toBeNull();
+    });
+
+    it('GetCommand を正しいキーで送信する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Item: mockAttributes };
+      });
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      await repo.get('u1', 'hiyori');
+      expect(sent[0]).toBeInstanceOf(GetCommand);
+      const input = (sent[0] as GetCommand).input;
+      expect(input.Key?.PK).toBe('USER#u1');
+      expect(input.Key?.SK).toBe('CHAR#hiyori#MEMORY#SUMMARY');
+    });
+
+    it('アイテムが存在する場合はエンティティを返す', async () => {
+      const client = makeClient(async () => ({ Item: mockAttributes }));
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      const entity = await repo.get('u1', 'hiyori');
+      expect(entity?.UserID).toBe('u1');
+      expect(entity?.SummaryText).toBe('コーヒーが好きな人');
+    });
+
+    it('DynamoDB エラーを DatabaseError にラップする', async () => {
+      const client = makeClient(async () => {
+        throw new Error('接続エラー');
+      });
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      await expect(repo.get('u1', 'hiyori')).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
+  describe('put', () => {
+    it('UpdateCommand を送信する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Attributes: mockAttributes };
+      });
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      await repo.put(baseInput);
+      expect(sent[0]).toBeInstanceOf(UpdateCommand);
+    });
+
+    it('正しいキーで UpdateCommand を送信する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Attributes: mockAttributes };
+      });
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      await repo.put(baseInput);
+      const input = (sent[0] as UpdateCommand).input;
+      expect(input.Key?.PK).toBe('USER#u1');
+      expect(input.Key?.SK).toBe('CHAR#hiyori#MEMORY#SUMMARY');
+    });
+
+    it('UpdateExpression に if_not_exists(CreatedAt) が含まれる', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Attributes: mockAttributes };
+      });
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      await repo.put(baseInput);
+      const input = (sent[0] as UpdateCommand).input;
+      expect(input.UpdateExpression).toContain('if_not_exists(CreatedAt');
+    });
+
+    it('エンティティを返す', async () => {
+      const client = makeClient(async () => ({ Attributes: mockAttributes }));
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      const entity = await repo.put(baseInput);
+      expect(entity.UserID).toBe('u1');
+      expect(entity.SummaryText).toBe('コーヒーが好きな人');
+      expect(entity.UpdatedAt).toBe(fixedNow);
+    });
+
+    it('DynamoDB エラーを DatabaseError にラップする', async () => {
+      const client = makeClient(async () => {
+        throw new Error('書き込みエラー');
+      });
+      const repo = new DynamoDBMemorySummaryRepository(client as never, tableName, () => fixedNow);
+      await expect(repo.put(baseInput)).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-message.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-message.repository.test.ts
@@ -293,4 +293,86 @@ describe('DynamoDBMessageRepository', () => {
       ).rejects.toBeInstanceOf(DatabaseError);
     });
   });
+
+  describe('listSince', () => {
+    const msgItem = {
+      PK: 'USER#u1',
+      SK: 'CHAR#hiyori#MSG#ULID-FIXED',
+      Type: 'Message',
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      MessageID: 'ULID-FIXED',
+      Role: 'user',
+      Text: 'こんにちは',
+      CreatedAt: now,
+      UpdatedAt: now,
+    };
+
+    it('QueryCommand を ScanIndexForward=true で送信する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Items: [] };
+      });
+      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      await repo.listSince('u1', 'hiyori', 0);
+      expect(sent[0]).toBeInstanceOf(QueryCommand);
+      const input = (sent[0] as QueryCommand).input;
+      expect(input.ScanIndexForward).toBe(true);
+    });
+
+    it('sinceMs > 0 の場合 FilterExpression を付与する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Items: [] };
+      });
+      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      await repo.listSince('u1', 'hiyori', now - 1000);
+      const input = (sent[0] as QueryCommand).input;
+      expect(input.FilterExpression).toContain('CreatedAt');
+      expect(input.ExpressionAttributeValues?.[':sinceMs']).toBe(now - 1000);
+    });
+
+    it('sinceMs=0 の場合 FilterExpression を付与しない', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Items: [] };
+      });
+      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      await repo.listSince('u1', 'hiyori', 0);
+      const input = (sent[0] as QueryCommand).input;
+      expect(input.FilterExpression).toBeUndefined();
+    });
+
+    it('アイテムをエンティティに変換して返す', async () => {
+      const client = makeClient(async () => ({ Items: [msgItem] }));
+      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      const result = await repo.listSince('u1', 'hiyori', 0);
+      expect(result).toHaveLength(1);
+      expect(result[0].Text).toBe('こんにちは');
+    });
+
+    it('ページネーション: LastEvaluatedKey があれば再クエリする', async () => {
+      let call = 0;
+      const client = makeClient(async () => {
+        call++;
+        if (call === 1) return { Items: [msgItem], LastEvaluatedKey: { PK: 'marker' } };
+        return { Items: [] };
+      });
+      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      const result = await repo.listSince('u1', 'hiyori', 0);
+      expect(call).toBe(2);
+      expect(result).toHaveLength(1);
+    });
+
+    it('DynamoDB エラーは DatabaseError でラップ', async () => {
+      const client = makeClient(async () => {
+        throw new Error('DB エラー');
+      });
+      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      await expect(repo.listSince('u1', 'hiyori', 0)).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-message.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-message.repository.test.ts
@@ -314,7 +314,12 @@ describe('DynamoDBMessageRepository', () => {
         sent.push(cmd);
         return { Items: [] };
       });
-      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
       await repo.listSince('u1', 'hiyori', 0);
       expect(sent[0]).toBeInstanceOf(QueryCommand);
       const input = (sent[0] as QueryCommand).input;
@@ -327,7 +332,12 @@ describe('DynamoDBMessageRepository', () => {
         sent.push(cmd);
         return { Items: [] };
       });
-      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
       await repo.listSince('u1', 'hiyori', now - 1000);
       const input = (sent[0] as QueryCommand).input;
       expect(input.FilterExpression).toContain('CreatedAt');
@@ -340,7 +350,12 @@ describe('DynamoDBMessageRepository', () => {
         sent.push(cmd);
         return { Items: [] };
       });
-      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
       await repo.listSince('u1', 'hiyori', 0);
       const input = (sent[0] as QueryCommand).input;
       expect(input.FilterExpression).toBeUndefined();
@@ -348,7 +363,12 @@ describe('DynamoDBMessageRepository', () => {
 
     it('アイテムをエンティティに変換して返す', async () => {
       const client = makeClient(async () => ({ Items: [msgItem] }));
-      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
       const result = await repo.listSince('u1', 'hiyori', 0);
       expect(result).toHaveLength(1);
       expect(result[0].Text).toBe('こんにちは');
@@ -361,7 +381,12 @@ describe('DynamoDBMessageRepository', () => {
         if (call === 1) return { Items: [msgItem], LastEvaluatedKey: { PK: 'marker' } };
         return { Items: [] };
       });
-      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
       const result = await repo.listSince('u1', 'hiyori', 0);
       expect(call).toBe(2);
       expect(result).toHaveLength(1);
@@ -371,7 +396,12 @@ describe('DynamoDBMessageRepository', () => {
       const client = makeClient(async () => {
         throw new Error('DB エラー');
       });
-      const repo = new DynamoDBMessageRepository(client as never, tableName, ulidFactory, () => now);
+      const repo = new DynamoDBMessageRepository(
+        client as never,
+        tableName,
+        ulidFactory,
+        () => now
+      );
       await expect(repo.listSince('u1', 'hiyori', 0)).rejects.toBeInstanceOf(DatabaseError);
     });
   });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-memory-summary.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-memory-summary.repository.test.ts
@@ -1,0 +1,69 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryMemorySummaryRepository } from '../../../src/repositories/in-memory-memory-summary.repository.js';
+import type { CreateMemorySummaryInput } from '../../../src/entities/memory-summary.entity.js';
+
+const baseInput: CreateMemorySummaryInput = {
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  SummaryText: 'コーヒーが好きな人',
+  LastCompressedAt: 1_750_000_000_000,
+};
+
+describe('InMemoryMemorySummaryRepository', () => {
+  const makeRepo = (nowMs = () => 1_750_000_000_000) =>
+    new InMemoryMemorySummaryRepository(new InMemorySingleTableStore(), nowMs);
+
+  describe('get', () => {
+    it('存在しない場合は null を返す', async () => {
+      const repo = makeRepo();
+      expect(await repo.get('u1', 'hiyori')).toBeNull();
+    });
+
+    it('put 後に get するとエンティティが返る', async () => {
+      const repo = makeRepo();
+      await repo.put(baseInput);
+      const entity = await repo.get('u1', 'hiyori');
+      expect(entity).not.toBeNull();
+      expect(entity?.SummaryText).toBe('コーヒーが好きな人');
+    });
+  });
+
+  describe('put', () => {
+    it('エンティティを保存して返す', async () => {
+      const repo = makeRepo();
+      const entity = await repo.put(baseInput);
+      expect(entity.UserID).toBe('u1');
+      expect(entity.CharacterID).toBe('hiyori');
+      expect(entity.SummaryText).toBe('コーヒーが好きな人');
+      expect(entity.CreatedAt).toBe(1_750_000_000_000);
+      expect(entity.UpdatedAt).toBe(1_750_000_000_000);
+    });
+
+    it('2 回 put したとき CreatedAt が初回の値を維持する', async () => {
+      let tick = 1_000;
+      const repo = new InMemoryMemorySummaryRepository(
+        new InMemorySingleTableStore(),
+        () => tick
+      );
+      const first = await repo.put(baseInput);
+      tick = 2_000;
+      const second = await repo.put({ ...baseInput, SummaryText: '更新済み要約' });
+
+      expect(first.CreatedAt).toBe(1_000);
+      expect(second.CreatedAt).toBe(1_000); // 初回の CreatedAt が保持される
+      expect(second.UpdatedAt).toBe(2_000);
+      expect(second.SummaryText).toBe('更新済み要約');
+    });
+
+    it('異なるユーザーは独立して保存される', async () => {
+      const repo = makeRepo();
+      await repo.put({ ...baseInput, UserID: 'u1' });
+      await repo.put({ ...baseInput, UserID: 'u2', SummaryText: '別ユーザーの要約' });
+
+      const e1 = await repo.get('u1', 'hiyori');
+      const e2 = await repo.get('u2', 'hiyori');
+      expect(e1?.SummaryText).toBe('コーヒーが好きな人');
+      expect(e2?.SummaryText).toBe('別ユーザーの要約');
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/in-memory-memory-summary.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-memory-summary.repository.test.ts
@@ -41,10 +41,7 @@ describe('InMemoryMemorySummaryRepository', () => {
 
     it('2 回 put したとき CreatedAt が初回の値を維持する', async () => {
       let tick = 1_000;
-      const repo = new InMemoryMemorySummaryRepository(
-        new InMemorySingleTableStore(),
-        () => tick
-      );
+      const repo = new InMemoryMemorySummaryRepository(new InMemorySingleTableStore(), () => tick);
       const first = await repo.put(baseInput);
       tick = 2_000;
       const second = await repo.put({ ...baseInput, SummaryText: '更新済み要約' });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-message.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-message.repository.test.ts
@@ -216,4 +216,43 @@ describe('InMemoryMessageRepository', () => {
       expect(result.truncated).toBe(true);
     });
   });
+
+  describe('listSince', () => {
+    it('メッセージなしなら空配列', async () => {
+      const result = await repo.listSince('u1', 'hiyori', 0);
+      expect(result).toEqual([]);
+    });
+
+    it('sinceMs=0 なら全件を時系列昇順で返す', async () => {
+      const a = await createMessage('user', 'first');
+      const b = await createMessage('assistant', 'second');
+      const result = await repo.listSince('u1', 'hiyori', 0);
+      expect(result.map((m) => m.MessageID)).toEqual([a.MessageID, b.MessageID]);
+    });
+
+    it('sinceMs 以降のメッセージのみ返す（boundary exclusive）', async () => {
+      const a = await createMessage('user', 'before');
+      const boundary = currentTime;
+      const b = await createMessage('assistant', 'after');
+
+      const result = await repo.listSince('u1', 'hiyori', boundary);
+      expect(result.map((m) => m.MessageID)).toEqual([b.MessageID]);
+      expect(result.find((m) => m.MessageID === a.MessageID)).toBeUndefined();
+    });
+
+    it('全件が sinceMs より古い場合は空配列', async () => {
+      await createMessage('user', 'old');
+      const result = await repo.listSince('u1', 'hiyori', Date.now() + 999_999);
+      expect(result).toEqual([]);
+    });
+
+    it('別キャラのメッセージは混入しない', async () => {
+      await createMessage('user', 'hiyori msg');
+      currentTime += 1;
+      await repo.create({ UserID: 'u1', CharacterID: 'other', Role: 'user', Text: 'other' });
+      const result = await repo.listSince('u1', 'hiyori', 0);
+      expect(result).toHaveLength(1);
+      expect(result[0].Text).toBe('hiyori msg');
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -37,6 +37,7 @@ function makeLLMClient(chunks: string[]): ILLMClient {
       yield* stringsToStream(chunks);
     }),
     chatComplete: jest.fn(),
+    summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
   };
 }
 
@@ -66,6 +67,7 @@ function makeRepo(
       totalTokens: 0,
       truncated: false,
     })),
+    listSince: jest.fn(async () => []),
     ...overrides,
   };
 }
@@ -488,6 +490,7 @@ describe('runChatUseCase', () => {
           throw new Error('llm down');
         }),
         chatComplete: jest.fn(),
+        summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
       };
       const voice = makeVoiceClient();
       const repo = makeRepo();

--- a/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
@@ -1,0 +1,168 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { compressConversation } from '../../../src/usecases/compress-conversation.usecase.js';
+import { InMemoryMemorySummaryRepository } from '../../../src/repositories/in-memory-memory-summary.repository.js';
+import { InMemoryMessageRepository } from '../../../src/repositories/in-memory-message.repository.js';
+import { InMemoryMemoryRepository } from '../../../src/repositories/in-memory-memory.repository.js';
+import type { ILLMClient } from '../../../src/llm-client/types.js';
+import type { CompressConversationParams } from '../../../src/usecases/compress-conversation.usecase.js';
+
+const fixedNow = 1_750_000_000_000;
+let tick = fixedNow;
+
+const makeLLMClient = (
+  result = { mergedSummary: '新要約', newMemoryCandidates: [] as { category: string; content: string }[] }
+): ILLMClient & { summarizeCalls: number } => {
+  let summarizeCalls = 0;
+  return {
+    async *chatStream() { yield ''; },
+    async chatComplete() { return ''; },
+    async summarize() {
+      summarizeCalls++;
+      return result;
+    },
+    get summarizeCalls() { return summarizeCalls; },
+  };
+};
+
+const makeRepos = () => {
+  const store = new InMemorySingleTableStore();
+  tick = fixedNow;
+  const nowMs = () => tick;
+  const ulidFactory = () => `ULID-${tick++}`;
+
+  return {
+    summaryRepo: new InMemoryMemorySummaryRepository(store, nowMs),
+    messageRepo: new InMemoryMessageRepository(store, ulidFactory, nowMs),
+    memoryRepo: new InMemoryMemoryRepository(store, ulidFactory, nowMs),
+  };
+};
+
+const makeParams = (
+  overrides: Partial<CompressConversationParams> = {}
+): CompressConversationParams => ({
+  ...makeRepos(),
+  llmClient: makeLLMClient(),
+  characterName: 'ひより',
+  now: () => fixedNow,
+  ...overrides,
+});
+
+describe('compressConversation', () => {
+  it('メッセージが 0 件のとき LLM を呼ばずに return する', async () => {
+    const llmClient = makeLLMClient();
+    const params = makeParams({ llmClient });
+    await compressConversation('u1', 'hiyori', params);
+    expect(llmClient.summarizeCalls).toBe(0);
+  });
+
+  it('メッセージがあれば LLM を 1 回呼ぶ', async () => {
+    const llmClient = makeLLMClient();
+    const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'こんにちは' });
+
+    await compressConversation('u1', 'hiyori', {
+      summaryRepo, messageRepo, memoryRepo, llmClient, characterName: 'ひより', now: () => fixedNow,
+    });
+
+    expect(llmClient.summarizeCalls).toBe(1);
+  });
+
+  it('MEMORY#SUMMARY が更新される', async () => {
+    const llmClient = makeLLMClient({ mergedSummary: '要約テキスト', newMemoryCandidates: [] });
+    const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'テスト' });
+
+    await compressConversation('u1', 'hiyori', {
+      summaryRepo, messageRepo, memoryRepo, llmClient, characterName: 'ひより', now: () => fixedNow,
+    });
+
+    const updated = await summaryRepo.get('u1', 'hiyori');
+    expect(updated?.SummaryText).toBe('要約テキスト');
+    expect(updated?.LastCompressedAt).toBe(fixedNow);
+  });
+
+  it('新規記憶候補が Tier C として保存される', async () => {
+    const candidates = [
+      { category: 'food', content: 'ケーキが好き' },
+      { category: 'hobby', content: '映画が好き' },
+    ];
+    const llmClient = makeLLMClient({ mergedSummary: '要約', newMemoryCandidates: candidates });
+    const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'テスト' });
+
+    await compressConversation('u1', 'hiyori', {
+      summaryRepo, messageRepo, memoryRepo, llmClient, characterName: 'ひより', now: () => fixedNow,
+    });
+
+    const foodMems = await memoryRepo.listByTier('u1', 'hiyori', 'C');
+    expect(foodMems).toHaveLength(2);
+    const categories = foodMems.map((m) => m.Category).sort();
+    expect(categories).toEqual(['food', 'hobby']);
+    expect(foodMems.every((m) => m.Tier === 'C')).toBe(true);
+  });
+
+  it('前回圧縮以降のメッセージのみ処理する（listSince が lastCompressedAt を使う）', async () => {
+    const capturedMessages: Array<{ role: string; text: string }> = [];
+    const spyClient: ILLMClient = {
+      async *chatStream() { yield ''; },
+      async chatComplete() { return ''; },
+      async summarize(input) {
+        capturedMessages.push(...input.newMessages);
+        return { mergedSummary: '', newMemoryCandidates: [] };
+      },
+    };
+
+    const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: '古い' });
+    const midPoint = tick;
+
+    tick = midPoint + 1;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'assistant', Text: '新しい' });
+
+    // lastCompressedAt = midPoint → midPoint より後のメッセージ（「新しい」）のみ対象
+    await summaryRepo.put({
+      UserID: 'u1', CharacterID: 'hiyori',
+      SummaryText: '既存要約',
+      LastCompressedAt: midPoint,
+    });
+
+    await compressConversation('u1', 'hiyori', {
+      summaryRepo, messageRepo, memoryRepo, llmClient: spyClient, characterName: 'ひより', now: () => tick,
+    });
+
+    expect(capturedMessages).toHaveLength(1);
+    expect(capturedMessages[0].text).toBe('新しい');
+  });
+
+  it('既存 summaryText が LLM に渡される', async () => {
+    let capturedExisting: string | undefined = 'none';
+    const spyClient: ILLMClient = {
+      async *chatStream() { yield ''; },
+      async chatComplete() { return ''; },
+      async summarize(input) {
+        capturedExisting = input.existingSummary;
+        return { mergedSummary: '', newMemoryCandidates: [] };
+      },
+    };
+
+    const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await summaryRepo.put({
+      UserID: 'u1', CharacterID: 'hiyori',
+      SummaryText: '既存の要約内容',
+      LastCompressedAt: 0,
+    });
+    tick = fixedNow + 1;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'new' });
+
+    await compressConversation('u1', 'hiyori', {
+      summaryRepo, messageRepo, memoryRepo, llmClient: spyClient, characterName: 'ひより',
+    });
+
+    expect(capturedExisting).toBe('既存の要約内容');
+  });
+});

--- a/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
@@ -10,17 +10,26 @@ const fixedNow = 1_750_000_000_000;
 let tick = fixedNow;
 
 const makeLLMClient = (
-  result = { mergedSummary: '新要約', newMemoryCandidates: [] as { category: string; content: string }[] }
+  result = {
+    mergedSummary: '新要約',
+    newMemoryCandidates: [] as { category: string; content: string }[],
+  }
 ): ILLMClient & { summarizeCalls: number } => {
   let summarizeCalls = 0;
   return {
-    async *chatStream() { yield ''; },
-    async chatComplete() { return ''; },
+    async *chatStream() {
+      yield '';
+    },
+    async chatComplete() {
+      return '';
+    },
     async summarize() {
       summarizeCalls++;
       return result;
     },
-    get summarizeCalls() { return summarizeCalls; },
+    get summarizeCalls() {
+      return summarizeCalls;
+    },
   };
 };
 
@@ -59,10 +68,20 @@ describe('compressConversation', () => {
     const llmClient = makeLLMClient();
     const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
     tick = fixedNow;
-    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'こんにちは' });
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'user',
+      Text: 'こんにちは',
+    });
 
     await compressConversation('u1', 'hiyori', {
-      summaryRepo, messageRepo, memoryRepo, llmClient, characterName: 'ひより', now: () => fixedNow,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+      characterName: 'ひより',
+      now: () => fixedNow,
     });
 
     expect(llmClient.summarizeCalls).toBe(1);
@@ -75,7 +94,12 @@ describe('compressConversation', () => {
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'テスト' });
 
     await compressConversation('u1', 'hiyori', {
-      summaryRepo, messageRepo, memoryRepo, llmClient, characterName: 'ひより', now: () => fixedNow,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+      characterName: 'ひより',
+      now: () => fixedNow,
     });
 
     const updated = await summaryRepo.get('u1', 'hiyori');
@@ -94,7 +118,12 @@ describe('compressConversation', () => {
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'テスト' });
 
     await compressConversation('u1', 'hiyori', {
-      summaryRepo, messageRepo, memoryRepo, llmClient, characterName: 'ひより', now: () => fixedNow,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+      characterName: 'ひより',
+      now: () => fixedNow,
     });
 
     const foodMems = await memoryRepo.listByTier('u1', 'hiyori', 'C');
@@ -107,8 +136,12 @@ describe('compressConversation', () => {
   it('前回圧縮以降のメッセージのみ処理する（listSince が lastCompressedAt を使う）', async () => {
     const capturedMessages: Array<{ role: string; text: string }> = [];
     const spyClient: ILLMClient = {
-      async *chatStream() { yield ''; },
-      async chatComplete() { return ''; },
+      async *chatStream() {
+        yield '';
+      },
+      async chatComplete() {
+        return '';
+      },
       async summarize(input) {
         capturedMessages.push(...input.newMessages);
         return { mergedSummary: '', newMemoryCandidates: [] };
@@ -121,17 +154,28 @@ describe('compressConversation', () => {
     const midPoint = tick;
 
     tick = midPoint + 1;
-    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'assistant', Text: '新しい' });
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'assistant',
+      Text: '新しい',
+    });
 
     // lastCompressedAt = midPoint → midPoint より後のメッセージ（「新しい」）のみ対象
     await summaryRepo.put({
-      UserID: 'u1', CharacterID: 'hiyori',
+      UserID: 'u1',
+      CharacterID: 'hiyori',
       SummaryText: '既存要約',
       LastCompressedAt: midPoint,
     });
 
     await compressConversation('u1', 'hiyori', {
-      summaryRepo, messageRepo, memoryRepo, llmClient: spyClient, characterName: 'ひより', now: () => tick,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient: spyClient,
+      characterName: 'ひより',
+      now: () => tick,
     });
 
     expect(capturedMessages).toHaveLength(1);
@@ -141,8 +185,12 @@ describe('compressConversation', () => {
   it('既存 summaryText が LLM に渡される', async () => {
     let capturedExisting: string | undefined = 'none';
     const spyClient: ILLMClient = {
-      async *chatStream() { yield ''; },
-      async chatComplete() { return ''; },
+      async *chatStream() {
+        yield '';
+      },
+      async chatComplete() {
+        return '';
+      },
       async summarize(input) {
         capturedExisting = input.existingSummary;
         return { mergedSummary: '', newMemoryCandidates: [] };
@@ -152,7 +200,8 @@ describe('compressConversation', () => {
     const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
     tick = fixedNow;
     await summaryRepo.put({
-      UserID: 'u1', CharacterID: 'hiyori',
+      UserID: 'u1',
+      CharacterID: 'hiyori',
       SummaryText: '既存の要約内容',
       LastCompressedAt: 0,
     });
@@ -160,7 +209,11 @@ describe('compressConversation', () => {
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'new' });
 
     await compressConversation('u1', 'hiyori', {
-      summaryRepo, messageRepo, memoryRepo, llmClient: spyClient, characterName: 'ひより',
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient: spyClient,
+      characterName: 'ひより',
     });
 
     expect(capturedExisting).toBe('既存の要約内容');


### PR DESCRIPTION
## 変更の概要

Issue #3281 「[Feature] [リブトーク Phase 3c] 圧縮要約バッチ（EventBridge + Lambda、日次）」の実装。

全アクティブユーザーの会話を日次で圧縮要約する仕組みを追加する。

### 追加したもの

**コア（`services/livetalk/core`）**
- `MemorySummaryEntity` / `MemorySummaryMapper` / `DynamoDBMemorySummaryRepository` / `InMemoryMemorySummaryRepository` — 圧縮要約の永続化
- `MessageRepository.listSince` — lastCompressedAt 以降のメッセージを取得
- `ILLMClient.summarize` / `parseSummarizeResult` — LLM による要約抽出（gpt-5-mini）
- `buildSystemPrompt` / `buildChatMessages` に `summaryText` 注入（"あなたがこれまでに知ったこと"）
- `compressConversation` usecase — 1ユーザー×1キャラの圧縮要約（Tier C 記憶候補抽出）

**バッチ（`services/livetalk/batch`）**
- `compressAllConversations` usecase — DynamoDB Scan で全 Profile を列挙し hiyori の会話を圧縮
- `compress-conversations.handler` — EventBridge からの Lambda エントリポイント

**インフラ（`infra/livetalk`）**
- `LiveTalkBatchEcrStack` — バッチ用 ECR リポジトリ
- `LiveTalkBatchStack` — Lambda（FROM_IMAGE/512MB/15分）+ EventBridge cron（JST 03:00）+ DLQ + IAM
- `infra-common` SSM_PARAMETERS に `LIVETALK_BATCH_ECR_REPOSITORY_NAME/URI` 追加

## 関連 Issue

Issue #3281

## 変更種別

- [x] 新機能追加

## 実装チェックリスト

- [x] `MemorySummaryEntity` 定義・Mapper・DynamoDB/InMemory リポジトリ
- [x] `MessageRepository.listSince` 実装（DynamoDB / InMemory）
- [x] `ILLMClient.summarize` + `parseSummarizeResult`（コードブロック除去・fallback 対応）
- [x] `buildSystemPrompt` / `buildChatMessages` に summaryText 注入
- [x] `compressConversation` usecase（DI / スキップ判定 / Tier C 保存）
- [x] `services/livetalk/batch/` 一式（Handler / Usecase / Dockerfile / jest.config.ts）
- [x] `LiveTalkBatchEcrStack` + `LiveTalkBatchStack`（CDK）
- [x] 全テストカバレッジ 80%+ 維持（core: 404 テスト、batch: 9 テスト、infra: 78 テスト）

## テスト内容

```
livetalk-core:  404 tests, 34 suites — PASS
livetalk-batch:   9 tests,  2 suites — PASS（coverage: 100% stmt/func/lines, 90.9% branch）
infra-livetalk:  78 tests,  7 suites — PASS
```

主要テストケース：
- `compressConversation`: メッセージ 0 件スキップ / LLM 1 回呼び出し / MEMORY#SUMMARY 更新 / Tier C 保存 / lastCompressedAt フィルタ / 既存要約の引き継ぎ
- `compressAllConversations`: 全ユーザースキャン / 1ユーザー失敗でも継続 / ページネーション対応 / 不正 UserID 除外
- `parseSummarizeResult`: JSON コードブロック / 空 content フィルタ / category fallback
- CDK: Lambda 15分タイムアウト / EventBridge cron(0 18 * * ? *) / DLQ / ECR SSM パラメータ

## レビューポイント

- EventBridge スケジュール: `cron(0 18 * * ? *)` = UTC 18:00 = JST 翌 03:00
- Lambda タイムアウト: 15 分（全ユーザー処理の最大所要時間に余裕を持たせた）
- `listSince(sinceMs=0)` は FilterExpression を省略して全件取得（初回圧縮時）
- `parseSummarizeResult` の fallback は `{ mergedSummary: rawText, newMemoryCandidates: [] }`
- `EmbeddingMemoryRepository` は Decorator パターン（`DynamoDBMemoryRepository` を内包）

---
_Generated by [Claude Code](https://claude.ai/code/session_01VU4zC8w9V5kSN248o5cfZM)_