### PR TITLE
ci(livetalk): Batch を CI/CD ワークフローに組み込み

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -79,10 +79,13 @@ jobs:
           ENVIRONMENT: ${{ steps.setup-environment.outputs.environment }}
           STACK_SUFFIX: ${{ steps.setup-environment.outputs.stack-suffix }}
         run: |
-          npm run cdk --workspace=@nagiyu/infra-livetalk -- deploy NagiyuLiveTalkEcr${STACK_SUFFIX} \
+          # メインの Web ECR と Batch ECR を一括 deploy する（相互依存なし）。
+          npm run cdk --workspace=@nagiyu/infra-livetalk -- deploy \
+            NagiyuLiveTalkEcr${STACK_SUFFIX} \
+            NagiyuLiveTalkBatchEcr${STACK_SUFFIX} \
             --require-approval never
 
-          echo "LiveTalk ECR repository deployed (environment: $ENVIRONMENT)"
+          echo "LiveTalk ECR repositories deployed (environment: $ENVIRONMENT)"
 
       - name: Deploy LiveTalk Secrets Stack
         env:
@@ -175,6 +178,52 @@ jobs:
           docker push "$REPOSITORY_URI:latest"
 
           echo "image-uri=$REPOSITORY_URI:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+  build-batch:
+    name: Build and Push Batch Image
+    runs-on: ubuntu-latest
+    needs: infrastructure-ecr
+
+    outputs:
+      environment: ${{ needs.infrastructure-ecr.outputs.environment }}
+      stack-suffix: ${{ needs.infrastructure-ecr.outputs.stack-suffix }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Batch Docker image
+        uses: ./.github/actions/build-docker-image
+        with:
+          dockerfile: services/livetalk/batch/Dockerfile
+          # Batch ECR リポジトリ名は命名規則から決定論的に組み立てる（SSM 非依存）。
+          image-tag: ${{ steps.login-ecr.outputs.registry }}/nagiyu-livetalk-batch-ecr-${{ needs.infrastructure-ecr.outputs.environment }}:${{ github.sha }}
+
+      - name: Push Batch Docker image to ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: nagiyu-livetalk-batch-ecr-${{ needs.infrastructure-ecr.outputs.environment }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+          # Also tag as latest（Batch Lambda は :latest を参照する）
+          docker tag "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+
+          echo "Batch image pushed: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
   infrastructure-app:
     name: Deploy DynamoDB, ALB and ECS Service Stacks
@@ -302,6 +351,77 @@ jobs:
             echo "Health check passed."
           fi
 
+  infrastructure-batch:
+    name: Deploy Batch Stack (Lambda + EventBridge)
+    runs-on: ubuntu-latest
+    needs: [infrastructure-ecr, build-batch]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js and install dependencies
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: '24'
+
+      - name: Build common infrastructure package
+        run: npm run build --workspace=@nagiyu/infra-common
+
+      - name: Build CDK TypeScript
+        run: npm run build --workspace=@nagiyu/infra-livetalk
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Fetch secrets from Secrets Manager
+        id: fetch-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            OPENAI_API_KEY,/nagiyu/livetalk/${{ needs.infrastructure-ecr.outputs.environment }}/openai/api-key
+          parse-json-secrets: true
+
+      - name: Deploy LiveTalk Batch Stack
+        env:
+          ENVIRONMENT: ${{ needs.infrastructure-ecr.outputs.environment }}
+          STACK_SUFFIX: ${{ needs.infrastructure-ecr.outputs.stack-suffix }}
+          OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+        run: |
+          # Batch Lambda は build-batch で push 済みの :latest イメージを参照する。
+          # ECR / イメージが先行しているため、Lambda 作成は失敗しない。
+          npm run cdk --workspace=@nagiyu/infra-livetalk -- deploy \
+            NagiyuLiveTalkBatch${STACK_SUFFIX} \
+            --context openAiApiKey="$OPENAI_API_KEY" \
+            --require-approval never
+
+          echo "LiveTalk Batch stack deployed (environment: $ENVIRONMENT)"
+
+      - name: Update Batch Lambda code with latest image
+        env:
+          ENVIRONMENT: ${{ needs.infrastructure-ecr.outputs.environment }}
+        run: |
+          # 既存スタックへの再デプロイでは :latest タグが不変のため CloudFormation が
+          # Lambda コードを更新しない。明示的に最新イメージへ更新する。
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          ECR_REGISTRY="$ACCOUNT_ID.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com"
+          IMAGE_URI="$ECR_REGISTRY/nagiyu-livetalk-batch-ecr-$ENVIRONMENT:latest"
+
+          aws lambda update-function-code \
+            --function-name "nagiyu-livetalk-batch-compress-$ENVIRONMENT" \
+            --image-uri "$IMAGE_URI" \
+            --region ${{ env.AWS_REGION }}
+
+          aws lambda wait function-updated \
+            --function-name "nagiyu-livetalk-batch-compress-$ENVIRONMENT" \
+            --region ${{ env.AWS_REGION }}
+
+          echo "Batch Lambda updated with image: $IMAGE_URI"
+
   infrastructure-cloudfront:
     name: Deploy CloudFront Distribution
     runs-on: ubuntu-latest
@@ -369,7 +489,7 @@ jobs:
   summary:
     name: Deployment Summary
     runs-on: ubuntu-latest
-    needs: [build, infrastructure-app, infrastructure-cloudfront]
+    needs: [build, build-batch, infrastructure-app, infrastructure-batch, infrastructure-cloudfront]
     if: always()
 
     steps:
@@ -389,6 +509,7 @@ jobs:
             echo "- **App Version**: $APP_VERSION"
             echo "- **Image (SHA tag)**: \`$IMAGE_URI\`"
             echo "- **Latest tag**: same digest also pushed as \`:latest\`"
+            echo "- **Batch Lambda**: \`nagiyu-livetalk-batch-compress-$ENVIRONMENT\`（EventBridge 日次 JST 03:00）"
             echo "- **ALB DNS**: \`$ALB_DNS\`"
             echo "- **Custom Domain**: https://$CUSTOM_DOMAIN"
             echo ""

--- a/.github/workflows/livetalk-verify.yml
+++ b/.github/workflows/livetalk-verify.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Run ESLint on web
         run: npm run lint --workspace=@nagiyu/livetalk-web
 
+      - name: Run ESLint on batch
+        run: npm run lint --workspace=@nagiyu/livetalk-batch
+
   format-check:
     name: Format Check
     runs-on: ubuntu-latest
@@ -61,6 +64,9 @@ jobs:
 
       - name: Check web formatting
         run: npm run format:check --workspace=@nagiyu/livetalk-web
+
+      - name: Check batch formatting
+        run: npm run format:check --workspace=@nagiyu/livetalk-batch
 
   synth-infra:
     name: Synthesize Infrastructure
@@ -93,8 +99,10 @@ jobs:
         run: |
           npm run synth --workspace=@nagiyu/infra-livetalk -- \
             NagiyuLiveTalkEcrDev \
+            NagiyuLiveTalkBatchEcrDev \
             NagiyuLiveTalkAlbDev \
             NagiyuLiveTalkServiceDev \
+            NagiyuLiveTalkBatchDev \
             NagiyuLiveTalkCloudFrontDev
 
       - name: Synthesize CDK stacks (prod)
@@ -104,8 +112,10 @@ jobs:
         run: |
           npm run synth --workspace=@nagiyu/infra-livetalk -- \
             NagiyuLiveTalkEcrProd \
+            NagiyuLiveTalkBatchEcrProd \
             NagiyuLiveTalkAlbProd \
             NagiyuLiveTalkServiceProd \
+            NagiyuLiveTalkBatchProd \
             NagiyuLiveTalkCloudFrontProd
 
   build:
@@ -153,6 +163,12 @@ jobs:
           image-tag: livetalk-verify-test
           build-args: APP_VERSION=${{ steps.get-version.outputs.app-version }}
 
+      - name: Build Batch Docker image
+        uses: ./.github/actions/build-docker-image
+        with:
+          dockerfile: services/livetalk/batch/Dockerfile
+          image-tag: livetalk-batch-verify-test
+
   unit-test:
     name: Run Unit Tests
     runs-on: ubuntu-latest
@@ -182,6 +198,9 @@ jobs:
 
       - name: Run web unit tests
         run: npm run test --workspace @nagiyu/livetalk-web
+
+      - name: Run batch unit tests
+        run: npm run test --workspace @nagiyu/livetalk-batch
 
   coverage:
     name: Test Coverage Check

--- a/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
+++ b/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
@@ -78,7 +78,7 @@ export async function compressAllConversations(
     }
   }
 
-  logger.info('[compressAllConversations] 全ユーザー処理完了', result);
+  logger.info('[compressAllConversations] 全ユーザー処理完了', { ...result });
   return result;
 }
 


### PR DESCRIPTION
## 変更の概要

Issue #3281（リブトーク Phase 3c 圧縮要約バッチ）で Batch の CDK スタック・サービス実装は追加しましたが、**`livetalk-deploy` / `livetalk-verify` ワークフローへの組み込みが漏れており、Batch がデプロイも検証もされない状態**でした。これを解消します。

dev での動作確認を進める中で「Batch Lambda が dev に存在しない」ことが判明し、原因が CD ワークフローの欠落であると特定したための追加対応です。

### deploy（`livetalk-deploy.yml`）

- `infrastructure-ecr` ジョブで `NagiyuLiveTalkBatchEcr` も deploy
- **`build-batch` ジョブ**を新設し、Batch イメージを ECR へ push（`:sha` / `:latest`）
- **`infrastructure-batch` ジョブ**を新設し、`NagiyuLiveTalkBatch` を deploy
  - `OPENAI_API_KEY` を Secrets Manager から取得し `--context openAiApiKey` で渡す（`infrastructure-app` と同パターン）
  - 再デプロイ時に `:latest` タグが不変で CloudFormation が Lambda コードを更新しない問題に対し、`update-function-code` + `wait function-updated` を実行（niconico の Batch デプロイと同パターン）
- **ECR作成 → イメージpush → Lambda deploy** の順序を `needs` で保証（Lambda が空リポジトリを参照して失敗するのを防止）

### verify（`livetalk-verify.yml`）

batch サービス（`@nagiyu/livetalk-batch`）が CI で一切検証されていなかったため、以下を追加：

- `lint` / `format:check` / `unit test` に batch を追加
- `docker-build` で Batch イメージもビルド検証
- `synth-infra` で `BatchEcr` / `Batch` スタックも synth（dev / prod）

## 関連 Issue

Issue #3281（圧縮要約バッチ Phase 3c）の積み残し対応。
※ integration → develop の PR で `Closes #` を付与する運用のため、本 PR には含めません。

## 変更種別

- [x] CI/CD（GitHub Actions ワークフロー）

## 実装チェックリスト

- [x] Batch ECR / Batch スタックを deploy 対象に追加
- [x] Batch イメージのビルド & push ジョブを追加
- [x] deploy 順序（ECR → image → Lambda）を `needs` で保証
- [x] verify に batch の lint / format / unit test / docker build / synth を追加
- [x] Batch ECR リポジトリ名は命名規則から決定論的に組み立て（SSM 非依存）

## テスト内容

ローカル検証：

- `@nagiyu/livetalk-batch` ユニットテスト：**9件 / 2 suites パス**
- 全 6 スタックの `cdk synth`（dev）成功（`Ecr` / `BatchEcr` / `Alb` / `Service` / `Batch` / `CloudFront`）
- ワークフロー YAML 構文チェック OK
- `format:check` のローカル warn は gitignore 済みの `coverage/` 由来（CI のクリーンチェックアウトでは対象外）
- `lint` のローカルエラーは `@eslint/js` 未インストールのローカル環境問題（core でも同一）で、CI の `npm ci` では解消

## レビューポイント

- `build-batch` → `infrastructure-batch` の `needs` 依存順序が意図通りか
- `update-function-code` による `:latest` 反映の運用が他サービス（niconico）と整合しているか
- Batch ECR リポジトリ URI を `<account>.dkr.ecr.<region>.amazonaws.com/nagiyu-livetalk-batch-ecr-<env>` で決定論的に構築している点（SSM 非依存方針との整合）


---
_Generated by [Claude Code](https://claude.ai/code/session_01VU4zC8w9V5kSN248o5cfZM)_