### PR TITLE
[Phase 3d] 暗黙確認・訂正検出（Issue #3282）

### DIFF
--- a/services/livetalk/core/src/characters/prompt-builder.ts
+++ b/services/livetalk/core/src/characters/prompt-builder.ts
@@ -1,5 +1,6 @@
 import type { CharacterDefinition } from './types.js';
 import type { MessageEntity } from '../entities/message.entity.js';
+import type { MemoryEntity } from '../entities/memory.entity.js';
 import type { ChatMessage } from '../llm-client/types.js';
 import type { RetrievedMemory } from '../memory/types.js';
 
@@ -16,7 +17,8 @@ export function buildSystemPrompt(
   character: CharacterDefinition,
   now: Date,
   retrievedMemories: RetrievedMemory[] = [],
-  summaryText?: string
+  summaryText?: string,
+  newLearnings?: MemoryEntity[]
 ): string {
   const { personality, displayName } = character;
   const timeOfDay = getTimeOfDay(now);
@@ -38,8 +40,9 @@ export function buildSystemPrompt(
 
   const hasSummary = summaryText && summaryText.trim().length > 0;
   const hasMemories = retrievedMemories.length > 0;
+  const hasNewLearnings = newLearnings !== undefined && newLearnings.length > 0;
 
-  if (!hasSummary && !hasMemories) return base;
+  if (!hasSummary && !hasMemories && !hasNewLearnings) return base;
 
   const sections: string[] = [base];
 
@@ -50,6 +53,13 @@ export function buildSystemPrompt(
   if (hasMemories) {
     const memoriesSection = retrievedMemories.map((r) => `- ${r.memory.Content}`).join('\n');
     sections.push(`あなたが覚えていること：\n${memoriesSection}`);
+  }
+
+  if (hasNewLearnings) {
+    const learningsSection = newLearnings!.map((m) => `- ${m.Content}`).join('\n');
+    sections.push(
+      `あなたが新しく知ったこと：\n${learningsSection}\n\n新しく知ったことについては、自然な流れで「覚えとくね」と伝えるか、あなたの感想を一言添えてください。ただし、毎回触れる必要はありません。`
+    );
   }
 
   return sections.join('\n\n');
@@ -69,9 +79,10 @@ export function buildChatMessages(
   history: MessageEntity[],
   userText: string,
   retrievedMemories: RetrievedMemory[] = [],
-  summaryText?: string
+  summaryText?: string,
+  newLearnings?: MemoryEntity[]
 ): ChatMessage[] {
-  const systemPrompt = buildSystemPrompt(character, now, retrievedMemories, summaryText);
+  const systemPrompt = buildSystemPrompt(character, now, retrievedMemories, summaryText, newLearnings);
   const messages: ChatMessage[] = [{ role: 'system', content: systemPrompt }];
 
   for (const msg of history) {

--- a/services/livetalk/core/src/characters/prompt-builder.ts
+++ b/services/livetalk/core/src/characters/prompt-builder.ts
@@ -82,7 +82,13 @@ export function buildChatMessages(
   summaryText?: string,
   newLearnings?: MemoryEntity[]
 ): ChatMessage[] {
-  const systemPrompt = buildSystemPrompt(character, now, retrievedMemories, summaryText, newLearnings);
+  const systemPrompt = buildSystemPrompt(
+    character,
+    now,
+    retrievedMemories,
+    summaryText,
+    newLearnings
+  );
   const messages: ChatMessage[] = [{ role: 'system', content: systemPrompt }];
 
   for (const msg of history) {

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -67,3 +67,26 @@ export const MEMORY_DEFAULT_CONFIDENCE = {
   C: 0.5,
   D: 0.2,
 } as const;
+
+/**
+ * 訂正検出時に対象 Memory の Confidence から差し引くペナルティ値（Phase 3d）。
+ * 0.8 → 0.5 → 0.2 と 3 回連続訂正で自動削除閾値に達する設計。
+ */
+export const CORRECTION_CONFIDENCE_PENALTY = 0.3;
+
+/**
+ * Confidence がこの値を下回った Memory は自動削除する閾値（Phase 3d）。
+ */
+export const MEMORY_AUTO_DELETE_THRESHOLD = 0.2;
+
+/**
+ * 「覚えとくね」発話を促すプロンプトに同一 Memory を含める間隔（ミリ秒）。
+ * 同じ記憶について毎ターン「覚えとくね」と言わないための cooldown（Phase 3d）。
+ */
+export const CONFIRMATION_COOLDOWN_MS = 3 * 60 * 60 * 1000; // 3 時間
+
+/**
+ * Tier C 記憶の「再言及」と判定する cosine similarity 下限閾値（Phase 3d）。
+ * 高めに設定することで false positive（無関係な話題での昇格）を抑制する。
+ */
+export const PROMOTION_SIMILARITY_THRESHOLD = 0.7;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -6,7 +6,13 @@ export * from './constants.js';
 // Memory retrieval + confirmation + correction
 export { cosineSimilarity, MemoryRetriever } from './memory/index.js';
 export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './memory/index.js';
-export { detectCorrection, identifyPromotionCandidates, identifyNewLearnings, applyCorrection, executePromotion } from './memory/index.js';
+export {
+  detectCorrection,
+  identifyPromotionCandidates,
+  identifyNewLearnings,
+  applyCorrection,
+  executePromotion,
+} from './memory/index.js';
 export type { CorrectionResult } from './memory/index.js';
 
 // Safety

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -3,9 +3,11 @@ export * from './llm-client/index.js';
 export type { SummarizeInput, SummarizeResult, MemoryCandidate } from './llm-client/types.js';
 export * from './constants.js';
 
-// Memory retrieval
+// Memory retrieval + confirmation + correction
 export { cosineSimilarity, MemoryRetriever } from './memory/index.js';
 export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './memory/index.js';
+export { detectCorrection, identifyPromotionCandidates, identifyNewLearnings, applyCorrection, executePromotion } from './memory/index.js';
+export type { CorrectionResult } from './memory/index.js';
 
 // Safety
 export * from './safety/index.js';

--- a/services/livetalk/core/src/memory/confirmation.ts
+++ b/services/livetalk/core/src/memory/confirmation.ts
@@ -25,9 +25,7 @@ async function judgePromotionsWithLLM(
   candidates: MemoryEntity[],
   llmClient: ILLMClient
 ): Promise<MemoryEntity[]> {
-  const memoriesText = candidates
-    .map((m) => `- ID: ${m.MemoryID}、内容: ${m.Content}`)
-    .join('\n');
+  const memoriesText = candidates.map((m) => `- ID: ${m.MemoryID}、内容: ${m.Content}`).join('\n');
 
   const prompt = `以下はユーザーの発話と、過去に一度だけ観測された記憶（Tier C）の候補です。
 
@@ -44,10 +42,9 @@ ${memoriesText}
 {"promotions": [{"memoryId": "...", "promote": true}, {"memoryId": "...", "promote": false}]}`;
 
   try {
-    const raw = await llmClient.chatComplete(
-      [{ role: 'user', content: prompt }],
-      { purpose: 'classify' }
-    );
+    const raw = await llmClient.chatComplete([{ role: 'user', content: prompt }], {
+      purpose: 'classify',
+    });
 
     const jsonMatch = raw.match(/\{[\s\S]*\}/);
     if (!jsonMatch) return [];
@@ -55,9 +52,7 @@ ${memoriesText}
     const parsed = JSON.parse(jsonMatch[0]) as { promotions?: PromotionJudgment[] };
     if (!Array.isArray(parsed.promotions)) return [];
 
-    const promoteIds = new Set(
-      parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId)
-    );
+    const promoteIds = new Set(parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId));
 
     return candidates.filter((m) => promoteIds.has(m.MemoryID));
   } catch (err) {
@@ -76,7 +71,6 @@ ${memoriesText}
  * @param memoryRepository - Memory リポジトリ
  * @param embeddingClient - Embedding クライアント
  * @param llmClient - LLM クライアント（classify 用途）
- * @param nowMs - 現在時刻（ミリ秒、テスト差し替え用）
  */
 export async function identifyPromotionCandidates(
   userId: string,
@@ -84,8 +78,7 @@ export async function identifyPromotionCandidates(
   userInput: string,
   memoryRepository: MemoryRepository,
   embeddingClient: IEmbeddingClient,
-  llmClient: ILLMClient,
-  nowMs: number = Date.now()
+  llmClient: ILLMClient
 ): Promise<MemoryEntity[]> {
   // Tier C 全件取得
   let tierCMemories: MemoryEntity[];

--- a/services/livetalk/core/src/memory/confirmation.ts
+++ b/services/livetalk/core/src/memory/confirmation.ts
@@ -1,0 +1,145 @@
+/**
+ * Tier C 記憶の昇格候補検出と「覚えとくね」プロンプト生成（Phase 3d / Issue #3282）。
+ *
+ * フロー:
+ *   1. Tier C 記憶を全件取得
+ *   2. ユーザー入力の embedding と cosine similarity を計算
+ *   3. 閾値超えた候補を LLM で「本当に再言及か」判定
+ *   4. cooldown 適用で「覚えとくね」を毎ターン言わないよう制御
+ */
+
+import { logger } from '@nagiyu/common';
+import type { IEmbeddingClient, ILLMClient } from '../llm-client/types.js';
+import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
+import type { MemoryEntity } from '../entities/memory.entity.js';
+import { cosineSimilarity } from './embedding.js';
+import { CONFIRMATION_COOLDOWN_MS, PROMOTION_SIMILARITY_THRESHOLD } from '../constants.js';
+
+interface PromotionJudgment {
+  memoryId: string;
+  promote: boolean;
+}
+
+async function judgePromotionsWithLLM(
+  userInput: string,
+  candidates: MemoryEntity[],
+  llmClient: ILLMClient
+): Promise<MemoryEntity[]> {
+  const memoriesText = candidates
+    .map((m) => `- ID: ${m.MemoryID}、内容: ${m.Content}`)
+    .join('\n');
+
+  const prompt = `以下はユーザーの発話と、過去に一度だけ観測された記憶（Tier C）の候補です。
+
+【ユーザーの発話】
+${userInput}
+
+【昇格候補の記憶】
+${memoriesText}
+
+ユーザーの発話が上記の記憶について再確認・強調・肯定している場合のみ昇格（promote: true）としてください。
+単に話題が関連しているだけでは昇格しません。ユーザーが同じ情報を再度明示している場合のみ昇格です。
+
+以下の JSON 形式で返してください（JSON のみ）:
+{"promotions": [{"memoryId": "...", "promote": true}, {"memoryId": "...", "promote": false}]}`;
+
+  try {
+    const raw = await llmClient.chatComplete(
+      [{ role: 'user', content: prompt }],
+      { purpose: 'classify' }
+    );
+
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return [];
+
+    const parsed = JSON.parse(jsonMatch[0]) as { promotions?: PromotionJudgment[] };
+    if (!Array.isArray(parsed.promotions)) return [];
+
+    const promoteIds = new Set(
+      parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId)
+    );
+
+    return candidates.filter((m) => promoteIds.has(m.MemoryID));
+  } catch (err) {
+    logger.warn('[confirmation] LLM 昇格判定に失敗しました', { err });
+    return [];
+  }
+}
+
+/**
+ * 現在のユーザー入力に対して Tier C 記憶の中から「再言及」されたものを抽出し、
+ * LLM で昇格すべきかを判定して返す。
+ *
+ * @param userId - ユーザー ID
+ * @param characterId - キャラクター ID
+ * @param userInput - 現在のユーザー発話
+ * @param memoryRepository - Memory リポジトリ
+ * @param embeddingClient - Embedding クライアント
+ * @param llmClient - LLM クライアント（classify 用途）
+ * @param nowMs - 現在時刻（ミリ秒、テスト差し替え用）
+ */
+export async function identifyPromotionCandidates(
+  userId: string,
+  characterId: string,
+  userInput: string,
+  memoryRepository: MemoryRepository,
+  embeddingClient: IEmbeddingClient,
+  llmClient: ILLMClient,
+  nowMs: number = Date.now()
+): Promise<MemoryEntity[]> {
+  // Tier C 全件取得
+  let tierCMemories: MemoryEntity[];
+  try {
+    tierCMemories = await memoryRepository.listByTier(userId, characterId, 'C');
+  } catch (err) {
+    logger.warn('[confirmation] Tier C 記憶の取得に失敗しました', { err });
+    return [];
+  }
+
+  if (tierCMemories.length === 0) return [];
+
+  // ユーザー入力の embedding 生成（失敗時はスキップ）
+  let queryEmbedding: number[];
+  try {
+    queryEmbedding = await embeddingClient.embed(userInput);
+  } catch (err) {
+    logger.warn('[confirmation] embedding 生成に失敗しました（昇格判定スキップ）', { err });
+    return [];
+  }
+
+  // cosine similarity で再言及候補を抽出
+  const candidates: MemoryEntity[] = [];
+  for (const memory of tierCMemories) {
+    if (!memory.Embedding || memory.Embedding.length === 0) continue;
+    const similarity = cosineSimilarity(queryEmbedding, memory.Embedding);
+    if (similarity >= PROMOTION_SIMILARITY_THRESHOLD) {
+      candidates.push(memory);
+    }
+  }
+
+  if (candidates.length === 0) return [];
+
+  // LLM で昇格判定（fail-warn: エラー時は空配列で継続）
+  return await judgePromotionsWithLLM(userInput, candidates, llmClient);
+}
+
+/**
+ * 「新しく学んだこと」としてプロンプトに含める Memory を返す。
+ *
+ * 条件:
+ * - 昇格候補（Tier C → B）であること
+ * - cooldown 経過（直近 CONFIRMATION_COOLDOWN_MS 以内に参照済みは除外）
+ *   → 同じ記憶について毎ターン「覚えとくね」と言わないよう制御する
+ *
+ * @param promotionCandidates - 昇格候補 Memory 一覧
+ * @param nowMs - 現在時刻（ミリ秒、テスト差し替え用）
+ */
+export function identifyNewLearnings(
+  promotionCandidates: MemoryEntity[],
+  nowMs: number = Date.now()
+): MemoryEntity[] {
+  return promotionCandidates.filter((m) => {
+    if (m.LastReferencedAt === undefined) return true;
+    return nowMs - m.LastReferencedAt >= CONFIRMATION_COOLDOWN_MS;
+  });
+}

--- a/services/livetalk/core/src/memory/correction-detector.ts
+++ b/services/livetalk/core/src/memory/correction-detector.ts
@@ -1,0 +1,166 @@
+/**
+ * ユーザー入力の暗黙訂正検出（Phase 3d / Issue #3282）。
+ *
+ * フロー:
+ *   1. キーワード検出（高速フィルタ）: 「いや」「違う」「実は」等
+ *   2. 追加情報パターン除外: 「いや、それも好き」等は訂正ではなく補足
+ *   3. LLM 最終判定（GPT-4o-mini 相当）: false positive 抑制
+ *
+ * 方針:
+ * - false negative を低めに（ユーザーの訂正を無視するのは UX 致命傷）
+ * - false positive は LLM 判定で抑制
+ */
+
+import { logger } from '@nagiyu/common';
+import type { ILLMClient } from '../llm-client/types.js';
+import type { MemoryEntity } from '../entities/memory.entity.js';
+import type { RetrievedMemory } from './types.js';
+
+export interface CorrectionResult {
+  detected: boolean;
+  /** 訂正対象の Memory */
+  targetMemories: MemoryEntity[];
+  /** 訂正後の値（LLM が取得できた場合のみ） */
+  newValue?: string;
+}
+
+/** 訂正を示すキーワードパターン */
+const CORRECTION_KEYWORDS: RegExp[] = [
+  /いや[、,\s！。]/,
+  /いや$/,
+  /(?:違う|ちがう)/,
+  /実は/,
+  /やっぱり/,
+  /そうじゃない/,
+  /そうでもない/,
+  /(?:あれ|ちょっと)[、,\s]?(?:違|間違)/,
+  /間違[いえ]/,
+];
+
+/**
+ * 追加情報パターン（訂正ではなく補足・追加の可能性が高い）。
+ * 「いや、それも好き」「違う、どちらも」等は除外する。
+ */
+const ADDITION_PATTERNS: RegExp[] = [
+  /(?:いや|違う|ちがう)[、,\s].*?も(?:好き|嫌い|得意|苦手|ある|持って|やって)/,
+  /(?:いや|違う|ちがう)[、,\s].*?(?:どちらも|両方|全部)/,
+  /実は[、,\s].*?も(?:好き|嫌い|得意|苦手)/,
+];
+
+function hasKeyword(text: string): boolean {
+  return CORRECTION_KEYWORDS.some((p) => p.test(text));
+}
+
+function isAdditionPattern(text: string): boolean {
+  return ADDITION_PATTERNS.some((p) => p.test(text));
+}
+
+interface LLMCorrectionResponse {
+  detected: boolean;
+  targetMemoryIds?: string[];
+  newValue?: string;
+}
+
+async function classifyWithLLM(
+  userInput: string,
+  previousAssistantMessage: string,
+  memories: MemoryEntity[],
+  llmClient: ILLMClient
+): Promise<LLMCorrectionResponse> {
+  if (memories.length === 0) return { detected: false };
+
+  const memoriesText = memories
+    .map((m) => `- ID: ${m.MemoryID}、内容: ${m.Content}`)
+    .join('\n');
+
+  const prompt = `以下はキャラクターとユーザーの会話のやり取りです。
+
+【キャラクターの直前の発話】
+${previousAssistantMessage}
+
+【ユーザーの最新の発話】
+${userInput}
+
+【キャラクターが参照していた記憶（ユーザーについての情報）】
+${memoriesText}
+
+ユーザーは上記の記憶のいずれかを訂正しようとしていますか？
+
+判断基準:
+- 「いや、それも好きだよ」のような追加情報は訂正ではありません
+- 「違う、本当は〇〇なんだ」のような明確な否定・修正のみ訂正です
+- ユーザーが会話の流れと無関係な訂正をする可能性は低いです
+
+訂正している場合（JSON のみ、説明不要）:
+{"detected": true, "targetMemoryIds": ["memory_id"], "newValue": "訂正後の値（取れる場合のみ）"}
+
+訂正していない場合:
+{"detected": false}`;
+
+  try {
+    const raw = await llmClient.chatComplete(
+      [{ role: 'user', content: prompt }],
+      { purpose: 'classify' }
+    );
+
+    const jsonMatch = raw.match(/\{[\s\S]*?\}/);
+    if (!jsonMatch) return { detected: false };
+
+    const parsed = JSON.parse(jsonMatch[0]) as LLMCorrectionResponse;
+    return {
+      detected: Boolean(parsed.detected),
+      targetMemoryIds: parsed.detected ? (parsed.targetMemoryIds ?? []) : undefined,
+      newValue: parsed.newValue,
+    };
+  } catch (err) {
+    logger.warn('[correction-detector] LLM 訂正判定に失敗しました', { err });
+    return { detected: false };
+  }
+}
+
+/**
+ * ユーザー入力が直前のキャラ応答で参照された Memory への訂正かを検出する。
+ *
+ * @param userInput - 現在のユーザー発話
+ * @param previousAssistantMessage - 直前のキャラ応答テキスト
+ * @param retrievedMemories - 直前ターンで取得・注入された Memory
+ * @param llmClient - LLM クライアント（classify 用途）
+ */
+export async function detectCorrection(
+  userInput: string,
+  previousAssistantMessage: string,
+  retrievedMemories: RetrievedMemory[],
+  llmClient: ILLMClient
+): Promise<CorrectionResult> {
+  const empty: CorrectionResult = { detected: false, targetMemories: [] };
+
+  if (!userInput.trim() || retrievedMemories.length === 0) return empty;
+
+  // ステップ 1: キーワード検出（高速フィルタ）
+  if (!hasKeyword(userInput)) return empty;
+
+  // ステップ 2: 追加情報パターン除外
+  if (isAdditionPattern(userInput)) return empty;
+
+  // ステップ 3: LLM 最終判定
+  const memories = retrievedMemories.map((r) => r.memory);
+  const llmResult = await classifyWithLLM(
+    userInput,
+    previousAssistantMessage,
+    memories,
+    llmClient
+  );
+
+  if (!llmResult.detected || !llmResult.targetMemoryIds?.length) return empty;
+
+  const targetMemoryIds = new Set(llmResult.targetMemoryIds);
+  const targetMemories = memories.filter((m) => targetMemoryIds.has(m.MemoryID));
+
+  if (targetMemories.length === 0) return empty;
+
+  return {
+    detected: true,
+    targetMemories,
+    newValue: llmResult.newValue,
+  };
+}

--- a/services/livetalk/core/src/memory/correction-detector.ts
+++ b/services/livetalk/core/src/memory/correction-detector.ts
@@ -69,9 +69,7 @@ async function classifyWithLLM(
 ): Promise<LLMCorrectionResponse> {
   if (memories.length === 0) return { detected: false };
 
-  const memoriesText = memories
-    .map((m) => `- ID: ${m.MemoryID}、内容: ${m.Content}`)
-    .join('\n');
+  const memoriesText = memories.map((m) => `- ID: ${m.MemoryID}、内容: ${m.Content}`).join('\n');
 
   const prompt = `以下はキャラクターとユーザーの会話のやり取りです。
 
@@ -98,10 +96,9 @@ ${memoriesText}
 {"detected": false}`;
 
   try {
-    const raw = await llmClient.chatComplete(
-      [{ role: 'user', content: prompt }],
-      { purpose: 'classify' }
-    );
+    const raw = await llmClient.chatComplete([{ role: 'user', content: prompt }], {
+      purpose: 'classify',
+    });
 
     const jsonMatch = raw.match(/\{[\s\S]*?\}/);
     if (!jsonMatch) return { detected: false };
@@ -144,12 +141,7 @@ export async function detectCorrection(
 
   // ステップ 3: LLM 最終判定
   const memories = retrievedMemories.map((r) => r.memory);
-  const llmResult = await classifyWithLLM(
-    userInput,
-    previousAssistantMessage,
-    memories,
-    llmClient
-  );
+  const llmResult = await classifyWithLLM(userInput, previousAssistantMessage, memories, llmClient);
 
   if (!llmResult.detected || !llmResult.targetMemoryIds?.length) return empty;
 

--- a/services/livetalk/core/src/memory/index.ts
+++ b/services/livetalk/core/src/memory/index.ts
@@ -1,3 +1,7 @@
 export { cosineSimilarity } from './embedding.js';
 export { MemoryRetriever } from './retrieval.js';
 export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './types.js';
+export { detectCorrection } from './correction-detector.js';
+export type { CorrectionResult } from './correction-detector.js';
+export { identifyPromotionCandidates, identifyNewLearnings } from './confirmation.js';
+export { applyCorrection, executePromotion } from './promotion.js';

--- a/services/livetalk/core/src/memory/promotion.ts
+++ b/services/livetalk/core/src/memory/promotion.ts
@@ -1,0 +1,105 @@
+/**
+ * Memory の昇格・降格・訂正適用ロジック（Phase 3d / Issue #3282）。
+ *
+ * - applyCorrection: 訂正検出結果を Memory に反映（confidence 減算、閾値割れで削除）
+ * - executePromotion: 昇格候補を Tier C → B に昇格
+ */
+
+import { logger } from '@nagiyu/common';
+import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
+import type { MemoryEntity } from '../entities/memory.entity.js';
+import type { CorrectionResult } from './correction-detector.js';
+import { CORRECTION_CONFIDENCE_PENALTY, MEMORY_AUTO_DELETE_THRESHOLD } from '../constants.js';
+
+/**
+ * 訂正結果を Memory に適用する。
+ *
+ * - 対象 Memory の Confidence を CORRECTION_CONFIDENCE_PENALTY 分下げる
+ * - Confidence < MEMORY_AUTO_DELETE_THRESHOLD の場合は削除する
+ * - newValue が取得できていれば Content も更新する
+ * - エラーは warn ログのみ（fail-warn パターン）
+ */
+export async function applyCorrection(
+  correction: CorrectionResult,
+  memoryRepository: MemoryRepository
+): Promise<void> {
+  if (!correction.detected || correction.targetMemories.length === 0) return;
+
+  await Promise.all(
+    correction.targetMemories.map(async (memory) => {
+      const newConfidence = Math.max(0, memory.Confidence - CORRECTION_CONFIDENCE_PENALTY);
+
+      if (newConfidence < MEMORY_AUTO_DELETE_THRESHOLD) {
+        try {
+          await memoryRepository.delete({
+            userId: memory.UserID,
+            characterId: memory.CharacterID,
+            tier: memory.Tier,
+            category: memory.Category,
+            memoryId: memory.MemoryID,
+          });
+          logger.info('[promotion] 訂正により記憶を自動削除しました', {
+            memoryId: memory.MemoryID,
+            confidence: memory.Confidence,
+          });
+        } catch (err) {
+          logger.warn('[promotion] 記憶の削除に失敗しました', {
+            err,
+            memoryId: memory.MemoryID,
+          });
+        }
+        return;
+      }
+
+      try {
+        await memoryRepository.update({
+          UserID: memory.UserID,
+          CharacterID: memory.CharacterID,
+          MemoryID: memory.MemoryID,
+          Tier: memory.Tier,
+          Category: memory.Category,
+          Confidence: newConfidence,
+          ...(correction.newValue !== undefined && { Content: correction.newValue }),
+        });
+        logger.info('[promotion] 訂正により記憶の信頼度を下げました', {
+          memoryId: memory.MemoryID,
+          before: memory.Confidence,
+          after: newConfidence,
+        });
+      } catch (err) {
+        logger.warn('[promotion] 記憶の更新に失敗しました', {
+          err,
+          memoryId: memory.MemoryID,
+        });
+      }
+    })
+  );
+}
+
+/**
+ * 昇格候補の Tier C 記憶を Tier B に昇格する。
+ *
+ * fire-and-forget 用途（エラーは warn のみ、呼び出し元はレスポンスを待たない）。
+ */
+export async function executePromotion(
+  promotionCandidates: MemoryEntity[],
+  memoryRepository: MemoryRepository
+): Promise<void> {
+  if (promotionCandidates.length === 0) return;
+
+  await Promise.all(
+    promotionCandidates.map(async (memory) => {
+      try {
+        await memoryRepository.promote(memory, 'B');
+        logger.info('[promotion] Tier C → B 昇格を実行しました', {
+          memoryId: memory.MemoryID,
+        });
+      } catch (err) {
+        logger.warn('[promotion] 記憶の昇格に失敗しました', {
+          err,
+          memoryId: memory.MemoryID,
+        });
+      }
+    })
+  );
+}

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -1,10 +1,12 @@
 import { logger } from '@nagiyu/common';
-import type { ILLMClient } from '../llm-client/types.js';
+import type { IEmbeddingClient, ILLMClient } from '../llm-client/types.js';
 import type { IVoiceClient } from '../voicevox/types.js';
 import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
 import type { MessageRepository } from '../repositories/message.repository.interface.js';
 import type { SafetyEventRepository } from '../repositories/safety-event.repository.interface.js';
 import type { CharacterDefinition } from '../characters/types.js';
+import type { MemoryEntity } from '../entities/memory.entity.js';
+import type { MessageEntity } from '../entities/message.entity.js';
 import { buildChatMessages } from '../characters/prompt-builder.js';
 import { SentenceBuffer } from '../lib/sentence-splitter.js';
 import {
@@ -18,6 +20,9 @@ import { buildModerationReplacementMessage, buildSafetyMessage } from '../safety
 import { SAFETY_RESOURCES } from '../safety/resources.js';
 import type { IModerationClient, SafetyResource } from '../safety/types.js';
 import type { IMemoryRetriever, RetrievedMemory } from '../memory/types.js';
+import { detectCorrection } from '../memory/correction-detector.js';
+import { identifyNewLearnings, identifyPromotionCandidates } from '../memory/confirmation.js';
+import { applyCorrection, executePromotion } from '../memory/promotion.js';
 
 /**
  * /api/chat ストリーミングレスポンスの各イベント型。
@@ -56,9 +61,18 @@ export interface ChatUseCaseParams {
   memoryRetriever?: IMemoryRetriever;
   /** memoryRetriever が指定された場合に使う Memory リポジトリ */
   memoryRepository?: MemoryRepository;
+  /** Tier C 昇格候補検出に使う Embedding クライアント。未指定時は昇格処理をスキップする */
+  embeddingClient?: IEmbeddingClient;
 }
 
 type SynthesisResult = { index: number; text: string; audio: string | null };
+
+function getLastAssistantMessage(history: MessageEntity[]): string | null {
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].Role === 'assistant') return history[i].Text;
+  }
+  return null;
+}
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
@@ -160,6 +174,7 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     moderationClient,
     memoryRetriever,
     memoryRepository,
+    embeddingClient,
   } = params;
 
   // 1. 直近会話履歴取得
@@ -234,13 +249,53 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     }
   }
 
+  // 4a. 暗黙訂正検出（fail-warn: エラー時はスキップして継続）
+  if (memoryRepository && retrievedMemories.length > 0) {
+    const lastAssistantMessage = getLastAssistantMessage(history);
+    if (lastAssistantMessage) {
+      try {
+        const correction = await detectCorrection(
+          userText,
+          lastAssistantMessage,
+          retrievedMemories,
+          llmClient
+        );
+        if (correction.detected) {
+          await applyCorrection(correction, memoryRepository);
+        }
+      } catch (err) {
+        logger.warn('[chat-usecase] 暗黙訂正検出に失敗しました（スキップして継続）', { err });
+      }
+    }
+  }
+
+  // 4b. Tier C 昇格候補検出（fail-warn: エラー時は空配列で継続）
+  let promotionCandidates: MemoryEntity[] = [];
+  if (memoryRepository && embeddingClient) {
+    try {
+      promotionCandidates = await identifyPromotionCandidates(
+        userId,
+        characterId,
+        userText,
+        memoryRepository,
+        embeddingClient,
+        llmClient
+      );
+    } catch (err) {
+      logger.warn('[chat-usecase] 昇格候補検出に失敗しました（スキップして継続）', { err });
+    }
+  }
+  const newLearnings = identifyNewLearnings(promotionCandidates);
+
   // 5. LLM ストリーミング（通常フロー）
   const chatMessages = buildChatMessages(
     character,
     new Date(),
     history,
     userText,
-    retrievedMemories
+    retrievedMemories,
+    undefined,
+    newLearnings.length > 0 ? newLearnings : undefined
   );
   const sentenceBuffer = new SentenceBuffer();
   let fullResponseText = '';
@@ -334,7 +389,14 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     }
   }
 
-  // 11. 参照済み Memory の referencedCount / lastReferencedAt を更新（fire-and-forget）
+  // 11. Tier C → B 昇格を実行（fire-and-forget）
+  if (memoryRepository && promotionCandidates.length > 0) {
+    void executePromotion(promotionCandidates, memoryRepository).catch((err) => {
+      logger.warn('[chat-usecase] Tier C → B 昇格に失敗しました', { err });
+    });
+  }
+
+  // 12. 参照済み Memory の referencedCount / lastReferencedAt を更新（fire-and-forget）
   if (memoryRepository && retrievedMemories.length > 0) {
     const now = Date.now();
     void Promise.all(

--- a/services/livetalk/core/tests/unit/memory/confirmation.test.ts
+++ b/services/livetalk/core/tests/unit/memory/confirmation.test.ts
@@ -1,8 +1,14 @@
-import { identifyPromotionCandidates, identifyNewLearnings } from '../../../src/memory/confirmation.js';
+import {
+  identifyPromotionCandidates,
+  identifyNewLearnings,
+} from '../../../src/memory/confirmation.js';
 import type { IEmbeddingClient, ILLMClient } from '../../../src/llm-client/types.js';
 import type { MemoryRepository } from '../../../src/repositories/memory.repository.interface.js';
 import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
-import { CONFIRMATION_COOLDOWN_MS, PROMOTION_SIMILARITY_THRESHOLD } from '../../../src/constants.js';
+import {
+  CONFIRMATION_COOLDOWN_MS,
+  PROMOTION_SIMILARITY_THRESHOLD,
+} from '../../../src/constants.js';
 
 const FIXED_NOW = 1_750_000_000_000;
 
@@ -57,8 +63,12 @@ describe('identifyPromotionCandidates', () => {
     it('Tier C が空なら空配列を返す', async () => {
       const repo = makeMemoryRepo([]);
       const result = await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒーが好き', repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE), makeLLMClient(''), FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒーが好き',
+        repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        makeLLMClient('')
       );
       expect(result).toHaveLength(0);
     });
@@ -70,8 +80,12 @@ describe('identifyPromotionCandidates', () => {
       const repo = makeMemoryRepo([mem]);
       const llm = makeLLMClient('');
       const result = await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒー飲んだ', repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒー飲んだ',
+        repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        llm
       );
       expect(result).toHaveLength(0);
       expect(llm.chatComplete).not.toHaveBeenCalled();
@@ -81,16 +95,18 @@ describe('identifyPromotionCandidates', () => {
   describe('similarity 閾値', () => {
     it(`similarity >= ${PROMOTION_SIMILARITY_THRESHOLD} の場合のみ LLM 判定に進む`, async () => {
       const highSim = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE); // coffee に近い
-      const lowSim = makeMemoryC('c2', 'スポーツが好き', VEC_SPORTS);  // 直交
+      const lowSim = makeMemoryC('c2', 'スポーツが好き', VEC_SPORTS); // 直交
       const repo = makeMemoryRepo([highSim, lowSim]);
-      const llm = makeLLMClient(
-        '{"promotions": [{"memoryId": "c1", "promote": true}]}'
-      );
+      const llm = makeLLMClient('{"promotions": [{"memoryId": "c1", "promote": true}]}');
       await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒー飲んだ', repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒー飲んだ',
+        repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        llm
       );
-      const [_, promptArg] = (llm.chatComplete as jest.Mock).mock.calls[0];
+      const [, promptArg] = (llm.chatComplete as jest.Mock).mock.calls[0];
       // LLM に渡したメッセージに c2 が含まれていないことを確認
       expect(JSON.stringify(promptArg ?? '')).not.toContain('c2');
     });
@@ -100,12 +116,14 @@ describe('identifyPromotionCandidates', () => {
     it('LLM が promote: true を返した Memory を返す', async () => {
       const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
       const repo = makeMemoryRepo([mem]);
-      const llm = makeLLMClient(
-        '{"promotions": [{"memoryId": "c1", "promote": true}]}'
-      );
+      const llm = makeLLMClient('{"promotions": [{"memoryId": "c1", "promote": true}]}');
       const result = await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒーの話', repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒーの話',
+        repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        llm
       );
       expect(result).toHaveLength(1);
       expect(result[0].MemoryID).toBe('c1');
@@ -114,12 +132,14 @@ describe('identifyPromotionCandidates', () => {
     it('LLM が promote: false を返した Memory は含まない', async () => {
       const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
       const repo = makeMemoryRepo([mem]);
-      const llm = makeLLMClient(
-        '{"promotions": [{"memoryId": "c1", "promote": false}]}'
-      );
+      const llm = makeLLMClient('{"promotions": [{"memoryId": "c1", "promote": false}]}');
       const result = await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒーの話', repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒーの話',
+        repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        llm
       );
       expect(result).toHaveLength(0);
     });
@@ -129,12 +149,18 @@ describe('identifyPromotionCandidates', () => {
       const repo = makeMemoryRepo([mem]);
       const llm = {
         chatStream: jest.fn(),
-        chatComplete: jest.fn(async () => { throw new Error('API error'); }),
+        chatComplete: jest.fn(async () => {
+          throw new Error('API error');
+        }),
         summarize: jest.fn(),
       } as unknown as ILLMClient;
       const result = await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒーの話', repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒーの話',
+        repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        llm
       );
       expect(result).toHaveLength(0);
     });
@@ -144,8 +170,12 @@ describe('identifyPromotionCandidates', () => {
       const repo = makeMemoryRepo([mem]);
       const llm = makeLLMClient('invalid json');
       const result = await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒーの話', repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒーの話',
+        repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        llm
       );
       expect(result).toHaveLength(0);
     });
@@ -155,11 +185,17 @@ describe('identifyPromotionCandidates', () => {
     it('Tier C 取得がエラーなら空配列で継続する', async () => {
       const repo = {
         ...makeMemoryRepo([]),
-        listByTier: jest.fn(async () => { throw new Error('DynamoDB error'); }),
+        listByTier: jest.fn(async () => {
+          throw new Error('DynamoDB error');
+        }),
       } as unknown as MemoryRepository;
       const result = await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒー', repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE), makeLLMClient(''), FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒー',
+        repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE),
+        makeLLMClient('')
       );
       expect(result).toHaveLength(0);
     });
@@ -168,10 +204,17 @@ describe('identifyPromotionCandidates', () => {
       const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
       const repo = makeMemoryRepo([mem]);
       const failingEmbed: IEmbeddingClient = {
-        embed: jest.fn(async () => { throw new Error('embed error'); }),
+        embed: jest.fn(async () => {
+          throw new Error('embed error');
+        }),
       };
       const result = await identifyPromotionCandidates(
-        'u1', 'hiyori', 'コーヒー', repo, failingEmbed, makeLLMClient(''), FIXED_NOW
+        'u1',
+        'hiyori',
+        'コーヒー',
+        repo,
+        failingEmbed,
+        makeLLMClient('')
       );
       expect(result).toHaveLength(0);
     });

--- a/services/livetalk/core/tests/unit/memory/confirmation.test.ts
+++ b/services/livetalk/core/tests/unit/memory/confirmation.test.ts
@@ -1,0 +1,232 @@
+import { identifyPromotionCandidates, identifyNewLearnings } from '../../../src/memory/confirmation.js';
+import type { IEmbeddingClient, ILLMClient } from '../../../src/llm-client/types.js';
+import type { MemoryRepository } from '../../../src/repositories/memory.repository.interface.js';
+import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
+import { CONFIRMATION_COOLDOWN_MS, PROMOTION_SIMILARITY_THRESHOLD } from '../../../src/constants.js';
+
+const FIXED_NOW = 1_750_000_000_000;
+
+function makeMemoryC(id: string, content: string, embedding?: number[]): MemoryEntity {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    MemoryID: id,
+    Tier: 'C',
+    Category: 'food',
+    Content: content,
+    Confidence: 0.5,
+    ReferencedCount: 1,
+    CreatedAt: FIXED_NOW - 100000,
+    UpdatedAt: FIXED_NOW - 100000,
+    Embedding: embedding,
+  };
+}
+
+function makeMemoryRepo(tierC: MemoryEntity[]): MemoryRepository {
+  return {
+    listByTier: jest.fn(async (_u, _c, tier) => (tier === 'C' ? tierC : [])),
+    put: jest.fn(),
+    get: jest.fn(),
+    listByCategory: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    promote: jest.fn(),
+    demote: jest.fn(),
+  } as unknown as MemoryRepository;
+}
+
+function makeEmbeddingClient(vec: number[]): IEmbeddingClient {
+  return { embed: jest.fn(async () => vec) };
+}
+
+function makeLLMClient(response: string): ILLMClient {
+  return {
+    chatStream: jest.fn(),
+    chatComplete: jest.fn(async () => response),
+    summarize: jest.fn(),
+  } as unknown as ILLMClient;
+}
+
+// テスト用ベクトル（直交）
+const VEC_COFFEE = [1, 0, 0];
+const VEC_SPORTS = [0, 1, 0];
+const VEC_QUERY_COFFEE = [0.99, 0.1, 0]; // coffee に近い
+
+describe('identifyPromotionCandidates', () => {
+  describe('Tier C 記憶なし', () => {
+    it('Tier C が空なら空配列を返す', async () => {
+      const repo = makeMemoryRepo([]);
+      const result = await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒーが好き', repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE), makeLLMClient(''), FIXED_NOW
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('embedding 未設定', () => {
+    it('embedding がない Tier C 記憶はスキップする', async () => {
+      const mem = makeMemoryC('c1', 'コーヒーが好き'); // embedding なし
+      const repo = makeMemoryRepo([mem]);
+      const llm = makeLLMClient('');
+      const result = await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒー飲んだ', repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+      );
+      expect(result).toHaveLength(0);
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('similarity 閾値', () => {
+    it(`similarity >= ${PROMOTION_SIMILARITY_THRESHOLD} の場合のみ LLM 判定に進む`, async () => {
+      const highSim = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE); // coffee に近い
+      const lowSim = makeMemoryC('c2', 'スポーツが好き', VEC_SPORTS);  // 直交
+      const repo = makeMemoryRepo([highSim, lowSim]);
+      const llm = makeLLMClient(
+        '{"promotions": [{"memoryId": "c1", "promote": true}]}'
+      );
+      await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒー飲んだ', repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+      );
+      const [_, promptArg] = (llm.chatComplete as jest.Mock).mock.calls[0];
+      // LLM に渡したメッセージに c2 が含まれていないことを確認
+      expect(JSON.stringify(promptArg ?? '')).not.toContain('c2');
+    });
+  });
+
+  describe('LLM 昇格判定', () => {
+    it('LLM が promote: true を返した Memory を返す', async () => {
+      const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
+      const repo = makeMemoryRepo([mem]);
+      const llm = makeLLMClient(
+        '{"promotions": [{"memoryId": "c1", "promote": true}]}'
+      );
+      const result = await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒーの話', repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].MemoryID).toBe('c1');
+    });
+
+    it('LLM が promote: false を返した Memory は含まない', async () => {
+      const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
+      const repo = makeMemoryRepo([mem]);
+      const llm = makeLLMClient(
+        '{"promotions": [{"memoryId": "c1", "promote": false}]}'
+      );
+      const result = await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒーの話', repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('LLM がエラーを投げても空配列で継続する（fail-warn）', async () => {
+      const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
+      const repo = makeMemoryRepo([mem]);
+      const llm = {
+        chatStream: jest.fn(),
+        chatComplete: jest.fn(async () => { throw new Error('API error'); }),
+        summarize: jest.fn(),
+      } as unknown as ILLMClient;
+      const result = await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒーの話', repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('LLM が不正 JSON を返しても空配列で継続する', async () => {
+      const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
+      const repo = makeMemoryRepo([mem]);
+      const llm = makeLLMClient('invalid json');
+      const result = await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒーの話', repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE), llm, FIXED_NOW
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('エラーハンドリング', () => {
+    it('Tier C 取得がエラーなら空配列で継続する', async () => {
+      const repo = {
+        ...makeMemoryRepo([]),
+        listByTier: jest.fn(async () => { throw new Error('DynamoDB error'); }),
+      } as unknown as MemoryRepository;
+      const result = await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒー', repo,
+        makeEmbeddingClient(VEC_QUERY_COFFEE), makeLLMClient(''), FIXED_NOW
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('embedding 生成がエラーなら空配列で継続する', async () => {
+      const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
+      const repo = makeMemoryRepo([mem]);
+      const failingEmbed: IEmbeddingClient = {
+        embed: jest.fn(async () => { throw new Error('embed error'); }),
+      };
+      const result = await identifyPromotionCandidates(
+        'u1', 'hiyori', 'コーヒー', repo, failingEmbed, makeLLMClient(''), FIXED_NOW
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+});
+
+describe('identifyNewLearnings', () => {
+  function makeCandidate(id: string, lastReferencedAt?: number): MemoryEntity {
+    return makeMemoryC(id, `content ${id}`, VEC_COFFEE, lastReferencedAt);
+  }
+
+  function makeMemoryC(id: string, content: string, _: number[], lastRef?: number): MemoryEntity {
+    return {
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      MemoryID: id,
+      Tier: 'C',
+      Category: 'food',
+      Content: content,
+      Confidence: 0.5,
+      ReferencedCount: 1,
+      LastReferencedAt: lastRef,
+      CreatedAt: FIXED_NOW - 100000,
+      UpdatedAt: FIXED_NOW - 100000,
+    };
+  }
+
+  it('空配列を渡すと空配列を返す', () => {
+    expect(identifyNewLearnings([], FIXED_NOW)).toHaveLength(0);
+  });
+
+  it('LastReferencedAt が未設定の記憶は含める（初回参照）', () => {
+    const m = makeCandidate('c1', undefined);
+    const result = identifyNewLearnings([m], FIXED_NOW);
+    expect(result).toHaveLength(1);
+  });
+
+  it(`直近 ${CONFIRMATION_COOLDOWN_MS}ms 以内に参照済みの記憶は除外する`, () => {
+    const m = makeCandidate('c1', FIXED_NOW - CONFIRMATION_COOLDOWN_MS + 1000); // cooldown 内
+    const result = identifyNewLearnings([m], FIXED_NOW);
+    expect(result).toHaveLength(0);
+  });
+
+  it(`cooldown 以上経過していれば含める`, () => {
+    const m = makeCandidate('c1', FIXED_NOW - CONFIRMATION_COOLDOWN_MS - 1); // cooldown 超過
+    const result = identifyNewLearnings([m], FIXED_NOW);
+    expect(result).toHaveLength(1);
+  });
+
+  it('cooldown 内のものと外のものが混在する場合、外のもののみ返す', () => {
+    const recent = makeCandidate('c1', FIXED_NOW - 1000); // cooldown 内
+    const old = makeCandidate('c2', FIXED_NOW - CONFIRMATION_COOLDOWN_MS * 2); // cooldown 超過
+    const fresh = makeCandidate('c3', undefined); // 未参照
+    const result = identifyNewLearnings([recent, old, fresh], FIXED_NOW);
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.MemoryID).sort()).toEqual(['c2', 'c3']);
+  });
+});

--- a/services/livetalk/core/tests/unit/memory/correction-detector.test.ts
+++ b/services/livetalk/core/tests/unit/memory/correction-detector.test.ts
@@ -64,24 +64,14 @@ describe('detectCorrection', () => {
   describe('追加情報パターン除外（false positive 抑制）', () => {
     it('「いや、それも好きだよ」は訂正と検出しない', async () => {
       const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"]}');
-      const result = await detectCorrection(
-        'いや、コーヒーも好きだよ',
-        prevMsg,
-        memories,
-        llm
-      );
+      const result = await detectCorrection('いや、コーヒーも好きだよ', prevMsg, memories, llm);
       expect(result.detected).toBe(false);
       expect(llm.chatComplete).not.toHaveBeenCalled();
     });
 
     it('「違う、どちらも好き」は訂正と検出しない', async () => {
       const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"]}');
-      const result = await detectCorrection(
-        '違う、どちらも好き！',
-        prevMsg,
-        memories,
-        llm
-      );
+      const result = await detectCorrection('違う、どちらも好き！', prevMsg, memories, llm);
       expect(result.detected).toBe(false);
       expect(llm.chatComplete).not.toHaveBeenCalled();
     });
@@ -101,7 +91,9 @@ describe('detectCorrection', () => {
 
   describe('LLM 最終判定', () => {
     it('LLM が detected: true を返せば訂正を検出する', async () => {
-      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"], "newValue": "お茶が好き"}');
+      const llm = makeLLMClient(
+        '{"detected": true, "targetMemoryIds": ["m1"], "newValue": "お茶が好き"}'
+      );
       const result = await detectCorrection('違う、お茶が好きなんだ', prevMsg, memories, llm);
       expect(result.detected).toBe(true);
       expect(result.targetMemories).toHaveLength(1);
@@ -126,7 +118,9 @@ describe('detectCorrection', () => {
     it('LLM がエラーを投げても detected: false で継続する（fail-warn）', async () => {
       const llm = {
         chatStream: jest.fn(),
-        chatComplete: jest.fn(async () => { throw new Error('API error'); }),
+        chatComplete: jest.fn(async () => {
+          throw new Error('API error');
+        }),
         summarize: jest.fn(),
       } as unknown as ILLMClient;
       const result = await detectCorrection('違う！', prevMsg, memories, llm);
@@ -150,9 +144,7 @@ describe('detectCorrection', () => {
         makeRetrieved('m1', 'コーヒーが好き'),
         makeRetrieved('m2', '趣味はゲーム'),
       ];
-      const llm = makeLLMClient(
-        '{"detected": true, "targetMemoryIds": ["m1", "m2"]}'
-      );
+      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1", "m2"]}');
       const result = await detectCorrection(
         '実は違う、お茶が好きで趣味は読書なんだ',
         prevMsg,
@@ -178,15 +170,13 @@ describe('detectCorrection', () => {
       expect(llm.chatComplete).toHaveBeenCalled();
     });
 
-    it.each([
-      ['そうだよ'],
-      ['うん、コーヒー好き'],
-      ['ありがとう！'],
-      ['もっと教えて'],
-    ])('「%s」はキーワード検出で LLM を呼ばない', async (input) => {
-      const llm = makeLLMClient('');
-      await detectCorrection(input, prevMsg, memories, llm);
-      expect(llm.chatComplete).not.toHaveBeenCalled();
-    });
+    it.each([['そうだよ'], ['うん、コーヒー好き'], ['ありがとう！'], ['もっと教えて']])(
+      '「%s」はキーワード検出で LLM を呼ばない',
+      async (input) => {
+        const llm = makeLLMClient('');
+        await detectCorrection(input, prevMsg, memories, llm);
+        expect(llm.chatComplete).not.toHaveBeenCalled();
+      }
+    );
   });
 });

--- a/services/livetalk/core/tests/unit/memory/correction-detector.test.ts
+++ b/services/livetalk/core/tests/unit/memory/correction-detector.test.ts
@@ -1,0 +1,192 @@
+import { detectCorrection } from '../../../src/memory/correction-detector.js';
+import type { ILLMClient } from '../../../src/llm-client/types.js';
+import type { RetrievedMemory } from '../../../src/memory/types.js';
+import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
+
+const FIXED_NOW = 1_750_000_000_000;
+
+function makeMemory(id: string, content: string): MemoryEntity {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    MemoryID: id,
+    Tier: 'B',
+    Category: 'food',
+    Content: content,
+    Confidence: 0.8,
+    ReferencedCount: 3,
+    LastReferencedAt: FIXED_NOW - 10000,
+    CreatedAt: FIXED_NOW - 100000,
+    UpdatedAt: FIXED_NOW - 10000,
+  };
+}
+
+function makeRetrieved(id: string, content: string): RetrievedMemory {
+  return { memory: makeMemory(id, content), similarity: 0.9 };
+}
+
+function makeLLMClient(response: string): ILLMClient {
+  return {
+    chatStream: jest.fn(),
+    chatComplete: jest.fn(async () => response),
+    summarize: jest.fn(),
+  } as unknown as ILLMClient;
+}
+
+describe('detectCorrection', () => {
+  const prevMsg = 'コーヒーが好きなんだね！わかった。';
+  const memories = [makeRetrieved('m1', 'コーヒーが好き')];
+
+  describe('キーワード検出（高速フィルタ）', () => {
+    it('訂正キーワードがなければ LLM を呼ばずに detected: false を返す', async () => {
+      const llm = makeLLMClient('');
+      const result = await detectCorrection('そうだよ！', prevMsg, memories, llm);
+      expect(result.detected).toBe(false);
+      expect(result.targetMemories).toHaveLength(0);
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+
+    it('取得した Memory が空なら detected: false を返す（キーワードありでも）', async () => {
+      const llm = makeLLMClient('');
+      const result = await detectCorrection('違う！', prevMsg, [], llm);
+      expect(result.detected).toBe(false);
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+
+    it('空入力は detected: false を返す', async () => {
+      const llm = makeLLMClient('');
+      const result = await detectCorrection('', prevMsg, memories, llm);
+      expect(result.detected).toBe(false);
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('追加情報パターン除外（false positive 抑制）', () => {
+    it('「いや、それも好きだよ」は訂正と検出しない', async () => {
+      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"]}');
+      const result = await detectCorrection(
+        'いや、コーヒーも好きだよ',
+        prevMsg,
+        memories,
+        llm
+      );
+      expect(result.detected).toBe(false);
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+
+    it('「違う、どちらも好き」は訂正と検出しない', async () => {
+      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"]}');
+      const result = await detectCorrection(
+        '違う、どちらも好き！',
+        prevMsg,
+        memories,
+        llm
+      );
+      expect(result.detected).toBe(false);
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+
+    it('「実は、コーヒーもお茶も好き」は訂正と検出しない', async () => {
+      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"]}');
+      const result = await detectCorrection(
+        '実は、コーヒーもお茶も好きなんだ',
+        prevMsg,
+        memories,
+        llm
+      );
+      expect(result.detected).toBe(false);
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('LLM 最終判定', () => {
+    it('LLM が detected: true を返せば訂正を検出する', async () => {
+      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"], "newValue": "お茶が好き"}');
+      const result = await detectCorrection('違う、お茶が好きなんだ', prevMsg, memories, llm);
+      expect(result.detected).toBe(true);
+      expect(result.targetMemories).toHaveLength(1);
+      expect(result.targetMemories[0].MemoryID).toBe('m1');
+      expect(result.newValue).toBe('お茶が好き');
+    });
+
+    it('LLM が detected: false を返せば検出しない', async () => {
+      const llm = makeLLMClient('{"detected": false}');
+      const result = await detectCorrection('いや、まあそうだね', prevMsg, memories, llm);
+      expect(result.detected).toBe(false);
+      expect(result.targetMemories).toHaveLength(0);
+    });
+
+    it('LLM が存在しない memoryId を返しても targetMemories は空', async () => {
+      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["nonexistent"]}');
+      const result = await detectCorrection('違う！', prevMsg, memories, llm);
+      expect(result.detected).toBe(false);
+      expect(result.targetMemories).toHaveLength(0);
+    });
+
+    it('LLM がエラーを投げても detected: false で継続する（fail-warn）', async () => {
+      const llm = {
+        chatStream: jest.fn(),
+        chatComplete: jest.fn(async () => { throw new Error('API error'); }),
+        summarize: jest.fn(),
+      } as unknown as ILLMClient;
+      const result = await detectCorrection('違う！', prevMsg, memories, llm);
+      expect(result.detected).toBe(false);
+    });
+
+    it('LLM が不正 JSON を返しても detected: false で継続する', async () => {
+      const llm = makeLLMClient('invalid json');
+      const result = await detectCorrection('違う！', prevMsg, memories, llm);
+      expect(result.detected).toBe(false);
+    });
+
+    it('LLM がコードブロック付き JSON を返しても正しくパースする', async () => {
+      const llm = makeLLMClient('```json\n{"detected": true, "targetMemoryIds": ["m1"]}\n```');
+      const result = await detectCorrection('違う！', prevMsg, memories, llm);
+      expect(result.detected).toBe(true);
+    });
+
+    it('複数の訂正対象を返す場合、全て targetMemories に含まれる', async () => {
+      const multiMemories = [
+        makeRetrieved('m1', 'コーヒーが好き'),
+        makeRetrieved('m2', '趣味はゲーム'),
+      ];
+      const llm = makeLLMClient(
+        '{"detected": true, "targetMemoryIds": ["m1", "m2"]}'
+      );
+      const result = await detectCorrection(
+        '実は違う、お茶が好きで趣味は読書なんだ',
+        prevMsg,
+        multiMemories,
+        llm
+      );
+      expect(result.detected).toBe(true);
+      expect(result.targetMemories).toHaveLength(2);
+    });
+  });
+
+  describe('訂正キーワードバリエーション', () => {
+    it.each([
+      ['違う、お茶が好き'],
+      ['ちがう、お茶が好き'],
+      ['実は猫アレルギーなんだ'],
+      ['やっぱり、違う'],
+      ['そうじゃない！'],
+      ['あれ、間違えた'],
+    ])('「%s」はキーワード検出を通過して LLM まで到達する', async (input) => {
+      const llm = makeLLMClient('{"detected": false}');
+      await detectCorrection(input, prevMsg, memories, llm);
+      expect(llm.chatComplete).toHaveBeenCalled();
+    });
+
+    it.each([
+      ['そうだよ'],
+      ['うん、コーヒー好き'],
+      ['ありがとう！'],
+      ['もっと教えて'],
+    ])('「%s」はキーワード検出で LLM を呼ばない', async (input) => {
+      const llm = makeLLMClient('');
+      await detectCorrection(input, prevMsg, memories, llm);
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/memory/promotion.test.ts
+++ b/services/livetalk/core/tests/unit/memory/promotion.test.ts
@@ -113,9 +113,7 @@ describe('applyCorrection', () => {
       const mem = makeMemory('m1', confidence);
       const repo = makeRepo();
       await applyCorrection({ detected: true, targetMemories: [mem] }, repo);
-      expect(repo.delete).toHaveBeenCalledWith(
-        expect.objectContaining({ memoryId: 'm1' })
-      );
+      expect(repo.delete).toHaveBeenCalledWith(expect.objectContaining({ memoryId: 'm1' }));
       expect(repo.update).not.toHaveBeenCalled();
     });
 
@@ -133,19 +131,26 @@ describe('applyCorrection', () => {
     it('update がエラーを投げても他の Memory の処理を続ける（fail-warn）', async () => {
       const mems = [makeMemory('m1', 0.8), makeMemory('m2', 0.8)];
       const repo = makeRepo({
-        update: jest.fn()
+        update: jest
+          .fn()
           .mockRejectedValueOnce(new Error('DB error'))
           .mockResolvedValueOnce(makeMemory('m2', 0.5)),
       });
-      await expect(applyCorrection({ detected: true, targetMemories: mems }, repo)).resolves.not.toThrow();
+      await expect(
+        applyCorrection({ detected: true, targetMemories: mems }, repo)
+      ).resolves.not.toThrow();
     });
 
     it('delete がエラーを投げても fail-warn で継続する', async () => {
       const mem = makeMemory('m1', 0.1); // 確実に削除対象
       const repo = makeRepo({
-        delete: jest.fn(async () => { throw new Error('DB error'); }),
+        delete: jest.fn(async () => {
+          throw new Error('DB error');
+        }),
       });
-      await expect(applyCorrection({ detected: true, targetMemories: [mem] }, repo)).resolves.not.toThrow();
+      await expect(
+        applyCorrection({ detected: true, targetMemories: [mem] }, repo)
+      ).resolves.not.toThrow();
     });
   });
 });
@@ -174,7 +179,8 @@ describe('executePromotion', () => {
   it('promote がエラーを投げても fail-warn で継続する', async () => {
     const mems = [makeMemory('c1', 0.5, 'C'), makeMemory('c2', 0.6, 'C')];
     const repo = makeRepo({
-      promote: jest.fn()
+      promote: jest
+        .fn()
         .mockRejectedValueOnce(new Error('DB error'))
         .mockResolvedValueOnce({ ...mems[1], Tier: 'B' }),
     });

--- a/services/livetalk/core/tests/unit/memory/promotion.test.ts
+++ b/services/livetalk/core/tests/unit/memory/promotion.test.ts
@@ -1,0 +1,184 @@
+import { applyCorrection, executePromotion } from '../../../src/memory/promotion.js';
+import type { MemoryRepository } from '../../../src/repositories/memory.repository.interface.js';
+import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
+import type { CorrectionResult } from '../../../src/memory/correction-detector.js';
+import {
+  CORRECTION_CONFIDENCE_PENALTY,
+  MEMORY_AUTO_DELETE_THRESHOLD,
+} from '../../../src/constants.js';
+
+const FIXED_NOW = 1_750_000_000_000;
+
+function makeMemory(
+  id: string,
+  confidence: number,
+  tier: MemoryEntity['Tier'] = 'B'
+): MemoryEntity {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    MemoryID: id,
+    Tier: tier,
+    Category: 'food',
+    Content: 'コーヒーが好き',
+    Confidence: confidence,
+    ReferencedCount: 2,
+    CreatedAt: FIXED_NOW - 100000,
+    UpdatedAt: FIXED_NOW - 10000,
+  };
+}
+
+function makeRepo(overrides: Partial<MemoryRepository> = {}): MemoryRepository {
+  return {
+    put: jest.fn(),
+    get: jest.fn(),
+    listByTier: jest.fn(),
+    listByCategory: jest.fn(),
+    update: jest.fn(async (input) => ({ ...makeMemory(input.MemoryID, input.Confidence ?? 0.5) })),
+    delete: jest.fn(async () => {}),
+    promote: jest.fn(async (mem) => ({ ...mem, Tier: 'B' as const })),
+    demote: jest.fn(),
+    ...overrides,
+  } as unknown as MemoryRepository;
+}
+
+describe('applyCorrection', () => {
+  describe('detected: false', () => {
+    it('detected が false なら何もしない', async () => {
+      const repo = makeRepo();
+      const correction: CorrectionResult = { detected: false, targetMemories: [] };
+      await applyCorrection(correction, repo);
+      expect(repo.update).not.toHaveBeenCalled();
+      expect(repo.delete).not.toHaveBeenCalled();
+    });
+
+    it('targetMemories が空なら何もしない', async () => {
+      const repo = makeRepo();
+      const correction: CorrectionResult = { detected: true, targetMemories: [] };
+      await applyCorrection(correction, repo);
+      expect(repo.update).not.toHaveBeenCalled();
+      expect(repo.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confidence 減算', () => {
+    it(`confidence を ${CORRECTION_CONFIDENCE_PENALTY} 減算する`, async () => {
+      const mem = makeMemory('m1', 0.8);
+      const repo = makeRepo();
+      await applyCorrection({ detected: true, targetMemories: [mem] }, repo);
+      expect(repo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MemoryID: 'm1',
+          Confidence: 0.8 - CORRECTION_CONFIDENCE_PENALTY,
+        })
+      );
+      expect(repo.delete).not.toHaveBeenCalled();
+    });
+
+    it('newValue がある場合は Content も更新する', async () => {
+      const mem = makeMemory('m1', 0.8);
+      const repo = makeRepo();
+      await applyCorrection(
+        { detected: true, targetMemories: [mem], newValue: 'お茶が好き' },
+        repo
+      );
+      expect(repo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MemoryID: 'm1',
+          Content: 'お茶が好き',
+        })
+      );
+    });
+
+    it('newValue がない場合は Content を更新しない', async () => {
+      const mem = makeMemory('m1', 0.8);
+      const repo = makeRepo();
+      await applyCorrection({ detected: true, targetMemories: [mem] }, repo);
+      const call = (repo.update as jest.Mock).mock.calls[0][0];
+      expect(call.Content).toBeUndefined();
+    });
+
+    it('複数の Memory を並行して処理する', async () => {
+      const mems = [makeMemory('m1', 0.8), makeMemory('m2', 0.7)];
+      const repo = makeRepo();
+      await applyCorrection({ detected: true, targetMemories: mems }, repo);
+      expect(repo.update).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('自動削除（threshold 割れ）', () => {
+    it(`confidence が ${MEMORY_AUTO_DELETE_THRESHOLD} 未満になる場合は削除する`, async () => {
+      const threshold = MEMORY_AUTO_DELETE_THRESHOLD;
+      const confidence = threshold + CORRECTION_CONFIDENCE_PENALTY - 0.01; // 減算後に threshold 未満
+      const mem = makeMemory('m1', confidence);
+      const repo = makeRepo();
+      await applyCorrection({ detected: true, targetMemories: [mem] }, repo);
+      expect(repo.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ memoryId: 'm1' })
+      );
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('confidence が 0.0 以下にならない（負にならない）', async () => {
+      // confidence が既に 0.1 → 減算後に 0 未満になるが、Math.max(0, ...) で 0 になる
+      const mem = makeMemory('m1', 0.1);
+      const repo = makeRepo();
+      // 0.1 - 0.3 = -0.2 → Math.max(0, -0.2) = 0 < threshold → 削除される
+      await applyCorrection({ detected: true, targetMemories: [mem] }, repo);
+      expect(repo.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe('エラーハンドリング', () => {
+    it('update がエラーを投げても他の Memory の処理を続ける（fail-warn）', async () => {
+      const mems = [makeMemory('m1', 0.8), makeMemory('m2', 0.8)];
+      const repo = makeRepo({
+        update: jest.fn()
+          .mockRejectedValueOnce(new Error('DB error'))
+          .mockResolvedValueOnce(makeMemory('m2', 0.5)),
+      });
+      await expect(applyCorrection({ detected: true, targetMemories: mems }, repo)).resolves.not.toThrow();
+    });
+
+    it('delete がエラーを投げても fail-warn で継続する', async () => {
+      const mem = makeMemory('m1', 0.1); // 確実に削除対象
+      const repo = makeRepo({
+        delete: jest.fn(async () => { throw new Error('DB error'); }),
+      });
+      await expect(applyCorrection({ detected: true, targetMemories: [mem] }, repo)).resolves.not.toThrow();
+    });
+  });
+});
+
+describe('executePromotion', () => {
+  it('昇格候補が空なら何もしない', async () => {
+    const repo = makeRepo();
+    await executePromotion([], repo);
+    expect(repo.promote).not.toHaveBeenCalled();
+  });
+
+  it('Tier C → B に昇格する', async () => {
+    const mem = makeMemory('c1', 0.5, 'C');
+    const repo = makeRepo();
+    await executePromotion([mem], repo);
+    expect(repo.promote).toHaveBeenCalledWith(mem, 'B');
+  });
+
+  it('複数 Memory を並行して昇格する', async () => {
+    const mems = [makeMemory('c1', 0.5, 'C'), makeMemory('c2', 0.6, 'C')];
+    const repo = makeRepo();
+    await executePromotion(mems, repo);
+    expect(repo.promote).toHaveBeenCalledTimes(2);
+  });
+
+  it('promote がエラーを投げても fail-warn で継続する', async () => {
+    const mems = [makeMemory('c1', 0.5, 'C'), makeMemory('c2', 0.6, 'C')];
+    const repo = makeRepo({
+      promote: jest.fn()
+        .mockRejectedValueOnce(new Error('DB error'))
+        .mockResolvedValueOnce({ ...mems[1], Tier: 'B' }),
+    });
+    await expect(executePromotion(mems, repo)).resolves.not.toThrow();
+    expect(repo.promote).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -952,17 +952,17 @@ describe('runChatUseCase', () => {
     }
 
     it('訂正検出時に memoryRepo.update を呼ぶ（confidence 減算）', async () => {
-      const history = [
-        makeMessage('assistant', 'コーヒーが好きなんだね！', 'a1'),
-      ];
+      const history = [makeMessage('assistant', 'コーヒーが好きなんだね！', 'a1')];
       const memories = [makeRetrieved('m1', 'コーヒーが好き')];
       const retriever = makeMemoryRetriever(memories);
       const memRepo = makeMemoryRepo();
       // LLM: classify → 訂正あり / stream → 通常応答
       const llm: ILLMClient = {
-        chatStream: jest.fn(async function* () { yield '了解！'; }),
-        chatComplete: jest.fn(async () =>
-          '{"detected": true, "targetMemoryIds": ["m1"], "newValue": "お茶が好き"}'
+        chatStream: jest.fn(async function* () {
+          yield '了解！';
+        }),
+        chatComplete: jest.fn(
+          async () => '{"detected": true, "targetMemoryIds": ["m1"], "newValue": "お茶が好き"}'
         ),
         summarize: jest.fn(),
       };
@@ -994,7 +994,9 @@ describe('runChatUseCase', () => {
       const retriever = makeMemoryRetriever(memories);
       const memRepo = makeMemoryRepo();
       const llm: ILLMClient = {
-        chatStream: jest.fn(async function* () { yield '了解！'; }),
+        chatStream: jest.fn(async function* () {
+          yield '了解！';
+        }),
         chatComplete: jest.fn(async () => '{"detected": false}'),
         summarize: jest.fn(),
       };
@@ -1024,8 +1026,12 @@ describe('runChatUseCase', () => {
       const retriever = makeMemoryRetriever(memories);
       const memRepo = makeMemoryRepo();
       const llm: ILLMClient = {
-        chatStream: jest.fn(async function* () { yield '了解！'; }),
-        chatComplete: jest.fn(async () => { throw new Error('API error'); }),
+        chatStream: jest.fn(async function* () {
+          yield '了解！';
+        }),
+        chatComplete: jest.fn(async () => {
+          throw new Error('API error');
+        }),
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();
@@ -1074,7 +1080,9 @@ describe('runChatUseCase', () => {
     it('embeddingClient がある場合は identifyPromotionCandidates を試みる', async () => {
       const memRepo = makeMemoryRepo();
       const llm: ILLMClient = {
-        chatStream: jest.fn(async function* () { yield '了解！'; }),
+        chatStream: jest.fn(async function* () {
+          yield '了解！';
+        }),
         chatComplete: jest.fn(async () => '{"promotions": []}'),
         summarize: jest.fn(),
       };
@@ -1134,10 +1142,10 @@ describe('runChatUseCase', () => {
       const memRepo = makeMemoryRepo();
       (memRepo.listByTier as jest.Mock).mockResolvedValue([tierCMem]);
       const llm: ILLMClient = {
-        chatStream: jest.fn(async function* () { yield '覚えとくね！'; }),
-        chatComplete: jest.fn(async () =>
-          '{"promotions": [{"memoryId": "c1", "promote": true}]}'
-        ),
+        chatStream: jest.fn(async function* () {
+          yield '覚えとくね！';
+        }),
+        chatComplete: jest.fn(async () => '{"promotions": [{"memoryId": "c1", "promote": true}]}'),
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -929,4 +929,257 @@ describe('runChatUseCase', () => {
       expect(events[events.length - 1]).toEqual({ type: 'done' });
     });
   });
+
+  // ── Phase 3d: 暗黙確認・訂正検出 ───────────────────────────────────────────
+
+  describe('暗黙訂正検出（Phase 3d）', () => {
+    function makeRetrieved(id: string, content: string): RetrievedMemory {
+      return {
+        memory: {
+          UserID: 'u1',
+          CharacterID: 'hiyori',
+          MemoryID: id,
+          Tier: 'B',
+          Category: 'food',
+          Content: content,
+          Confidence: 0.8,
+          ReferencedCount: 2,
+          CreatedAt: 0,
+          UpdatedAt: 0,
+        },
+        similarity: 0.9,
+      };
+    }
+
+    it('訂正検出時に memoryRepo.update を呼ぶ（confidence 減算）', async () => {
+      const history = [
+        makeMessage('assistant', 'コーヒーが好きなんだね！', 'a1'),
+      ];
+      const memories = [makeRetrieved('m1', 'コーヒーが好き')];
+      const retriever = makeMemoryRetriever(memories);
+      const memRepo = makeMemoryRepo();
+      // LLM: classify → 訂正あり / stream → 通常応答
+      const llm: ILLMClient = {
+        chatStream: jest.fn(async function* () { yield '了解！'; }),
+        chatComplete: jest.fn(async () =>
+          '{"detected": true, "targetMemoryIds": ["m1"], "newValue": "お茶が好き"}'
+        ),
+        summarize: jest.fn(),
+      };
+      const voice = makeVoiceClient();
+      const repo = makeRepo(history);
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: '違う、お茶が好きなんだ',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRetriever: retriever,
+          memoryRepository: memRepo,
+        })
+      );
+
+      expect(memRepo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MemoryID: 'm1',
+          Confidence: expect.any(Number),
+        })
+      );
+    });
+
+    it('直前アシスタントメッセージがない場合は訂正検出をスキップする', async () => {
+      const memories = [makeRetrieved('m1', 'コーヒーが好き')];
+      const retriever = makeMemoryRetriever(memories);
+      const memRepo = makeMemoryRepo();
+      const llm: ILLMClient = {
+        chatStream: jest.fn(async function* () { yield '了解！'; }),
+        chatComplete: jest.fn(async () => '{"detected": false}'),
+        summarize: jest.fn(),
+      };
+      const voice = makeVoiceClient();
+      // history にアシスタントメッセージなし
+      const repo = makeRepo([makeMessage('user', '最初のメッセージ')]);
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: '違う！',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRetriever: retriever,
+          memoryRepository: memRepo,
+        })
+      );
+
+      // chatComplete が classify 用途で呼ばれないことを確認
+      expect(llm.chatComplete).not.toHaveBeenCalled();
+    });
+
+    it('訂正検出がエラーを投げても LLM 応答を継続する（fail-warn）', async () => {
+      const history = [makeMessage('assistant', 'コーヒーが好きなんだね！', 'a1')];
+      const memories = [makeRetrieved('m1', 'コーヒーが好き')];
+      const retriever = makeMemoryRetriever(memories);
+      const memRepo = makeMemoryRepo();
+      const llm: ILLMClient = {
+        chatStream: jest.fn(async function* () { yield '了解！'; }),
+        chatComplete: jest.fn(async () => { throw new Error('API error'); }),
+        summarize: jest.fn(),
+      };
+      const voice = makeVoiceClient();
+      const repo = makeRepo(history);
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: '違う！',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRetriever: retriever,
+          memoryRepository: memRepo,
+        })
+      );
+
+      // エラーにならず done が来る
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+    });
+
+    it('memoryRepository が未指定の場合は訂正検出をスキップする', async () => {
+      const memories = [makeRetrieved('m1', 'コーヒーが好き')];
+      const retriever = makeMemoryRetriever(memories);
+      const llm = makeLLMClient(['了解！']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo([makeMessage('assistant', 'コーヒーが好きなんだね！', 'a1')]);
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: '違う！',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRetriever: retriever,
+          // memoryRepository なし
+        })
+      );
+
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+    });
+  });
+
+  describe('Tier C 昇格候補検出（Phase 3d）', () => {
+    it('embeddingClient がある場合は identifyPromotionCandidates を試みる', async () => {
+      const memRepo = makeMemoryRepo();
+      const llm: ILLMClient = {
+        chatStream: jest.fn(async function* () { yield '了解！'; }),
+        chatComplete: jest.fn(async () => '{"promotions": []}'),
+        summarize: jest.fn(),
+      };
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const embeddingClient = { embed: jest.fn(async () => [1, 0, 0]) };
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRepository: memRepo,
+          embeddingClient,
+        })
+      );
+
+      expect(memRepo.listByTier).toHaveBeenCalledWith('u1', 'hiyori', 'C');
+    });
+
+    it('embeddingClient が未指定なら昇格候補検出をスキップする', async () => {
+      const memRepo = makeMemoryRepo();
+      const llm = makeLLMClient(['了解！']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRepository: memRepo,
+          // embeddingClient なし
+        })
+      );
+
+      // Tier C 取得は呼ばれない
+      expect(memRepo.listByTier).not.toHaveBeenCalledWith('u1', 'hiyori', 'C');
+    });
+
+    it('昇格候補がある場合 executePromotion が呼ばれる（fire-and-forget）', async () => {
+      const tierCMem: MemoryEntity = {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        MemoryID: 'c1',
+        Tier: 'C',
+        Category: 'food',
+        Content: 'コーヒーが好き',
+        Confidence: 0.5,
+        ReferencedCount: 1,
+        CreatedAt: 0,
+        UpdatedAt: 0,
+        Embedding: [1, 0, 0],
+      };
+      const memRepo = makeMemoryRepo();
+      (memRepo.listByTier as jest.Mock).mockResolvedValue([tierCMem]);
+      const llm: ILLMClient = {
+        chatStream: jest.fn(async function* () { yield '覚えとくね！'; }),
+        chatComplete: jest.fn(async () =>
+          '{"promotions": [{"memoryId": "c1", "promote": true}]}'
+        ),
+        summarize: jest.fn(),
+      };
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const embeddingClient = { embed: jest.fn(async () => [0.99, 0.01, 0]) };
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRepository: memRepo,
+          embeddingClient,
+        })
+      );
+
+      // promote が呼ばれるまで少し待つ（fire-and-forget）
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(memRepo.promote).toHaveBeenCalledWith(tierCMem, 'B');
+    });
+
+    it('昇格候補検出がエラーを投げても LLM 応答を継続する（fail-warn）', async () => {
+      const memRepo = makeMemoryRepo();
+      (memRepo.listByTier as jest.Mock).mockRejectedValue(new Error('DB error'));
+      const llm = makeLLMClient(['了解！']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const embeddingClient = { embed: jest.fn(async () => [1, 0, 0]) };
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          memoryRepository: memRepo,
+          embeddingClient,
+        })
+      );
+
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+    });
+  });
 });

--- a/services/livetalk/web/src/app/api/chat/route.ts
+++ b/services/livetalk/web/src/app/api/chat/route.ts
@@ -7,6 +7,7 @@ import { getVoicevoxClient } from '@/lib/server/voicevox';
 import { getMemoryRepository, getMessageRepository } from '@/lib/server/repositories';
 import { getModerationClient, getSafetyEventRepository } from '@/lib/server/safety';
 import { getMemoryRetriever } from '@/lib/server/memory-retriever';
+import { getEmbeddingClient } from '@/lib/server/embedding';
 import { CHAT_ERROR_MESSAGES, CHAT_MAX_TEXT_LENGTH } from './constants';
 
 interface ChatRequest {
@@ -92,6 +93,7 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
           moderationClient: getModerationClient(),
           memoryRetriever: getMemoryRetriever(),
           memoryRepository: getMemoryRepository(),
+          embeddingClient: getEmbeddingClient(),
         });
 
         for await (const event of eventGenerator) {

--- a/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
@@ -22,6 +22,9 @@ jest.mock('@/lib/server/safety', () => ({
 jest.mock('@/lib/server/memory-retriever', () => ({
   getMemoryRetriever: jest.fn().mockReturnValue({}),
 }));
+jest.mock('@/lib/server/embedding', () => ({
+  getEmbeddingClient: jest.fn().mockReturnValue({}),
+}));
 
 // runChatUseCase をモック化して依存 I/O を切り離す
 jest.mock('@nagiyu/livetalk-core', () => ({


### PR DESCRIPTION
## 変更の概要

リブトーク Phase 3d（Issue #3282）の実装。
**Tier C 記憶の再言及による C→B 昇格**と、**ユーザー訂正発言の検出・信頼度操作**を追加する。

## 関連 Issue

#3282（Phase 3d）/ Parent: #3186（Phase 3）

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ 80% 以上を確保）
- [x] 関連ドキュメントを更新した
- [x] ローカルでテストが全て通ることを確認した（463 テスト全通過）
- [x] ビルドエラーがないことを確認した（@nagiyu/common 未ビルドによる既存の解決エラーのみ）

## 新規ファイル

| ファイル | 役割 |
|---|---|
| `core/src/memory/correction-detector.ts` | 訂正検出：キーワード→追加情報除外→LLM 最終判定の 3 段階フロー |
| `core/src/memory/confirmation.ts` | 昇格候補検出（Tier C + embedding 類似度 + LLM 判定）+ cooldown 制御 |
| `core/src/memory/promotion.ts` | `applyCorrection`（confidence 減算・閾値削除）/ `executePromotion`（C→B 昇格） |

## 修正ファイル

| ファイル | 変更内容 |
|---|---|
| `constants.ts` | `CORRECTION_CONFIDENCE_PENALTY=0.3` / `MEMORY_AUTO_DELETE_THRESHOLD=0.2` / `CONFIRMATION_COOLDOWN_MS` / `PROMOTION_SIMILARITY_THRESHOLD=0.7` |
| `characters/prompt-builder.ts` | `newLearnings?: MemoryEntity[]` 追加。「新しく学んだこと」セクションを自然な指示文として挿入 |
| `usecases/chat-usecase.ts` | retrieve 後に訂正検出→`applyCorrection`、昇格候補検出→prompt 注入、応答後に `executePromotion`（fire-and-forget）を追加。`embeddingClient` を params に追加 |
| `web/src/app/api/chat/route.ts` | `embeddingClient: getEmbeddingClient()` を渡すよう更新 |

## chat-usecase のフロー変更（追加ステップ）

```
4.  Memory retrieve (A+B、既存)
4a. 暗黙訂正検出（直前アシスタントメッセージ + retrievedMemories + LLM判定）
    → 検出時: applyCorrection（confidence 減算、< 0.2 で削除）
4b. Tier C 昇格候補検出（embedding 類似度 + LLM判定）
    → newLearnings = cooldown 経過分のみ
5.  prompt 構築（newLearnings → 「新しく学んだこと」セクション追加）
    ...（LLM ストリーミング、VOICEVOX、Moderation は既存と同じ）
11. executePromotion（昇格候補 C→B、fire-and-forget）[新規]
12. referencedCount 更新（既存）
```

## テスト内容

- `correction-detector.test.ts`: 51 ケース
  - キーワード高速フィルタ（LLM 呼び出しなし）
  - 追加情報パターン除外（「いや、それも好きだよ」等の false positive 抑制）
  - LLM 統合（detected: true/false、不正 JSON、API エラー）
- `confirmation.test.ts`: Tier C 取得・embedding 類似度・LLM 判定・cooldown 制御・各種エラーハンドリング
- `promotion.test.ts`: confidence 減算・閾値削除・Content 更新・複数並行処理・fail-warn
- `chat-usecase.test.ts` 追加分: Phase 3d 統合テスト（訂正検出フロー・昇格フロー・fail-warn）
- **合計 463 テスト全通過、カバレッジ 80% 以上**

## レビューポイント

- `correction-detector.ts`: キーワードパターン・追加情報除外パターンの網羅性（false positive/negative のバランス）
- `confirmation.ts`: `PROMOTION_SIMILARITY_THRESHOLD=0.7` の妥当性（実運用で調整が必要な可能性あり）
- `chat-usecase.ts` L252-288: 訂正検出と昇格候補検出が両方 LLM classify を呼ぶ設計。同一ターンで最大 2 回 `chatComplete` が走るため、コスト面の確認をお願いします

## 補足事項

- 本フェーズは confidence 操作のみ（Tier 降格は Issue 本文の指示通り「別途」）
- 親密度連動・記憶編集 UI は Phase 3e/3f で対応
- `CONFIRMATION_COOLDOWN_MS=3h`・`PROMOTION_SIMILARITY_THRESHOLD=0.7` は実運用で調整可能な定数として切り出してあります

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScsNStmkpMeGHMhpdGDnoK)_