### PR TITLE
診断: 昇格候補の類似度スコアと LLM 判定結果のログ出力（#3282 検証用）

### DIFF
--- a/services/livetalk/core/src/memory/confirmation.ts
+++ b/services/livetalk/core/src/memory/confirmation.ts
@@ -46,6 +46,12 @@ ${memoriesText}
       purpose: 'classify',
     });
 
+    // 診断ログ（Issue #3282 検証用）: LLM 昇格判定の生応答
+    logger.info('[confirmation] LLM 昇格判定の生応答', {
+      candidateIds: candidates.map((m) => m.MemoryID),
+      raw,
+    });
+
     const jsonMatch = raw.match(/\{[\s\S]*\}/);
     if (!jsonMatch) return [];
 
@@ -53,8 +59,14 @@ ${memoriesText}
     if (!Array.isArray(parsed.promotions)) return [];
 
     const promoteIds = new Set(parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId));
+    const promoted = candidates.filter((m) => promoteIds.has(m.MemoryID));
 
-    return candidates.filter((m) => promoteIds.has(m.MemoryID));
+    // 診断ログ（Issue #3282 検証用）: 昇格と判定された記憶
+    logger.info('[confirmation] LLM 昇格判定結果', {
+      promotedIds: promoted.map((m) => m.MemoryID),
+    });
+
+    return promoted;
   } catch (err) {
     logger.warn('[confirmation] LLM 昇格判定に失敗しました', { err });
     return [];
@@ -101,14 +113,31 @@ export async function identifyPromotionCandidates(
   }
 
   // cosine similarity で再言及候補を抽出
-  const candidates: MemoryEntity[] = [];
-  for (const memory of tierCMemories) {
-    if (!memory.Embedding || memory.Embedding.length === 0) continue;
-    const similarity = cosineSimilarity(queryEmbedding, memory.Embedding);
-    if (similarity >= PROMOTION_SIMILARITY_THRESHOLD) {
-      candidates.push(memory);
-    }
-  }
+  const scored = tierCMemories
+    .filter((m) => m.Embedding && m.Embedding.length > 0)
+    .map((m) => ({
+      memory: m,
+      similarity: cosineSimilarity(queryEmbedding, m.Embedding as number[]),
+    }));
+
+  const candidates = scored
+    .filter((s) => s.similarity >= PROMOTION_SIMILARITY_THRESHOLD)
+    .map((s) => s.memory);
+
+  // 診断ログ（Issue #3282 検証用）: 各 Tier C 記憶の類似度と閾値通過状況
+  logger.info('[confirmation] 昇格候補の類似度スコア', {
+    userInput,
+    threshold: PROMOTION_SIMILARITY_THRESHOLD,
+    tierCCount: tierCMemories.length,
+    passedCount: candidates.length,
+    scores: scored
+      .map((s) => ({
+        memoryId: s.memory.MemoryID,
+        content: s.memory.Content.slice(0, 30),
+        similarity: Number(s.similarity.toFixed(4)),
+      }))
+      .sort((a, b) => b.similarity - a.similarity),
+  });
 
   if (candidates.length === 0) return [];
 


### PR DESCRIPTION
## 変更の概要

Phase 3d（暗黙確認・訂正検出 / #3282）の dev 検証で、Tier C 記憶の再言及をしても昇格（C→B）が発火しない事象を調査中。本変更は原因を切り分けるための**一時的な診断ログ**を `identifyPromotionCandidates` に追加する。

dev での検証フォレンジックから、以下まで確定済み:
- チャットは成立し、アカウント・characterId・userId（PK）は一致が証明済み（メッセージが同 PK に書き込まれている）
- Phase 3d コードはデプロイ済み（稼働イメージに該当コード・`embeddingClient` 配線あり）
- embedding 失敗・LLM 失敗の警告ログは出ていない
- それでも `promote()` は一度も呼ばれていない（MEM#B が 0 件）

→ `identifyPromotionCandidates` が空配列を返しているが、原因が「**cosine 類似度が閾値 0.7 未満**」なのか「**LLM が昇格不要と判定**」なのか、どちらも無音のため本番ログから判別できない。

## 変更内容

`services/livetalk/core/src/memory/confirmation.ts` に `logger.info` を 2 箇所追加（デフォルト LOG_LEVEL=INFO で出力される）:

1. **昇格候補の類似度スコア**: 各 Tier C 記憶の cosine 類似度（降順）、閾値、通過件数、Tier C 件数
2. **LLM 昇格判定の生応答と結果**: LLM に渡した候補 ID・生レスポンス・昇格と判定された ID

これにより、次回 dev での再言及テスト時に CloudWatch で①②のどちらで弾かれているかを特定できる。

## 変更種別

- [x] 調査・診断用の一時変更

## 実装チェックリスト

- [x] TypeScript strict mode 通過（`tsc`）
- [x] ESLint 通過
- [x] Prettier 通過
- [x] ユニットテスト通過（core: 463 件）
- [x] 既存の昇格判定ロジックの挙動は不変（ログ追加のみ、候補抽出ロジックは等価にリファクタ）

## テスト内容

- `npm run build / lint / format:check --workspace @nagiyu/livetalk-core` 通過
- `confirmation.test.ts` 14 件含む core 全 463 件通過

## レビューポイント

- 本ログは検証完了後に削除（または DEBUG レベルへ降格）する想定。原因特定後の扱いは別途相談。
- ログに `userInput` と記憶 Content（先頭30文字）を含めるため、dev 限定の一時措置として許容できるか。

## UI 変更

なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScsNStmkpMeGHMhpdGDnoK)_