### PR TITLE
修正: 昇格類似度閾値を 0.7→0.5 に緩和し Tier C 再言及の取りこぼしを解消（#3282）

### DIFF
--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -87,6 +87,11 @@ export const CONFIRMATION_COOLDOWN_MS = 3 * 60 * 60 * 1000; // 3 時間
 
 /**
  * Tier C 記憶の「再言及」と判定する cosine similarity 下限閾値（Phase 3d）。
- * 高めに設定することで false positive（無関係な話題での昇格）を抑制する。
+ *
+ * 保存ベクトルは記憶の説明文（三人称）、クエリは生の口語発話（一人称）で
+ * 文体が異なるため、明確な再言及でも cosine は 0.6〜0.7 程度に留まる
+ * （dev 検証で「モンハン」再言及が 0.68 を記録し、閾値 0.7 で取りこぼした）。
+ * 類似度は粗いプレフィルタとし、最終的な昇格可否は後段の LLM 判定に委ねるため、
+ * 緩めの 0.5 に設定する（無関係な話題は cosine ≤ 0.4 で十分に分離できる）。
  */
-export const PROMOTION_SIMILARITY_THRESHOLD = 0.7;
+export const PROMOTION_SIMILARITY_THRESHOLD = 0.5;


### PR DESCRIPTION
## 変更の概要

Phase 3d（暗黙確認・訂正検出 / #3282）の dev 検証で判明した「Tier C 記憶を再言及しても昇格（C→B）しない」事象への対応。

### 原因（診断ログで確定）

PR #3301 で追加した診断ログにより、dev で再言及テストを実施したところ:

```
発話: "ゲームの中だとモンハンがトップクラスに好きなんだよねー"
→ 最も近い記憶「好きなゲームは『モンハン』」の cosine = 0.6797
→ 閾値 0.7 に届かず passedCount: 0（LLM 判定の手前で全候補が脱落）
```

保存ベクトルは記憶の**説明文（三人称）**、クエリは**生の口語発話（一人称）**で文体が異なるため、明確な再言及でも cosine が 0.6〜0.7 程度に留まり、閾値 0.7 では取りこぼしていた。

参考スコア分布（同一発話時）:
- モンハン再言及: 0.68 / 0.60
- 無関係（コーヒー・挨拶・仕事疲れ等）: ≤ 0.40

### 変更内容

- `PROMOTION_SIMILARITY_THRESHOLD` を **0.7 → 0.5** に緩和（`services/livetalk/core/src/constants.ts`）
  - 再言及（0.60〜0.68）を拾い、無関係（≤0.40）は除外できる
  - 類似度は粗いプレフィルタであり、最終的な昇格可否は後段の LLM 判定が担うため、閾値は緩めが設計的に適切
- PR #3301 で追加した診断 info ログ（`confirmation.ts`）は**残置**
  - マージ後の dev で閾値 0.5 の効果（実際に昇格が発火するか）を観察するため
  - 検証完了後に別途削除または DEBUG レベルへ降格する想定

## 変更種別

- [x] バグ修正（昇格が発火しない問題の解消）

## 実装チェックリスト

- [x] TypeScript strict mode 通過（`tsc`）
- [x] ESLint 通過
- [x] Prettier 通過
- [x] ユニットテスト通過（core: 463 件）

## テスト内容

- `npm run build / lint / format:check --workspace @nagiyu/livetalk-core` 通過
- core 全 463 件通過（`confirmation.test.ts` は閾値定数を参照しているため緩和後も整合）

## レビューポイント

- 閾値 0.5 の妥当性: dev 実測で「再言及 0.60〜0.68 / 無関係 ≤0.40」と明確に分離しており、0.5 は両者の間。誤検出は LLM が排除する二段構え。
- 診断ログを当面残す方針で問題ないか（dev 限定の観察用途）。

## UI 変更

なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScsNStmkpMeGHMhpdGDnoK)_