### PR TITLE
調整: 昇格判定の診断ログを info→debug に降格（#3282 検証完了に伴う後始末）

### DIFF
--- a/services/livetalk/core/src/memory/confirmation.ts
+++ b/services/livetalk/core/src/memory/confirmation.ts
@@ -46,8 +46,8 @@ ${memoriesText}
       purpose: 'classify',
     });
 
-    // 診断ログ（Issue #3282 検証用）: LLM 昇格判定の生応答
-    logger.info('[confirmation] LLM 昇格判定の生応答', {
+    // 診断ログ（Issue #3282）: LLM 昇格判定の生応答（LOG_LEVEL=DEBUG 時のみ出力）
+    logger.debug('[confirmation] LLM 昇格判定の生応答', {
       candidateIds: candidates.map((m) => m.MemoryID),
       raw,
     });
@@ -61,8 +61,8 @@ ${memoriesText}
     const promoteIds = new Set(parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId));
     const promoted = candidates.filter((m) => promoteIds.has(m.MemoryID));
 
-    // 診断ログ（Issue #3282 検証用）: 昇格と判定された記憶
-    logger.info('[confirmation] LLM 昇格判定結果', {
+    // 診断ログ（Issue #3282）: 昇格と判定された記憶（LOG_LEVEL=DEBUG 時のみ出力）
+    logger.debug('[confirmation] LLM 昇格判定結果', {
       promotedIds: promoted.map((m) => m.MemoryID),
     });
 
@@ -124,8 +124,8 @@ export async function identifyPromotionCandidates(
     .filter((s) => s.similarity >= PROMOTION_SIMILARITY_THRESHOLD)
     .map((s) => s.memory);
 
-  // 診断ログ（Issue #3282 検証用）: 各 Tier C 記憶の類似度と閾値通過状況
-  logger.info('[confirmation] 昇格候補の類似度スコア', {
+  // 診断ログ（Issue #3282）: 各 Tier C 記憶の類似度と閾値通過状況（LOG_LEVEL=DEBUG 時のみ出力）
+  logger.debug('[confirmation] 昇格候補の類似度スコア', {
     userInput,
     threshold: PROMOTION_SIMILARITY_THRESHOLD,
     tierCCount: tierCMemories.length,


### PR DESCRIPTION
## 変更の概要

Phase 3d（#3282）の dev 実機検証が完了したため、検証用に追加していた診断ログ（PR #3301）を `logger.info` → `logger.debug` に降格する。通常運用（LOG_LEVEL=INFO）では出力されず、必要時のみ `LOG_LEVEL=DEBUG` で確認できる。

### 背景

PR #3301 で `confirmation.ts` に診断 info ログを追加し、dev で昇格・訂正フローを実機確認した。結果、以下を全て確認済み:

- Tier C→B 昇格（類似度 0.71〜0.73 で通過 → LLM 判定 → 昇格）
- 暗黙訂正検出 → 信頼度低下（0.5→0.2）+ Content 更新
- 再訂正による自動削除（0.2→0 で threshold 割れ削除）

検証目的を達成したため、毎ターン `userInput` や記憶 Content を出力する診断 info ログは過剰になる。`logger.debug` に降格して通常運用では非出力とする。

### 変更内容

`services/livetalk/core/src/memory/confirmation.ts` の診断ログ 3 箇所を `logger.info` → `logger.debug` に変更:

- 昇格候補の類似度スコア
- LLM 昇格判定の生応答
- LLM 昇格判定結果

なお `promotion.ts` の状態変化ログ（昇格実行・信頼度低下・自動削除）は Phase 3d 本体実装のもので、状態が変化したときのみ出力される監査ログのため `info` のまま維持する。

## 変更種別

- [x] リファクタ（ログレベル調整）

## 実装チェックリスト

- [x] TypeScript strict mode 通過
- [x] ESLint 通過
- [x] Prettier 通過
- [x] ユニットテスト通過（core: 463 件）

## テスト内容

- `npm run build / lint / format:check --workspace @nagiyu/livetalk-core` 通過
- core 全 463 件通過

## レビューポイント

- 診断ログを完全削除せず DEBUG 残置とする方針（将来のトラブルシュート時に `LOG_LEVEL=DEBUG` で再利用可能）。

## UI 変更

なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScsNStmkpMeGHMhpdGDnoK)_