### PR TITLE
[Fix] 記憶編集 UI: 日本語 category の編集不可とタブ視認性を改善

### DIFF
--- a/services/livetalk/web/src/app/api/memory/constants.ts
+++ b/services/livetalk/web/src/app/api/memory/constants.ts
@@ -8,7 +8,7 @@ export const MEMORY_ERROR_MESSAGES = {
   EMPTY_PATCH: 'content または category を指定してください',
   INVALID_CONTENT: 'content が不正です',
   CONTENT_TOO_LONG: 'content が長すぎます',
-  INVALID_CATEGORY: 'category が不正です（英小文字・数字・ハイフン・アンダースコアのみ）',
+  INVALID_CATEGORY: 'category が不正です（空にできません。「#」は使えません）',
   CATEGORY_TOO_LONG: 'category が長すぎます',
   NOT_FOUND: '指定された記憶が見つかりません',
   FETCH_FAILED: '記憶の取得に失敗しました',

--- a/services/livetalk/web/src/components/MemoryEditModal.tsx
+++ b/services/livetalk/web/src/components/MemoryEditModal.tsx
@@ -26,7 +26,7 @@ export interface MemoryEditModalProps {
 }
 
 const ERROR_MESSAGES = {
-  VALIDATION: '入力内容を確認してください（content は必須、category は英小文字・数字のみ）。',
+  VALIDATION: '入力内容を確認してください（内容は必須、カテゴリに「#」は使えません）。',
 } as const;
 
 /**
@@ -83,7 +83,7 @@ export default function MemoryEditModal({
             onChange={(e) => setCategory(e.target.value)}
             fullWidth
             maxLength={MEMORY_CATEGORY_MAX_LENGTH}
-            helperText="英小文字・数字・ハイフン・アンダースコアのみ"
+            helperText="「#」は使えません"
           />
           {error && (
             <Typography color="error" variant="body2" role="alert" data-testid="memory-edit-error">

--- a/services/livetalk/web/src/components/MemoryTierTabs.tsx
+++ b/services/livetalk/web/src/components/MemoryTierTabs.tsx
@@ -20,8 +20,11 @@ export default function MemoryTierTabs({ value, onChange }: MemoryTierTabsProps)
       <Tabs
         value={value}
         onChange={(_e, next: Tier) => onChange(next)}
-        variant="fullWidth"
         aria-label="記憶の階層タブ"
+        sx={{
+          '& .MuiTab-root': { fontWeight: 500 },
+          '& .Mui-selected': { fontWeight: 700 },
+        }}
       >
         {VISIBLE_TIERS.map((tier) => (
           <Tooltip key={tier} title={TIER_DESCRIPTIONS[tier]} arrow>

--- a/services/livetalk/web/src/lib/memory/validation.ts
+++ b/services/livetalk/web/src/lib/memory/validation.ts
@@ -1,8 +1,4 @@
 import type { Tier } from '@nagiyu/livetalk-core';
-
-// TIERS を livetalk-core からランタイムインポートすると @nagiyu/aws → node:crypto が
-// クライアントバンドルに混入するため、ここで値を複製して依存を断つ。
-const TIERS: readonly Tier[] = ['A', 'B', 'C', 'D'] as const;
 import type { MemoryPatchInput } from './types';
 
 /**
@@ -12,6 +8,10 @@ import type { MemoryPatchInput } from './types';
  * （カバレッジ計測対象は `src/lib/**` のみ）。
  */
 
+// TIERS を livetalk-core からランタイムインポートすると @nagiyu/aws → node:crypto が
+// クライアントバンドルに混入するため、ここで値を複製して依存を断つ。
+const TIERS: readonly Tier[] = ['A', 'B', 'C', 'D'] as const;
+
 /** content の最大文字数。LLM プロンプトに注入されるため過度に長い記憶を弾く。 */
 export const MEMORY_CONTENT_MAX_LENGTH = 500;
 
@@ -19,10 +19,14 @@ export const MEMORY_CONTENT_MAX_LENGTH = 500;
 export const MEMORY_CATEGORY_MAX_LENGTH = 50;
 
 /**
- * category に使える文字（英小文字・数字・ハイフン・アンダースコア）。
- * SK 区切り文字 `#` の混入を防ぐため厳格に制限する。
+ * category に使えない文字。
+ *
+ * 記憶生成側（LLM 抽出）は category を日本語で付与するため、編集側もそれに合わせて
+ * 日本語を許容する。ただし SK（`CHAR#...#MEM#<tier>#<category>#<ulid>`）の区切り文字
+ * `#` が混入すると SK 構造が壊れるため `#` は禁止する。あわせて改行・タブ等の制御文字も禁止する。
  */
-const CATEGORY_PATTERN = /^[a-z0-9_-]+$/;
+// eslint-disable-next-line no-control-regex
+const CATEGORY_FORBIDDEN_PATTERN = /[#\u0000-\u001f]/;
 
 export interface ValidatedMemoryPatch {
   content?: string;
@@ -45,7 +49,7 @@ export type PatchValidationResult =
  *
  * - content / category の少なくとも一方が必要
  * - content は空白のみを許さず、最大長を超えない
- * - category は許可文字のみ・最大長を超えない
+ * - category は空でなく、`#`・制御文字を含まず、最大長を超えない（日本語可）
  */
 export function validateMemoryPatch(body: unknown): PatchValidationResult {
   if (typeof body !== 'object' || body === null) {
@@ -74,10 +78,13 @@ export function validateMemoryPatch(body: unknown): PatchValidationResult {
       return { ok: false, error: 'INVALID_CATEGORY' };
     }
     const trimmed = input.category.trim();
+    if (!trimmed) {
+      return { ok: false, error: 'INVALID_CATEGORY' };
+    }
     if (trimmed.length > MEMORY_CATEGORY_MAX_LENGTH) {
       return { ok: false, error: 'CATEGORY_TOO_LONG' };
     }
-    if (!CATEGORY_PATTERN.test(trimmed)) {
+    if (CATEGORY_FORBIDDEN_PATTERN.test(trimmed)) {
       return { ok: false, error: 'INVALID_CATEGORY' };
     }
     result.category = trimmed;

--- a/services/livetalk/web/tests/unit/components/MemoryEditModal.test.tsx
+++ b/services/livetalk/web/tests/unit/components/MemoryEditModal.test.tsx
@@ -32,12 +32,24 @@ describe('MemoryEditModal', () => {
     expect(onSave).toHaveBeenCalledWith('enc-id', { content: '紅茶が好き', category: 'food' });
   });
 
-  it('不正な category はエラー表示し onSave を呼ばない', () => {
+  it('日本語 category でも保存できる（編集不可バグの回帰防止）', () => {
     const onSave = jest.fn();
     render(<MemoryEditModal open memory={memory} onSave={onSave} onClose={jest.fn()} />);
 
     fireEvent.change(screen.getByLabelText('カテゴリ'), {
-      target: { value: '日本語カテゴリ' },
+      target: { value: '好み' },
+    });
+    fireEvent.click(screen.getByTestId('memory-edit-save'));
+
+    expect(onSave).toHaveBeenCalledWith('enc-id', { content: 'コーヒーが好き', category: '好み' });
+  });
+
+  it('# を含む category はエラー表示し onSave を呼ばない', () => {
+    const onSave = jest.fn();
+    render(<MemoryEditModal open memory={memory} onSave={onSave} onClose={jest.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('カテゴリ'), {
+      target: { value: 'a#b' },
     });
     fireEvent.click(screen.getByTestId('memory-edit-save'));
 

--- a/services/livetalk/web/tests/unit/lib/memory/validation.test.ts
+++ b/services/livetalk/web/tests/unit/lib/memory/validation.test.ts
@@ -54,12 +54,40 @@ describe('validateMemoryPatch', () => {
     expect(validateMemoryPatch({ category: 5 })).toEqual({ ok: false, error: 'INVALID_CATEGORY' });
   });
 
-  it('category に不正文字があれば INVALID_CATEGORY', () => {
-    expect(validateMemoryPatch({ category: 'Food!' })).toEqual({
+  it('日本語 category を許容する（生成側に合わせる）', () => {
+    expect(validateMemoryPatch({ category: '好み' })).toEqual({
+      ok: true,
+      value: { category: '好み' },
+    });
+    expect(validateMemoryPatch({ category: '趣味・ゲーム' })).toEqual({
+      ok: true,
+      value: { category: '趣味・ゲーム' },
+    });
+  });
+
+  it('content のみの patch が日本語 category 既存データでも通る（編集不可バグの回帰防止）', () => {
+    expect(validateMemoryPatch({ content: '紅茶が好き' })).toEqual({
+      ok: true,
+      value: { content: '紅茶が好き' },
+    });
+  });
+
+  it('category が空文字なら INVALID_CATEGORY', () => {
+    expect(validateMemoryPatch({ category: '   ' })).toEqual({
       ok: false,
       error: 'INVALID_CATEGORY',
     });
-    expect(validateMemoryPatch({ category: '好み' })).toEqual({
+  });
+
+  it('category に SK 区切り文字 # が含まれると INVALID_CATEGORY', () => {
+    expect(validateMemoryPatch({ category: 'a#b' })).toEqual({
+      ok: false,
+      error: 'INVALID_CATEGORY',
+    });
+  });
+
+  it('category に改行・制御文字が含まれると INVALID_CATEGORY', () => {
+    expect(validateMemoryPatch({ category: 'a\nb' })).toEqual({
       ok: false,
       error: 'INVALID_CATEGORY',
     });


### PR DESCRIPTION
## 変更の概要

Phase 3e（記憶編集 UI、#3283）を dev 環境で実データ検証して見つかった 2 件の問題を修正する。

### 問題 1: 既存の記憶が 1 件も編集保存できない（実害大）

記憶生成側（LLM 抽出）は category を**日本語**で付与する（dev 実データは全件が `好み`・`趣味・ゲーム` 等）。一方、編集側のバリデーション `validateMemoryPatch` は category を `^[a-z0-9_-]+$`（英数字のみ）に制限していたため、`MemoryEditModal` が常に `{ content, category }` を送る仕様と相まって、**content だけ直したくても既存の日本語 category が弾かれ、現存する記憶を 1 件も編集できなかった**。

- `CATEGORY_PATTERN`（英数字限定）を撤廃し、SK 区切り文字 `#` と制御文字のみを禁止する `CATEGORY_FORBIDDEN_PATTERN` に変更（日本語可）
- category の空文字も明示的に弾く
- 関連するエラーメッセージ・helperText・モーダル文言を新ルールに合わせて更新

### 問題 2: Tier タブの選択状態が分かりにくい

`MemoryTierTabs` の `variant="fullWidth"` により 3 タブが画面幅で 3 等分され、選択中の青いインジケーターが間延びして判別しにくかった。プラットフォームの先行例（`services/portal/web` の `ServiceDocumentNav`）は `variant` 指定なし（MUI デフォルト）で見やすい。

- `variant="fullWidth"` を除去（portal に合わせる）
- `sx` で選択タブの `fontWeight` を強調し視認性を改善

## 関連 Issue

#3306（親: #3182、フォロー元: #3283）

## 変更種別

- [x] バグ修正
- [x] その他（UI 視認性の改善）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（本修正はドキュメント変更不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `validation.test`: 日本語 category 許容・content 単独編集の成功・`#` / 制御文字 / 空文字の異常系を追加（旧「日本語 = 不正」前提を是正）
- `MemoryEditModal.test`: 日本語 category 保存成功・`#` でエラーになるケースに更新
- ローカル結果: web 全 **146 件パス**、カバレッジ **85.36%**（`validation.ts` 100%）、lint / format クリーン、`next build` 成功

## レビューポイント

- **category バリデーションの方針**: 生成側（日本語 category）に編集側を合わせる形にした。SK（`CHAR#...#MEM#<tier>#<category>#<ulid>`）を壊さないため `#` の禁止は維持している（category 変更は `delete + put` で SK を再構築するため）
- タブの視認性改善は見た目のみの変更。E2E の `tier-tab-*` testid は不変

## スクリーンショット（該当する場合）

dev 検証時のスクリーンショットで、`variant="fullWidth"` の間延びと、日本語 category（「好み」）保存時の「入力内容を確認してください…」エラーを確認済み。本修正で両者が解消される。

## 補足事項

dev 検証中、新規ユーザーで会話した内容が記憶一覧に出ない事象も観測したが、これは記憶抽出がバッチ処理であることに起因し（チャット直後には MemoryEntity 未生成）、記憶編集 UI の不具合ではないため本 PR のスコープ外（#3306 に記載）。

---
_Generated by [Claude Code](https://claude.ai/code/session_011wTWzPnxMEAw2z5Wq88tbh)_