### PR TITLE
feat(livetalk): 構造化ログ + CloudWatch EMF メトリクス計測 (#3315)

### DIFF
--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -18,7 +18,12 @@ export { persistInterestCategories } from './interest/index.js';
 
 // Memory retrieval + confirmation + correction
 export { cosineSimilarity, MemoryRetriever } from './memory/index.js';
-export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory, RetrieveResult } from './memory/index.js';
+export type {
+  IMemoryRetriever,
+  RetrieveOptions,
+  RetrievedMemory,
+  RetrieveResult,
+} from './memory/index.js';
 export {
   detectCorrection,
   identifyPromotionCandidates,
@@ -47,7 +52,14 @@ export {
   emitBatchMetricsLog,
   emitBatchMetricsEMF,
 } from './observability/index.js';
-export type { PhaseTimer, EmfUnit, EmfMetricDefinition, EmfPayloadOptions, ChatMetrics, BatchMetrics } from './observability/index.js';
+export type {
+  PhaseTimer,
+  EmfUnit,
+  EmfMetricDefinition,
+  EmfPayloadOptions,
+  ChatMetrics,
+  BatchMetrics,
+} from './observability/index.js';
 
 // Chat usecase
 export { runChatUseCase, type ChatEvent, type ChatUseCaseParams } from './usecases/chat-usecase.js';

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -18,7 +18,7 @@ export { persistInterestCategories } from './interest/index.js';
 
 // Memory retrieval + confirmation + correction
 export { cosineSimilarity, MemoryRetriever } from './memory/index.js';
-export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './memory/index.js';
+export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory, RetrieveResult } from './memory/index.js';
 export {
   detectCorrection,
   identifyPromotionCandidates,
@@ -36,6 +36,18 @@ export * from './characters/index.js';
 
 // Sentence splitter
 export { SentenceBuffer } from './lib/sentence-splitter.js';
+
+// Observability
+export {
+  createPhaseTimer,
+  buildEmfPayload,
+  createChatMetrics,
+  emitChatMetricsLog,
+  emitChatMetricsEMF,
+  emitBatchMetricsLog,
+  emitBatchMetricsEMF,
+} from './observability/index.js';
+export type { PhaseTimer, EmfUnit, EmfMetricDefinition, EmfPayloadOptions, ChatMetrics, BatchMetrics } from './observability/index.js';
 
 // Chat usecase
 export { runChatUseCase, type ChatEvent, type ChatUseCaseParams } from './usecases/chat-usecase.js';

--- a/services/livetalk/core/src/memory/confirmation.ts
+++ b/services/livetalk/core/src/memory/confirmation.ts
@@ -95,7 +95,7 @@ export async function identifyPromotionCandidates(
   // Tier C 全件取得
   let tierCMemories: MemoryEntity[];
   try {
-    tierCMemories = await memoryRepository.listByTier(userId, characterId, 'C');
+    ({ items: tierCMemories } = await memoryRepository.listByTier(userId, characterId, 'C'));
   } catch (err) {
     logger.warn('[confirmation] Tier C 記憶の取得に失敗しました', { err });
     return [];

--- a/services/livetalk/core/src/memory/index.ts
+++ b/services/livetalk/core/src/memory/index.ts
@@ -1,6 +1,11 @@
 export { cosineSimilarity } from './embedding.js';
 export { MemoryRetriever } from './retrieval.js';
-export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory, RetrieveResult } from './types.js';
+export type {
+  IMemoryRetriever,
+  RetrieveOptions,
+  RetrievedMemory,
+  RetrieveResult,
+} from './types.js';
 export { detectCorrection } from './correction-detector.js';
 export type { CorrectionResult } from './correction-detector.js';
 export { identifyPromotionCandidates, identifyNewLearnings } from './confirmation.js';

--- a/services/livetalk/core/src/memory/index.ts
+++ b/services/livetalk/core/src/memory/index.ts
@@ -1,6 +1,6 @@
 export { cosineSimilarity } from './embedding.js';
 export { MemoryRetriever } from './retrieval.js';
-export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './types.js';
+export type { IMemoryRetriever, RetrieveOptions, RetrievedMemory, RetrieveResult } from './types.js';
 export { detectCorrection } from './correction-detector.js';
 export type { CorrectionResult } from './correction-detector.js';
 export { identifyPromotionCandidates, identifyNewLearnings } from './confirmation.js';

--- a/services/livetalk/core/src/memory/retrieval.ts
+++ b/services/livetalk/core/src/memory/retrieval.ts
@@ -1,7 +1,7 @@
 import type { IEmbeddingClient } from '../llm-client/types.js';
 import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
 import { cosineSimilarity } from './embedding.js';
-import type { IMemoryRetriever, RetrieveOptions, RetrievedMemory } from './types.js';
+import type { IMemoryRetriever, RetrieveOptions, RetrievedMemory, RetrieveResult } from './types.js';
 
 /**
  * embedding ベースの Memory retriever。
@@ -33,11 +33,11 @@ export class MemoryRetriever implements IMemoryRetriever {
     userId: string,
     characterId: string,
     options: RetrieveOptions
-  ): Promise<RetrievedMemory[]> {
+  ): Promise<RetrieveResult> {
     const { userInput, maxTierB, cooldownMs, categoryCapPerConversation } = options;
 
     // 1. Tier A 全件（無条件）
-    const tierAMemories = await this.memoryRepository.listByTier(userId, characterId, 'A');
+    const { items: tierAMemories, consumedCapacity: tierARcu } = await this.memoryRepository.listByTier(userId, characterId, 'A');
     const tierAResults: RetrievedMemory[] = tierAMemories.map((memory) => ({
       memory,
       similarity: 1.0,
@@ -48,11 +48,14 @@ export class MemoryRetriever implements IMemoryRetriever {
     try {
       queryEmbedding = await this.embeddingClient.embed(userInput);
     } catch {
-      return tierAResults;
+      return {
+        memories: tierAResults,
+        consumedCapacity: tierARcu,
+      };
     }
 
     // 3. Tier B 全件取得 + cosine similarity 計算
-    const tierBMemories = await this.memoryRepository.listByTier(userId, characterId, 'B');
+    const { items: tierBMemories, consumedCapacity: tierBRcu } = await this.memoryRepository.listByTier(userId, characterId, 'B');
     const now = this.nowMs();
 
     const tierBCandidates: RetrievedMemory[] = [];
@@ -86,6 +89,10 @@ export class MemoryRetriever implements IMemoryRetriever {
       tierBResults.push(candidate);
     }
 
-    return [...tierAResults, ...tierBResults];
+    const totalRcu = (tierARcu ?? 0) + (tierBRcu ?? 0);
+    return {
+      memories: [...tierAResults, ...tierBResults],
+      consumedCapacity: totalRcu > 0 ? totalRcu : undefined,
+    };
   }
 }

--- a/services/livetalk/core/src/memory/retrieval.ts
+++ b/services/livetalk/core/src/memory/retrieval.ts
@@ -1,7 +1,12 @@
 import type { IEmbeddingClient } from '../llm-client/types.js';
 import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
 import { cosineSimilarity } from './embedding.js';
-import type { IMemoryRetriever, RetrieveOptions, RetrievedMemory, RetrieveResult } from './types.js';
+import type {
+  IMemoryRetriever,
+  RetrieveOptions,
+  RetrievedMemory,
+  RetrieveResult,
+} from './types.js';
 
 /**
  * embedding ベースの Memory retriever。
@@ -37,7 +42,8 @@ export class MemoryRetriever implements IMemoryRetriever {
     const { userInput, maxTierB, cooldownMs, categoryCapPerConversation } = options;
 
     // 1. Tier A 全件（無条件）
-    const { items: tierAMemories, consumedCapacity: tierARcu } = await this.memoryRepository.listByTier(userId, characterId, 'A');
+    const { items: tierAMemories, consumedCapacity: tierARcu } =
+      await this.memoryRepository.listByTier(userId, characterId, 'A');
     const tierAResults: RetrievedMemory[] = tierAMemories.map((memory) => ({
       memory,
       similarity: 1.0,
@@ -55,7 +61,8 @@ export class MemoryRetriever implements IMemoryRetriever {
     }
 
     // 3. Tier B 全件取得 + cosine similarity 計算
-    const { items: tierBMemories, consumedCapacity: tierBRcu } = await this.memoryRepository.listByTier(userId, characterId, 'B');
+    const { items: tierBMemories, consumedCapacity: tierBRcu } =
+      await this.memoryRepository.listByTier(userId, characterId, 'B');
     const now = this.nowMs();
 
     const tierBCandidates: RetrievedMemory[] = [];

--- a/services/livetalk/core/src/memory/types.ts
+++ b/services/livetalk/core/src/memory/types.ts
@@ -21,9 +21,5 @@ export interface RetrieveResult {
 }
 
 export interface IMemoryRetriever {
-  retrieve(
-    userId: string,
-    characterId: string,
-    options: RetrieveOptions
-  ): Promise<RetrieveResult>;
+  retrieve(userId: string, characterId: string, options: RetrieveOptions): Promise<RetrieveResult>;
 }

--- a/services/livetalk/core/src/memory/types.ts
+++ b/services/livetalk/core/src/memory/types.ts
@@ -13,10 +13,17 @@ export interface RetrievedMemory {
   similarity: number;
 }
 
+/** retrieve の戻り値。消費 RCU を best-effort で含む。 */
+export interface RetrieveResult {
+  memories: RetrievedMemory[];
+  /** DynamoDB 消費 RCU の合計（Tier A + Tier B クエリ分）。best-effort で undefined の場合がある。 */
+  consumedCapacity?: number;
+}
+
 export interface IMemoryRetriever {
   retrieve(
     userId: string,
     characterId: string,
     options: RetrieveOptions
-  ): Promise<RetrievedMemory[]>;
+  ): Promise<RetrieveResult>;
 }

--- a/services/livetalk/core/src/observability/emf.ts
+++ b/services/livetalk/core/src/observability/emf.ts
@@ -1,0 +1,51 @@
+/**
+ * CloudWatch Embedded Metric Format (EMF) のペイロードを組み立てる。
+ *
+ * stdout への console.log 出力だけで CloudWatch が自動メトリクス化する仕組み。
+ * ECS → CloudWatch Logs → CloudWatch Metrics の経路で、追加の IAM 権限・
+ * インフラ変更は不要。
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+ */
+
+export type EmfUnit = 'Count' | 'Milliseconds' | 'Bytes' | 'None' | 'Percent' | 'Seconds';
+
+export interface EmfMetricDefinition {
+  name: string;
+  value: number;
+  unit: EmfUnit;
+}
+
+export interface EmfPayloadOptions {
+  namespace: string;
+  /** Dimension キー → 値 のマップ。順序は保持される。 */
+  dimensions: Record<string, string>;
+  metrics: EmfMetricDefinition[];
+  /** Unix ms タイムスタンプ。省略時は呼び出し時刻を使う。 */
+  timestamp?: number;
+}
+
+export function buildEmfPayload(options: EmfPayloadOptions): string {
+  const { namespace, dimensions, metrics, timestamp = Date.now() } = options;
+  const dimensionKeys = Object.keys(dimensions);
+
+  const emfObject: Record<string, unknown> = {
+    _aws: {
+      Timestamp: timestamp,
+      CloudWatchMetrics: [
+        {
+          Namespace: namespace,
+          Dimensions: [dimensionKeys],
+          Metrics: metrics.map((m) => ({ Name: m.name, Unit: m.unit })),
+        },
+      ],
+    },
+    ...dimensions,
+  };
+
+  for (const m of metrics) {
+    emfObject[m.name] = m.value;
+  }
+
+  return JSON.stringify(emfObject);
+}

--- a/services/livetalk/core/src/observability/index.ts
+++ b/services/livetalk/core/src/observability/index.ts
@@ -1,0 +1,14 @@
+export { createPhaseTimer } from './timer.js';
+export type { PhaseTimer } from './timer.js';
+
+export { buildEmfPayload } from './emf.js';
+export type { EmfUnit, EmfMetricDefinition, EmfPayloadOptions } from './emf.js';
+
+export {
+  createChatMetrics,
+  emitChatMetricsLog,
+  emitChatMetricsEMF,
+  emitBatchMetricsLog,
+  emitBatchMetricsEMF,
+} from './metrics.js';
+export type { ChatMetrics, BatchMetrics } from './metrics.js';

--- a/services/livetalk/core/src/observability/metrics.ts
+++ b/services/livetalk/core/src/observability/metrics.ts
@@ -1,0 +1,154 @@
+import { logger } from '@nagiyu/common';
+import { buildEmfPayload, type EmfMetricDefinition } from './emf.js';
+
+/** チャット 1 回分の計測値を集約するアキュムレータ。 */
+export interface ChatMetrics {
+  userId: string;
+  characterId: string;
+  timestamp: string;
+
+  /** プロンプトトークン内訳（概算・tiktoken gpt-4o ベース） */
+  promptTokens: {
+    /** system プロンプトの基底部分（メモリ・サマリを除く） */
+    system: number;
+    /** プロンプトに注入されたサマリ部分（現在は常に 0、将来の注入に備えて追跡） */
+    summary: number;
+    /** プロンプトに注入された記憶・学習内容（Tier A/B + newLearnings） */
+    memory: number;
+    /** 会話履歴 + 今回のユーザー発話 */
+    messages: number;
+    total: number;
+  };
+
+  /** retrieval で注入した件数（プロンプト gating が機能しているか確認用） */
+  retrievedTierACount: number;
+  retrievedTierBCount: number;
+
+  /** DynamoDB に保存されている MemorySummary のサイズ（単調増加の検知用） */
+  summaryTokenCount: number;
+  summaryCharCount: number;
+
+  /** Tier A の総件数（リトリーバルで全件取得されるため線形コスト） */
+  tierATotalCount: number;
+
+  /** 各フェーズのレイテンシ（ms）。計測できなかった場合は undefined */
+  latency: {
+    retrieve?: number;
+    promotionCheck?: number;
+    llmTtfb?: number;
+    llmTotal?: number;
+    voicevoxTotal?: number;
+    chatTotal?: number;
+  };
+
+  /** DynamoDB 消費 RCU（取得できた範囲のみ）*/
+  dynamodb: {
+    messagesConsumedRcu?: number;
+    memoryConsumedRcu?: number;
+  };
+}
+
+export function createChatMetrics(userId: string, characterId: string): ChatMetrics {
+  return {
+    userId,
+    characterId,
+    timestamp: new Date().toISOString(),
+    promptTokens: { system: 0, summary: 0, memory: 0, messages: 0, total: 0 },
+    retrievedTierACount: 0,
+    retrievedTierBCount: 0,
+    summaryTokenCount: 0,
+    summaryCharCount: 0,
+    tierATotalCount: 0,
+    latency: {},
+    dynamodb: {},
+  };
+}
+
+/** L1: 構造化ログを emit する（PII を含まない）。 */
+export function emitChatMetricsLog(metrics: ChatMetrics): void {
+  logger.info('[chat-observability] チャット計測', {
+    userId: metrics.userId,
+    characterId: metrics.characterId,
+    promptTokens: metrics.promptTokens,
+    retrievedTierACount: metrics.retrievedTierACount,
+    retrievedTierBCount: metrics.retrievedTierBCount,
+    summaryTokenCount: metrics.summaryTokenCount,
+    summaryCharCount: metrics.summaryCharCount,
+    tierATotalCount: metrics.tierATotalCount,
+    latencyMs: metrics.latency,
+    dynamodbRcu: metrics.dynamodb,
+  });
+}
+
+/** L2: CloudWatch EMF メトリクスを emit する（Namespace: LiveTalk/Chat）。 */
+export function emitChatMetricsEMF(metrics: ChatMetrics): void {
+  const environment = process.env.NODE_ENV ?? 'unknown';
+
+  const emfMetrics: EmfMetricDefinition[] = [
+    { name: 'PromptTotalTokens', value: metrics.promptTokens.total, unit: 'Count' },
+    { name: 'TierACount', value: metrics.tierATotalCount, unit: 'Count' },
+    { name: 'MemorySummaryTokens', value: metrics.summaryTokenCount, unit: 'Count' },
+  ];
+
+  if (metrics.latency.llmTtfb !== undefined) {
+    emfMetrics.push({ name: 'LLMTimeToFirstToken', value: metrics.latency.llmTtfb, unit: 'Milliseconds' });
+  }
+  if (metrics.latency.chatTotal !== undefined) {
+    emfMetrics.push({ name: 'ChatTotalLatency', value: metrics.latency.chatTotal, unit: 'Milliseconds' });
+  }
+  if (metrics.latency.retrieve !== undefined) {
+    emfMetrics.push({ name: 'RetrieveLatency', value: metrics.latency.retrieve, unit: 'Milliseconds' });
+  }
+
+  const payload = buildEmfPayload({
+    namespace: 'LiveTalk/Chat',
+    dimensions: { Environment: environment, CharacterId: metrics.characterId },
+    metrics: emfMetrics,
+  });
+  console.log(payload);
+}
+
+/** 圧縮バッチ 1 回分の計測値。 */
+export interface BatchMetrics {
+  userId: string;
+  characterId: string;
+  timestamp: string;
+  messageCount: number;
+  /** 圧縮後の MemorySummary トークン数（単調増加の検知用） */
+  summaryTokenCount: number;
+  summaryCharCount: number;
+  latencyMs?: number;
+}
+
+/** L1: バッチ計測の構造化ログを emit する。 */
+export function emitBatchMetricsLog(metrics: BatchMetrics): void {
+  logger.info('[batch-observability] 圧縮バッチ計測', {
+    userId: metrics.userId,
+    characterId: metrics.characterId,
+    messageCount: metrics.messageCount,
+    summaryTokenCount: metrics.summaryTokenCount,
+    summaryCharCount: metrics.summaryCharCount,
+    latencyMs: metrics.latencyMs,
+  });
+}
+
+/** L2: バッチ EMF メトリクスを emit する（Namespace: LiveTalk/Batch）。 */
+export function emitBatchMetricsEMF(metrics: BatchMetrics): void {
+  const environment = process.env.NODE_ENV ?? 'unknown';
+
+  const emfMetrics: EmfMetricDefinition[] = [
+    { name: 'MemorySummaryTokens', value: metrics.summaryTokenCount, unit: 'Count' },
+    { name: 'CompressedMessageCount', value: metrics.messageCount, unit: 'Count' },
+  ];
+
+  if (metrics.latencyMs !== undefined) {
+    emfMetrics.push({ name: 'BatchLatency', value: metrics.latencyMs, unit: 'Milliseconds' });
+  }
+
+  const payload = buildEmfPayload({
+    namespace: 'LiveTalk/Batch',
+    dimensions: { Environment: environment, CharacterId: metrics.characterId },
+    metrics: emfMetrics,
+  });
+  console.log(payload);
+}

--- a/services/livetalk/core/src/observability/metrics.ts
+++ b/services/livetalk/core/src/observability/metrics.ts
@@ -91,13 +91,25 @@ export function emitChatMetricsEMF(metrics: ChatMetrics): void {
   ];
 
   if (metrics.latency.llmTtfb !== undefined) {
-    emfMetrics.push({ name: 'LLMTimeToFirstToken', value: metrics.latency.llmTtfb, unit: 'Milliseconds' });
+    emfMetrics.push({
+      name: 'LLMTimeToFirstToken',
+      value: metrics.latency.llmTtfb,
+      unit: 'Milliseconds',
+    });
   }
   if (metrics.latency.chatTotal !== undefined) {
-    emfMetrics.push({ name: 'ChatTotalLatency', value: metrics.latency.chatTotal, unit: 'Milliseconds' });
+    emfMetrics.push({
+      name: 'ChatTotalLatency',
+      value: metrics.latency.chatTotal,
+      unit: 'Milliseconds',
+    });
   }
   if (metrics.latency.retrieve !== undefined) {
-    emfMetrics.push({ name: 'RetrieveLatency', value: metrics.latency.retrieve, unit: 'Milliseconds' });
+    emfMetrics.push({
+      name: 'RetrieveLatency',
+      value: metrics.latency.retrieve,
+      unit: 'Milliseconds',
+    });
   }
 
   const payload = buildEmfPayload({

--- a/services/livetalk/core/src/observability/timer.ts
+++ b/services/livetalk/core/src/observability/timer.ts
@@ -1,0 +1,35 @@
+import { performance } from 'perf_hooks';
+
+export interface PhaseTimer {
+  start(phase: string): void;
+  end(phase: string): number;
+  elapsedMs(phase: string): number | undefined;
+}
+
+/**
+ * フェーズごとのレイテンシ計測ヘルパー。
+ * performance.now() ベース（ミリ秒精度、整数に丸める）。
+ */
+export function createPhaseTimer(): PhaseTimer {
+  const starts = new Map<string, number>();
+  const ends = new Map<string, number>();
+
+  return {
+    start(phase: string): void {
+      starts.set(phase, performance.now());
+    },
+    end(phase: string): number {
+      const startTime = starts.get(phase);
+      if (startTime === undefined) return 0;
+      const endTime = performance.now();
+      ends.set(phase, endTime);
+      return Math.round(endTime - startTime);
+    },
+    elapsedMs(phase: string): number | undefined {
+      const startTime = starts.get(phase);
+      const endTime = ends.get(phase);
+      if (startTime === undefined || endTime === undefined) return undefined;
+      return Math.round(endTime - startTime);
+    },
+  };
+}

--- a/services/livetalk/core/src/repositories/dynamodb-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-memory.repository.ts
@@ -23,7 +23,7 @@ import {
   buildMemoryTierSKPrefix,
   buildUserPK,
 } from '../mappers/keys.js';
-import type { MemoryRepository } from './memory.repository.interface.js';
+import type { MemoryListResult, MemoryRepository } from './memory.repository.interface.js';
 
 export class DynamoDBMemoryRepository implements MemoryRepository {
   private readonly mapper: MemoryMapper;
@@ -97,7 +97,7 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
     userId: string,
     characterId: string,
     tier: Tier
-  ): Promise<MemoryEntity[]> {
+  ): Promise<MemoryListResult> {
     const pk = buildUserPK(userId);
     const prefix = buildMemoryTierSKPrefix(characterId, tier);
     return this.queryByPrefix(pk, prefix);
@@ -110,7 +110,7 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
   ): Promise<MemoryEntity[]> {
     const pk = buildUserPK(userId);
     const prefix = buildMemoryAllTiersSKPrefix(characterId);
-    const all = await this.queryByPrefix(pk, prefix);
+    const { items: all } = await this.queryByPrefix(pk, prefix);
     return all.filter((m) => m.Category === category);
   }
 
@@ -242,8 +242,12 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
     }
   }
 
-  private async queryByPrefix(pk: string, skPrefix: string): Promise<MemoryEntity[]> {
-    const results: MemoryEntity[] = [];
+  private async queryByPrefix(
+    pk: string,
+    skPrefix: string
+  ): Promise<{ items: MemoryEntity[]; consumedCapacity: number }> {
+    const items: MemoryEntity[] = [];
+    let totalConsumedCapacity = 0;
     let exclusiveStartKey: Record<string, unknown> | undefined;
 
     for (;;) {
@@ -256,6 +260,7 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
             ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
             ExpressionAttributeValues: { ':pk': pk, ':prefix': skPrefix },
             ExclusiveStartKey: exclusiveStartKey,
+            ReturnConsumedCapacity: 'TOTAL',
           })
         );
       } catch (error) {
@@ -263,15 +268,17 @@ export class DynamoDBMemoryRepository implements MemoryRepository {
         throw new DatabaseError(message, error instanceof Error ? error : undefined);
       }
 
+      totalConsumedCapacity += result.ConsumedCapacity?.CapacityUnits ?? 0;
+
       for (const raw of result.Items ?? []) {
-        results.push(this.mapper.toEntity(raw as unknown as DynamoDBItem));
+        items.push(this.mapper.toEntity(raw as unknown as DynamoDBItem));
       }
 
       if (!result.LastEvaluatedKey) break;
       exclusiveStartKey = result.LastEvaluatedKey;
     }
 
-    return results;
+    return { items, consumedCapacity: totalConsumedCapacity };
   }
 
   private resolveTtlSec(tier: Tier): number | null {

--- a/services/livetalk/core/src/repositories/dynamodb-message.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-message.repository.ts
@@ -162,6 +162,7 @@ export class DynamoDBMessageRepository implements MessageRepository {
     const collected: MessageEntity[] = [];
     let totalTokens = 0;
     let truncated = false;
+    let totalConsumedCapacity = 0;
     let exclusiveStartKey: Record<string, unknown> | undefined;
 
     while (collected.length < hardLimit) {
@@ -183,6 +184,7 @@ export class DynamoDBMessageRepository implements MessageRepository {
             ScanIndexForward: false,
             Limit: TOKEN_BUDGETED_QUERY_PAGE_SIZE,
             ExclusiveStartKey: exclusiveStartKey,
+            ReturnConsumedCapacity: 'TOTAL',
           })
         );
       } catch (error) {
@@ -190,6 +192,7 @@ export class DynamoDBMessageRepository implements MessageRepository {
         throw new DatabaseError(message, error instanceof Error ? error : undefined);
       }
 
+      totalConsumedCapacity += result.ConsumedCapacity?.CapacityUnits ?? 0;
       const items = result.Items ?? [];
       let pageExhausted = true;
       for (const raw of items) {
@@ -237,6 +240,7 @@ export class DynamoDBMessageRepository implements MessageRepository {
       messages: collected,
       totalTokens,
       truncated,
+      consumedCapacity: totalConsumedCapacity > 0 ? totalConsumedCapacity : undefined,
     };
   }
 }

--- a/services/livetalk/core/src/repositories/embedding-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/embedding-memory.repository.ts
@@ -7,7 +7,7 @@ import type {
   Tier,
   UpdateMemoryInput,
 } from '../entities/memory.entity.js';
-import type { MemoryRepository } from './memory.repository.interface.js';
+import type { MemoryListResult, MemoryRepository } from './memory.repository.interface.js';
 
 /**
  * MemoryRepository の Decorator。
@@ -37,7 +37,7 @@ export class EmbeddingMemoryRepository implements MemoryRepository {
     userId: string,
     characterId: string,
     tier: Tier
-  ): Promise<MemoryEntity[]> {
+  ): Promise<MemoryListResult> {
     return this.inner.listByTier(userId, characterId, tier);
   }
 

--- a/services/livetalk/core/src/repositories/in-memory-memory.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-memory.repository.ts
@@ -14,7 +14,7 @@ import {
   buildMemoryTierSKPrefix,
   buildUserPK,
 } from '../mappers/keys.js';
-import type { MemoryRepository } from './memory.repository.interface.js';
+import type { MemoryListResult, MemoryRepository } from './memory.repository.interface.js';
 
 export class InMemoryMemoryRepository implements MemoryRepository {
   private readonly mapper: MemoryMapper;
@@ -67,14 +67,14 @@ export class InMemoryMemoryRepository implements MemoryRepository {
     userId: string,
     characterId: string,
     tier: Tier
-  ): Promise<MemoryEntity[]> {
+  ): Promise<MemoryListResult> {
     const pk = buildUserPK(userId);
     const prefix = buildMemoryTierSKPrefix(characterId, tier);
     const { items } = this.store.query(
       { pk, sk: { operator: 'begins_with', value: prefix } },
       { limit: Number.MAX_SAFE_INTEGER }
     );
-    return items.map((item) => this.mapper.toEntity(item));
+    return { items: items.map((item) => this.mapper.toEntity(item)) };
   }
 
   public async listByCategory(

--- a/services/livetalk/core/src/repositories/memory.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/memory.repository.interface.ts
@@ -6,6 +6,15 @@ import type {
   UpdateMemoryInput,
 } from '../entities/memory.entity.js';
 
+/**
+ * listByTier の戻り値。消費 RCU を best-effort で含む。
+ * InMemory 実装は consumedCapacity を返さない（undefined）。
+ */
+export interface MemoryListResult {
+  items: MemoryEntity[];
+  consumedCapacity?: number;
+}
+
 export interface MemoryRepository {
   /**
    * メモリを保存する。`MemoryID` 未指定時は ULID を自動採番する。
@@ -20,8 +29,9 @@ export interface MemoryRepository {
 
   /**
    * 指定 Tier のメモリを全件取得する。
+   * consumedCapacity は DynamoDB 実装のみ設定する（best-effort）。
    */
-  listByTier(userId: string, characterId: string, tier: Tier): Promise<MemoryEntity[]>;
+  listByTier(userId: string, characterId: string, tier: Tier): Promise<MemoryListResult>;
 
   /**
    * 指定カテゴリのメモリを Tier 横断で全件取得する。

--- a/services/livetalk/core/src/repositories/message.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/message.repository.interface.ts
@@ -36,6 +36,8 @@ export interface RecentMessagesResult {
   totalTokens: number;
   /** トークン上限に達して打ち切ったかどうか（true なら更に古いメッセージがある可能性） */
   truncated: boolean;
+  /** DynamoDB 消費 RCU の合計（best-effort、InMemory 実装は undefined）。 */
+  consumedCapacity?: number;
 }
 
 /**

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -1,16 +1,19 @@
+import { performance } from 'perf_hooks';
 import { logger } from '@nagiyu/common';
 import { calculateAffectionDelta, isNewActiveDay } from '../affection/calculator.js';
 import type { IEmbeddingClient, ILLMClient } from '../llm-client/types.js';
 import type { IVoiceClient } from '../voicevox/types.js';
 import type { CharacterStateRepository } from '../repositories/character-state.repository.interface.js';
 import type { MemoryRepository } from '../repositories/memory.repository.interface.js';
+import type { MemorySummaryRepository } from '../repositories/memory-summary.repository.interface.js';
 import type { MessageRepository } from '../repositories/message.repository.interface.js';
 import type { SafetyEventRepository } from '../repositories/safety-event.repository.interface.js';
 import type { CharacterDefinition } from '../characters/types.js';
 import type { MemoryEntity } from '../entities/memory.entity.js';
 import type { MessageEntity } from '../entities/message.entity.js';
-import { buildChatMessages } from '../characters/prompt-builder.js';
+import { buildChatMessages, buildSystemPrompt } from '../characters/prompt-builder.js';
 import { SentenceBuffer } from '../lib/sentence-splitter.js';
+import { getDefaultTokenCounter } from '../lib/token-counter.js';
 import {
   DEFAULT_CHARACTER_ID,
   MEMORY_CATEGORY_CAP,
@@ -25,6 +28,12 @@ import type { IMemoryRetriever, RetrievedMemory } from '../memory/types.js';
 import { detectCorrection } from '../memory/correction-detector.js';
 import { identifyNewLearnings, identifyPromotionCandidates } from '../memory/confirmation.js';
 import { applyCorrection, executePromotion } from '../memory/promotion.js';
+import { createPhaseTimer } from '../observability/timer.js';
+import {
+  createChatMetrics,
+  emitChatMetricsLog,
+  emitChatMetricsEMF,
+} from '../observability/metrics.js';
 
 /**
  * /api/chat ストリーミングレスポンスの各イベント型。
@@ -67,9 +76,11 @@ export interface ChatUseCaseParams {
   embeddingClient?: IEmbeddingClient;
   /** CharacterState リポジトリ。未指定時は親密度更新をスキップする */
   characterStateRepository?: CharacterStateRepository;
+  /** MemorySummary リポジトリ。計測のみに使用（プロンプトへの注入はしない）。未指定時は計測をスキップする */
+  memorySummaryRepository?: MemorySummaryRepository;
 }
 
-type SynthesisResult = { index: number; text: string; audio: string | null };
+type SynthesisResult = { index: number; text: string; audio: string | null; elapsedMs: number };
 
 function getLastAssistantMessage(history: MessageEntity[]): string | null {
   for (let i = history.length - 1; i >= 0; i--) {
@@ -93,13 +104,14 @@ async function synthesizeSentence(
   speakerId: number,
   index: number
 ): Promise<SynthesisResult> {
+  const start = performance.now();
   try {
     const wav = await voiceClient.synthesize(text, speakerId);
     const audio = arrayBufferToBase64(wav);
-    return { index, text, audio };
+    return { index, text, audio, elapsedMs: Math.round(performance.now() - start) };
   } catch (err) {
     logger.error('[chat-usecase] VOICEVOX 合成に失敗しました', { err });
-    return { index, text, audio: null };
+    return { index, text, audio: null, elapsedMs: Math.round(performance.now() - start) };
   }
 }
 
@@ -180,10 +192,19 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     memoryRepository,
     embeddingClient,
     characterStateRepository,
+    memorySummaryRepository,
   } = params;
 
-  // 1. 直近会話履歴取得（+ CharacterState を先取りして prevLastInteractionAt を確保）
-  const [{ messages: history }, prevCharacterState] = await Promise.all([
+  const chatStart = performance.now();
+  const metrics = createChatMetrics(userId, characterId);
+  const timer = createPhaseTimer();
+
+  // 1. 直近会話履歴取得（+ CharacterState + MemorySummary を並行取得）
+  const [
+    { messages: history, totalTokens: messagesTotalTokens, consumedCapacity: messagesRcu },
+    prevCharacterState,
+    fetchedSummary,
+  ] = await Promise.all([
     messageRepository.getRecentByTokenBudget({ userId, characterId }),
     characterStateRepository
       ? characterStateRepository.getById({ userId, characterId }).catch((err) => {
@@ -191,7 +212,20 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
           return null;
         })
       : Promise.resolve(null),
+    memorySummaryRepository
+      ? memorySummaryRepository.get(userId, characterId).catch((err) => {
+          logger.warn('[chat-usecase] MemorySummary の取得に失敗しました（計測スキップ）', { err });
+          return null;
+        })
+      : Promise.resolve(null),
   ]);
+
+  // MemorySummary のサイズを計測（単調増加の検知）
+  if (fetchedSummary) {
+    metrics.summaryCharCount = fetchedSummary.SummaryText.length;
+    metrics.summaryTokenCount = getDefaultTokenCounter().countTokens(fetchedSummary.SummaryText);
+  }
+  metrics.dynamodb.messagesConsumedRcu = messagesRcu;
 
   // 2. ユーザーメッセージを保存
   await messageRepository.create({
@@ -247,16 +281,28 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
   // 4. Memory retrieve（fail-warn: エラー時は空配列で継続）
   let retrievedMemories: RetrievedMemory[] = [];
   if (memoryRetriever) {
+    timer.start('retrieve');
     try {
-      retrievedMemories = await memoryRetriever.retrieve(userId, characterId, {
+      const retrieveResult = await memoryRetriever.retrieve(userId, characterId, {
         userInput: userText,
         maxTierB: MEMORY_MAX_TIER_B,
         cooldownMs: MEMORY_COOLDOWN_MS,
         categoryCapPerConversation: MEMORY_CATEGORY_CAP,
       });
+      timer.end('retrieve');
+      retrievedMemories = retrieveResult.memories;
+      metrics.retrievedTierACount = retrievedMemories.filter((r) => r.memory.Tier === 'A').length;
+      metrics.retrievedTierBCount = retrievedMemories.filter((r) => r.memory.Tier === 'B').length;
+      // Tier A はリトリーバルで全件取得されるため、注入数 = 総件数
+      metrics.tierATotalCount = metrics.retrievedTierACount;
+      if (retrieveResult.consumedCapacity !== undefined) {
+        metrics.dynamodb.memoryConsumedRcu = retrieveResult.consumedCapacity;
+      }
     } catch (err) {
+      timer.end('retrieve');
       logger.warn('[chat-usecase] Memory retrieve に失敗しました（メモリなしで継続）', { err });
     }
+    metrics.latency.retrieve = timer.elapsedMs('retrieve');
   }
 
   // 4a. 暗黙訂正検出（fail-warn: エラー時はスキップして継続）
@@ -282,6 +328,7 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
   // 4b. Tier C 昇格候補検出（fail-warn: エラー時は空配列で継続）
   let promotionCandidates: MemoryEntity[] = [];
   if (memoryRepository && embeddingClient) {
+    timer.start('promotionCheck');
     try {
       promotionCandidates = await identifyPromotionCandidates(
         userId,
@@ -291,9 +338,12 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
         embeddingClient,
         llmClient
       );
+      timer.end('promotionCheck');
     } catch (err) {
+      timer.end('promotionCheck');
       logger.warn('[chat-usecase] 昇格候補検出に失敗しました（スキップして継続）', { err });
     }
+    metrics.latency.promotionCheck = timer.elapsedMs('promotionCheck');
   }
   const newLearnings = identifyNewLearnings(promotionCandidates);
 
@@ -307,12 +357,40 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     undefined,
     newLearnings.length > 0 ? newLearnings : undefined
   );
+
+  // プロンプトトークン内訳を計算（best-effort）
+  try {
+    const counter = getDefaultTokenCounter();
+    const baseSystem = buildSystemPrompt(character, new Date());
+    const memoryTokens =
+      retrievedMemories.reduce((sum, r) => sum + counter.countTokens(r.memory.Content), 0) +
+      newLearnings.reduce((sum, m) => sum + counter.countTokens(m.Content), 0);
+    const messageTokens = messagesTotalTokens + counter.countTokensForMessage(userText);
+    const systemTokens = counter.countTokens(baseSystem);
+    metrics.promptTokens = {
+      system: systemTokens,
+      summary: 0,
+      memory: memoryTokens,
+      messages: messageTokens,
+      total: systemTokens + memoryTokens + messageTokens,
+    };
+  } catch (err) {
+    logger.warn('[chat-usecase] プロンプトトークン計算に失敗しました（スキップ）', { err });
+  }
+
   const sentenceBuffer = new SentenceBuffer();
   let fullResponseText = '';
   const pendingSynthesis: Array<Promise<SynthesisResult>> = [];
   let sentenceIndex = 0;
 
+  const llmStart = performance.now();
+  let llmTtfbCaptured = false;
+
   for await (const delta of llmClient.chatStream(chatMessages)) {
+    if (!llmTtfbCaptured) {
+      metrics.latency.llmTtfb = Math.round(performance.now() - llmStart);
+      llmTtfbCaptured = true;
+    }
     yield { type: 'text', delta };
     fullResponseText += delta;
 
@@ -325,6 +403,8 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     }
   }
 
+  metrics.latency.llmTotal = Math.round(performance.now() - llmStart);
+
   const remaining = sentenceBuffer.flush();
   if (remaining) {
     const idx = sentenceIndex;
@@ -333,13 +413,16 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     );
   }
 
-  // 7. sentence events を順番通りに yield
+  // 7. sentence events を順番通りに yield（VOICEVOX 合計レイテンシを集計）
+  let voicevoxTotalMs = 0;
   for (const promise of pendingSynthesis) {
     const result = await promise;
+    voicevoxTotalMs += result.elapsedMs;
     if (result.audio !== null) {
       yield { type: 'sentence', index: result.index, text: result.text, audio: result.audio };
     }
   }
+  metrics.latency.voicevoxTotal = voicevoxTotalMs > 0 ? voicevoxTotalMs : undefined;
 
   // 8. Moderation API チェック（fail-warn: エラー時は通常応答を通す）
   if (moderationClient && fullResponseText.trim()) {
@@ -382,7 +465,16 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
   }
 
   // 9. done
+  metrics.latency.chatTotal = Math.round(performance.now() - chatStart);
   yield { type: 'done' };
+
+  // 計測結果を emit（best-effort: 例外が本処理を止めない）
+  try {
+    emitChatMetricsLog(metrics);
+    emitChatMetricsEMF(metrics);
+  } catch (err) {
+    logger.warn('[chat-usecase] 計測の emit に失敗しました', { err });
+  }
 
   // 10. アシスタントメッセージを保存
   const assistantText = fullResponseText.trim();

--- a/services/livetalk/core/src/usecases/compress-conversation.usecase.ts
+++ b/services/livetalk/core/src/usecases/compress-conversation.usecase.ts
@@ -1,4 +1,7 @@
+import { performance } from 'perf_hooks';
 import { logger } from '@nagiyu/common';
+import { getDefaultTokenCounter } from '../lib/token-counter.js';
+import { emitBatchMetricsLog, emitBatchMetricsEMF } from '../observability/metrics.js';
 import { MEMORY_DEFAULT_CONFIDENCE } from '../constants.js';
 import { calculateBidirectionalityDelta } from '../affection/calculator.js';
 import { persistInterestCategories } from '../interest/category-extractor.js';
@@ -49,6 +52,8 @@ export async function compressConversation(
     characterStateRepo,
   } = params;
 
+  const batchStart = performance.now();
+
   const summary = await summaryRepo.get(userId, characterId);
   const lastCompressedAt = summary?.LastCompressedAt ?? 0;
 
@@ -77,6 +82,25 @@ export async function compressConversation(
     SummaryText: result.mergedSummary,
     LastCompressedAt: now(),
   });
+
+  // バッチ計測（best-effort）
+  try {
+    const counter = getDefaultTokenCounter();
+    const summaryTokenCount = counter.countTokens(result.mergedSummary);
+    const batchMetrics = {
+      userId,
+      characterId,
+      timestamp: new Date().toISOString(),
+      messageCount: messages.length,
+      summaryTokenCount,
+      summaryCharCount: result.mergedSummary.length,
+      latencyMs: Math.round(performance.now() - batchStart),
+    };
+    emitBatchMetricsLog(batchMetrics);
+    emitBatchMetricsEMF(batchMetrics);
+  } catch (err) {
+    logger.warn('[compressConversation] バッチ計測の emit に失敗しました', { err });
+  }
 
   for (const candidate of result.newMemoryCandidates) {
     await memoryRepo.put({

--- a/services/livetalk/core/tests/unit/memory/confirmation.test.ts
+++ b/services/livetalk/core/tests/unit/memory/confirmation.test.ts
@@ -30,7 +30,7 @@ function makeMemoryC(id: string, content: string, embedding?: number[]): MemoryE
 
 function makeMemoryRepo(tierC: MemoryEntity[]): MemoryRepository {
   return {
-    listByTier: jest.fn(async (_u, _c, tier) => (tier === 'C' ? tierC : [])),
+    listByTier: jest.fn(async (_u, _c, tier) => (tier === 'C' ? { items: tierC } : { items: [] })),
     put: jest.fn(),
     get: jest.fn(),
     listByCategory: jest.fn(),

--- a/services/livetalk/core/tests/unit/memory/retrieval.test.ts
+++ b/services/livetalk/core/tests/unit/memory/retrieval.test.ts
@@ -256,7 +256,9 @@ describe('MemoryRetriever', () => {
         ...defaultOptions,
         categoryCapPerConversation: 1,
       });
-      const food = result.memories.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
+      const food = result.memories.filter(
+        (r) => r.memory.Tier === 'B' && r.memory.Category === 'food'
+      );
       expect(food).toHaveLength(1);
     });
 
@@ -292,7 +294,9 @@ describe('MemoryRetriever', () => {
         categoryCapPerConversation: 2,
         maxTierB: 10,
       });
-      const food = result.memories.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
+      const food = result.memories.filter(
+        (r) => r.memory.Tier === 'B' && r.memory.Category === 'food'
+      );
       expect(food).toHaveLength(2);
     });
   });

--- a/services/livetalk/core/tests/unit/memory/retrieval.test.ts
+++ b/services/livetalk/core/tests/unit/memory/retrieval.test.ts
@@ -30,9 +30,9 @@ function makeMemory(
 function makeMemoryRepo(tierA: MemoryEntity[] = [], tierB: MemoryEntity[] = []): MemoryRepository {
   return {
     listByTier: jest.fn(async (_userId, _charId, tier) => {
-      if (tier === 'A') return tierA;
-      if (tier === 'B') return tierB;
-      return [];
+      if (tier === 'A') return { items: tierA };
+      if (tier === 'B') return { items: tierB };
+      return { items: [] };
     }),
     put: jest.fn(),
     get: jest.fn(),
@@ -69,7 +69,7 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
-      const tierAResults = result.filter((r) => r.memory.Tier === 'A');
+      const tierAResults = result.memories.filter((r) => r.memory.Tier === 'A');
       expect(tierAResults).toHaveLength(2);
       expect(tierAResults.every((r) => r.similarity === 1.0)).toBe(true);
     });
@@ -92,7 +92,7 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
-      expect(result.filter((r) => r.memory.Tier === 'A')).toHaveLength(1);
+      expect(result.memories.filter((r) => r.memory.Tier === 'A')).toHaveLength(1);
     });
   });
 
@@ -125,7 +125,7 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', { ...defaultOptions, maxTierB: 2 });
-      const tierBResults = result.filter((r) => r.memory.Tier === 'B');
+      const tierBResults = result.memories.filter((r) => r.memory.Tier === 'B');
       expect(tierBResults).toHaveLength(2);
       expect(tierBResults[0].memory.Content).toBe('コーヒー好き');
     });
@@ -147,7 +147,7 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
-      const tierBResults = result.filter((r) => r.memory.Tier === 'B');
+      const tierBResults = result.memories.filter((r) => r.memory.Tier === 'B');
       expect(tierBResults).toHaveLength(1);
       expect(tierBResults[0].memory.Content).toBe('スポーツ好き');
     });
@@ -178,7 +178,7 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
-      const tierBResults = result.filter((r) => r.memory.Tier === 'B');
+      const tierBResults = result.memories.filter((r) => r.memory.Tier === 'B');
       expect(tierBResults).toHaveLength(1);
       expect(tierBResults[0].memory.Content).toBe('スポーツ好き');
     });
@@ -201,7 +201,7 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
-      expect(result.filter((r) => r.memory.Tier === 'B')).toHaveLength(1);
+      expect(result.memories.filter((r) => r.memory.Tier === 'B')).toHaveLength(1);
     });
 
     it('LastReferencedAt が未設定の Memory は cooldown 除外されない', async () => {
@@ -220,7 +220,7 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
-      expect(result.filter((r) => r.memory.Tier === 'B')).toHaveLength(1);
+      expect(result.memories.filter((r) => r.memory.Tier === 'B')).toHaveLength(1);
     });
   });
 
@@ -256,7 +256,7 @@ describe('MemoryRetriever', () => {
         ...defaultOptions,
         categoryCapPerConversation: 1,
       });
-      const food = result.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
+      const food = result.memories.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
       expect(food).toHaveLength(1);
     });
 
@@ -292,7 +292,7 @@ describe('MemoryRetriever', () => {
         categoryCapPerConversation: 2,
         maxTierB: 10,
       });
-      const food = result.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
+      const food = result.memories.filter((r) => r.memory.Tier === 'B' && r.memory.Category === 'food');
       expect(food).toHaveLength(2);
     });
   });
@@ -322,8 +322,8 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
-      expect(result).toHaveLength(1);
-      expect(result[0].memory.Tier).toBe('A');
+      expect(result.memories).toHaveLength(1);
+      expect(result.memories[0].memory.Tier).toBe('A');
     });
   });
 
@@ -347,8 +347,8 @@ describe('MemoryRetriever', () => {
       );
 
       const result = await retriever.retrieve('u1', 'hiyori', defaultOptions);
-      expect(result.some((r) => r.memory.Tier === 'A')).toBe(true);
-      expect(result.some((r) => r.memory.Tier === 'B')).toBe(true);
+      expect(result.memories.some((r) => r.memory.Tier === 'A')).toBe(true);
+      expect(result.memories.some((r) => r.memory.Tier === 'B')).toBe(true);
     });
   });
 });

--- a/services/livetalk/core/tests/unit/observability/emf.test.ts
+++ b/services/livetalk/core/tests/unit/observability/emf.test.ts
@@ -1,0 +1,108 @@
+import { buildEmfPayload } from '../../../src/observability/emf.js';
+
+describe('buildEmfPayload', () => {
+  it('有効な EMF JSON 文字列を返す', () => {
+    const payload = buildEmfPayload({
+      namespace: 'LiveTalk/Chat',
+      dimensions: { Environment: 'dev', CharacterId: 'hiyori' },
+      metrics: [{ name: 'PromptTotalTokens', value: 1234, unit: 'Count' }],
+      timestamp: 1_700_000_000_000,
+    });
+
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    expect(parsed).toBeDefined();
+  });
+
+  it('_aws.CloudWatchMetrics に正しい Namespace を含む', () => {
+    const payload = buildEmfPayload({
+      namespace: 'LiveTalk/Chat',
+      dimensions: { Environment: 'prod' },
+      metrics: [{ name: 'ChatTotalLatency', value: 800, unit: 'Milliseconds' }],
+    });
+
+    const parsed = JSON.parse(payload) as {
+      _aws: { CloudWatchMetrics: Array<{ Namespace: string }> };
+    };
+    expect(parsed._aws.CloudWatchMetrics[0].Namespace).toBe('LiveTalk/Chat');
+  });
+
+  it('Dimensions に全ディメンションキーが含まれる', () => {
+    const payload = buildEmfPayload({
+      namespace: 'LiveTalk/Chat',
+      dimensions: { Environment: 'dev', CharacterId: 'hiyori' },
+      metrics: [{ name: 'TierACount', value: 5, unit: 'Count' }],
+    });
+
+    const parsed = JSON.parse(payload) as {
+      _aws: { CloudWatchMetrics: Array<{ Dimensions: string[][] }> };
+    };
+    const dims = parsed._aws.CloudWatchMetrics[0].Dimensions[0];
+    expect(dims).toContain('Environment');
+    expect(dims).toContain('CharacterId');
+  });
+
+  it('メトリクス値がトップレベルに展開される', () => {
+    const payload = buildEmfPayload({
+      namespace: 'LiveTalk/Chat',
+      dimensions: { Environment: 'dev' },
+      metrics: [
+        { name: 'PromptTotalTokens', value: 500, unit: 'Count' },
+        { name: 'LLMTimeToFirstToken', value: 300, unit: 'Milliseconds' },
+      ],
+    });
+
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    expect(parsed['PromptTotalTokens']).toBe(500);
+    expect(parsed['LLMTimeToFirstToken']).toBe(300);
+  });
+
+  it('ディメンション値がトップレベルに展開される', () => {
+    const payload = buildEmfPayload({
+      namespace: 'LiveTalk/Chat',
+      dimensions: { Environment: 'staging', CharacterId: 'hiyori' },
+      metrics: [{ name: 'TierACount', value: 3, unit: 'Count' }],
+    });
+
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    expect(parsed['Environment']).toBe('staging');
+    expect(parsed['CharacterId']).toBe('hiyori');
+  });
+
+  it('Metrics 定義に Name と Unit が含まれる', () => {
+    const payload = buildEmfPayload({
+      namespace: 'LiveTalk/Batch',
+      dimensions: { Environment: 'dev' },
+      metrics: [{ name: 'MemorySummaryTokens', value: 800, unit: 'Count' }],
+    });
+
+    const parsed = JSON.parse(payload) as {
+      _aws: { CloudWatchMetrics: Array<{ Metrics: Array<{ Name: string; Unit: string }> }> };
+    };
+    const metric = parsed._aws.CloudWatchMetrics[0].Metrics[0];
+    expect(metric.Name).toBe('MemorySummaryTokens');
+    expect(metric.Unit).toBe('Count');
+  });
+
+  it('timestamp を省略した場合は呼び出し時刻が使われる', () => {
+    const before = Date.now();
+    const payload = buildEmfPayload({
+      namespace: 'LiveTalk/Chat',
+      dimensions: { Environment: 'dev' },
+      metrics: [{ name: 'TierACount', value: 0, unit: 'Count' }],
+    });
+    const after = Date.now();
+
+    const parsed = JSON.parse(payload) as { _aws: { Timestamp: number } };
+    expect(parsed._aws.Timestamp).toBeGreaterThanOrEqual(before);
+    expect(parsed._aws.Timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it('メトリクスが空でも有効な JSON を生成する', () => {
+    const payload = buildEmfPayload({
+      namespace: 'LiveTalk/Chat',
+      dimensions: { Environment: 'dev' },
+      metrics: [],
+    });
+    expect(() => JSON.parse(payload)).not.toThrow();
+  });
+});

--- a/services/livetalk/core/tests/unit/observability/metrics.test.ts
+++ b/services/livetalk/core/tests/unit/observability/metrics.test.ts
@@ -1,4 +1,10 @@
-import { createChatMetrics, emitChatMetricsLog, emitChatMetricsEMF, emitBatchMetricsLog, emitBatchMetricsEMF } from '../../../src/observability/metrics.js';
+import {
+  createChatMetrics,
+  emitChatMetricsLog,
+  emitChatMetricsEMF,
+  emitBatchMetricsLog,
+  emitBatchMetricsEMF,
+} from '../../../src/observability/metrics.js';
 
 describe('createChatMetrics', () => {
   it('初期値はすべてゼロ・空のまま返す', () => {

--- a/services/livetalk/core/tests/unit/observability/metrics.test.ts
+++ b/services/livetalk/core/tests/unit/observability/metrics.test.ts
@@ -1,0 +1,163 @@
+import { createChatMetrics, emitChatMetricsLog, emitChatMetricsEMF, emitBatchMetricsLog, emitBatchMetricsEMF } from '../../../src/observability/metrics.js';
+
+describe('createChatMetrics', () => {
+  it('初期値はすべてゼロ・空のまま返す', () => {
+    const metrics = createChatMetrics('u1', 'hiyori');
+    expect(metrics.userId).toBe('u1');
+    expect(metrics.characterId).toBe('hiyori');
+    expect(metrics.promptTokens.total).toBe(0);
+    expect(metrics.retrievedTierACount).toBe(0);
+    expect(metrics.retrievedTierBCount).toBe(0);
+    expect(metrics.summaryTokenCount).toBe(0);
+    expect(metrics.summaryCharCount).toBe(0);
+    expect(metrics.tierATotalCount).toBe(0);
+    expect(metrics.latency).toEqual({});
+    expect(metrics.dynamodb).toEqual({});
+  });
+
+  it('timestamp が ISO8601 形式である', () => {
+    const metrics = createChatMetrics('u1', 'hiyori');
+    expect(() => new Date(metrics.timestamp)).not.toThrow();
+    expect(new Date(metrics.timestamp).toISOString()).toBe(metrics.timestamp);
+  });
+});
+
+describe('emitChatMetricsLog', () => {
+  it('logger.info を呼び出す（例外を throw しない）', () => {
+    const metrics = createChatMetrics('u1', 'hiyori');
+    metrics.promptTokens = { system: 100, summary: 0, memory: 50, messages: 200, total: 350 };
+    metrics.latency.chatTotal = 1200;
+    expect(() => emitChatMetricsLog(metrics)).not.toThrow();
+  });
+
+  it('PII（会話本文）がログに含まれない', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const metrics = createChatMetrics('u1', 'hiyori');
+    emitChatMetricsLog(metrics);
+    const output = logSpy.mock.calls.map((args) => JSON.stringify(args)).join('');
+    expect(output).not.toContain('会話本文');
+    logSpy.mockRestore();
+  });
+});
+
+describe('emitChatMetricsEMF', () => {
+  it('console.log で EMF JSON を出力する', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const metrics = createChatMetrics('u1', 'hiyori');
+    metrics.promptTokens.total = 500;
+    metrics.tierATotalCount = 3;
+    metrics.summaryTokenCount = 200;
+    metrics.latency.llmTtfb = 400;
+    metrics.latency.chatTotal = 1500;
+    metrics.latency.retrieve = 100;
+
+    emitChatMetricsEMF(metrics);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed['PromptTotalTokens']).toBe(500);
+    expect(parsed['TierACount']).toBe(3);
+    expect(parsed['MemorySummaryTokens']).toBe(200);
+    expect(parsed['LLMTimeToFirstToken']).toBe(400);
+    expect(parsed['ChatTotalLatency']).toBe(1500);
+    expect(parsed['RetrieveLatency']).toBe(100);
+    expect((parsed['_aws'] as { CloudWatchMetrics: unknown[] }).CloudWatchMetrics).toBeDefined();
+    logSpy.mockRestore();
+  });
+
+  it('latency が undefined の場合は該当メトリクスを出力しない', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const metrics = createChatMetrics('u1', 'hiyori');
+
+    emitChatMetricsEMF(metrics);
+
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).not.toContain('LLMTimeToFirstToken');
+    expect(output).not.toContain('ChatTotalLatency');
+    expect(output).not.toContain('RetrieveLatency');
+    logSpy.mockRestore();
+  });
+
+  it('例外を throw しない（best-effort）', () => {
+    const metrics = createChatMetrics('u1', 'hiyori');
+    jest.spyOn(console, 'log').mockImplementation(() => {
+      throw new Error('stdout error');
+    });
+    expect(() => emitChatMetricsEMF(metrics)).toThrow();
+    jest.restoreAllMocks();
+  });
+
+  it('EMF の Namespace が LiveTalk/Chat である', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const metrics = createChatMetrics('u1', 'hiyori');
+    emitChatMetricsEMF(metrics);
+    const output = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as {
+      _aws: { CloudWatchMetrics: Array<{ Namespace: string }> };
+    };
+    expect(parsed._aws.CloudWatchMetrics[0].Namespace).toBe('LiveTalk/Chat');
+    logSpy.mockRestore();
+  });
+});
+
+describe('emitBatchMetricsLog', () => {
+  it('例外を throw しない', () => {
+    const batchMetrics = {
+      userId: 'u1',
+      characterId: 'hiyori',
+      timestamp: new Date().toISOString(),
+      messageCount: 10,
+      summaryTokenCount: 500,
+      summaryCharCount: 1000,
+      latencyMs: 2000,
+    };
+    expect(() => emitBatchMetricsLog(batchMetrics)).not.toThrow();
+  });
+});
+
+describe('emitBatchMetricsEMF', () => {
+  it('EMF の Namespace が LiveTalk/Batch である', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const batchMetrics = {
+      userId: 'u1',
+      characterId: 'hiyori',
+      timestamp: new Date().toISOString(),
+      messageCount: 5,
+      summaryTokenCount: 300,
+      summaryCharCount: 600,
+      latencyMs: 1000,
+    };
+
+    emitBatchMetricsEMF(batchMetrics);
+
+    const output = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as {
+      _aws: { CloudWatchMetrics: Array<{ Namespace: string }> };
+    };
+    expect(parsed._aws.CloudWatchMetrics[0].Namespace).toBe('LiveTalk/Batch');
+    logSpy.mockRestore();
+  });
+
+  it('MemorySummaryTokens と CompressedMessageCount を含む', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const batchMetrics = {
+      userId: 'u1',
+      characterId: 'hiyori',
+      timestamp: new Date().toISOString(),
+      messageCount: 7,
+      summaryTokenCount: 400,
+      summaryCharCount: 800,
+      latencyMs: 3000,
+    };
+
+    emitBatchMetricsEMF(batchMetrics);
+
+    const output = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed['MemorySummaryTokens']).toBe(400);
+    expect(parsed['CompressedMessageCount']).toBe(7);
+    expect(parsed['BatchLatency']).toBe(3000);
+    logSpy.mockRestore();
+  });
+});

--- a/services/livetalk/core/tests/unit/observability/timer.test.ts
+++ b/services/livetalk/core/tests/unit/observability/timer.test.ts
@@ -1,0 +1,54 @@
+import { createPhaseTimer } from '../../../src/observability/timer.js';
+
+describe('createPhaseTimer', () => {
+  it('start/end で経過時間（ms）を返す', async () => {
+    const timer = createPhaseTimer();
+    timer.start('phase1');
+    await new Promise((r) => setTimeout(r, 30));
+    const elapsed = timer.end('phase1');
+    expect(elapsed).toBeGreaterThanOrEqual(20);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('end を先に呼んだ場合は 0 を返す', () => {
+    const timer = createPhaseTimer();
+    const elapsed = timer.end('notStarted');
+    expect(elapsed).toBe(0);
+  });
+
+  it('elapsedMs は計測済みフェーズの値を返す', async () => {
+    const timer = createPhaseTimer();
+    timer.start('p');
+    await new Promise((r) => setTimeout(r, 10));
+    timer.end('p');
+    const ms = timer.elapsedMs('p');
+    expect(ms).toBeDefined();
+    expect(ms!).toBeGreaterThanOrEqual(0);
+  });
+
+  it('elapsedMs は未計測フェーズに対して undefined を返す', () => {
+    const timer = createPhaseTimer();
+    expect(timer.elapsedMs('unknown')).toBeUndefined();
+  });
+
+  it('elapsedMs は start したが end していないフェーズに対して undefined を返す', () => {
+    const timer = createPhaseTimer();
+    timer.start('partial');
+    expect(timer.elapsedMs('partial')).toBeUndefined();
+  });
+
+  it('複数フェーズを独立して計測できる', async () => {
+    const timer = createPhaseTimer();
+    timer.start('a');
+    await new Promise((r) => setTimeout(r, 10));
+    timer.start('b');
+    await new Promise((r) => setTimeout(r, 10));
+    timer.end('a');
+    timer.end('b');
+    const a = timer.elapsedMs('a');
+    const b = timer.elapsedMs('b');
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a!).toBeGreaterThan(b!);
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-memory.repository.test.ts
@@ -221,7 +221,7 @@ describe('DynamoDBMemoryRepository', () => {
         () => fixedNow
       );
       const result = await repo.listByTier('u1', 'hiyori', 'B');
-      expect(result).toHaveLength(1);
+      expect(result.items).toHaveLength(1);
       expect(sent[0]).toBeInstanceOf(QueryCommand);
       const input = (sent[0] as QueryCommand).input;
       expect(input.ExpressionAttributeValues?.[':pk']).toBe('USER#u1');

--- a/services/livetalk/core/tests/unit/repositories/in-memory-memory.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-memory.repository.test.ts
@@ -103,8 +103,8 @@ describe('InMemoryMemoryRepository', () => {
       await repo.put({ ...baseInput, Tier: 'B', Category: 'hobby', Content: '読書' });
 
       const result = await repo.listByTier('u1', 'hiyori', 'B');
-      expect(result).toHaveLength(2);
-      expect(result.every((m) => m.Tier === 'B')).toBe(true);
+      expect(result.items).toHaveLength(2);
+      expect(result.items.every((m) => m.Tier === 'B')).toBe(true);
     });
 
     it('別ユーザー / 別キャラのメモリは混入しない', async () => {
@@ -113,7 +113,7 @@ describe('InMemoryMemoryRepository', () => {
       await repo.put({ ...baseInput, CharacterID: 'other', Tier: 'A' });
 
       const result = await repo.listByTier('u1', 'hiyori', 'A');
-      expect(result).toHaveLength(1);
+      expect(result.items).toHaveLength(1);
     });
   });
 

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -118,7 +118,7 @@ function makeModerationClient(
 
 function makeMemoryRetriever(memories: RetrievedMemory[] = []): IMemoryRetriever {
   return {
-    retrieve: jest.fn(async () => memories),
+    retrieve: jest.fn(async () => ({ memories })),
   };
 }
 
@@ -126,7 +126,7 @@ function makeMemoryRepo(): MemoryRepository {
   return {
     put: jest.fn(),
     get: jest.fn(async () => null),
-    listByTier: jest.fn(async () => []),
+    listByTier: jest.fn(async () => ({ items: [] })),
     listByCategory: jest.fn(async () => []),
     update: jest.fn(
       async (input) =>
@@ -1140,7 +1140,7 @@ describe('runChatUseCase', () => {
         Embedding: [1, 0, 0],
       };
       const memRepo = makeMemoryRepo();
-      (memRepo.listByTier as jest.Mock).mockResolvedValue([tierCMem]);
+      (memRepo.listByTier as jest.Mock).mockResolvedValue({ items: [tierCMem] });
       const llm: ILLMClient = {
         chatStream: jest.fn(async function* () {
           yield '覚えとくね！';

--- a/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
@@ -133,7 +133,7 @@ describe('compressConversation', () => {
       now: () => fixedNow,
     });
 
-    const foodMems = await memoryRepo.listByTier('u1', 'hiyori', 'C');
+    const { items: foodMems } = await memoryRepo.listByTier('u1', 'hiyori', 'C');
     expect(foodMems).toHaveLength(2);
     const categories = foodMems.map((m) => m.Category).sort();
     expect(categories).toEqual(['food', 'hobby']);

--- a/services/livetalk/web/src/app/api/memory/route.ts
+++ b/services/livetalk/web/src/app/api/memory/route.ts
@@ -35,7 +35,7 @@ export const GET = withAuth(getSession, 'livetalk:chat', async (session, request
     const tiers = parsed.tier ? [parsed.tier] : VISIBLE_TIERS;
     const collected: MemoryEntity[] = [];
     for (const tier of tiers) {
-      const items = await repo.listByTier(userId, characterId, tier);
+      const { items } = await repo.listByTier(userId, characterId, tier);
       collected.push(...items);
     }
 

--- a/services/livetalk/web/tests/unit/app/api/memory/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/memory/route.test.ts
@@ -67,8 +67,10 @@ describe('GET /api/memory', () => {
   it('tier 未指定なら A/B/C を横断取得しソートして返す', async () => {
     mockGetSession.mockResolvedValue(session);
     const listByTier = jest.fn(async (_u: string, _c: string, tier: string) => {
-      if (tier === 'A') return { items: [makeEntity({ MemoryID: 'a', Tier: 'A', LastReferencedAt: 100 })] };
-      if (tier === 'B') return { items: [makeEntity({ MemoryID: 'b', Tier: 'B', LastReferencedAt: 200 })] };
+      if (tier === 'A')
+        return { items: [makeEntity({ MemoryID: 'a', Tier: 'A', LastReferencedAt: 100 })] };
+      if (tier === 'B')
+        return { items: [makeEntity({ MemoryID: 'b', Tier: 'B', LastReferencedAt: 200 })] };
       return { items: [] };
     });
     mockGetRepo.mockReturnValue(makeRepo({ listByTier }));

--- a/services/livetalk/web/tests/unit/app/api/memory/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/memory/route.test.ts
@@ -42,7 +42,7 @@ const makeEntity = (over: Partial<MemoryEntity> = {}): MemoryEntity => ({
 
 const makeRepo = (over: Partial<MemoryRepository> = {}): MemoryRepository =>
   ({
-    listByTier: jest.fn(async () => []),
+    listByTier: jest.fn(async () => ({ items: [] })),
     get: jest.fn(),
     put: jest.fn(),
     listByCategory: jest.fn(),
@@ -67,9 +67,9 @@ describe('GET /api/memory', () => {
   it('tier 未指定なら A/B/C を横断取得しソートして返す', async () => {
     mockGetSession.mockResolvedValue(session);
     const listByTier = jest.fn(async (_u: string, _c: string, tier: string) => {
-      if (tier === 'A') return [makeEntity({ MemoryID: 'a', Tier: 'A', LastReferencedAt: 100 })];
-      if (tier === 'B') return [makeEntity({ MemoryID: 'b', Tier: 'B', LastReferencedAt: 200 })];
-      return [];
+      if (tier === 'A') return { items: [makeEntity({ MemoryID: 'a', Tier: 'A', LastReferencedAt: 100 })] };
+      if (tier === 'B') return { items: [makeEntity({ MemoryID: 'b', Tier: 'B', LastReferencedAt: 200 })] };
+      return { items: [] };
     });
     mockGetRepo.mockReturnValue(makeRepo({ listByTier }));
 
@@ -86,7 +86,7 @@ describe('GET /api/memory', () => {
 
   it('tier 指定ならその Tier のみ取得', async () => {
     mockGetSession.mockResolvedValue(session);
-    const listByTier = jest.fn(async () => [makeEntity({ Tier: 'C' })]);
+    const listByTier = jest.fn(async () => ({ items: [makeEntity({ Tier: 'C' })] }));
     mockGetRepo.mockReturnValue(makeRepo({ listByTier }));
 
     const res = await GET(req('http://localhost/api/memory?tier=C'));

--- a/tasks/livetalk/design.md
+++ b/tasks/livetalk/design.md
@@ -615,3 +615,66 @@ LLM プロンプトは以下3系統で構成される：
 ### 可逆性
 
 編集機能を将来復活させる場合は別途新規 Issue で対応する。その際は三層整合性問題（②③の更新、または注釈で許容）への対処も設計に含めること。
+
+---
+
+## 可観測性（Observability）設計 (#3315)
+
+### 概要
+
+構造化ログ（L1）と CloudWatch EMF メトリクス（L2）を組み合わせ、コンテキストサイズと応答速度を計測する。
+
+### 設計方針
+
+- **Best-effort 計測**: すべての計測コードは try/catch で囲み、例外がチャット応答を止めない
+- **PII 保護**: ログ・メトリクスにはトークン数・レイテンシ・件数のみ記録（会話本文を含めない）
+- **EMF 出力**: `console.log` でトップレベル `_aws` キーを持つ JSON を直接出力（logger ラッパーは EMF 構造を壊すため使わない）
+- **L1 ログ**: `@nagiyu/common` の `logger.info` を使用（構造化ログ）
+
+### 実装ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `src/observability/timer.ts` | フェーズタイマー（`createPhaseTimer`）。`performance.now()` を使ったサブミリ秒計測 |
+| `src/observability/emf.ts` | EMF JSON ビルダー（`buildEmfPayload`）。`_aws.CloudWatchMetrics` 構造を組み立てる |
+| `src/observability/metrics.ts` | チャット・バッチ用メトリクス管理。`ChatMetrics` / `BatchMetrics` の生成・ログ出力・EMF 出力 |
+| `src/observability/index.ts` | 上記 3 ファイルの re-export |
+
+### EMF メトリクス定義
+
+#### チャット用（Namespace: `LiveTalk/Chat`）
+
+| メトリクス名 | 単位 | 内容 |
+|------------|------|------|
+| `PromptTotalTokens` | Count | プロンプト合計トークン数 |
+| `TierACount` | Count | 取得した Tier A 記憶件数 |
+| `MemorySummaryTokens` | Count | 記憶サマリーのトークン数 |
+| `LLMTimeToFirstToken` | Milliseconds | LLM TTFB（最初のトークン到達まで）|
+| `ChatTotalLatency` | Milliseconds | チャット全体レイテンシ |
+| `RetrieveLatency` | Milliseconds | 記憶取得レイテンシ（取得時のみ出力）|
+
+#### バッチ用（Namespace: `LiveTalk/Batch`）
+
+| メトリクス名 | 単位 | 内容 |
+|------------|------|------|
+| `MemorySummaryTokens` | Count | 圧縮後サマリーのトークン数 |
+| `CompressedMessageCount` | Count | 圧縮対象メッセージ数 |
+| `BatchLatency` | Milliseconds | バッチ処理全体レイテンシ |
+
+### ディメンション
+
+- `Environment`: `process.env.NODE_ENV`（`production` / `development` / `test`）
+- `CharacterId`: キャラクター ID
+
+### DynamoDB 消費 RCU 計測
+
+`ReturnConsumedCapacity: 'TOTAL'` を以下のクエリに追加し、実際の消費 RCU を `ChatMetrics.dynamodb` に記録する。
+
+- `DynamoDBMessageRepository.getRecentByTokenBudget` → `dynamodb.messagesConsumedRcu`
+- `DynamoDBMemoryRepository.queryByPrefix`（`listByTier` 経由）→ `dynamodb.memoryConsumedRcu`
+
+### インターフェース変更
+
+- `MemoryRepository.listByTier` の戻り値を `MemoryEntity[]` から `MemoryListResult`（`{ items: MemoryEntity[]; consumedCapacity?: number }`）に変更
+- `IMemoryRetriever.retrieve` の戻り値を `RetrievedMemory[]` から `RetrieveResult`（`{ memories: RetrievedMemory[]; consumedCapacity?: number }`）に変更
+- `RecentMessagesResult` に `consumedCapacity?: number` を追加


### PR DESCRIPTION
## 変更の概要

Issue #3315（Phase 3h）の実装。構造化ログ（L1）と CloudWatch EMF メトリクス（L2）を導入し、コンテキストサイズと応答速度を計測できるようにした。

### 新規ファイル

| ファイル | 内容 |
|---------|------|
| `src/observability/timer.ts` | フェーズタイマー（`createPhaseTimer`）。`performance.now()` を使ったサブミリ秒計測 |
| `src/observability/emf.ts` | EMF JSON ビルダー（`buildEmfPayload`）。`_aws.CloudWatchMetrics` 構造を組み立て `console.log` で出力 |
| `src/observability/metrics.ts` | チャット・バッチ用メトリクス管理（`ChatMetrics` / `BatchMetrics`）の生成・ログ出力・EMF 出力 |
| `src/observability/index.ts` | 上記の re-export |

### 主な変更

- `chat-usecase.ts`: フェーズタイマー・プロンプトトークン数・レイテンシ・DynamoDB RCU を計測し、完了後に L1 ログ + L2 EMF を出力
- `compress-conversation.usecase.ts`: バッチ処理完了後にサマリートークン数・レイテンシを EMF 出力
- `MemoryRepository.listByTier` の戻り値を `MemoryListResult`（`{ items, consumedCapacity? }`）に変更（DynamoDB RCU 計測対応）
- `IMemoryRetriever.retrieve` の戻り値を `RetrieveResult`（`{ memories, consumedCapacity? }`）に変更
- `DynamoDBMemoryRepository` / `DynamoDBMessageRepository` に `ReturnConsumedCapacity: 'TOTAL'` を追加

## 関連 Issue

#3315

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（`tasks/livetalk/design.md` に observability セクションを追記）
- [x] ローカルでテストが全て通ることを確認した（534 件すべてパス）

## テスト内容

- `tests/unit/observability/timer.test.ts`: `createPhaseTimer` の 6 ケース（start/end 計測、end 先出し → 0、未計測 → undefined 等）
- `tests/unit/observability/emf.test.ts`: `buildEmfPayload` の 8 ケース（EMF 構造、Namespace、Dimensions、メトリクス値、タイムスタンプデフォルト等）
- `tests/unit/observability/metrics.test.ts`: `createChatMetrics` / `emitChatMetricsLog` / `emitChatMetricsEMF` / `emitBatchMetricsLog` / `emitBatchMetricsEMF` の 11 ケース
- 既存テスト: `MemoryListResult` / `RetrieveResult` への型変更に合わせてモック・アサーションを更新（全 43 スイート / 534 件パス）

## レビューポイント

- **EMF 出力を `console.log` で直接行う設計**: `logger` ラッパーは `{timestamp, level, message, context}` で JSON をラップするため EMF の `_aws` トップレベル構造が壊れる。この制約から `console.log` を直接使用している（`metrics.ts:108` 参照）
- **`MemoryListResult` インターフェース変更の影響範囲**: `confirmation.ts` / `retrieval.ts` / `web/api/memory/route.ts` の呼び出し元すべてを更新済み
- **`memorySummaryRepository` のオプション化**: チャット時のサマリーサイズ計測のために `ChatUseCaseParams` に追加。未指定時はサマリートークン数 0 として記録するため既存動作に影響なし
- **Best-effort 計測**: すべての計測コードは try/catch で囲み、計測失敗がチャット応答を止めない

## 補足事項

- EMF の Namespace: チャット → `LiveTalk/Chat`、バッチ → `LiveTalk/Batch`
- Dimensions: `Environment`（`process.env.NODE_ENV`）と `CharacterId`
- `LLMTimeToFirstToken` / `ChatTotalLatency` / `RetrieveLatency` は値が存在する場合のみ EMF に含める（`undefined` 時はフィールド自体を出力しない）

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRex6xsGGTP3f9F1HBjn4L)_