### PR TITLE
[Phase 3i] LLMレスポンスのStructured Outputs化（Issue #3316）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20241,7 +20241,8 @@
         "@nagiyu/common": "*",
         "js-tiktoken": "^1.0.21",
         "openai": "^6.33.0",
-        "ulid": "^3.0.1"
+        "ulid": "^3.0.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/services/livetalk/core/package.json
+++ b/services/livetalk/core/package.json
@@ -21,7 +21,8 @@
     "@nagiyu/common": "*",
     "js-tiktoken": "^1.0.21",
     "openai": "^6.33.0",
-    "ulid": "^3.0.1"
+    "ulid": "^3.0.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/services/livetalk/core/src/llm-client/openai-client.ts
+++ b/services/livetalk/core/src/llm-client/openai-client.ts
@@ -256,7 +256,8 @@ function toSummarizeResult(raw: z.infer<typeof SummarizeResultSchema>): Summariz
   return {
     mergedSummary: raw.mergedSummary,
     newMemoryCandidates,
-    interestCategories: interestCategories && interestCategories.length > 0 ? interestCategories : undefined,
+    interestCategories:
+      interestCategories && interestCategories.length > 0 ? interestCategories : undefined,
     bidirectionalityScore,
   };
 }

--- a/services/livetalk/core/src/llm-client/openai-client.ts
+++ b/services/livetalk/core/src/llm-client/openai-client.ts
@@ -1,10 +1,12 @@
 import OpenAI from 'openai';
+import { zodTextFormat } from 'openai/helpers/zod';
 import type {
   EasyInputMessage,
   Response,
   ResponseStreamEvent,
 } from 'openai/resources/responses/responses';
 import type { Stream } from 'openai/streaming';
+import { z } from 'zod';
 import type {
   ChatMessage,
   ChatOptions,
@@ -15,6 +17,7 @@ import type {
   SummarizeInput,
   SummarizeResult,
 } from './types.js';
+import { SummarizeResultSchema } from './schemas/summarize.schema.js';
 
 /**
  * OpenAI 実装の用途別既定モデル（GPT-5 系）。
@@ -33,6 +36,7 @@ export const OPENAI_DEFAULT_MODELS: PurposeModelMap = {
 export const OPENAI_ERROR_MESSAGES = {
   EMPTY_MESSAGES: 'メッセージが空です',
   EMPTY_API_KEY: 'OpenAI API キーが指定されていません',
+  REFUSAL: 'LLM が応答を拒否しました（refusal）',
 } as const;
 
 export interface OpenAIClientOptions {
@@ -103,6 +107,28 @@ export class OpenAIClient implements ILLMClient {
     return response.output_text ?? '';
   }
 
+  public async chatStructured<T extends z.ZodType>(
+    messages: ChatMessage[],
+    schema: T,
+    options: ChatOptions = {}
+  ): Promise<z.infer<T>> {
+    this.assertMessages(messages);
+    const response = await this.client.responses.parse({
+      model: this.resolveModel(options),
+      stream: false,
+      input: messages.map(toEasyInputMessage),
+      temperature: options.temperature,
+      max_output_tokens: options.maxTokens,
+      text: { format: zodTextFormat(schema, 'structured_output') },
+    });
+
+    if (response.output_parsed === null || response.output_parsed === undefined) {
+      throw new Error(OPENAI_ERROR_MESSAGES.REFUSAL);
+    }
+
+    return response.output_parsed as z.infer<T>;
+  }
+
   public async summarize(input: SummarizeInput): Promise<SummarizeResult> {
     const { existingSummary, newMessages, characterName } = input;
 
@@ -121,29 +147,20 @@ ${existingSection}
 新しい会話：
 ${messagesSection}
 
-以下の JSON を返してください（余分なテキストなし）：
-{
-  "mergedSummary": "既存と新規をマージした最新要約（日本語）",
-  "newMemoryCandidates": [
-    { "category": "カテゴリ名", "content": "記憶の内容（日本語）" }
-  ],
-  "interestCategories": [
-    { "category": "ユーザーが興味を示したカテゴリ（日本語、例: アニメ・コーヒー）", "weight": 1 }
-  ],
-  "bidirectionalityScore": 0.0
-}
+mergedSummary（既存と新規をマージした最新要約、日本語）、
+newMemoryCandidates（新規記憶候補の配列、category と content を含む）、
+interestCategories（ユーザーが興味を示したカテゴリ配列、category と weight を含む。なければ空配列）、
+bidirectionalityScore（ユーザーが ${characterName} の発話に反応・質問返しをした割合 0.0〜1.0。
+  キャラ発信の話題にユーザーが乗った場合は高く 0.7〜1.0、ユーザーが一方的に話し続けた場合は低く 0.0〜0.3）
+を返してください。`;
 
-bidirectionalityScore の算出方法：
-- ユーザーが ${characterName} の発話に対して反応・深掘り・質問返しをした割合を 0.0〜1.0 で示す
-- キャラ発信の話題にユーザーが乗った場合、キャラへの質問を返した場合は高く（0.7〜1.0）
-- ユーザーが一方的に話し続けた場合や短い返答のみの場合は低く（0.0〜0.3）
-- 会話が存在する場合のみ算出し、新しい会話が空の場合は 0.0 とする`;
+    const raw = await this.chatStructured(
+      [{ role: 'user', content: prompt }],
+      SummarizeResultSchema,
+      { purpose: 'summarize' }
+    );
 
-    const rawText = await this.chatComplete([{ role: 'user', content: prompt }], {
-      purpose: 'summarize',
-    });
-
-    return parseSummarizeResult(rawText);
+    return toSummarizeResult(raw);
   }
 
   private assertMessages(messages: ChatMessage[]): void {
@@ -207,6 +224,39 @@ export function parseSummarizeResult(rawText: string): SummarizeResult {
     mergedSummary,
     newMemoryCandidates,
     interestCategories: interestCategories.length > 0 ? interestCategories : undefined,
+    bidirectionalityScore,
+  };
+}
+
+/**
+ * `SummarizeResultSchema` でデコードされた生データを `SummarizeResult` に変換する。
+ *
+ * Structured Outputs により型は保証済みなので、ここでは意味的バリデーション（content 空除外等）のみ行う。
+ */
+function toSummarizeResult(raw: z.infer<typeof SummarizeResultSchema>): SummarizeResult {
+  const newMemoryCandidates: MemoryCandidate[] = raw.newMemoryCandidates
+    .map((c) => ({
+      category: c.category.length > 0 ? c.category : 'general',
+      content: c.content,
+    }))
+    .filter((c) => c.content.length > 0);
+
+  const interestCategories =
+    raw.interestCategories && raw.interestCategories.length > 0
+      ? raw.interestCategories
+          .filter((c) => c.category.length > 0)
+          .map((c) => ({ category: c.category, weight: c.weight > 0 ? c.weight : 1 }))
+      : undefined;
+
+  const bidirectionalityScore =
+    typeof raw.bidirectionalityScore === 'number'
+      ? Math.min(1, Math.max(0, raw.bidirectionalityScore))
+      : undefined;
+
+  return {
+    mergedSummary: raw.mergedSummary,
+    newMemoryCandidates,
+    interestCategories: interestCategories && interestCategories.length > 0 ? interestCategories : undefined,
     bidirectionalityScore,
   };
 }

--- a/services/livetalk/core/src/llm-client/schemas/confirmation.schema.ts
+++ b/services/livetalk/core/src/llm-client/schemas/confirmation.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+/**
+ * `confirmation.ts` の `judgePromotionsWithLLM` 向け Structured Outputs スキーマ。
+ *
+ * @see Issue #3316
+ */
+export const ConfirmationResponseSchema = z.object({
+  promotions: z.array(
+    z.object({
+      memoryId: z.string(),
+      promote: z.boolean(),
+    })
+  ),
+});
+
+export type ConfirmationResponseRaw = z.infer<typeof ConfirmationResponseSchema>;

--- a/services/livetalk/core/src/llm-client/schemas/correction.schema.ts
+++ b/services/livetalk/core/src/llm-client/schemas/correction.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * `correction-detector.ts` の `classifyWithLLM` 向け Structured Outputs スキーマ。
+ *
+ * @see Issue #3316
+ */
+export const CorrectionResponseSchema = z.object({
+  detected: z.boolean(),
+  targetMemoryIds: z.array(z.string()).nullable(),
+  newValue: z.string().nullable(),
+});
+
+export type CorrectionResponseRaw = z.infer<typeof CorrectionResponseSchema>;

--- a/services/livetalk/core/src/llm-client/schemas/index.ts
+++ b/services/livetalk/core/src/llm-client/schemas/index.ts
@@ -1,0 +1,8 @@
+export { SummarizeResultSchema } from './summarize.schema.js';
+export type { SummarizeResultRaw } from './summarize.schema.js';
+
+export { CorrectionResponseSchema } from './correction.schema.js';
+export type { CorrectionResponseRaw } from './correction.schema.js';
+
+export { ConfirmationResponseSchema } from './confirmation.schema.js';
+export type { ConfirmationResponseRaw } from './confirmation.schema.js';

--- a/services/livetalk/core/src/llm-client/schemas/summarize.schema.ts
+++ b/services/livetalk/core/src/llm-client/schemas/summarize.schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+/**
+ * `ILLMClient.summarize` の Structured Outputs 用 Zod スキーマ。
+ *
+ * OpenAI strict モードの制約により、optional フィールドは `nullable()` で表現する。
+ * `interestCategories` / `bidirectionalityScore` は未取得時に null を返すことを許容。
+ *
+ * @see Issue #3316
+ */
+export const SummarizeResultSchema = z.object({
+  mergedSummary: z.string(),
+  newMemoryCandidates: z.array(
+    z.object({
+      category: z.string(),
+      content: z.string(),
+    })
+  ),
+  interestCategories: z
+    .array(
+      z.object({
+        category: z.string(),
+        weight: z.number(),
+      })
+    )
+    .nullable(),
+  bidirectionalityScore: z.number().nullable(),
+});
+
+export type SummarizeResultRaw = z.infer<typeof SummarizeResultSchema>;

--- a/services/livetalk/core/src/llm-client/types.ts
+++ b/services/livetalk/core/src/llm-client/types.ts
@@ -6,7 +6,10 @@
  *
  * @see tasks/livetalk/design.md §4.4
  * @see Issue #3248
+ * @see Issue #3316 (Structured Outputs 化)
  */
+
+import type { z } from 'zod';
 
 /**
  * チャットメッセージ 1 件。
@@ -53,6 +56,18 @@ export interface ChatOptions {
 export interface ILLMClient {
   chatStream(messages: ChatMessage[], options?: ChatOptions): AsyncIterable<string>;
   chatComplete(messages: ChatMessage[], options?: ChatOptions): Promise<string>;
+  /**
+   * Structured Outputs によるスキーマ保証付き呼び出し。
+   *
+   * Provider が Structured Outputs をネイティブサポートする場合はデコーダレベルで保証し、
+   * そうでない場合は `chatComplete` + JSON.parse にフォールバックしてよい。
+   * refusal が発生した場合は Error を throw する。
+   */
+  chatStructured<T extends z.ZodType>(
+    messages: ChatMessage[],
+    schema: T,
+    options?: ChatOptions
+  ): Promise<z.infer<T>>;
   summarize(input: SummarizeInput): Promise<SummarizeResult>;
 }
 

--- a/services/livetalk/core/src/memory/confirmation.ts
+++ b/services/livetalk/core/src/memory/confirmation.ts
@@ -14,11 +14,7 @@ import type { MemoryRepository } from '../repositories/memory.repository.interfa
 import type { MemoryEntity } from '../entities/memory.entity.js';
 import { cosineSimilarity } from './embedding.js';
 import { CONFIRMATION_COOLDOWN_MS, PROMOTION_SIMILARITY_THRESHOLD } from '../constants.js';
-
-interface PromotionJudgment {
-  memoryId: string;
-  promote: boolean;
-}
+import { ConfirmationResponseSchema } from '../llm-client/schemas/confirmation.schema.js';
 
 async function judgePromotionsWithLLM(
   userInput: string,
@@ -38,31 +34,27 @@ ${memoriesText}
 ユーザーの発話が上記の記憶について再確認・強調・肯定している場合のみ昇格（promote: true）としてください。
 単に話題が関連しているだけでは昇格しません。ユーザーが同じ情報を再度明示している場合のみ昇格です。
 
-以下の JSON 形式で返してください（JSON のみ）:
-{"promotions": [{"memoryId": "...", "promote": true}, {"memoryId": "...", "promote": false}]}`;
+promotions 配列（memoryId と promote を含むオブジェクトの配列）を返してください。`;
 
   try {
-    const raw = await llmClient.chatComplete([{ role: 'user', content: prompt }], {
-      purpose: 'classify',
-    });
+    const parsed = await llmClient.chatStructured(
+      [{ role: 'user', content: prompt }],
+      ConfirmationResponseSchema,
+      { purpose: 'classify' }
+    );
 
-    // 診断ログ（Issue #3282）: LLM 昇格判定の生応答（LOG_LEVEL=DEBUG 時のみ出力）
-    logger.debug('[confirmation] LLM 昇格判定の生応答', {
+    // 診断ログ（Issue #3282）: LLM 昇格判定結果（LOG_LEVEL=DEBUG 時のみ出力）
+    logger.debug('[confirmation] LLM 昇格判定結果', {
       candidateIds: candidates.map((m) => m.MemoryID),
-      raw,
+      promotions: parsed.promotions,
     });
 
-    const jsonMatch = raw.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) return [];
-
-    const parsed = JSON.parse(jsonMatch[0]) as { promotions?: PromotionJudgment[] };
-    if (!Array.isArray(parsed.promotions)) return [];
-
-    const promoteIds = new Set(parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId));
+    const promoteIds = new Set(
+      parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId)
+    );
     const promoted = candidates.filter((m) => promoteIds.has(m.MemoryID));
 
-    // 診断ログ（Issue #3282）: 昇格と判定された記憶（LOG_LEVEL=DEBUG 時のみ出力）
-    logger.debug('[confirmation] LLM 昇格判定結果', {
+    logger.debug('[confirmation] 昇格と判定された記憶', {
       promotedIds: promoted.map((m) => m.MemoryID),
     });
 

--- a/services/livetalk/core/src/memory/confirmation.ts
+++ b/services/livetalk/core/src/memory/confirmation.ts
@@ -49,9 +49,7 @@ promotions 配列（memoryId と promote を含むオブジェクトの配列）
       promotions: parsed.promotions,
     });
 
-    const promoteIds = new Set(
-      parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId)
-    );
+    const promoteIds = new Set(parsed.promotions.filter((p) => p.promote).map((p) => p.memoryId));
     const promoted = candidates.filter((m) => promoteIds.has(m.MemoryID));
 
     logger.debug('[confirmation] 昇格と判定された記憶', {

--- a/services/livetalk/core/src/memory/correction-detector.ts
+++ b/services/livetalk/core/src/memory/correction-detector.ts
@@ -15,6 +15,7 @@ import { logger } from '@nagiyu/common';
 import type { ILLMClient } from '../llm-client/types.js';
 import type { MemoryEntity } from '../entities/memory.entity.js';
 import type { RetrievedMemory } from './types.js';
+import { CorrectionResponseSchema } from '../llm-client/schemas/correction.schema.js';
 
 export interface CorrectionResult {
   detected: boolean;
@@ -89,25 +90,22 @@ ${memoriesText}
 - 「違う、本当は〇〇なんだ」のような明確な否定・修正のみ訂正です
 - ユーザーが会話の流れと無関係な訂正をする可能性は低いです
 
-訂正している場合（JSON のみ、説明不要）:
-{"detected": true, "targetMemoryIds": ["memory_id"], "newValue": "訂正後の値（取れる場合のみ）"}
-
-訂正していない場合:
-{"detected": false}`;
+detected（訂正していれば true）、
+targetMemoryIds（訂正対象の memoryId 配列、訂正がなければ空配列）、
+newValue（訂正後の値が取れる場合のみ設定、取れない場合は null）
+を返してください。`;
 
   try {
-    const raw = await llmClient.chatComplete([{ role: 'user', content: prompt }], {
-      purpose: 'classify',
-    });
+    const parsed = await llmClient.chatStructured(
+      [{ role: 'user', content: prompt }],
+      CorrectionResponseSchema,
+      { purpose: 'classify' }
+    );
 
-    const jsonMatch = raw.match(/\{[\s\S]*?\}/);
-    if (!jsonMatch) return { detected: false };
-
-    const parsed = JSON.parse(jsonMatch[0]) as LLMCorrectionResponse;
     return {
-      detected: Boolean(parsed.detected),
+      detected: parsed.detected,
       targetMemoryIds: parsed.detected ? (parsed.targetMemoryIds ?? []) : undefined,
-      newValue: parsed.newValue,
+      newValue: parsed.newValue ?? undefined,
     };
   } catch (err) {
     logger.warn('[correction-detector] LLM 訂正判定に失敗しました', { err });

--- a/services/livetalk/core/tests/unit/llm-client/openai-client.test.ts
+++ b/services/livetalk/core/tests/unit/llm-client/openai-client.test.ts
@@ -6,6 +6,7 @@ import {
   parseSummarizeResult,
 } from '../../../src/llm-client/openai-client.js';
 import type { ChatMessage, SummarizeInput } from '../../../src/llm-client/types.js';
+import { z } from 'zod';
 
 function makeStreamEvents(deltas: Array<string | null>): AsyncIterable<unknown> {
   return {
@@ -33,12 +34,14 @@ function makeStreamEvents(deltas: Array<string | null>): AsyncIterable<unknown> 
 function makeMockOpenAI(): {
   client: OpenAI;
   create: jest.Mock;
+  parse: jest.Mock;
 } {
   const create = jest.fn();
+  const parse = jest.fn();
   const client = {
-    responses: { create },
+    responses: { create, parse },
   } as unknown as OpenAI;
-  return { client, create };
+  return { client, create, parse };
 }
 
 const messages: ChatMessage[] = [
@@ -195,6 +198,53 @@ describe('OpenAIClient', () => {
     });
   });
 
+  describe('chatStructured', () => {
+    const testSchema = z.object({ value: z.string(), count: z.number() });
+
+    it('parse の output_parsed を返す', async () => {
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({ output_parsed: { value: 'テスト', count: 3 } });
+
+      const livetalk = new OpenAIClient({ client });
+      const result = await livetalk.chatStructured(messages, testSchema);
+
+      expect(result).toEqual({ value: 'テスト', count: 3 });
+      expect(parse).toHaveBeenCalledWith(
+        expect.objectContaining({ model: OPENAI_DEFAULT_MODELS.conversation })
+      );
+    });
+
+    it('purpose=classify は gpt-5-mini モデルを使用する', async () => {
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({ output_parsed: { value: 'ok', count: 0 } });
+
+      const livetalk = new OpenAIClient({ client });
+      await livetalk.chatStructured(messages, testSchema, { purpose: 'classify' });
+
+      expect(parse.mock.calls[0][0].model).toBe(OPENAI_DEFAULT_MODELS.classify);
+    });
+
+    it('output_parsed が null の場合 REFUSAL エラーを投げる', async () => {
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({ output_parsed: null });
+
+      const livetalk = new OpenAIClient({ client });
+
+      await expect(livetalk.chatStructured(messages, testSchema)).rejects.toThrow(
+        OPENAI_ERROR_MESSAGES.REFUSAL
+      );
+    });
+
+    it('messages が空なら EMPTY_MESSAGES を投げる', async () => {
+      const { client } = makeMockOpenAI();
+      const livetalk = new OpenAIClient({ client });
+
+      await expect(livetalk.chatStructured([], testSchema)).rejects.toThrow(
+        OPENAI_ERROR_MESSAGES.EMPTY_MESSAGES
+      );
+    });
+  });
+
   describe('summarize', () => {
     const baseInput: SummarizeInput = {
       existingSummary: 'コーヒーが好き',
@@ -205,25 +255,32 @@ describe('OpenAIClient', () => {
       characterName: 'ひより',
     };
 
-    it('chatComplete を purpose=summarize で呼び出す', async () => {
-      const { client, create } = makeMockOpenAI();
-      create.mockResolvedValue({
-        output_text: '{"mergedSummary":"テスト","newMemoryCandidates":[]}',
+    it('chatStructured を purpose=summarize で呼び出す', async () => {
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({
+        output_parsed: {
+          mergedSummary: 'テスト',
+          newMemoryCandidates: [],
+          interestCategories: null,
+          bidirectionalityScore: null,
+        },
       });
       const livetalk = new OpenAIClient({ client });
       await livetalk.summarize(baseInput);
-      expect(create).toHaveBeenCalledWith(
+      expect(parse).toHaveBeenCalledWith(
         expect.objectContaining({ model: OPENAI_DEFAULT_MODELS.summarize })
       );
     });
 
-    it('JSON レスポンスを SummarizeResult に変換する', async () => {
-      const { client, create } = makeMockOpenAI();
-      create.mockResolvedValue({
-        output_text: JSON.stringify({
+    it('Structured Outputs レスポンスを SummarizeResult に変換する', async () => {
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({
+        output_parsed: {
           mergedSummary: 'コーヒーとケーキが好き',
           newMemoryCandidates: [{ category: 'food', content: 'ケーキが好き' }],
-        }),
+          interestCategories: null,
+          bidirectionalityScore: null,
+        },
       });
       const livetalk = new OpenAIClient({ client });
       const result = await livetalk.summarize(baseInput);
@@ -233,13 +290,74 @@ describe('OpenAIClient', () => {
     });
 
     it('existingSummary が undefined のとき「既存の要約：なし」をプロンプトに含める', async () => {
-      const { client, create } = makeMockOpenAI();
-      create.mockResolvedValue({ output_text: '{"mergedSummary":"","newMemoryCandidates":[]}' });
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({
+        output_parsed: {
+          mergedSummary: '',
+          newMemoryCandidates: [],
+          interestCategories: null,
+          bidirectionalityScore: null,
+        },
+      });
       const livetalk = new OpenAIClient({ client });
       await livetalk.summarize({ ...baseInput, existingSummary: undefined });
-      const calledMessages = (create.mock.calls[0] as [{ input: Array<{ content: string }> }])[0]
+      const calledMessages = (parse.mock.calls[0] as [{ input: Array<{ content: string }> }])[0]
         .input;
       expect(calledMessages[0].content).toContain('既存の要約：なし');
+    });
+
+    it('interestCategories を正しく変換する', async () => {
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({
+        output_parsed: {
+          mergedSummary: 'ok',
+          newMemoryCandidates: [],
+          interestCategories: [
+            { category: 'アニメ', weight: 2 },
+            { category: 'コーヒー', weight: 1 },
+          ],
+          bidirectionalityScore: 0.7,
+        },
+      });
+      const livetalk = new OpenAIClient({ client });
+      const result = await livetalk.summarize(baseInput);
+      expect(result.interestCategories).toHaveLength(2);
+      expect(result.interestCategories?.[0].category).toBe('アニメ');
+      expect(result.bidirectionalityScore).toBeCloseTo(0.7);
+    });
+
+    it('bidirectionalityScore を 0〜1 にクランプする', async () => {
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({
+        output_parsed: {
+          mergedSummary: 'ok',
+          newMemoryCandidates: [],
+          interestCategories: null,
+          bidirectionalityScore: 1.5,
+        },
+      });
+      const livetalk = new OpenAIClient({ client });
+      const result = await livetalk.summarize(baseInput);
+      expect(result.bidirectionalityScore).toBe(1);
+    });
+
+    it('content が空の候補は除外する', async () => {
+      const { client, parse } = makeMockOpenAI();
+      parse.mockResolvedValue({
+        output_parsed: {
+          mergedSummary: 'ok',
+          newMemoryCandidates: [
+            { category: 'a', content: '' },
+            { category: 'b', content: '有効' },
+          ],
+          interestCategories: null,
+          bidirectionalityScore: null,
+        },
+      });
+      const livetalk = new OpenAIClient({ client });
+      const result = await livetalk.summarize(baseInput);
+      expect(result.newMemoryCandidates).toHaveLength(1);
+      expect(result.newMemoryCandidates[0].content).toBe('有効');
     });
   });
 });

--- a/services/livetalk/core/tests/unit/memory/confirmation.test.ts
+++ b/services/livetalk/core/tests/unit/memory/confirmation.test.ts
@@ -45,10 +45,11 @@ function makeEmbeddingClient(vec: number[]): IEmbeddingClient {
   return { embed: jest.fn(async () => vec) };
 }
 
-function makeLLMClient(response: string): ILLMClient {
+function makeLLMClient(response: object): ILLMClient {
   return {
     chatStream: jest.fn(),
-    chatComplete: jest.fn(async () => response),
+    chatComplete: jest.fn(),
+    chatStructured: jest.fn(async () => response),
     summarize: jest.fn(),
   } as unknown as ILLMClient;
 }
@@ -68,7 +69,7 @@ describe('identifyPromotionCandidates', () => {
         'コーヒーが好き',
         repo,
         makeEmbeddingClient(VEC_QUERY_COFFEE),
-        makeLLMClient('')
+        makeLLMClient({ promotions: [] })
       );
       expect(result).toHaveLength(0);
     });
@@ -78,7 +79,7 @@ describe('identifyPromotionCandidates', () => {
     it('embedding がない Tier C 記憶はスキップする', async () => {
       const mem = makeMemoryC('c1', 'コーヒーが好き'); // embedding なし
       const repo = makeMemoryRepo([mem]);
-      const llm = makeLLMClient('');
+      const llm = makeLLMClient({ promotions: [] });
       const result = await identifyPromotionCandidates(
         'u1',
         'hiyori',
@@ -88,7 +89,7 @@ describe('identifyPromotionCandidates', () => {
         llm
       );
       expect(result).toHaveLength(0);
-      expect(llm.chatComplete).not.toHaveBeenCalled();
+      expect(llm.chatStructured).not.toHaveBeenCalled();
     });
   });
 
@@ -97,7 +98,7 @@ describe('identifyPromotionCandidates', () => {
       const highSim = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE); // coffee に近い
       const lowSim = makeMemoryC('c2', 'スポーツが好き', VEC_SPORTS); // 直交
       const repo = makeMemoryRepo([highSim, lowSim]);
-      const llm = makeLLMClient('{"promotions": [{"memoryId": "c1", "promote": true}]}');
+      const llm = makeLLMClient({ promotions: [{ memoryId: 'c1', promote: true }] });
       await identifyPromotionCandidates(
         'u1',
         'hiyori',
@@ -106,7 +107,7 @@ describe('identifyPromotionCandidates', () => {
         makeEmbeddingClient(VEC_QUERY_COFFEE),
         llm
       );
-      const [, promptArg] = (llm.chatComplete as jest.Mock).mock.calls[0];
+      const [, promptArg] = (llm.chatStructured as jest.Mock).mock.calls[0];
       // LLM に渡したメッセージに c2 が含まれていないことを確認
       expect(JSON.stringify(promptArg ?? '')).not.toContain('c2');
     });
@@ -116,7 +117,7 @@ describe('identifyPromotionCandidates', () => {
     it('LLM が promote: true を返した Memory を返す', async () => {
       const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
       const repo = makeMemoryRepo([mem]);
-      const llm = makeLLMClient('{"promotions": [{"memoryId": "c1", "promote": true}]}');
+      const llm = makeLLMClient({ promotions: [{ memoryId: 'c1', promote: true }] });
       const result = await identifyPromotionCandidates(
         'u1',
         'hiyori',
@@ -132,7 +133,7 @@ describe('identifyPromotionCandidates', () => {
     it('LLM が promote: false を返した Memory は含まない', async () => {
       const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
       const repo = makeMemoryRepo([mem]);
-      const llm = makeLLMClient('{"promotions": [{"memoryId": "c1", "promote": false}]}');
+      const llm = makeLLMClient({ promotions: [{ memoryId: 'c1', promote: false }] });
       const result = await identifyPromotionCandidates(
         'u1',
         'hiyori',
@@ -149,26 +150,12 @@ describe('identifyPromotionCandidates', () => {
       const repo = makeMemoryRepo([mem]);
       const llm = {
         chatStream: jest.fn(),
-        chatComplete: jest.fn(async () => {
+        chatComplete: jest.fn(),
+        chatStructured: jest.fn(async () => {
           throw new Error('API error');
         }),
         summarize: jest.fn(),
       } as unknown as ILLMClient;
-      const result = await identifyPromotionCandidates(
-        'u1',
-        'hiyori',
-        'コーヒーの話',
-        repo,
-        makeEmbeddingClient(VEC_QUERY_COFFEE),
-        llm
-      );
-      expect(result).toHaveLength(0);
-    });
-
-    it('LLM が不正 JSON を返しても空配列で継続する', async () => {
-      const mem = makeMemoryC('c1', 'コーヒーが好き', VEC_COFFEE);
-      const repo = makeMemoryRepo([mem]);
-      const llm = makeLLMClient('invalid json');
       const result = await identifyPromotionCandidates(
         'u1',
         'hiyori',
@@ -195,7 +182,7 @@ describe('identifyPromotionCandidates', () => {
         'コーヒー',
         repo,
         makeEmbeddingClient(VEC_QUERY_COFFEE),
-        makeLLMClient('')
+        makeLLMClient({ promotions: [] })
       );
       expect(result).toHaveLength(0);
     });
@@ -214,7 +201,7 @@ describe('identifyPromotionCandidates', () => {
         'コーヒー',
         repo,
         failingEmbed,
-        makeLLMClient('')
+        makeLLMClient({ promotions: [] })
       );
       expect(result).toHaveLength(0);
     });

--- a/services/livetalk/core/tests/unit/memory/correction-detector.test.ts
+++ b/services/livetalk/core/tests/unit/memory/correction-detector.test.ts
@@ -25,10 +25,11 @@ function makeRetrieved(id: string, content: string): RetrievedMemory {
   return { memory: makeMemory(id, content), similarity: 0.9 };
 }
 
-function makeLLMClient(response: string): ILLMClient {
+function makeLLMClient(response: object): ILLMClient {
   return {
     chatStream: jest.fn(),
-    chatComplete: jest.fn(async () => response),
+    chatComplete: jest.fn(),
+    chatStructured: jest.fn(async () => response),
     summarize: jest.fn(),
   } as unknown as ILLMClient;
 }
@@ -39,45 +40,45 @@ describe('detectCorrection', () => {
 
   describe('キーワード検出（高速フィルタ）', () => {
     it('訂正キーワードがなければ LLM を呼ばずに detected: false を返す', async () => {
-      const llm = makeLLMClient('');
+      const llm = makeLLMClient({ detected: false, targetMemoryIds: null, newValue: null });
       const result = await detectCorrection('そうだよ！', prevMsg, memories, llm);
       expect(result.detected).toBe(false);
       expect(result.targetMemories).toHaveLength(0);
-      expect(llm.chatComplete).not.toHaveBeenCalled();
+      expect(llm.chatStructured).not.toHaveBeenCalled();
     });
 
     it('取得した Memory が空なら detected: false を返す（キーワードありでも）', async () => {
-      const llm = makeLLMClient('');
+      const llm = makeLLMClient({ detected: false, targetMemoryIds: null, newValue: null });
       const result = await detectCorrection('違う！', prevMsg, [], llm);
       expect(result.detected).toBe(false);
-      expect(llm.chatComplete).not.toHaveBeenCalled();
+      expect(llm.chatStructured).not.toHaveBeenCalled();
     });
 
     it('空入力は detected: false を返す', async () => {
-      const llm = makeLLMClient('');
+      const llm = makeLLMClient({ detected: false, targetMemoryIds: null, newValue: null });
       const result = await detectCorrection('', prevMsg, memories, llm);
       expect(result.detected).toBe(false);
-      expect(llm.chatComplete).not.toHaveBeenCalled();
+      expect(llm.chatStructured).not.toHaveBeenCalled();
     });
   });
 
   describe('追加情報パターン除外（false positive 抑制）', () => {
     it('「いや、それも好きだよ」は訂正と検出しない', async () => {
-      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"]}');
+      const llm = makeLLMClient({ detected: true, targetMemoryIds: ['m1'], newValue: null });
       const result = await detectCorrection('いや、コーヒーも好きだよ', prevMsg, memories, llm);
       expect(result.detected).toBe(false);
-      expect(llm.chatComplete).not.toHaveBeenCalled();
+      expect(llm.chatStructured).not.toHaveBeenCalled();
     });
 
     it('「違う、どちらも好き」は訂正と検出しない', async () => {
-      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"]}');
+      const llm = makeLLMClient({ detected: true, targetMemoryIds: ['m1'], newValue: null });
       const result = await detectCorrection('違う、どちらも好き！', prevMsg, memories, llm);
       expect(result.detected).toBe(false);
-      expect(llm.chatComplete).not.toHaveBeenCalled();
+      expect(llm.chatStructured).not.toHaveBeenCalled();
     });
 
     it('「実は、コーヒーもお茶も好き」は訂正と検出しない', async () => {
-      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1"]}');
+      const llm = makeLLMClient({ detected: true, targetMemoryIds: ['m1'], newValue: null });
       const result = await detectCorrection(
         '実は、コーヒーもお茶も好きなんだ',
         prevMsg,
@@ -85,15 +86,17 @@ describe('detectCorrection', () => {
         llm
       );
       expect(result.detected).toBe(false);
-      expect(llm.chatComplete).not.toHaveBeenCalled();
+      expect(llm.chatStructured).not.toHaveBeenCalled();
     });
   });
 
   describe('LLM 最終判定', () => {
     it('LLM が detected: true を返せば訂正を検出する', async () => {
-      const llm = makeLLMClient(
-        '{"detected": true, "targetMemoryIds": ["m1"], "newValue": "お茶が好き"}'
-      );
+      const llm = makeLLMClient({
+        detected: true,
+        targetMemoryIds: ['m1'],
+        newValue: 'お茶が好き',
+      });
       const result = await detectCorrection('違う、お茶が好きなんだ', prevMsg, memories, llm);
       expect(result.detected).toBe(true);
       expect(result.targetMemories).toHaveLength(1);
@@ -102,14 +105,18 @@ describe('detectCorrection', () => {
     });
 
     it('LLM が detected: false を返せば検出しない', async () => {
-      const llm = makeLLMClient('{"detected": false}');
+      const llm = makeLLMClient({ detected: false, targetMemoryIds: null, newValue: null });
       const result = await detectCorrection('いや、まあそうだね', prevMsg, memories, llm);
       expect(result.detected).toBe(false);
       expect(result.targetMemories).toHaveLength(0);
     });
 
     it('LLM が存在しない memoryId を返しても targetMemories は空', async () => {
-      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["nonexistent"]}');
+      const llm = makeLLMClient({
+        detected: true,
+        targetMemoryIds: ['nonexistent'],
+        newValue: null,
+      });
       const result = await detectCorrection('違う！', prevMsg, memories, llm);
       expect(result.detected).toBe(false);
       expect(result.targetMemories).toHaveLength(0);
@@ -118,7 +125,8 @@ describe('detectCorrection', () => {
     it('LLM がエラーを投げても detected: false で継続する（fail-warn）', async () => {
       const llm = {
         chatStream: jest.fn(),
-        chatComplete: jest.fn(async () => {
+        chatComplete: jest.fn(),
+        chatStructured: jest.fn(async () => {
           throw new Error('API error');
         }),
         summarize: jest.fn(),
@@ -127,24 +135,16 @@ describe('detectCorrection', () => {
       expect(result.detected).toBe(false);
     });
 
-    it('LLM が不正 JSON を返しても detected: false で継続する', async () => {
-      const llm = makeLLMClient('invalid json');
-      const result = await detectCorrection('違う！', prevMsg, memories, llm);
-      expect(result.detected).toBe(false);
-    });
-
-    it('LLM がコードブロック付き JSON を返しても正しくパースする', async () => {
-      const llm = makeLLMClient('```json\n{"detected": true, "targetMemoryIds": ["m1"]}\n```');
-      const result = await detectCorrection('違う！', prevMsg, memories, llm);
-      expect(result.detected).toBe(true);
-    });
-
     it('複数の訂正対象を返す場合、全て targetMemories に含まれる', async () => {
       const multiMemories = [
         makeRetrieved('m1', 'コーヒーが好き'),
         makeRetrieved('m2', '趣味はゲーム'),
       ];
-      const llm = makeLLMClient('{"detected": true, "targetMemoryIds": ["m1", "m2"]}');
+      const llm = makeLLMClient({
+        detected: true,
+        targetMemoryIds: ['m1', 'm2'],
+        newValue: null,
+      });
       const result = await detectCorrection(
         '実は違う、お茶が好きで趣味は読書なんだ',
         prevMsg,
@@ -165,17 +165,17 @@ describe('detectCorrection', () => {
       ['そうじゃない！'],
       ['あれ、間違えた'],
     ])('「%s」はキーワード検出を通過して LLM まで到達する', async (input) => {
-      const llm = makeLLMClient('{"detected": false}');
+      const llm = makeLLMClient({ detected: false, targetMemoryIds: null, newValue: null });
       await detectCorrection(input, prevMsg, memories, llm);
-      expect(llm.chatComplete).toHaveBeenCalled();
+      expect(llm.chatStructured).toHaveBeenCalled();
     });
 
     it.each([['そうだよ'], ['うん、コーヒー好き'], ['ありがとう！'], ['もっと教えて']])(
       '「%s」はキーワード検出で LLM を呼ばない',
       async (input) => {
-        const llm = makeLLMClient('');
+        const llm = makeLLMClient({ detected: false, targetMemoryIds: null, newValue: null });
         await detectCorrection(input, prevMsg, memories, llm);
-        expect(llm.chatComplete).not.toHaveBeenCalled();
+        expect(llm.chatStructured).not.toHaveBeenCalled();
       }
     );
   });

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -37,7 +37,11 @@ function makeLLMClient(chunks: string[]): ILLMClient {
       yield* stringsToStream(chunks);
     }),
     chatComplete: jest.fn(),
-    chatStructured: jest.fn(async () => ({ detected: false, targetMemoryIds: null, newValue: null })),
+    chatStructured: jest.fn(async () => ({
+      detected: false,
+      targetMemoryIds: null,
+      newValue: null,
+    })),
     summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
   };
 }
@@ -491,7 +495,11 @@ describe('runChatUseCase', () => {
           throw new Error('llm down');
         }),
         chatComplete: jest.fn(),
-        chatStructured: jest.fn(async () => ({ detected: false, targetMemoryIds: null, newValue: null })),
+        chatStructured: jest.fn(async () => ({
+          detected: false,
+          targetMemoryIds: null,
+          newValue: null,
+        })),
         summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
       };
       const voice = makeVoiceClient();
@@ -1003,7 +1011,11 @@ describe('runChatUseCase', () => {
           yield '了解！';
         }),
         chatComplete: jest.fn(),
-        chatStructured: jest.fn(async () => ({ detected: false, targetMemoryIds: null, newValue: null })),
+        chatStructured: jest.fn(async () => ({
+          detected: false,
+          targetMemoryIds: null,
+          newValue: null,
+        })),
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -37,6 +37,7 @@ function makeLLMClient(chunks: string[]): ILLMClient {
       yield* stringsToStream(chunks);
     }),
     chatComplete: jest.fn(),
+    chatStructured: jest.fn(async () => ({ detected: false, targetMemoryIds: null, newValue: null })),
     summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
   };
 }
@@ -490,6 +491,7 @@ describe('runChatUseCase', () => {
           throw new Error('llm down');
         }),
         chatComplete: jest.fn(),
+        chatStructured: jest.fn(async () => ({ detected: false, targetMemoryIds: null, newValue: null })),
         summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
       };
       const voice = makeVoiceClient();
@@ -961,9 +963,12 @@ describe('runChatUseCase', () => {
         chatStream: jest.fn(async function* () {
           yield '了解！';
         }),
-        chatComplete: jest.fn(
-          async () => '{"detected": true, "targetMemoryIds": ["m1"], "newValue": "お茶が好き"}'
-        ),
+        chatComplete: jest.fn(),
+        chatStructured: jest.fn(async () => ({
+          detected: true,
+          targetMemoryIds: ['m1'],
+          newValue: 'お茶が好き',
+        })),
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();
@@ -997,7 +1002,8 @@ describe('runChatUseCase', () => {
         chatStream: jest.fn(async function* () {
           yield '了解！';
         }),
-        chatComplete: jest.fn(async () => '{"detected": false}'),
+        chatComplete: jest.fn(),
+        chatStructured: jest.fn(async () => ({ detected: false, targetMemoryIds: null, newValue: null })),
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();
@@ -1016,8 +1022,8 @@ describe('runChatUseCase', () => {
         })
       );
 
-      // chatComplete が classify 用途で呼ばれないことを確認
-      expect(llm.chatComplete).not.toHaveBeenCalled();
+      // chatStructured が classify 用途で呼ばれないことを確認（訂正検出スキップ）
+      expect(llm.chatStructured).not.toHaveBeenCalled();
     });
 
     it('訂正検出がエラーを投げても LLM 応答を継続する（fail-warn）', async () => {
@@ -1029,7 +1035,8 @@ describe('runChatUseCase', () => {
         chatStream: jest.fn(async function* () {
           yield '了解！';
         }),
-        chatComplete: jest.fn(async () => {
+        chatComplete: jest.fn(),
+        chatStructured: jest.fn(async () => {
           throw new Error('API error');
         }),
         summarize: jest.fn(),
@@ -1083,7 +1090,8 @@ describe('runChatUseCase', () => {
         chatStream: jest.fn(async function* () {
           yield '了解！';
         }),
-        chatComplete: jest.fn(async () => '{"promotions": []}'),
+        chatComplete: jest.fn(),
+        chatStructured: jest.fn(async () => ({ promotions: [] })),
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();
@@ -1145,7 +1153,8 @@ describe('runChatUseCase', () => {
         chatStream: jest.fn(async function* () {
           yield '覚えとくね！';
         }),
-        chatComplete: jest.fn(async () => '{"promotions": [{"memoryId": "c1", "promote": true}]}'),
+        chatComplete: jest.fn(),
+        chatStructured: jest.fn(async () => ({ promotions: [{ memoryId: 'c1', promote: true }] })),
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -41,7 +41,7 @@ function makeLLMClient(chunks: string[]): ILLMClient {
       detected: false,
       targetMemoryIds: null,
       newValue: null,
-    })),
+    })) as unknown as ILLMClient['chatStructured'],
     summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
   };
 }
@@ -499,7 +499,7 @@ describe('runChatUseCase', () => {
           detected: false,
           targetMemoryIds: null,
           newValue: null,
-        })),
+        })) as unknown as ILLMClient['chatStructured'],
         summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
       };
       const voice = makeVoiceClient();
@@ -976,7 +976,7 @@ describe('runChatUseCase', () => {
           detected: true,
           targetMemoryIds: ['m1'],
           newValue: 'お茶が好き',
-        })),
+        })) as unknown as ILLMClient['chatStructured'],
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();
@@ -1015,7 +1015,7 @@ describe('runChatUseCase', () => {
           detected: false,
           targetMemoryIds: null,
           newValue: null,
-        })),
+        })) as unknown as ILLMClient['chatStructured'],
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();
@@ -1103,7 +1103,9 @@ describe('runChatUseCase', () => {
           yield '了解！';
         }),
         chatComplete: jest.fn(),
-        chatStructured: jest.fn(async () => ({ promotions: [] })),
+        chatStructured: jest.fn(async () => ({
+          promotions: [],
+        })) as unknown as ILLMClient['chatStructured'],
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();
@@ -1166,7 +1168,9 @@ describe('runChatUseCase', () => {
           yield '覚えとくね！';
         }),
         chatComplete: jest.fn(),
-        chatStructured: jest.fn(async () => ({ promotions: [{ memoryId: 'c1', promote: true }] })),
+        chatStructured: jest.fn(async () => ({
+          promotions: [{ memoryId: 'c1', promote: true }],
+        })) as unknown as ILLMClient['chatStructured'],
         summarize: jest.fn(),
       };
       const voice = makeVoiceClient();

--- a/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
@@ -30,6 +30,9 @@ const makeLLMClient = (
     async chatComplete() {
       return '';
     },
+    async chatStructured() {
+      return {} as never;
+    },
     async summarize() {
       summarizeCalls++;
       return result;
@@ -149,6 +152,9 @@ describe('compressConversation', () => {
       async chatComplete() {
         return '';
       },
+      async chatStructured() {
+        return {} as never;
+      },
       async summarize(input) {
         capturedMessages.push(...input.newMessages);
         return { mergedSummary: '', newMemoryCandidates: [] };
@@ -197,6 +203,9 @@ describe('compressConversation', () => {
       },
       async chatComplete() {
         return '';
+      },
+      async chatStructured() {
+        return {} as never;
       },
       async summarize(input) {
         capturedExisting = input.existingSummary;

--- a/tasks/livetalk/design.md
+++ b/tasks/livetalk/design.md
@@ -677,4 +677,44 @@ LLM プロンプトは以下3系統で構成される：
 
 - `MemoryRepository.listByTier` の戻り値を `MemoryEntity[]` から `MemoryListResult`（`{ items: MemoryEntity[]; consumedCapacity?: number }`）に変更
 - `IMemoryRetriever.retrieve` の戻り値を `RetrievedMemory[]` から `RetrieveResult`（`{ memories: RetrievedMemory[]; consumedCapacity?: number }`）に変更
+
+---
+
+## ADR-008: LLM レスポンスの Structured Outputs 化（Issue #3316）
+
+### 背景
+
+Phase 3d 以降の `summarize`・`classifyWithLLM`・`judgePromotionsWithLLM` は、プロンプトで「JSON のみ返せ」と指示し `JSON.parse` で解析する実装だった。この方式には以下の問題があった：
+
+- **Silent failure**: `JSON.parse` 失敗時に `{ mergedSummary: rawText, newMemoryCandidates: [] }` を返してしまい、記憶抽出が静かに失われる
+- **フォーマット揺れ**: JSON を `\`\`\`json ... \`\`\`` で囲む・改行を混ぜるなど、LLM によって出力が安定しない
+- **型保証の欠如**: パース後も `unknown` キャストで受け取り、型エラーがランタイムまで露呈しない
+
+### 決定事項
+
+OpenAI Responses API の **Structured Outputs** (`responses.parse` + `zodTextFormat`) を採用する。
+
+### 設計方針
+
+1. **`ILLMClient` に `chatStructured<T>` を追加**: Provider 抽象化を維持しつつ Structured Outputs を使えるようにする。`chatStructured` は Zod スキーマを受け取り、デコーダレベルの型保証を提供する。
+2. **Zod スキーマを `src/llm-client/schemas/` に集約**: `summarize.schema.ts` / `correction.schema.ts` / `confirmation.schema.ts` の 3 ファイルで管理する。
+3. **OpenAI strict モード対応**: `nullable()` で optional フィールドを表現する（strict モードでは `optional()` ≒ undefined は使えない）。
+4. **refusal を first-class error 化**: `output_parsed` が null/undefined の場合は専用エラー（`REFUSAL`）で throw する。
+5. **`parseSummarizeResult` は廃止しない**: 後方互換のためエクスポートを維持する（既存テスト・他コードへの影響を最小化）。`summarize` の実装は `chatStructured` + `toSummarizeResult` に切り替え済み。
+6. **chat ストリーミング（`chatStream`）は対象外**: 会話応答はストリーミングで返すため JSON スキーマが適用できない。Structured Outputs の対象は分類・要約・昇格判定のみ。
+7. **Stock Tracker との共通基盤化はしない**: Stock Tracker は OpenAI を直接呼び出すが、LiveTalk は `ILLMClient` 抽象化を通じて使う。前提が異なるため YAGNI。
+
+### 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/llm-client/types.ts` | `chatStructured<T>` メソッドを `ILLMClient` interface に追加 |
+| `src/llm-client/schemas/summarize.schema.ts` | `SummarizeResultSchema`（Zod） |
+| `src/llm-client/schemas/correction.schema.ts` | `CorrectionResponseSchema`（Zod） |
+| `src/llm-client/schemas/confirmation.schema.ts` | `ConfirmationResponseSchema`（Zod） |
+| `src/llm-client/schemas/index.ts` | 上記 3 スキーマの re-export |
+| `src/llm-client/openai-client.ts` | `chatStructured` 実装、`summarize` を Structured Outputs 化、`toSummarizeResult` 追加 |
+| `src/memory/correction-detector.ts` | `classifyWithLLM` を `chatStructured` + `CorrectionResponseSchema` に変更 |
+| `src/memory/confirmation.ts` | `judgePromotionsWithLLM` を `chatStructured` + `ConfirmationResponseSchema` に変更 |
+| `package.json`（livetalk/core） | `zod ^4.3.6` を dependencies に追加 |
 - `RecentMessagesResult` に `consumedCapacity?: number` を追加


### PR DESCRIPTION
## 変更の概要

Issue #3316 の対応。LLM の分類・要約レスポンスを OpenAI Structured Outputs（`responses.parse` + `zodTextFormat`）に移行し、JSON 手動パースによる silent failure を廃止する。

## 関連 Issue

Issue #3316（[Phase 3i] LLMレスポンスのStructured Outputs化）

## 変更種別

- [x] 新機能
- [x] 既存機能の改善
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [ ] インフラ変更

## 実装チェックリスト

- [x] `ILLMClient` に `chatStructured<T>` メソッドを追加（`types.ts`）
- [x] `src/llm-client/schemas/` に Zod スキーマを集約
  - [x] `summarize.schema.ts`（`SummarizeResultSchema`）
  - [x] `correction.schema.ts`（`CorrectionResponseSchema`）
  - [x] `confirmation.schema.ts`（`ConfirmationResponseSchema`）
- [x] `OpenAIClient.chatStructured` 実装（`responses.parse` + `zodTextFormat`）
- [x] `OpenAIClient.summarize` を Structured Outputs 化（`parseSummarizeResult` 廃止せずエクスポート維持）
- [x] `correction-detector.ts` の `classifyWithLLM` を `chatStructured` 化
- [x] `confirmation.ts` の `judgePromotionsWithLLM` を `chatStructured` 化
- [x] refusal 時の専用エラー（`REFUSAL`）追加
- [x] `zod ^4.3.6` を `livetalk/core/package.json` に追加
- [x] テスト更新（538件パス、全体カバレッジ 91.85%）
- [x] `design.md` に ADR-008 として設計決定を記録

## テスト内容

- `npm run test --workspace=services/livetalk/core`: 538件すべてパス
- カバレッジ: 全体 91.85%（80% 閾値クリア）、新規スキーマファイル 100%
- `chatStructured` の単体テスト: 正常系（output_parsed 返却）・refusal 系（null → エラー throw）・空メッセージ系を網羅

## レビューポイント

1. **`chatStructured` の refusal 処理**: `output_parsed` が null/undefined のとき `REFUSAL` エラーで throw する。OpenAI SDK が refusal を自動 throw する場合と、null を返す場合を両方処理している
2. **OpenAI strict モード対応**: `nullable()` で optional フィールドを表現（strict モードでは `optional()` = undefined が使えない制約への対応）
3. **`parseSummarizeResult` の維持**: `summarize` の実装は `chatStructured` に移行済みだが、他コードが参照している可能性を考慮してエクスポートを残した
4. **`chat-usecase.test.ts` のモック更新**: `chatComplete` → `chatStructured` への切り替えに合わせて、correction-detector・confirmation の mock 応答形式をオブジェクトに変更（JSON 文字列から）

https://claude.ai/code/session_01KW1Ev8PXvSx6ipD382dq7m

---
_Generated by [Claude Code](https://claude.ai/code/session_01KW1Ev8PXvSx6ipD382dq7m)_