### PR TITLE
[Phase 4a] ECS Task Definition に TZ=Asia/Tokyo を追加（#3327）

### DIFF
--- a/infra/common/package.json
+++ b/infra/common/package.json
@@ -23,5 +23,9 @@
   "dependencies": {
     "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "@types/node": "^25.9.1"
   }
 }

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -261,6 +261,9 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
         // OpenAI API キー（Phase 2b）。deploy ワークフローが Secrets Manager から取得して
         // CDK context 経由でここに注入する。アプリは process.env.OPENAI_API_KEY で参照する。
         OPENAI_API_KEY: openAiApiKey,
+        // Phase 4a / #3327: Node.js の new Date() を JST 基準にし、getTimeOfDay() の
+        // 時間帯判定（朝/昼/夜）を正しく動作させる。ISO8601 タイムスタンプは UTC のまま。
+        TZ: 'Asia/Tokyo',
       },
       portMappings: [
         {

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -269,6 +269,18 @@ describe('LiveTalkEcsServiceStack', () => {
     });
   });
 
+  it('TZ=Asia/Tokyo env を livetalk-web container に注入する（Phase 4a / #3327）', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: 'livetalk-web',
+          Environment: Match.arrayWith([{ Name: 'TZ', Value: 'Asia/Tokyo' }]),
+        }),
+      ]),
+    });
+  });
+
   it('Task Role に Secrets Manager 読取権限の PolicyStatement を持たない（CI-context 方式）', () => {
     const template = synth('dev');
     const policies = template.findResources('AWS::IAM::Policy');

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,10 @@
       "dependencies": {
         "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0"
+      },
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "@types/node": "^25.9.1"
       }
     },
     "infra/livetalk": {
@@ -182,6 +186,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "infra/node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "infra/node_modules/aws-cdk-lib": {
@@ -662,6 +676,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "infra/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "infra/quick-clip": {
       "name": "@nagiyu/infra-quick-clip",


### PR DESCRIPTION
## 変更の概要

ECS Fargate が UTC 動作のため、`getTimeOfDay()` の時間帯判定が JST の活発時間帯（14〜21 時）を「朝」と誤判定する問題を修正する。

`infra/livetalk/lib/ecs-service-stack.ts` の `livetalk-web` コンテナ environment に `TZ: 'Asia/Tokyo'` を 1 行追加した。Node.js は `TZ` 環境変数を尊重するため、`new Date()` 系の全 API が JST 基準になり、`getTimeOfDay()` の朝/昼/夜 判定が正しく動作するようになる。`environment` は props で dev/prod を受けてパラメータ化済みのため、この 1 箇所の修正で **dev/prod 両環境に反映**される。

> DynamoDB の ISO8601 タイムスタンプは `toISOString()` が TZ 非依存で UTC を返すため、引き続き UTC のまま。

## 関連 Issue

関連: #3327
親: #3187（Phase 4）

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（`ecs-service-stack.test.js` に TZ env 注入のテストを追加、20 tests 全通過）
- [ ] 関連ドキュメントを更新した（dev デプロイ後の動作確認は人力）
- [ ] CI/CD 設定を追加・更新した（該当なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `infra/livetalk/tests/unit/ecs-service-stack.test.js` に以下を追加:
  - `TZ=Asia/Tokyo` env が `livetalk-web` コンテナに注入されることを検証（`Match.arrayWith` 部分一致）
- 既存 19 テスト + 追加 1 テスト = **20 tests 全通過**
- `services/livetalk/core/tests/unit/characters/prompt-builder.test.ts` はローカル時刻コンストラクタを使用するため TZ 非依存、影響なし

## レビューポイント

- バッチ Lambda（`services/livetalk/batch/`）の TZ は **Phase 4c で判断**（Issue #3327 明記のとおり本 PR では対象外）
- `infra/common/package.json` に `@types/node` / `@types/jest` を追加（ビルドに必要だったが元から欠落していた型定義）

## スクリーンショット（該当する場合）

UI 変更なし

## 補足事項

dev デプロイ後、JST の活発時間帯（14〜21 時）に `/api/chat` を叩いて CloudWatch Logs で prompt 内の時間帯（「昼」「夜」）を確認することで完了条件を満たせる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkU9CzuqJadJPqaWW5QVyW)_