### PR TITLE
[リブトーク Phase 4b] sleeping 時の目パラメータのチラつき・待機中無効を修正 + 検証用に寝ぼけ時間を一時延長（Issue #3333）

### DIFF
--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -104,14 +104,21 @@ export const AFFECTION_BIDIRECTIONALITY_WEIGHT = 1.0;
 /**
  * 生活サイクルのデフォルト就寝時刻（"HH:mm" 形式、Asia/Tokyo 基準）。
  * ユーザーが設定を持たない場合にフォールバックする値（Phase 4b）。
+ *
+ * TEMPORARY（#3333 検証用）: sleeping 演出を日中いつでも確認できるよう、
+ * 就寝 06:00 / 起床 05:00（= 終日ほぼ sleeping、awake は 05:00–06:00 のみ）に
+ * 一時拡張している。検証完了後に本来値 '01:30' / '09:30' へ戻すこと。
  */
-export const LIFECYCLE_DEFAULT_BEDTIME = '01:30';
+export const LIFECYCLE_DEFAULT_BEDTIME = '06:00';
 
 /**
  * 生活サイクルのデフォルト起床時刻（"HH:mm" 形式、Asia/Tokyo 基準）。
  * ユーザーが設定を持たない場合にフォールバックする値（Phase 4b）。
+ *
+ * TEMPORARY（#3333 検証用）: 上記 LIFECYCLE_DEFAULT_BEDTIME を参照。
+ * 検証完了後に本来値 '09:30' へ戻すこと。
  */
-export const LIFECYCLE_DEFAULT_WAKE_UP_TIME = '09:30';
+export const LIFECYCLE_DEFAULT_WAKE_UP_TIME = '05:00';
 
 /**
  * Tier C 記憶の「再言及」と判定する cosine similarity 下限閾値（Phase 3d）。

--- a/services/livetalk/core/tests/unit/lifecycle/state-resolver.test.ts
+++ b/services/livetalk/core/tests/unit/lifecycle/state-resolver.test.ts
@@ -5,18 +5,21 @@ function makeDate(hour: number, minute = 0): Date {
 }
 
 describe('resolveLifecycleState', () => {
-  describe('デフォルト設定（就寝 01:30 / 起床 09:30）', () => {
+  // TEMPORARY（#3333 検証用）: デフォルトを就寝 06:00 / 起床 05:00（終日ほぼ
+  // sleeping、awake は 05:00–06:00 のみ）に一時拡張中。検証完了後、constants.ts の
+  // 本来値 '01:30' / '09:30' への復帰に合わせて本ブロックも元の期待値へ戻すこと。
+  describe('デフォルト設定（TEMPORARY: 就寝 06:00 / 起床 05:00）', () => {
     it.each([
+      [0, 0, 'sleeping'],
       [1, 30, 'sleeping'],
-      [5, 0, 'sleeping'],
-      [9, 0, 'sleeping'],
-      [9, 29, 'sleeping'],
-      [9, 30, 'awake'],
-      [12, 0, 'awake'],
-      [18, 0, 'awake'],
-      [23, 59, 'awake'],
-      [0, 0, 'awake'],
-      [1, 29, 'awake'],
+      [4, 59, 'sleeping'],
+      [5, 0, 'awake'],
+      [5, 30, 'awake'],
+      [5, 59, 'awake'],
+      [6, 0, 'sleeping'],
+      [9, 30, 'sleeping'],
+      [12, 0, 'sleeping'],
+      [23, 59, 'sleeping'],
     ] as [number, number, string][])('%i:%s → %s', (hour, minute, expected) => {
       const result = resolveLifecycleState(makeDate(hour, minute));
       expect(result).toBe(expected);

--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -288,40 +288,59 @@ export default function Live2DCanvas({
     };
   }, [audioBuffer, audioContext, modelReady]);
 
-  // sleeping 状態のとき、idle モーションのまばたきに上書きされないよう
-  // ticker.add で毎フレーム目パラメータを半開き（0.3）に強制セットする。
-  // awake に戻ったら ticker から外して通常のまばたきに委ねる。
+  // sleeping 状態のとき、目を半開き（0.3）に固定する。
+  //
+  // ライブラリの内部モデル更新は毎フレーム以下の順序で走る
+  // （pixi-live2d-display-lipsyncpatch / fork 元 pixi-live2d-display）:
+  //   1. emit('beforeMotionUpdate')
+  //   2. motionManager.update()      … idle モーション再生
+  //   3. emit('afterMotionUpdate')   … 割り込み可能なフック
+  //   4. eyeBlink.updateParameters() … 自動まばたきが目を上書き ★
+  //   5. lipSync / expression / breath
+  //   6. coreModel 確定・描画
+  //
+  // app.ticker.add では PIXI ティッカーと上記フローの実行順がフレームごとに前後し、
+  // 待機中は 4 の自動まばたきに毎フレーム負けて効かず、発話中は 4 より後に走った
+  // フレームだけ反映されてチラついていた（競合状態）。
+  //
+  // そこで 3 の afterMotionUpdate で目をセットしつつ、直後 4 の上書きを防ぐため
+  // sleeping 中だけ eyeBlink を一時無効化する。これで待機中・発話中とも確定的な
+  // タイミングで毎フレーム書き込まれ、安定して半開きになる。
   useEffect(() => {
-    const app = appRef.current;
     const model = modelRef.current;
-    if (!app || !model || !modelReady) return;
+    if (!model || !modelReady) return;
 
     if (lifecycleState !== 'sleeping') return;
 
     const EYE_VALUE = 0.3;
 
-    const setCoreParameter = (model: Live2DModelInstance, id: string, value: number) => {
+    const internalModel = model.internalModel as unknown as {
+      coreModel?: { setParameterValueById?: (id: string, value: number) => void };
+      eyeBlink?: unknown;
+      on?: (event: string, handler: () => void) => void;
+      off?: (event: string, handler: () => void) => void;
+    };
+
+    const applyEyes = () => {
+      if (lifecycleStateRef.current !== 'sleeping') return;
       try {
-        const coreModel = (
-          model.internalModel as unknown as {
-            coreModel?: { setParameterValueById?: (id: string, v: number) => void };
-          }
-        ).coreModel;
-        coreModel?.setParameterValueById?.(id, value);
+        internalModel.coreModel?.setParameterValueById?.('ParamEyeLOpen', EYE_VALUE);
+        internalModel.coreModel?.setParameterValueById?.('ParamEyeROpen', EYE_VALUE);
       } catch {
         // 型情報がない internal API のため best-effort
       }
     };
 
-    const tickerFn = () => {
-      if (lifecycleStateRef.current !== 'sleeping') return;
-      setCoreParameter(model, 'ParamEyeLOpen', EYE_VALUE);
-      setCoreParameter(model, 'ParamEyeROpen', EYE_VALUE);
-    };
+    // 自動まばたき（eyeBlink.updateParameters）が afterMotionUpdate 直後に目を
+    // 上書きするため、sleeping 中だけ無効化し、cleanup で元の参照に復元する。
+    const savedEyeBlink = internalModel.eyeBlink;
+    internalModel.eyeBlink = undefined;
 
-    app.ticker.add(tickerFn);
+    internalModel.on?.('afterMotionUpdate', applyEyes);
+
     return () => {
-      app.ticker.remove(tickerFn);
+      internalModel.off?.('afterMotionUpdate', applyEyes);
+      internalModel.eyeBlink = savedEyeBlink;
     };
   }, [lifecycleState, modelReady]);
 


### PR DESCRIPTION
## 変更の概要

Phase 4b（#3328）で実装した sleeping 時の Live2D 目パラメータ制御（半開き演出）の不具合を修正する。あわせて、実機検証を容易にするためデフォルトの寝ぼけ時間帯を**一時的に**延長する（検証後に戻す）。

### 症状

- 待機中（発話していないアイドル時）に目が半開きにならない
- 発話中の目がチラつく（半開きが安定せずまばたきと干渉する）

### 原因

`pixi-live2d-display-lipsyncpatch` の内部モデル更新は毎フレーム以下の順序で走る（fork 元 pixi-live2d-display 由来の既知フロー）:

```
1. emit('beforeMotionUpdate')
2. motionManager.update()        // idle モーション再生
3. emit('afterMotionUpdate')     // 割り込み可能なフック
4. eyeBlink.updateParameters()   // 自動まばたきが目を上書き ★
5. lipSync / expression / breath
6. coreModel 確定・描画
```

現状の `app.ticker.add()` は PIXI ティッカーと上記フローの実行順がフレームごとに前後するため、待機中は ④ の自動まばたきに毎フレーム負けて効かず、発話中は ④ より後に走ったフレームだけ反映されてチラついていた（競合状態）。

### 修正内容（恒久・目パラメータ）

`services/livetalk/web/src/components/Live2DCanvas.tsx` の sleeping 用 useEffect を差し替え:

1. `app.ticker.add` をやめ、内部モデルの **`afterMotionUpdate` イベント**（③、`motionManager.update` 直後・最終確定前）で `ParamEyeLOpen`/`ParamEyeROpen` を 0.3 にセット。
2. 直後 ④ の `eyeBlink.updateParameters()` による上書きを防ぐため、sleeping 中だけ `internalModel.eyeBlink` を一時 `undefined` にし、cleanup（awake 復帰・アンマウント時）で元の参照に復元。
3. `off('afterMotionUpdate', handler)` でリスナを確実に解除。

### ⚠️ 一時変更（検証後に必ず revert）

`services/livetalk/core/src/constants.ts` のデフォルト就寝/起床時刻を **06:00 / 05:00**（終日ほぼ sleeping、awake は 05:00–06:00 のみ）に一時拡張。sleeping 演出を日中いつでも確認できるようにするための暫定設定。

- 対象: `LIFECYCLE_DEFAULT_BEDTIME` / `LIFECYCLE_DEFAULT_WAKE_UP_TIME`（および `state-resolver.test.ts` のデフォルトブロック）
- いずれも `TEMPORARY（#3333 検証用）` マーカー付き
- **検証完了後、本来値 01:30 / 09:30 へ戻すこと。develop へ上げる前に必ず revert する。**

## 関連 Issue

関連 #3333（#3328 のサブ Issue。integration → develop の PR ではないため `Closes` は付けない）

## 変更種別

- [x] バグ修正

## ローカル検証状況（正直な記載）

このコンテナには livetalk-web の依存（`next` / `eslint`）が未インストールのため、**web の build / lint / unit test はローカル実行できていない**（CI に委ねる）。実行できたものは以下:

- [x] `format:check`（web / core）: PASS
- [x] core unit tests: 583 件 PASS（一時変更したデフォルト窓のテストも更新済み）
- [ ] web build / lint / test: ローカル実行不可 → **CI で確認**

## レビューポイント

- **実機確認が必須**: 待機中・発話中とも sleeping で目が安定して半開きになるか、awake へ戻った瞬間に通常のまばたきが復活するか（cleanup での eyeBlink 復元）。
- 型情報がない internal API（`internalModel.eyeBlink` / `coreModel.setParameterValueById` / `on`/`off`）を `as unknown as { ... }` で narrowing しており、ライブラリ内部実装に依存している点。`afterMotionUpdate`・`eyeBlink` は fork 元の既知挙動に基づく判断であり、dev 環境での確認が必要。
- 一時変更（寝ぼけ時間拡張）の revert 漏れに注意。

## 補足事項

- 口調（寝ぼけプロンプト）は Phase 4b 時点で意図通り動作しており、本 PR の目パラメータ修正のスコープ外。
- ブランチ名は `claude/livetalk-issue-3334-eyefix` だが、対応する Bug Issue は **#3333**（PR 番号 3334 と偶然一致しているだけ）。

https://claude.ai/code/session_014LBTgka3FBrtyoZb4HVcTj