### PR TITLE
[リブトーク Phase 4b] sleeping 中の瞬き復活 + 初回起動時の状態反映（Issue #3335）

### DIFF
--- a/services/livetalk/web/src/app/api/lifecycle/constants.ts
+++ b/services/livetalk/web/src/app/api/lifecycle/constants.ts
@@ -1,0 +1,3 @@
+export const LIFECYCLE_ERROR_MESSAGES = {
+  FETCH_FAILED: '生活サイクル状態の取得に失敗しました',
+} as const;

--- a/services/livetalk/web/src/app/api/lifecycle/route.ts
+++ b/services/livetalk/web/src/app/api/lifecycle/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import {
+  DEFAULT_CHARACTER_ID,
+  LIFECYCLE_DEFAULT_BEDTIME,
+  LIFECYCLE_DEFAULT_WAKE_UP_TIME,
+  resolveLifecycleState,
+} from '@nagiyu/livetalk-core';
+import { getSession } from '@/lib/server/session';
+import { getLifecycleRepository } from '@/lib/server/repositories';
+
+/**
+ * GET /api/lifecycle
+ *
+ * 現在のユーザー × キャラの生活サイクル状態（awake / sleeping）を返す（Phase 4b / Issue #3335）。
+ *
+ * フロントは初回起動時にこの値を取得し、初回発話を待たずに Live2D の目パラメータへ
+ * 反映する。チャットストリーム（/api/chat）の lifecycle event とは別系統の
+ * 「初期状態取得用」エンドポイント。
+ *
+ * レスポンス: `{ "state": "awake" | "sleeping" }`
+ *
+ * 演出のための情報なので、取得失敗時も 500 を返さず fail-safe で `awake` を返し、
+ * UI を止めない。
+ */
+export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
+  const userId = session.user.googleId;
+
+  try {
+    const lifecycle = await getLifecycleRepository().get({
+      userId,
+      characterId: DEFAULT_CHARACTER_ID,
+    });
+    const state = resolveLifecycleState(
+      new Date(),
+      lifecycle?.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME,
+      lifecycle?.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME
+    );
+    return NextResponse.json({ state });
+  } catch (error) {
+    // fail-safe: 演出のための情報なので UI を止めず awake を返す
+    console.error('[GET /api/lifecycle] 生活サイクル状態の取得に失敗しました', error);
+    return NextResponse.json({ state: 'awake' });
+  }
+});

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -84,6 +84,21 @@ export default function HomePage() {
       });
   }, []);
 
+  // 初回起動時に生活サイクル状態を取得し、初回発話を待たずに Live2D へ反映する。
+  // 失敗時は現状維持（'awake'）。演出のための取得なので UI は止めない。
+  useEffect(() => {
+    fetch('/api/lifecycle')
+      .then((res) => res.json())
+      .then((data: { state: LifecycleState }) => {
+        if (data.state === 'awake' || data.state === 'sleeping') {
+          setLifecycleState(data.state);
+        }
+      })
+      .catch(() => {
+        // 取得失敗時は初期値 'awake' のまま
+      });
+  }, []);
+
   // iOS Safari の Web Audio autoplay 制約対策。
   // user gesture（handleSubmit）の同期スタックで AudioContext を作成・resume することで、
   // 以降の AudioBufferSourceNode.start() が transient activation token を消費せず

--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -288,31 +288,35 @@ export default function Live2DCanvas({
     };
   }, [audioBuffer, audioContext, modelReady]);
 
-  // sleeping 状態のとき、目を半開き（0.3）に固定する。
+  // sleeping 状態のとき、目を半開き（0.3）にしつつ、たまにゆっくり瞬きさせる。
   //
   // ライブラリの内部モデル更新は毎フレーム以下の順序で走る
   // （pixi-live2d-display-lipsyncpatch / fork 元 pixi-live2d-display）:
   //   1. emit('beforeMotionUpdate')
   //   2. motionManager.update()      … idle モーション再生
   //   3. emit('afterMotionUpdate')   … 割り込み可能なフック
-  //   4. eyeBlink.updateParameters() … 自動まばたきが目を上書き ★
+  //   4. eyeBlink.updateParameters() … 自動まばたきが目を上書き（開き直す）
   //   5. lipSync / expression / breath
   //   6. coreModel 確定・描画
   //
-  // app.ticker.add では PIXI ティッカーと上記フローの実行順がフレームごとに前後し、
-  // 待機中は 4 の自動まばたきに毎フレーム負けて効かず、発話中は 4 より後に走った
-  // フレームだけ反映されてチラついていた（競合状態）。
+  // 4 の eyeBlink は 3 の afterMotionUpdate より後に走るため、afterMotionUpdate で
+  // 目を抑えても直後に開き直されてしまう（順序依存で半目が維持できない）。
+  // そこで eyeBlink を無効化（#3334 で安定実績のある方式）して 3 を最終決定とし、
+  // 瞬き自体は自前で駆動する。
   //
-  // そこで 3 の afterMotionUpdate で目をセットしつつ、直後 4 の上書きを防ぐため
-  // sleeping 中だけ eyeBlink を一時無効化する。これで待機中・発話中とも確定的な
-  // タイミングで毎フレーム書き込まれ、安定して半開きになる。
+  // 自前瞬き: 半開き 0.3 をベースに、ランダムな間隔（3〜6 秒）で 1 回、約 140ms かけて
+  // 0.3 → 0 → 0.3 と閉じて開く三角波を重ねる。eyeBlink を切っているので
+  // afterMotionUpdate の書き込みが確定し、待機中・発話中とも安定して反映される。
   useEffect(() => {
     const model = modelRef.current;
     if (!model || !modelReady) return;
 
     if (lifecycleState !== 'sleeping') return;
 
-    const EYE_VALUE = 0.3;
+    const EYE_MAX = 0.3;
+    const BLINK_DURATION_MS = 140;
+    const BLINK_INTERVAL_MIN_MS = 3000;
+    const BLINK_INTERVAL_RANGE_MS = 3000;
 
     const internalModel = model.internalModel as unknown as {
       coreModel?: { setParameterValueById?: (id: string, value: number) => void };
@@ -321,18 +325,39 @@ export default function Live2DCanvas({
       off?: (event: string, handler: () => void) => void;
     };
 
+    // 三角波で瞬きの開き値（0〜0.3）を計算する。瞬き窓の外は 0.3（半目）。
+    let blinkStart = -Infinity;
+    let nextBlinkAt =
+      performance.now() + BLINK_INTERVAL_MIN_MS + Math.random() * BLINK_INTERVAL_RANGE_MS;
+
+    const computeEyeOpen = (now: number): number => {
+      if (now >= nextBlinkAt && now > blinkStart + BLINK_DURATION_MS) {
+        blinkStart = now;
+        nextBlinkAt = now + BLINK_INTERVAL_MIN_MS + Math.random() * BLINK_INTERVAL_RANGE_MS;
+      }
+      const t = now - blinkStart;
+      if (t >= 0 && t < BLINK_DURATION_MS) {
+        const half = BLINK_DURATION_MS / 2;
+        // 0 → 1 → 0（閉じ具合）。half で最も閉じる
+        const closeRatio = t < half ? t / half : 1 - (t - half) / half;
+        return EYE_MAX * (1 - closeRatio);
+      }
+      return EYE_MAX;
+    };
+
     const applyEyes = () => {
       if (lifecycleStateRef.current !== 'sleeping') return;
       try {
-        internalModel.coreModel?.setParameterValueById?.('ParamEyeLOpen', EYE_VALUE);
-        internalModel.coreModel?.setParameterValueById?.('ParamEyeROpen', EYE_VALUE);
+        const value = computeEyeOpen(performance.now());
+        internalModel.coreModel?.setParameterValueById?.('ParamEyeLOpen', value);
+        internalModel.coreModel?.setParameterValueById?.('ParamEyeROpen', value);
       } catch {
         // 型情報がない internal API のため best-effort
       }
     };
 
     // 自動まばたき（eyeBlink.updateParameters）が afterMotionUpdate 直後に目を
-    // 上書きするため、sleeping 中だけ無効化し、cleanup で元の参照に復元する。
+    // 開き直すため、sleeping 中だけ無効化し、cleanup で元の参照に復元する。
     const savedEyeBlink = internalModel.eyeBlink;
     internalModel.eyeBlink = undefined;
 

--- a/services/livetalk/web/tests/unit/app/api/lifecycle/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/lifecycle/route.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/lifecycle/route';
+import { getSession } from '@/lib/server/session';
+import { getLifecycleRepository } from '@/lib/server/repositories';
+import type { LifecycleEntity, LifecycleRepository } from '@nagiyu/livetalk-core';
+
+jest.mock('@/lib/server/session', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@/lib/server/repositories', () => ({
+  getLifecycleRepository: jest.fn(),
+}));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetLifecycleRepo = getLifecycleRepository as jest.MockedFunction<
+  typeof getLifecycleRepository
+>;
+
+const validSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'u@example.com',
+    name: 'U',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+const makeEntity = (bedtime: string, wakeUpTime: string): LifecycleEntity => ({
+  UserID: 'g1',
+  CharacterID: 'hiyori',
+  Bedtime: bedtime,
+  WakeUpTime: wakeUpTime,
+  CreatedAt: 0,
+  UpdatedAt: 0,
+});
+
+const makeRepo = (entity: LifecycleEntity | null): LifecycleRepository => ({
+  get: jest.fn(async () => entity),
+  upsert: jest.fn(async () => entity ?? makeEntity('01:30', '09:30')),
+});
+
+const buildGetRequest = (): Request =>
+  new Request('http://localhost/api/lifecycle', { method: 'GET' });
+
+describe('GET /api/lifecycle', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('未認証は 401', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('就寝中の時間帯（終日 sleeping 設定）なら state: sleeping を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    // bedtime > wakeUpTime かつ起床直後の隙間が極小 → ほぼ常時 sleeping
+    // 00:00 起床 / 00:00 就寝は不可なので、起床 00:00・就寝 23:59 で
+    // 00:00〜23:59 を sleeping にする（境界の 1 分のみ awake）
+    mockGetLifecycleRepo.mockReturnValue(makeRepo(makeEntity('00:01', '00:00')));
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.state).toBe('sleeping');
+  });
+
+  it('起床中の時間帯（終日 awake 設定）なら state: awake を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    // bedtime < wakeUpTime だが窓が極小（00:00〜00:01 のみ sleeping）→ ほぼ常時 awake
+    mockGetLifecycleRepo.mockReturnValue(makeRepo(makeEntity('00:00', '00:01')));
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.state).toBe('awake');
+  });
+
+  it('Lifecycle が未設定でもデフォルト定数で判定して 200 を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    mockGetLifecycleRepo.mockReturnValue(makeRepo(null));
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(['awake', 'sleeping']).toContain(json.state);
+  });
+
+  it('リポジトリエラーでも fail-safe で state: awake / 200 を返す', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetSession.mockResolvedValue(validSession);
+    mockGetLifecycleRepo.mockReturnValue({
+      get: jest.fn(async () => {
+        throw new Error('db error');
+      }),
+      upsert: jest.fn(),
+    } as unknown as LifecycleRepository);
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.state).toBe('awake');
+    consoleSpy.mockRestore();
+  });
+});

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -90,6 +90,12 @@ function setupFetchMocks(chatOk = false, sentenceAudio?: string) {
         json: () => Promise.resolve({ consented: true }),
       });
     }
+    if (url === '/api/lifecycle') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+    }
     return Promise.resolve({ ok: chatOk, body: chatStream });
   });
 }


### PR DESCRIPTION
## 変更の概要

#3333 / PR #3334 でマージした sleeping 時の目パラメータ修正に対する、実機確認で判明した 2 点の追加課題を修正する。

### 課題1: sleeping 中に瞬きが止まる

#3334 では sleeping 中に `eyeBlink`（自動まばたき機構）を無効化して半目 0.3 に固定したため、瞬きが完全に止まっていた。

**修正**: `services/livetalk/web/src/components/Live2DCanvas.tsx`
- `eyeBlink` は無効化したまま（`afterMotionUpdate` の書き込みを最終決定にするため。`eyeBlink` は `afterMotionUpdate` より後に走るので、生かすと半目が開き直されてしまう）
- 瞬きを**自前駆動**に変更。半目 0.3 をベースに、ランダム間隔（3〜6 秒）で約 140ms の三角波（0.3→0→0.3）を重ね、たまにゆっくり瞬きする自然な挙動にした
- `eyeBlink` は cleanup で元の参照に復元

### 課題2: 初回起動〜初回入力までは半目にならない

`lifecycleState` はチャットストリーム（`/api/chat`）先頭でしか送られず、初回発話までフロントは状態を知らず `'awake'` のままだった。

**修正**:
- `GET /api/lifecycle` を新設（`route.ts` / `constants.ts`）。`withAuth` ガードのうえ `resolveLifecycleState` で現在状態を算出し `{ state }` を返す。取得失敗時は fail-safe で `awake` を返し UI を止めない
- `page.tsx`: 起動時に `/api/consent` と並行して `/api/lifecycle` を取得し、`lifecycleState` の初期値へ反映

## 関連 Issue

関連 #3335（#3328 のサブ Issue。integration → develop の PR ではないため `Closes` は付けない）

## 変更種別

- [x] バグ修正

## テスト内容

- `tests/unit/app/api/lifecycle/route.test.ts`（新規）: 認証ガード（401）・sleeping/awake 判定・未設定フォールバック・リポジトリエラー時の fail-safe（awake / 200）を検証
- `tests/unit/app/page.test.tsx`: 起動時 fetch モックに `/api/lifecycle` を追加
- Live2DCanvas はユニットテストでモック化されているため、瞬きの三角波自体のテストは追加せず実機確認で担保（既存方針踏襲）

## ローカル検証状況（正直な記載）

このコンテナには livetalk-web の依存（`next` / `eslint` / `pixi-live2d-display-lipsyncpatch`）が未インストールのため、**web の build / lint / test はローカル実行できていない**（CI に委ねる）。実行できたもの:

- [x] `format:check`（web / core）: PASS
- [ ] web build / lint / test: ローカル実行不可 → **CI で確認**

## レビューポイント

- **実機確認が必須**: ① sleeping 中に半目をベースとしてたまにゆっくり瞬きするか、② 初回起動時（初回入力前）から sleeping 時間帯なら半目で表示されるか、③ awake 復帰で通常まばたきに戻るか（cleanup での eyeBlink 復元）。
- 瞬きの間隔（3〜6 秒）・所要時間（140ms）・閉じ具合は決め打ち。実機で不自然なら調整。
- `afterMotionUpdate`・`eyeBlink`・`setParameterValueById` は fork 元 pixi-live2d-display の既知挙動に基づく判断（コンテナにライブラリ実体なし）。

## 補足事項

- ⚠️ #3334 で入れた検証用の一時設定（`LIFECYCLE_DEFAULT_BEDTIME/WAKE_UP_TIME` を 06:00/05:00 に拡張、`TEMPORARY（#3333 検証用）` マーカー）は**本 PR のスコープ外**。検証完了後に別途 revert する。
- ブランチ名は `claude/livetalk-issue-3335-eyefix`、対応 Issue は **#3335**。

https://claude.ai/code/session_014LBTgka3FBrtyoZb4HVcTj

---
_Generated by [Claude Code](https://claude.ai/code/session_014LBTgka3FBrtyoZb4HVcTj)_