### PR TITLE
[リブトーク Phase 4b] 検証用に延長した寝ぼけ時間を本来値（01:30/09:30）へ戻す（Issue #3338）

### DIFF
--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -104,21 +104,14 @@ export const AFFECTION_BIDIRECTIONALITY_WEIGHT = 1.0;
 /**
  * 生活サイクルのデフォルト就寝時刻（"HH:mm" 形式、Asia/Tokyo 基準）。
  * ユーザーが設定を持たない場合にフォールバックする値（Phase 4b）。
- *
- * TEMPORARY（#3333 検証用）: sleeping 演出を日中いつでも確認できるよう、
- * 就寝 06:00 / 起床 05:00（= 終日ほぼ sleeping、awake は 05:00–06:00 のみ）に
- * 一時拡張している。検証完了後に本来値 '01:30' / '09:30' へ戻すこと。
  */
-export const LIFECYCLE_DEFAULT_BEDTIME = '06:00';
+export const LIFECYCLE_DEFAULT_BEDTIME = '01:30';
 
 /**
  * 生活サイクルのデフォルト起床時刻（"HH:mm" 形式、Asia/Tokyo 基準）。
  * ユーザーが設定を持たない場合にフォールバックする値（Phase 4b）。
- *
- * TEMPORARY（#3333 検証用）: 上記 LIFECYCLE_DEFAULT_BEDTIME を参照。
- * 検証完了後に本来値 '09:30' へ戻すこと。
  */
-export const LIFECYCLE_DEFAULT_WAKE_UP_TIME = '05:00';
+export const LIFECYCLE_DEFAULT_WAKE_UP_TIME = '09:30';
 
 /**
  * Tier C 記憶の「再言及」と判定する cosine similarity 下限閾値（Phase 3d）。

--- a/services/livetalk/core/tests/unit/lifecycle/state-resolver.test.ts
+++ b/services/livetalk/core/tests/unit/lifecycle/state-resolver.test.ts
@@ -5,21 +5,18 @@ function makeDate(hour: number, minute = 0): Date {
 }
 
 describe('resolveLifecycleState', () => {
-  // TEMPORARY（#3333 検証用）: デフォルトを就寝 06:00 / 起床 05:00（終日ほぼ
-  // sleeping、awake は 05:00–06:00 のみ）に一時拡張中。検証完了後、constants.ts の
-  // 本来値 '01:30' / '09:30' への復帰に合わせて本ブロックも元の期待値へ戻すこと。
-  describe('デフォルト設定（TEMPORARY: 就寝 06:00 / 起床 05:00）', () => {
+  describe('デフォルト設定（就寝 01:30 / 起床 09:30）', () => {
     it.each([
-      [0, 0, 'sleeping'],
       [1, 30, 'sleeping'],
-      [4, 59, 'sleeping'],
-      [5, 0, 'awake'],
-      [5, 30, 'awake'],
-      [5, 59, 'awake'],
-      [6, 0, 'sleeping'],
-      [9, 30, 'sleeping'],
-      [12, 0, 'sleeping'],
-      [23, 59, 'sleeping'],
+      [5, 0, 'sleeping'],
+      [9, 0, 'sleeping'],
+      [9, 29, 'sleeping'],
+      [9, 30, 'awake'],
+      [12, 0, 'awake'],
+      [18, 0, 'awake'],
+      [23, 59, 'awake'],
+      [0, 0, 'awake'],
+      [1, 29, 'awake'],
     ] as [number, number, string][])('%i:%s → %s', (hour, minute, expected) => {
       const result = resolveLifecycleState(makeDate(hour, minute));
       expect(result).toBe(expected);


### PR DESCRIPTION
## 変更の概要

#3333（PR #3334）で sleeping 演出の実機確認のために一時拡張していたデフォルト就寝/起床時刻を、検証完了に伴い本来値へ戻す。

| 定数 | 検証用（一時） | 本来値（復帰後） |
|---|---|---|
| `LIFECYCLE_DEFAULT_BEDTIME` | `06:00` | `01:30` |
| `LIFECYCLE_DEFAULT_WAKE_UP_TIME` | `05:00` | `09:30` |

### 変更内容

- `services/livetalk/core/src/constants.ts`: 両定数を本来値へ戻し、`TEMPORARY（#3333 検証用）` コメントを削除
- `services/livetalk/core/tests/unit/lifecycle/state-resolver.test.ts`: 「デフォルト設定」describe ブロックの期待値を就寝 01:30 / 起床 09:30 の本来挙動へ戻す

新規ロジックの追加はなく、値とテスト期待値の復帰のみ。

## 関連 Issue

関連 #3338（integration → develop の PR ではないため `Closes` は付けない）

## 変更種別

- [x] その他（検証用一時設定の復帰）

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] ローカルでテストが全て通ることを確認した（core: 583 件 PASS）
- [x] format が通ることを確認した
- [x] `TEMPORARY（#3333 検証用）` マーカーの残存がないことを確認した

## テスト内容

- core ユニットテスト 583 件 PASS（state-resolver のデフォルト設定ブロックを本来値の期待値に更新済み）
- `grep` で `TEMPORARY（#3333` マーカーの残存ゼロを確認

## レビューポイント

- 値の復帰のみの軽微な変更。深夜 0 時跨ぎ（01:30→09:30 が sleeping）の境界テストが本来の期待値に戻っているか。

https://claude.ai/code/session_014LBTgka3FBrtyoZb4HVcTj

---
_Generated by [Claude Code](https://claude.ai/code/session_014LBTgka3FBrtyoZb4HVcTj)_