### PR TITLE
[Phase 4c] ユーザー活動時間学習バッチ実装（Issue #3329）

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -406,21 +406,28 @@ jobs:
           ENVIRONMENT: ${{ needs.infrastructure-ecr.outputs.environment }}
         run: |
           # 既存スタックへの再デプロイでは :latest タグが不変のため CloudFormation が
-          # Lambda コードを更新しない。明示的に最新イメージへ更新する。
+          # Lambda コードを更新しない。全バッチ Lambda に明示的に最新イメージを反映する。
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           ECR_REGISTRY="$ACCOUNT_ID.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com"
           IMAGE_URI="$ECR_REGISTRY/nagiyu-livetalk-batch-ecr-$ENVIRONMENT:latest"
 
-          aws lambda update-function-code \
-            --function-name "nagiyu-livetalk-batch-compress-$ENVIRONMENT" \
-            --image-uri "$IMAGE_URI" \
-            --region ${{ env.AWS_REGION }}
+          for FN in \
+            "nagiyu-livetalk-batch-compress-$ENVIRONMENT" \
+            "nagiyu-livetalk-batch-learn-user-activity-$ENVIRONMENT"; do
 
-          aws lambda wait function-updated \
-            --function-name "nagiyu-livetalk-batch-compress-$ENVIRONMENT" \
-            --region ${{ env.AWS_REGION }}
+            aws lambda update-function-code \
+              --function-name "$FN" \
+              --image-uri "$IMAGE_URI" \
+              --region ${{ env.AWS_REGION }}
 
-          echo "Batch Lambda updated with image: $IMAGE_URI"
+            aws lambda wait function-updated \
+              --function-name "$FN" \
+              --region ${{ env.AWS_REGION }}
+
+            echo "Batch Lambda updated: $FN"
+          done
+
+          echo "All batch Lambdas updated with image: $IMAGE_URI"
 
   infrastructure-cloudfront:
     name: Deploy CloudFront Distribution
@@ -509,7 +516,8 @@ jobs:
             echo "- **App Version**: $APP_VERSION"
             echo "- **Image (SHA tag)**: \`$IMAGE_URI\`"
             echo "- **Latest tag**: same digest also pushed as \`:latest\`"
-            echo "- **Batch Lambda**: \`nagiyu-livetalk-batch-compress-$ENVIRONMENT\`（EventBridge 日次 JST 03:00）"
+            echo "- **Batch Lambda（圧縮）**: \`nagiyu-livetalk-batch-compress-$ENVIRONMENT\`（EventBridge 日次 JST 03:00）"
+            echo "- **Batch Lambda（学習）**: \`nagiyu-livetalk-batch-learn-user-activity-$ENVIRONMENT\`（EventBridge 週次 JST 日曜 03:00）"
             echo "- **ALB DNS**: \`$ALB_DNS\`"
             echo "- **Custom Domain**: https://$CUSTOM_DOMAIN"
             echo ""

--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -22,16 +22,16 @@ export interface LiveTalkBatchStackProps extends cdk.StackProps {
 }
 
 /**
- * LiveTalk バッチ処理スタック（Phase 3c / Issue #3281）
+ * LiveTalk バッチ処理スタック（Phase 3c / Issue #3281、Phase 4c / Issue #3329）
  *
- * 日次で全ユーザーの会話を圧縮要約する Lambda を作成する。
- * - EventBridge: JST 03:00（UTC 18:00）に日次実行
- * - Lambda: FROM_IMAGE / 512MB / 15 分タイムアウト
- * - DLQ: 失敗時のデッドレター保持（7 日）
- * - IAM: DynamoDB 読み書き + CloudWatch Logs
+ * 圧縮要約バッチと活動時間学習バッチの 2 Lambda を管理する。
+ * - compress: 日次 JST 03:00（UTC 18:00）
+ * - learn-user-activity: 週次 JST 日曜 03:00（UTC 土曜 18:00）
+ * - DLQ / IAM Role は Lambda ごとに独立（障害切り分け・権限最小化）
  */
 export class LiveTalkBatchStack extends cdk.Stack {
   public readonly batchFunction: lambda.Function;
+  public readonly learnActivityFunction: lambda.Function;
 
   constructor(scope: Construct, id: string, props: LiveTalkBatchStackProps) {
     super(scope, id, props);
@@ -120,6 +120,67 @@ export class LiveTalkBatchStack extends cdk.Stack {
       })
     );
 
+    // ---- ユーザー活動時間学習バッチ（Phase 4c / Issue #3329）----
+
+    // 学習バッチ専用 DLQ（compress バッチと障害切り分けのため独立）
+    const learnActivityDlq = new sqs.Queue(this, 'LearnActivityDlq', {
+      queueName: `nagiyu-livetalk-learn-activity-dlq-${environment}`,
+      retentionPeriod: cdk.Duration.days(7),
+    });
+
+    // 学習バッチ専用 IAM Role（OpenAI 権限不要、DynamoDB read/write のみ）
+    const learnActivityRole = new iam.Role(this, 'LearnActivityExecutionRole', {
+      roleName: `nagiyu-livetalk-learn-activity-role-${environment}`,
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+      ],
+    });
+    dynamoTable.grantReadWriteData(learnActivityRole);
+    learnActivityDlq.grantSendMessages(learnActivityRole);
+    grantErrorEventsWrite(this, learnActivityRole, environment);
+
+    // 学習バッチ Lambda
+    this.learnActivityFunction = new lambda.Function(this, 'LearnActivityFunction', {
+      functionName: `nagiyu-livetalk-batch-learn-user-activity-${environment}`,
+      runtime: lambda.Runtime.FROM_IMAGE,
+      code: lambda.Code.fromEcrImage(batchRepository, {
+        tagOrDigest: 'latest',
+        cmd: ['services/livetalk/batch/dist/src/handlers/learn-user-activity.handler'],
+      }),
+      handler: lambda.Handler.FROM_IMAGE,
+      role: learnActivityRole,
+      memorySize: 512,
+      timeout: cdk.Duration.minutes(15),
+      environment: {
+        NODE_ENV: environment,
+        DYNAMODB_TABLE_NAME: dynamoTableName,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
+        TZ: 'Asia/Tokyo',
+      },
+      deadLetterQueue: learnActivityDlq,
+      tracing: lambda.Tracing.ACTIVE,
+      logRetention: logs.RetentionDays.ONE_MONTH,
+    });
+
+    // EventBridge: 週次 JST 日曜 03:00（= UTC 土曜 18:00）
+    const weeklyLearnRule = new events.Rule(this, 'WeeklyLearnActivityRule', {
+      ruleName: `livetalk-batch-learn-activity-${environment}`,
+      description: 'LiveTalk ユーザー活動時間学習バッチ（週次 JST 日曜 03:00）',
+      schedule: events.Schedule.cron({
+        minute: '0',
+        hour: '18',
+        weekDay: 'SAT',
+      }),
+    });
+    weeklyLearnRule.addTarget(
+      new targets.LambdaFunction(this.learnActivityFunction, {
+        deadLetterQueue: learnActivityDlq,
+        maxEventAge: cdk.Duration.hours(2),
+        retryAttempts: 1,
+      })
+    );
+
     // タグ
     cdk.Tags.of(this).add('Application', 'nagiyu');
     cdk.Tags.of(this).add('Service', 'livetalk');
@@ -135,6 +196,16 @@ export class LiveTalkBatchStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'BatchDlqUrl', {
       value: dlq.queueUrl,
       description: 'LiveTalk Batch DLQ URL',
+    });
+
+    new cdk.CfnOutput(this, 'LearnActivityFunctionArn', {
+      value: this.learnActivityFunction.functionArn,
+      description: 'LiveTalk Learn User Activity Lambda Function ARN',
+    });
+
+    new cdk.CfnOutput(this, 'LearnActivityDlqUrl', {
+      value: learnActivityDlq.queueUrl,
+      description: 'LiveTalk Learn User Activity DLQ URL',
     });
   }
 }

--- a/infra/livetalk/tests/unit/batch-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-stack.test.js
@@ -25,6 +25,25 @@ describe('LiveTalkBatchStack', () => {
     });
   });
 
+  it('学習バッチ用 Lambda 関数が存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: Match.stringLikeRegexp('livetalk-batch-learn-user-activity'),
+    });
+  });
+
+  it('バッチ Lambda を 2 つ作成する（圧縮 + 学習）', () => {
+    // logRetention は LogRetention 用の provider Lambda を別途生成するため、
+    // AWS::Lambda::Function の総数ではなく FunctionName で個別に検証する。
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: Match.stringLikeRegexp('livetalk-batch-compress'),
+    });
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: Match.stringLikeRegexp('livetalk-batch-learn-user-activity'),
+    });
+  });
+
   it('Lambda のタイムアウトは 15 分', () => {
     const { template } = synth();
     template.hasResourceProperties('AWS::Lambda::Function', {
@@ -50,21 +69,53 @@ describe('LiveTalkBatchStack', () => {
     });
   });
 
-  it('EventBridge ルールを 1 つ作成する', () => {
+  it('学習バッチ Lambda 環境変数に TZ=Asia/Tokyo が含まれる', () => {
     const { template } = synth();
-    template.resourceCountIs('AWS::Events::Rule', 1);
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: Match.stringLikeRegexp('livetalk-batch-learn-user-activity'),
+      Environment: {
+        Variables: Match.objectLike({
+          TZ: 'Asia/Tokyo',
+        }),
+      },
+    });
   });
 
-  it('EventBridge スケジュールは cron(0 18 * * ? *)', () => {
+  it('学習バッチ Lambda には OPENAI_API_KEY を含めない', () => {
+    const { stack } = synth();
+    const template = Template.fromStack(stack);
+    const functions = template.findResources('AWS::Lambda::Function', {
+      Properties: {
+        FunctionName: Match.stringLikeRegexp('livetalk-batch-learn-user-activity'),
+      },
+    });
+    const learnFn = Object.values(functions)[0];
+    const vars = learnFn.Properties.Environment.Variables;
+    expect(vars.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  it('EventBridge ルールを 2 つ作成する（日次圧縮 + 週次学習）', () => {
+    const { template } = synth();
+    template.resourceCountIs('AWS::Events::Rule', 2);
+  });
+
+  it('圧縮バッチの EventBridge スケジュールは cron(0 18 * * ? *)', () => {
     const { template } = synth();
     template.hasResourceProperties('AWS::Events::Rule', {
       ScheduleExpression: 'cron(0 18 * * ? *)',
     });
   });
 
-  it('SQS DLQ を 1 つ作成する', () => {
+  it('学習バッチの EventBridge スケジュールは週次（土曜 UTC 18:00）', () => {
     const { template } = synth();
-    template.resourceCountIs('AWS::SQS::Queue', 1);
+    template.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: 'cron(0 18 ? * SAT *)',
+    });
+  });
+
+  it('SQS DLQ を 2 つ作成する（圧縮 + 学習で分離）', () => {
+    const { template } = synth();
+    template.resourceCountIs('AWS::SQS::Queue', 2);
   });
 
   it('Lambda 実行ロールを作成する', () => {
@@ -83,6 +134,11 @@ describe('LiveTalkBatchStack', () => {
   it('BatchFunctionArn を Outputs に出力する', () => {
     const { template } = synth();
     template.hasOutput('BatchFunctionArn', Match.anyValue());
+  });
+
+  it('LearnActivityFunctionArn を Outputs に出力する', () => {
+    const { template } = synth();
+    template.hasOutput('LearnActivityFunctionArn', Match.anyValue());
   });
 
   it('prod 環境でも正しく生成する', () => {

--- a/services/livetalk/batch/src/handlers/learn-user-activity.ts
+++ b/services/livetalk/batch/src/handlers/learn-user-activity.ts
@@ -1,0 +1,83 @@
+import { logger, toErrorMessage } from '@nagiyu/common';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
+import {
+  DynamoDBLifecycleRepository,
+  DynamoDBMessageRepository,
+  defaultUlidFactory,
+} from '@nagiyu/livetalk-core';
+import { learnAllUserActivities } from '../usecases/learn-user-activity.usecase.js';
+
+const SERVICE_ID = 'livetalk';
+
+export interface ScheduledEvent {
+  version: string;
+  id: string;
+  'detail-type': string;
+  source: string;
+  account: string;
+  time: string;
+  region: string;
+  resources: string[];
+  detail: Record<string, unknown>;
+}
+
+export interface HandlerResponse {
+  statusCode: number;
+  body: string;
+}
+
+export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
+  logger.info('[learn-user-activity] バッチ開始', {
+    eventId: event.id,
+    eventTime: event.time,
+  });
+
+  try {
+    const docClient = getDynamoDBDocumentClient();
+    const tableName = getTableName();
+
+    const messageRepo = new DynamoDBMessageRepository(docClient, tableName, defaultUlidFactory);
+    const lifecycleRepo = new DynamoDBLifecycleRepository(docClient, tableName);
+
+    const result = await learnAllUserActivities({
+      docClient,
+      tableName,
+      messageRepo,
+      lifecycleRepo,
+    });
+
+    logger.info('[learn-user-activity] バッチ完了', {
+      eventId: event.id,
+      ...result,
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: 'ユーザー活動時間学習バッチが正常に完了しました',
+        ...result,
+      }),
+    };
+  } catch (error) {
+    const errorMessage = toErrorMessage(error);
+    logger.error('[learn-user-activity] バッチ失敗', {
+      eventId: event.id,
+      error: errorMessage,
+    });
+    await reportErrorEvent({
+      serviceId: SERVICE_ID,
+      severity: 'error',
+      title: 'ユーザー活動時間学習バッチ: 致命的エラー',
+      message: errorMessage,
+      context: { eventId: event.id },
+    });
+
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: 'ユーザー活動時間学習バッチでエラーが発生しました',
+        error: errorMessage,
+      }),
+    };
+  }
+}

--- a/services/livetalk/batch/src/index.ts
+++ b/services/livetalk/batch/src/index.ts
@@ -4,3 +4,10 @@ export type {
   CompressAllConversationsParams,
   CompressAllConversationsResult,
 } from './usecases/compress-conversations.usecase.js';
+
+export { handler as learnUserActivityHandler } from './handlers/learn-user-activity.js';
+export { learnAllUserActivities } from './usecases/learn-user-activity.usecase.js';
+export type {
+  LearnAllUserActivitiesParams,
+  LearnAllUserActivitiesResult,
+} from './usecases/learn-user-activity.usecase.js';

--- a/services/livetalk/batch/src/usecases/learn-user-activity.usecase.ts
+++ b/services/livetalk/batch/src/usecases/learn-user-activity.usecase.ts
@@ -1,0 +1,103 @@
+import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { logger, toErrorMessage } from '@nagiyu/common';
+import {
+  DEFAULT_CHARACTER_ID,
+  learnUserActivity,
+  type LifecycleRepository,
+  type MessageRepository,
+} from '@nagiyu/livetalk-core';
+
+export interface LearnAllUserActivitiesParams {
+  docClient: DynamoDBDocumentClient;
+  tableName: string;
+  messageRepo: MessageRepository;
+  lifecycleRepo: LifecycleRepository;
+  /** 学習基準日時（省略時は実行時刻）。テスト用差し替え可。 */
+  now?: () => Date;
+}
+
+export interface LearnAllUserActivitiesResult {
+  processedUsers: number;
+  skippedUsers: number;
+  failedUsers: number;
+  failedUserIds: string[];
+}
+
+/**
+ * 全アクティブユーザーの活動時間を学習する。
+ *
+ * DynamoDB を Scan して Type='Profile' のアイテムを列挙し、
+ * 各ユーザーについて DEFAULT_CHARACTER_ID（hiyori）の発話履歴を学習する。
+ */
+export async function learnAllUserActivities(
+  params: LearnAllUserActivitiesParams
+): Promise<LearnAllUserActivitiesResult> {
+  const { docClient, tableName, messageRepo, lifecycleRepo, now } = params;
+
+  const userIds = await scanAllUserIds(docClient, tableName);
+
+  logger.info('[learnAllUserActivities] ユーザー一覧取得完了', {
+    userCount: userIds.length,
+  });
+
+  const result: LearnAllUserActivitiesResult = {
+    processedUsers: 0,
+    skippedUsers: 0,
+    failedUsers: 0,
+    failedUserIds: [],
+  };
+
+  for (const userId of userIds) {
+    try {
+      const outcome = await learnUserActivity(userId, DEFAULT_CHARACTER_ID, {
+        messageRepo,
+        lifecycleRepo,
+        ...(now !== undefined && { now }),
+      });
+      if (outcome === 'skipped') {
+        result.skippedUsers++;
+      } else {
+        result.processedUsers++;
+      }
+    } catch (error) {
+      logger.error('[learnAllUserActivities] ユーザー処理失敗', {
+        userId,
+        error: toErrorMessage(error),
+      });
+      result.failedUsers++;
+      result.failedUserIds.push(userId);
+    }
+  }
+
+  logger.info('[learnAllUserActivities] 全ユーザー処理完了', { ...result });
+  return result;
+}
+
+async function scanAllUserIds(
+  docClient: DynamoDBDocumentClient,
+  tableName: string
+): Promise<string[]> {
+  const userIds: string[] = [];
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+  do {
+    const command = new ScanCommand({
+      TableName: tableName,
+      FilterExpression: '#type = :profile',
+      ExpressionAttributeNames: { '#type': 'Type' },
+      ExpressionAttributeValues: { ':profile': 'Profile' },
+      ProjectionExpression: 'UserID',
+      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
+    });
+
+    const response = await docClient.send(command);
+    for (const item of response.Items ?? []) {
+      if (typeof item.UserID === 'string' && item.UserID) {
+        userIds.push(item.UserID);
+      }
+    }
+    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastEvaluatedKey !== undefined);
+
+  return userIds;
+}

--- a/services/livetalk/batch/tests/unit/handlers/learn-user-activity.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/learn-user-activity.test.ts
@@ -1,0 +1,93 @@
+import type { ScheduledEvent } from '../../../src/handlers/learn-user-activity.js';
+
+jest.mock('@nagiyu/aws', () => ({
+  getDynamoDBDocumentClient: jest.fn(() => ({})),
+  getTableName: jest.fn(() => 'test-table'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@nagiyu/livetalk-core', () => ({
+  DynamoDBMessageRepository: jest.fn(),
+  DynamoDBLifecycleRepository: jest.fn(),
+  defaultUlidFactory: jest.fn(),
+}));
+
+const mockLearnAll = jest.fn();
+jest.mock('../../../src/usecases/learn-user-activity.usecase.js', () => ({
+  learnAllUserActivities: (...args: unknown[]) => mockLearnAll(...args),
+}));
+
+const makeEvent = (overrides: Partial<ScheduledEvent> = {}): ScheduledEvent => ({
+  version: '0',
+  id: 'event-001',
+  'detail-type': 'Scheduled Event',
+  source: 'aws.events',
+  account: '123456789',
+  time: '2026-06-01T18:00:00Z',
+  region: 'us-east-1',
+  resources: [],
+  detail: {},
+  ...overrides,
+});
+
+describe('learn-user-activity handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('正常処理時に 200 を返す', async () => {
+    mockLearnAll.mockResolvedValue({
+      processedUsers: 3,
+      skippedUsers: 1,
+      failedUsers: 0,
+      failedUserIds: [],
+    });
+
+    const { handler } = await import('../../../src/handlers/learn-user-activity.js');
+    const response = await handler(makeEvent());
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.processedUsers).toBe(3);
+    expect(body.skippedUsers).toBe(1);
+  });
+
+  it('例外発生時に 500 を返す', async () => {
+    mockLearnAll.mockRejectedValue(new Error('DynamoDB 接続エラー'));
+
+    const { handler } = await import('../../../src/handlers/learn-user-activity.js');
+    const response = await handler(makeEvent());
+
+    expect(response.statusCode).toBe(500);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain('DynamoDB 接続エラー');
+  });
+
+  it('例外発生時に reportErrorEvent を呼ぶ', async () => {
+    const { reportErrorEvent } = await import('@nagiyu/aws');
+    mockLearnAll.mockRejectedValue(new Error('fatal'));
+
+    const { handler } = await import('../../../src/handlers/learn-user-activity.js');
+    await handler(makeEvent({ id: 'ev-999' }));
+
+    expect(reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'livetalk',
+        severity: 'error',
+      })
+    );
+  });
+
+  it('eventId が learnAllUserActivities に渡らなくても動作する', async () => {
+    mockLearnAll.mockResolvedValue({
+      processedUsers: 0,
+      skippedUsers: 0,
+      failedUsers: 0,
+      failedUserIds: [],
+    });
+
+    const { handler } = await import('../../../src/handlers/learn-user-activity.js');
+    const response = await handler(makeEvent({ id: 'ev-special' }));
+    expect(response.statusCode).toBe(200);
+  });
+});

--- a/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -1,0 +1,159 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import {
+  InMemoryMessageRepository,
+  InMemoryLifecycleRepository,
+} from '@nagiyu/livetalk-core';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  learnAllUserActivities,
+  type LearnAllUserActivitiesParams,
+} from '../../../src/usecases/learn-user-activity.usecase.js';
+
+const fixedNow = 1_750_000_000_000;
+let tick = fixedNow;
+
+const makeRepos = () => {
+  const store = new InMemorySingleTableStore();
+  tick = fixedNow;
+  const nowMs = () => tick;
+  const ulidFactory = () => `ULID-${tick++}`;
+  return {
+    messageRepo: new InMemoryMessageRepository(store, ulidFactory, nowMs),
+    lifecycleRepo: new InMemoryLifecycleRepository(store, nowMs),
+    store,
+  };
+};
+
+const makeDocClientMock = (userIds: string[]): DynamoDBDocumentClient => {
+  const items = userIds.map((id) => ({ UserID: id }));
+  return {
+    send: async () => ({ Items: items }),
+  } as unknown as DynamoDBDocumentClient;
+};
+
+const makeParams = (
+  overrides: Partial<LearnAllUserActivitiesParams> = {}
+): LearnAllUserActivitiesParams => {
+  const { messageRepo, lifecycleRepo } = makeRepos();
+  return {
+    docClient: makeDocClientMock([]),
+    tableName: 'test-table',
+    messageRepo,
+    lifecycleRepo,
+    ...overrides,
+  };
+};
+
+describe('learnAllUserActivities', () => {
+  it('ユーザーが 0 件のとき processedUsers=0 を返す', async () => {
+    const result = await learnAllUserActivities(makeParams());
+    expect(result.processedUsers).toBe(0);
+    expect(result.skippedUsers).toBe(0);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('メッセージのないユーザーは skipped にカウントされる', async () => {
+    const docClient = makeDocClientMock(['u1', 'u2']);
+    const result = await learnAllUserActivities(makeParams({ docClient }));
+    expect(result.skippedUsers).toBe(2);
+    expect(result.processedUsers).toBe(0);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('メッセージが 5 件以上のユーザーは processedUsers にカウントされる', async () => {
+    const store = new InMemorySingleTableStore();
+    tick = fixedNow;
+    const nowMs = () => tick;
+    const ulidFactory = () => `ULID-${tick++}`;
+    const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
+    const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+
+    // u1 に user ロールのメッセージを 5 件作成（fixedNow の 10 日前 = 30 日ウィンドウ内）
+    const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
+    for (let i = 0; i < 5; i++) {
+      tick = recentBase + i * 3600 * 1000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: `msg ${i}`,
+      });
+    }
+    // u2 はメッセージなし
+
+    const docClient = makeDocClientMock(['u1', 'u2']);
+    const result = await learnAllUserActivities({
+      docClient,
+      tableName: 'test',
+      messageRepo,
+      lifecycleRepo,
+      now: () => new Date(fixedNow),
+    });
+
+    expect(result.processedUsers).toBe(1);
+    expect(result.skippedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('ユーザー処理が失敗しても他のユーザーは処理継続する', async () => {
+    const { lifecycleRepo } = makeRepos();
+    const failingLifecycleRepo = {
+      ...lifecycleRepo,
+      updateUserActivityProfile: jest.fn().mockRejectedValue(new Error('DB エラー')),
+      get: jest.fn().mockResolvedValue(null),
+    };
+
+    const store = new InMemorySingleTableStore();
+    tick = fixedNow;
+    const ulidFactory = () => `ULID-${tick++}`;
+    const failingMessageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+
+    // u1 に 5 件（fixedNow の 10 日前 = 30 日ウィンドウ内）
+    const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
+    for (let i = 0; i < 5; i++) {
+      tick = recentBase + i * 3600 * 1000;
+      await failingMessageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: `msg ${i}`,
+      });
+    }
+
+    const docClient = makeDocClientMock(['u1', 'u2']);
+    const result = await learnAllUserActivities({
+      docClient,
+      tableName: 'test',
+      messageRepo: failingMessageRepo,
+      lifecycleRepo: failingLifecycleRepo as never,
+      now: () => new Date(fixedNow),
+    });
+
+    expect(result.failedUsers).toBeGreaterThanOrEqual(1);
+    expect(result.failedUserIds).toContain('u1');
+  });
+
+  it('DynamoDB の Scan がページネーションする場合も全ユーザーを取得する', async () => {
+    const { messageRepo, lifecycleRepo } = makeRepos();
+    let callCount = 0;
+    const paginatedDocClient = {
+      send: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { Items: [{ UserID: 'u1' }], LastEvaluatedKey: { PK: 'USER#u1' } };
+        }
+        return { Items: [{ UserID: 'u2' }] };
+      },
+    } as unknown as DynamoDBDocumentClient;
+
+    const result = await learnAllUserActivities({
+      docClient: paginatedDocClient,
+      tableName: 'test',
+      messageRepo,
+      lifecycleRepo,
+    });
+
+    expect(result.skippedUsers).toBe(2);
+    expect(callCount).toBe(2);
+  });
+});

--- a/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -1,8 +1,5 @@
 import { InMemorySingleTableStore } from '@nagiyu/aws';
-import {
-  InMemoryMessageRepository,
-  InMemoryLifecycleRepository,
-} from '@nagiyu/livetalk-core';
+import { InMemoryMessageRepository, InMemoryLifecycleRepository } from '@nagiyu/livetalk-core';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import {
   learnAllUserActivities,

--- a/services/livetalk/core/src/entities/lifecycle.entity.ts
+++ b/services/livetalk/core/src/entities/lifecycle.entity.ts
@@ -5,9 +5,22 @@
  *
  * Phase 4b スコープでは Bedtime / WakeUpTime をデフォルト固定で運用する。
  * ユーザーが自分でスケジュールを変更できる UI は Phase 4c 以降で実装する。
+ * Phase 4c 学習バッチで UserActivityProfile が追加される。
  */
 
 export type LifecycleState = 'awake' | 'sleeping';
+
+/** ユーザー活動時間の学習結果（Phase 4c バッチが書き込む）。 */
+export interface UserActivityProfile {
+  /** 最も活発な午前時間帯。"HH:00" 形式。 */
+  morningPeak: string;
+  /** 最も活発な夜時間帯。"HH:00" 形式。 */
+  eveningPeak: string;
+  /** 学習に使ったメッセージ数。 */
+  sampleSize: number;
+  /** 最終学習日時（ISO8601）。 */
+  lastLearnedAt: string;
+}
 
 export interface LifecycleEntity {
   UserID: string;
@@ -16,6 +29,8 @@ export interface LifecycleEntity {
   Bedtime: string;
   /** 起床時刻。"HH:mm" 形式（例: "09:30"） */
   WakeUpTime: string;
+  /** ユーザー活動時間学習結果（Phase 4c バッチが書き込むまでは undefined）。 */
+  UserActivityProfile?: UserActivityProfile;
   CreatedAt: number;
   UpdatedAt: number;
 }

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -62,13 +62,15 @@ export type {
 } from './observability/index.js';
 
 // Lifecycle
-export { resolveLifecycleState } from './lifecycle/index.js';
+export { resolveLifecycleState, buildHourlyHistogram, findPeakInRange } from './lifecycle/index.js';
+export type { HourHistogram } from './lifecycle/index.js';
 export type {
   LifecycleEntity,
   LifecycleKey,
   LifecycleState,
   CreateLifecycleInput,
   UpdateLifecycleInput,
+  UserActivityProfile,
 } from './entities/lifecycle.entity.js';
 export type { LifecycleRepository } from './repositories/lifecycle.repository.interface.js';
 export { InMemoryLifecycleRepository } from './repositories/in-memory-lifecycle.repository.js';
@@ -83,6 +85,12 @@ export {
   compressConversation,
   type CompressConversationParams,
 } from './usecases/compress-conversation.usecase.js';
+
+// Learn user activity usecase
+export {
+  learnUserActivity,
+  type LearnUserActivityParams,
+} from './usecases/learn-user-activity.usecase.js';
 
 // Entities
 export type {

--- a/services/livetalk/core/src/lifecycle/histogram.ts
+++ b/services/livetalk/core/src/lifecycle/histogram.ts
@@ -1,0 +1,60 @@
+import type { MessageEntity } from '../entities/message.entity.js';
+
+/** 時間帯別カウント配列（インデックス = 0〜23 時）。 */
+export type HourHistogram = number[];
+
+function getLocalHour(date: Date, timezone: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour: 'numeric',
+    hour12: false,
+  }).formatToParts(date);
+  const hourPart = parts.find((p) => p.type === 'hour');
+  if (!hourPart) return 0;
+  // "24" は翌日 0 時として返されることがある（Intl の実装差）
+  return parseInt(hourPart.value, 10) % 24;
+}
+
+/**
+ * メッセージの CreatedAt を指定タイムゾーンの時刻に変換し、
+ * 時間帯ごとの出現カウントを 24 要素の配列で返す。
+ */
+export function buildHourlyHistogram(
+  messages: MessageEntity[],
+  timezone = 'Asia/Tokyo'
+): HourHistogram {
+  const histogram: HourHistogram = new Array(24).fill(0) as HourHistogram;
+  for (const msg of messages) {
+    const hour = getLocalHour(new Date(msg.CreatedAt), timezone);
+    histogram[hour]++;
+  }
+  return histogram;
+}
+
+/**
+ * `fromHour`〜`toHour` の範囲でピーク時間帯を返す（wrap-around 対応）。
+ * `toHour` が 23 を超える場合は % 24 で折り返す（夜型ユーザー対応）。
+ * 同票の場合は fromHour に近い時間帯を優先する。
+ * 範囲内のカウントが全て 0 の場合は `null` を返す。
+ *
+ * @returns "HH:00" 形式、またはデータなしの場合 null
+ */
+export function findPeakInRange(
+  histogram: HourHistogram,
+  fromHour: number,
+  toHour: number
+): string | null {
+  let peakHour = -1;
+  let peakCount = 0;
+
+  for (let h = fromHour; h <= toHour; h++) {
+    const idx = h % 24;
+    if (histogram[idx] > peakCount) {
+      peakCount = histogram[idx];
+      peakHour = idx;
+    }
+  }
+
+  if (peakHour === -1) return null;
+  return `${String(peakHour).padStart(2, '0')}:00`;
+}

--- a/services/livetalk/core/src/lifecycle/index.ts
+++ b/services/livetalk/core/src/lifecycle/index.ts
@@ -1,1 +1,3 @@
 export { resolveLifecycleState } from './state-resolver.js';
+export { buildHourlyHistogram, findPeakInRange } from './histogram.js';
+export type { HourHistogram } from './histogram.js';

--- a/services/livetalk/core/src/mappers/lifecycle.mapper.ts
+++ b/services/livetalk/core/src/mappers/lifecycle.mapper.ts
@@ -4,8 +4,25 @@ import {
   type DynamoDBItem,
   type EntityMapper,
 } from '@nagiyu/aws';
-import type { LifecycleEntity, LifecycleKey } from '../entities/lifecycle.entity.js';
+import type {
+  LifecycleEntity,
+  LifecycleKey,
+  UserActivityProfile,
+} from '../entities/lifecycle.entity.js';
 import { buildLifecycleSK, buildUserPK } from './keys.js';
+
+function toUserActivityProfile(raw: unknown): UserActivityProfile {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('UserActivityProfile が不正です');
+  }
+  const obj = raw as Record<string, unknown>;
+  return {
+    morningPeak: validateStringField(obj['morningPeak'], 'UserActivityProfile.morningPeak'),
+    eveningPeak: validateStringField(obj['eveningPeak'], 'UserActivityProfile.eveningPeak'),
+    sampleSize: typeof obj['sampleSize'] === 'number' ? obj['sampleSize'] : 0,
+    lastLearnedAt: validateStringField(obj['lastLearnedAt'], 'UserActivityProfile.lastLearnedAt'),
+  };
+}
 
 export class LifecycleMapper implements EntityMapper<LifecycleEntity, LifecycleKey> {
   public readonly entityType = 'Lifecycle';
@@ -23,6 +40,9 @@ export class LifecycleMapper implements EntityMapper<LifecycleEntity, LifecycleK
       CharacterID: entity.CharacterID,
       Bedtime: entity.Bedtime,
       WakeUpTime: entity.WakeUpTime,
+      ...(entity.UserActivityProfile !== undefined && {
+        UserActivityProfile: entity.UserActivityProfile,
+      }),
       CreatedAt: entity.CreatedAt,
       UpdatedAt: entity.UpdatedAt,
     };
@@ -34,6 +54,9 @@ export class LifecycleMapper implements EntityMapper<LifecycleEntity, LifecycleK
       CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
       Bedtime: validateStringField(item.Bedtime, 'Bedtime'),
       WakeUpTime: validateStringField(item.WakeUpTime, 'WakeUpTime'),
+      ...(item.UserActivityProfile !== undefined && {
+        UserActivityProfile: toUserActivityProfile(item.UserActivityProfile),
+      }),
       CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
       UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
     };

--- a/services/livetalk/core/src/repositories/dynamodb-lifecycle.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-lifecycle.repository.ts
@@ -5,7 +5,9 @@ import type {
   LifecycleEntity,
   LifecycleKey,
   UpdateLifecycleInput,
+  UserActivityProfile,
 } from '../entities/lifecycle.entity.js';
+import { LIFECYCLE_DEFAULT_BEDTIME, LIFECYCLE_DEFAULT_WAKE_UP_TIME } from '../constants.js';
 import { LifecycleMapper } from '../mappers/lifecycle.mapper.js';
 import type { LifecycleRepository } from './lifecycle.repository.interface.js';
 
@@ -51,6 +53,35 @@ export class DynamoDBLifecycleRepository implements LifecycleRepository {
       CharacterID: input.CharacterID,
       Bedtime: updates.Bedtime ?? input.Bedtime,
       WakeUpTime: updates.WakeUpTime ?? input.WakeUpTime,
+      ...(existing?.UserActivityProfile !== undefined && {
+        UserActivityProfile: existing.UserActivityProfile,
+      }),
+      CreatedAt: existing?.CreatedAt ?? now,
+      UpdatedAt: now,
+    };
+    try {
+      await this.docClient.send(
+        new PutCommand({ TableName: this.tableName, Item: this.mapper.toItem(entity) })
+      );
+      return entity;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async updateUserActivityProfile(
+    key: LifecycleKey,
+    profile: UserActivityProfile
+  ): Promise<LifecycleEntity> {
+    const now = this.nowMs();
+    const existing = await this.get(key);
+    const entity: LifecycleEntity = {
+      UserID: key.userId,
+      CharacterID: key.characterId,
+      Bedtime: existing?.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME,
+      WakeUpTime: existing?.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME,
+      UserActivityProfile: profile,
       CreatedAt: existing?.CreatedAt ?? now,
       UpdatedAt: now,
     };

--- a/services/livetalk/core/src/repositories/in-memory-lifecycle.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-lifecycle.repository.ts
@@ -4,7 +4,9 @@ import type {
   LifecycleEntity,
   LifecycleKey,
   UpdateLifecycleInput,
+  UserActivityProfile,
 } from '../entities/lifecycle.entity.js';
+import { LIFECYCLE_DEFAULT_BEDTIME, LIFECYCLE_DEFAULT_WAKE_UP_TIME } from '../constants.js';
 import { LifecycleMapper } from '../mappers/lifecycle.mapper.js';
 import type { LifecycleRepository } from './lifecycle.repository.interface.js';
 
@@ -37,6 +39,28 @@ export class InMemoryLifecycleRepository implements LifecycleRepository {
       CharacterID: input.CharacterID,
       Bedtime: updates.Bedtime ?? input.Bedtime,
       WakeUpTime: updates.WakeUpTime ?? input.WakeUpTime,
+      ...(existing?.UserActivityProfile !== undefined && {
+        UserActivityProfile: existing.UserActivityProfile,
+      }),
+      CreatedAt: existing?.CreatedAt ?? now,
+      UpdatedAt: now,
+    };
+    this.store.put(this.mapper.toItem(entity));
+    return entity;
+  }
+
+  public async updateUserActivityProfile(
+    key: LifecycleKey,
+    profile: UserActivityProfile
+  ): Promise<LifecycleEntity> {
+    const now = this.nowMs();
+    const existing = await this.get(key);
+    const entity: LifecycleEntity = {
+      UserID: key.userId,
+      CharacterID: key.characterId,
+      Bedtime: existing?.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME,
+      WakeUpTime: existing?.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME,
+      UserActivityProfile: profile,
       CreatedAt: existing?.CreatedAt ?? now,
       UpdatedAt: now,
     };

--- a/services/livetalk/core/src/repositories/lifecycle.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/lifecycle.repository.interface.ts
@@ -3,6 +3,7 @@ import type {
   LifecycleEntity,
   LifecycleKey,
   UpdateLifecycleInput,
+  UserActivityProfile,
 } from '../entities/lifecycle.entity.js';
 
 /**
@@ -10,8 +11,17 @@ import type {
  *
  * Phase 4b では get のみ使用（デフォルト値フォールバックは usecase 層で行う）。
  * upsert は Phase 4c 以降のスケジュール設定 UI から使用する。
+ * updateUserActivityProfile は Phase 4c 学習バッチが使用する。
  */
 export interface LifecycleRepository {
   get(key: LifecycleKey): Promise<LifecycleEntity | null>;
   upsert(input: CreateLifecycleInput, updates?: UpdateLifecycleInput): Promise<LifecycleEntity>;
+  /**
+   * ユーザー活動時間プロファイルを更新する。
+   * 既存 LIFECYCLE アイテムがなければデフォルト値で新規作成する。
+   */
+  updateUserActivityProfile(
+    key: LifecycleKey,
+    profile: UserActivityProfile
+  ): Promise<LifecycleEntity>;
 }

--- a/services/livetalk/core/src/usecases/learn-user-activity.usecase.ts
+++ b/services/livetalk/core/src/usecases/learn-user-activity.usecase.ts
@@ -1,0 +1,65 @@
+import type { LifecycleRepository } from '../repositories/lifecycle.repository.interface.js';
+import type { MessageRepository } from '../repositories/message.repository.interface.js';
+import { buildHourlyHistogram, findPeakInRange } from '../lifecycle/histogram.js';
+
+const DEFAULT_MORNING_PEAK = '08:00';
+const DEFAULT_EVENING_PEAK = '21:00';
+const DEFAULT_SAMPLE_SIZE_THRESHOLD = 5;
+const DEFAULT_LOOKBACK_DAYS = 30;
+
+export interface LearnUserActivityParams {
+  messageRepo: MessageRepository;
+  lifecycleRepo: LifecycleRepository;
+  now?: () => Date;
+  /** 学習に必要な最低メッセージ数（デフォルト: 5）。 */
+  sampleSizeThreshold?: number;
+  /** 遡る日数（デフォルト: 30 日）。 */
+  lookbackDays?: number;
+  /** 時刻変換に使うタイムゾーン（デフォルト: 'Asia/Tokyo'）。 */
+  timezone?: string;
+}
+
+/**
+ * 1 ユーザー × 1 キャラの過去発話から活動時間を学習し LIFECYCLE に保存する。
+ *
+ * サンプル数が閾値未満の場合はスキップ（ノイズ防止）。
+ */
+export async function learnUserActivity(
+  userId: string,
+  characterId: string,
+  params: LearnUserActivityParams
+): Promise<'learned' | 'skipped'> {
+  const {
+    messageRepo,
+    lifecycleRepo,
+    now = () => new Date(),
+    sampleSizeThreshold = DEFAULT_SAMPLE_SIZE_THRESHOLD,
+    lookbackDays = DEFAULT_LOOKBACK_DAYS,
+    timezone = 'Asia/Tokyo',
+  } = params;
+
+  const nowDate = now();
+  const sinceMs = nowDate.getTime() - lookbackDays * 24 * 60 * 60 * 1000;
+
+  const allMessages = await messageRepo.listSince(userId, characterId, sinceMs);
+  const userMessages = allMessages.filter((m) => m.Role === 'user');
+
+  if (userMessages.length < sampleSizeThreshold) {
+    return 'skipped';
+  }
+
+  const histogram = buildHourlyHistogram(userMessages, timezone);
+
+  // morning: 5〜12 時、evening: 17〜翌 2 時（wrap-around）
+  const morningPeak = findPeakInRange(histogram, 5, 12) ?? DEFAULT_MORNING_PEAK;
+  const eveningPeak = findPeakInRange(histogram, 17, 26) ?? DEFAULT_EVENING_PEAK;
+
+  await lifecycleRepo.updateUserActivityProfile({ userId, characterId }, {
+    morningPeak,
+    eveningPeak,
+    sampleSize: userMessages.length,
+    lastLearnedAt: nowDate.toISOString(),
+  });
+
+  return 'learned';
+}

--- a/services/livetalk/core/src/usecases/learn-user-activity.usecase.ts
+++ b/services/livetalk/core/src/usecases/learn-user-activity.usecase.ts
@@ -54,12 +54,15 @@ export async function learnUserActivity(
   const morningPeak = findPeakInRange(histogram, 5, 12) ?? DEFAULT_MORNING_PEAK;
   const eveningPeak = findPeakInRange(histogram, 17, 26) ?? DEFAULT_EVENING_PEAK;
 
-  await lifecycleRepo.updateUserActivityProfile({ userId, characterId }, {
-    morningPeak,
-    eveningPeak,
-    sampleSize: userMessages.length,
-    lastLearnedAt: nowDate.toISOString(),
-  });
+  await lifecycleRepo.updateUserActivityProfile(
+    { userId, characterId },
+    {
+      morningPeak,
+      eveningPeak,
+      sampleSize: userMessages.length,
+      lastLearnedAt: nowDate.toISOString(),
+    }
+  );
 
   return 'learned';
 }

--- a/services/livetalk/core/tests/unit/lifecycle/histogram.test.ts
+++ b/services/livetalk/core/tests/unit/lifecycle/histogram.test.ts
@@ -137,7 +137,7 @@ describe('findPeakInRange', () => {
   it('morning range (5-12) のみ探索する', () => {
     const h = [...zeroHistogram];
     h[3] = 100; // 範囲外
-    h[7] = 5;   // 範囲内
+    h[7] = 5; // 範囲内
     expect(findPeakInRange(h, 5, 12)).toBe('07:00');
   });
 

--- a/services/livetalk/core/tests/unit/lifecycle/histogram.test.ts
+++ b/services/livetalk/core/tests/unit/lifecycle/histogram.test.ts
@@ -1,0 +1,149 @@
+import type { MessageEntity } from '../../../src/entities/message.entity.js';
+import { buildHourlyHistogram, findPeakInRange } from '../../../src/lifecycle/histogram.js';
+
+function makeUserMessage(createdAt: number): MessageEntity {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    MessageID: `msg-${createdAt}`,
+    Role: 'user',
+    Text: 'hello',
+    CreatedAt: createdAt,
+    UpdatedAt: createdAt,
+  };
+}
+
+// JST 2026-01-01 HH:00:00 の UTC Unix ms
+// JST = UTC+9 なので JST 8:00 = UTC -1 = 前日 23:00 UTC
+function jstHourToUtcMs(hour: number): number {
+  // 2026-01-01T00:00:00+09:00 = 2025-12-31T15:00:00Z
+  const jstEpochMs = Date.UTC(2025, 11, 31, 15, 0, 0); // JST 2026-01-01 00:00
+  return jstEpochMs + hour * 3600 * 1000;
+}
+
+describe('buildHourlyHistogram', () => {
+  it('メッセージなし → 全バケット 0', () => {
+    const result = buildHourlyHistogram([]);
+    expect(result).toHaveLength(24);
+    expect(result.every((v) => v === 0)).toBe(true);
+  });
+
+  it('JST 8 時のメッセージが bucket[8] にカウントされる', () => {
+    const msg = makeUserMessage(jstHourToUtcMs(8));
+    const result = buildHourlyHistogram([msg]);
+    expect(result[8]).toBe(1);
+    const others = result.filter((_, i) => i !== 8);
+    expect(others.every((v) => v === 0)).toBe(true);
+  });
+
+  it('JST 0 時のメッセージが bucket[0] にカウントされる', () => {
+    const msg = makeUserMessage(jstHourToUtcMs(0));
+    const result = buildHourlyHistogram([msg]);
+    expect(result[0]).toBe(1);
+  });
+
+  it('JST 23 時のメッセージが bucket[23] にカウントされる', () => {
+    const msg = makeUserMessage(jstHourToUtcMs(23));
+    const result = buildHourlyHistogram([msg]);
+    expect(result[23]).toBe(1);
+  });
+
+  it('複数メッセージが同じ時間帯に集まる', () => {
+    const msgs = [
+      makeUserMessage(jstHourToUtcMs(21)),
+      makeUserMessage(jstHourToUtcMs(21) + 1800000),
+      makeUserMessage(jstHourToUtcMs(21) + 3000000),
+    ];
+    const result = buildHourlyHistogram(msgs);
+    expect(result[21]).toBe(3);
+  });
+
+  it('複数の時間帯に分散する', () => {
+    const msgs = [
+      makeUserMessage(jstHourToUtcMs(8)),
+      makeUserMessage(jstHourToUtcMs(9)),
+      makeUserMessage(jstHourToUtcMs(21)),
+    ];
+    const result = buildHourlyHistogram(msgs);
+    expect(result[8]).toBe(1);
+    expect(result[9]).toBe(1);
+    expect(result[21]).toBe(1);
+    expect(result[0]).toBe(0);
+  });
+
+  it('配列は必ず長さ 24', () => {
+    const msgs = Array.from({ length: 10 }, (_, i) => makeUserMessage(jstHourToUtcMs(i)));
+    const result = buildHourlyHistogram(msgs);
+    expect(result).toHaveLength(24);
+  });
+
+  it('UTC タイムゾーンを指定するとバケットが変わる', () => {
+    // JST 8:00 = UTC 23:00 (前日)
+    const jst8 = jstHourToUtcMs(8);
+    const jstResult = buildHourlyHistogram([makeUserMessage(jst8)], 'Asia/Tokyo');
+    const utcResult = buildHourlyHistogram([makeUserMessage(jst8)], 'UTC');
+    expect(jstResult[8]).toBe(1);
+    expect(utcResult[23]).toBe(1);
+  });
+});
+
+describe('findPeakInRange', () => {
+  const zeroHistogram = new Array(24).fill(0) as number[];
+
+  it('全て 0 のヒストグラムでは null を返す', () => {
+    expect(findPeakInRange(zeroHistogram, 5, 12)).toBeNull();
+  });
+
+  it('範囲内の最大値の時間帯を返す', () => {
+    const h = [...zeroHistogram];
+    h[8] = 5;
+    h[10] = 3;
+    expect(findPeakInRange(h, 5, 12)).toBe('08:00');
+  });
+
+  it('"HH:00" 形式で返す（1 桁の時は 0 埋め）', () => {
+    const h = [...zeroHistogram];
+    h[5] = 1;
+    expect(findPeakInRange(h, 5, 12)).toBe('05:00');
+  });
+
+  it('2 桁の時間帯も正しくフォーマットする', () => {
+    const h = [...zeroHistogram];
+    h[21] = 3;
+    expect(findPeakInRange(h, 17, 23)).toBe('21:00');
+  });
+
+  it('同票の場合は fromHour に近い（先の）時間帯を返す', () => {
+    const h = [...zeroHistogram];
+    h[8] = 2;
+    h[10] = 2;
+    expect(findPeakInRange(h, 5, 12)).toBe('08:00');
+  });
+
+  it('wrap-around: toHour=26 で bucket[0]〜[2] も探索する', () => {
+    const h = [...zeroHistogram];
+    h[1] = 5; // 翌 1 時
+    h[20] = 3;
+    expect(findPeakInRange(h, 17, 26)).toBe('01:00');
+  });
+
+  it('wrap-around: 夜 23 時のピーク', () => {
+    const h = [...zeroHistogram];
+    h[23] = 4;
+    h[0] = 2;
+    expect(findPeakInRange(h, 17, 26)).toBe('23:00');
+  });
+
+  it('morning range (5-12) のみ探索する', () => {
+    const h = [...zeroHistogram];
+    h[3] = 100; // 範囲外
+    h[7] = 5;   // 範囲内
+    expect(findPeakInRange(h, 5, 12)).toBe('07:00');
+  });
+
+  it('範囲が 1 時間のみでも動作する', () => {
+    const h = [...zeroHistogram];
+    h[8] = 1;
+    expect(findPeakInRange(h, 8, 8)).toBe('08:00');
+  });
+});

--- a/services/livetalk/core/tests/unit/mappers/lifecycle.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/lifecycle.mapper.test.ts
@@ -19,14 +19,42 @@ describe('LifecycleMapper', () => {
     });
   });
 
-  it('toItem / toEntity は roundtrip する', () => {
+  it('toItem / toEntity は roundtrip する（UserActivityProfile なし）', () => {
     const item = mapper.toItem(baseEntity);
     expect(item.PK).toBe('USER#google-12345');
     expect(item.SK).toBe('CHAR#hiyori#LIFECYCLE');
     expect(item.Type).toBe('Lifecycle');
     expect(item.Bedtime).toBe('01:30');
     expect(item.WakeUpTime).toBe('09:30');
+    expect(item.UserActivityProfile).toBeUndefined();
     expect(mapper.toEntity(item)).toEqual(baseEntity);
+  });
+
+  it('UserActivityProfile を含む entity が roundtrip する', () => {
+    const entityWithProfile: LifecycleEntity = {
+      ...baseEntity,
+      UserActivityProfile: {
+        morningPeak: '08:00',
+        eveningPeak: '21:00',
+        sampleSize: 42,
+        lastLearnedAt: '2026-06-01T00:00:00.000Z',
+      },
+    };
+    const item = mapper.toItem(entityWithProfile);
+    expect(item.UserActivityProfile).toEqual({
+      morningPeak: '08:00',
+      eveningPeak: '21:00',
+      sampleSize: 42,
+      lastLearnedAt: '2026-06-01T00:00:00.000Z',
+    });
+    const restored = mapper.toEntity(item);
+    expect(restored).toEqual(entityWithProfile);
+  });
+
+  it('DynamoDB に UserActivityProfile がない場合は entity に含まれない', () => {
+    const item = mapper.toItem(baseEntity);
+    const entity = mapper.toEntity(item);
+    expect(entity.UserActivityProfile).toBeUndefined();
   });
 
   it('entityType は "Lifecycle"', () => {

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-lifecycle.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-lifecycle.repository.test.ts
@@ -109,4 +109,69 @@ describe('DynamoDBLifecycleRepository', () => {
       repo.upsert({ UserID: 'u1', CharacterID: 'hiyori', Bedtime: '01:30', WakeUpTime: '09:30' })
     ).rejects.toBeInstanceOf(DatabaseError);
   });
+
+  describe('updateUserActivityProfile', () => {
+    const profile = {
+      morningPeak: '08:00',
+      eveningPeak: '21:00',
+      sampleSize: 10,
+      lastLearnedAt: '2026-06-01T00:00:00.000Z',
+    };
+
+    it('既存なしの場合はデフォルト値で PutCommand を送る', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        if (cmd instanceof GetCommand) return { Item: undefined };
+        return {};
+      });
+      const repo = new DynamoDBLifecycleRepository(client as never, tableName, () => now);
+      const result = await repo.updateUserActivityProfile(
+        { userId: 'u1', characterId: 'hiyori' },
+        profile
+      );
+      expect(result.UserActivityProfile).toEqual(profile);
+      expect(result.CreatedAt).toBe(now);
+      const put = (sent[1] as PutCommand).input;
+      expect(put.Item?.UserActivityProfile).toEqual(profile);
+    });
+
+    it('既存ありの場合は Bedtime/WakeUpTime を保持する', async () => {
+      const existing = {
+        PK: 'USER#u1',
+        SK: 'CHAR#hiyori#LIFECYCLE',
+        Type: 'Lifecycle',
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Bedtime: '02:00',
+        WakeUpTime: '10:00',
+        CreatedAt: 1_600_000_000_000,
+        UpdatedAt: now - 5000,
+      };
+      const client = makeClient(async (cmd) => {
+        if (cmd instanceof GetCommand) return { Item: existing };
+        return {};
+      });
+      const repo = new DynamoDBLifecycleRepository(client as never, tableName, () => now);
+      const result = await repo.updateUserActivityProfile(
+        { userId: 'u1', characterId: 'hiyori' },
+        profile
+      );
+      expect(result.Bedtime).toBe('02:00');
+      expect(result.WakeUpTime).toBe('10:00');
+      expect(result.CreatedAt).toBe(1_600_000_000_000);
+      expect(result.UserActivityProfile).toEqual(profile);
+    });
+
+    it('Put エラーは DatabaseError でラップする', async () => {
+      const client = makeClient(async (cmd) => {
+        if (cmd instanceof GetCommand) return { Item: undefined };
+        throw new Error('put failure');
+      });
+      const repo = new DynamoDBLifecycleRepository(client as never, tableName, () => now);
+      await expect(
+        repo.updateUserActivityProfile({ userId: 'u1', characterId: 'hiyori' }, profile)
+      ).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-lifecycle.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-lifecycle.repository.test.ts
@@ -148,10 +148,7 @@ describe('InMemoryLifecycleRepository', () => {
       await repo.updateUserActivityProfile({ userId: 'u1', characterId: 'hiyori' }, profile);
       const profile2 = { ...profile, sampleSize: 99, morningPeak: '07:00' };
       now += 1000;
-      await repo.updateUserActivityProfile(
-        { userId: 'u1', characterId: 'hiyori' },
-        profile2
-      );
+      await repo.updateUserActivityProfile({ userId: 'u1', characterId: 'hiyori' }, profile2);
 
       const fetched = await repo.get({ userId: 'u1', characterId: 'hiyori' });
       expect(fetched?.UserActivityProfile?.sampleSize).toBe(99);

--- a/services/livetalk/core/tests/unit/repositories/in-memory-lifecycle.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-lifecycle.repository.test.ts
@@ -104,4 +104,70 @@ describe('InMemoryLifecycleRepository', () => {
     expect(r1?.Bedtime).toBe('01:30');
     expect(r2?.Bedtime).toBe('00:00');
   });
+
+  describe('updateUserActivityProfile', () => {
+    const profile = {
+      morningPeak: '08:00',
+      eveningPeak: '21:00',
+      sampleSize: 10,
+      lastLearnedAt: '2026-06-01T00:00:00.000Z',
+    };
+
+    it('既存なしの場合はデフォルト Bedtime/WakeUpTime で新規作成する', async () => {
+      const result = await repo.updateUserActivityProfile(
+        { userId: 'u1', characterId: 'hiyori' },
+        profile
+      );
+      expect(result.UserActivityProfile).toEqual(profile);
+      expect(result.Bedtime).toBeDefined();
+      expect(result.WakeUpTime).toBeDefined();
+
+      const fetched = await repo.get({ userId: 'u1', characterId: 'hiyori' });
+      expect(fetched?.UserActivityProfile).toEqual(profile);
+    });
+
+    it('既存ありの場合は Bedtime/WakeUpTime を保持する', async () => {
+      await repo.upsert({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Bedtime: '02:00',
+        WakeUpTime: '10:00',
+      });
+
+      now += 1000;
+      const result = await repo.updateUserActivityProfile(
+        { userId: 'u1', characterId: 'hiyori' },
+        profile
+      );
+      expect(result.Bedtime).toBe('02:00');
+      expect(result.WakeUpTime).toBe('10:00');
+      expect(result.UserActivityProfile).toEqual(profile);
+    });
+
+    it('二度呼ぶと最新プロファイルで上書きされる', async () => {
+      await repo.updateUserActivityProfile({ userId: 'u1', characterId: 'hiyori' }, profile);
+      const profile2 = { ...profile, sampleSize: 99, morningPeak: '07:00' };
+      now += 1000;
+      await repo.updateUserActivityProfile(
+        { userId: 'u1', characterId: 'hiyori' },
+        profile2
+      );
+
+      const fetched = await repo.get({ userId: 'u1', characterId: 'hiyori' });
+      expect(fetched?.UserActivityProfile?.sampleSize).toBe(99);
+      expect(fetched?.UserActivityProfile?.morningPeak).toBe('07:00');
+    });
+
+    it('upsert で UserActivityProfile が保持される', async () => {
+      await repo.updateUserActivityProfile({ userId: 'u1', characterId: 'hiyori' }, profile);
+      now += 1000;
+      await repo.upsert(
+        { UserID: 'u1', CharacterID: 'hiyori', Bedtime: '02:00', WakeUpTime: '10:00' },
+        { Bedtime: '02:00' }
+      );
+
+      const fetched = await repo.get({ userId: 'u1', characterId: 'hiyori' });
+      expect(fetched?.UserActivityProfile).toEqual(profile);
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -1,0 +1,236 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryMessageRepository } from '../../../src/repositories/in-memory-message.repository.js';
+import { InMemoryLifecycleRepository } from '../../../src/repositories/in-memory-lifecycle.repository.js';
+import { learnUserActivity } from '../../../src/usecases/learn-user-activity.usecase.js';
+
+const BASE_NOW_MS = 1_750_000_000_000;
+// JST 2026-01-01 21:00:00 相当（UTC 12:00）
+const JST_21_UTC_MS = Date.UTC(2026, 0, 1, 12, 0, 0);
+
+let tick = BASE_NOW_MS;
+
+const makeStore = () => {
+  tick = BASE_NOW_MS;
+  const store = new InMemorySingleTableStore();
+  return store;
+};
+
+const makeMessageRepo = (store: InMemorySingleTableStore) => {
+  const ulidFactory = () => `ULID-${tick++}`;
+  return new InMemoryMessageRepository(store, ulidFactory, () => tick);
+};
+
+const makeLifecycleRepo = (store: InMemorySingleTableStore) =>
+  new InMemoryLifecycleRepository(store, () => tick);
+
+// JST HH:00 のメッセージをN件作成（CreatedAt は UTC ms）
+function makeJstMessages(store: InMemorySingleTableStore, jstHour: number, count: number) {
+  const ulidFactory = () => `ULID-${tick++}`;
+  const messageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+  const utcBase = Date.UTC(2025, 11, 31, 15, 0, 0) + jstHour * 3600 * 1000; // JST 0:00 UTC + offset
+  const msgs: Promise<unknown>[] = [];
+  for (let i = 0; i < count; i++) {
+    tick = utcBase + i * 60000;
+    msgs.push(
+      messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: `msg ${i}`,
+      })
+    );
+  }
+  return Promise.all(msgs);
+}
+
+describe('learnUserActivity', () => {
+  it('サンプル数が閾値未満の場合は skipped を返す', async () => {
+    const store = makeStore();
+    const messageRepo = makeMessageRepo(store);
+    const lifecycleRepo = makeLifecycleRepo(store);
+
+    // 4 件（閾値 5 未満）
+    for (let i = 0; i < 4; i++) {
+      tick = BASE_NOW_MS + i * 1000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: 'hi',
+      });
+    }
+
+    const result = await learnUserActivity('u1', 'hiyori', {
+      messageRepo,
+      lifecycleRepo,
+      now: () => new Date(BASE_NOW_MS),
+    });
+
+    expect(result).toBe('skipped');
+    const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
+    expect(lc).toBeNull();
+  });
+
+  it('role=assistant のメッセージはカウントしない', async () => {
+    const store = makeStore();
+    const ulidFactory = () => `ULID-${tick++}`;
+    const messageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+    const lifecycleRepo = makeLifecycleRepo(store);
+
+    // assistant を 10 件、user を 3 件
+    for (let i = 0; i < 10; i++) {
+      tick = BASE_NOW_MS + i * 1000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'assistant',
+        Text: 'hello',
+      });
+    }
+    for (let i = 0; i < 3; i++) {
+      tick = BASE_NOW_MS + 10000 + i * 1000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: 'user msg',
+      });
+    }
+
+    const result = await learnUserActivity('u1', 'hiyori', {
+      messageRepo,
+      lifecycleRepo,
+      now: () => new Date(BASE_NOW_MS + 20000),
+    });
+
+    expect(result).toBe('skipped');
+  });
+
+  it('サンプル充足時に learned を返し userActivityProfile を保存する', async () => {
+    const store = makeStore();
+    const lifecycleRepo = makeLifecycleRepo(store);
+
+    // JST 21 時に 5 件（evening peak）
+    await makeJstMessages(store, 21, 5);
+
+    const nowDate = new Date(JST_21_UTC_MS + 100 * 24 * 3600 * 1000);
+    const result = await learnUserActivity('u1', 'hiyori', {
+      messageRepo: makeMessageRepo(store),
+      lifecycleRepo,
+      now: () => nowDate,
+      sampleSizeThreshold: 5,
+      lookbackDays: 200,
+    });
+
+    expect(result).toBe('learned');
+    const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
+    expect(lc?.UserActivityProfile).toBeDefined();
+    expect(lc?.UserActivityProfile?.eveningPeak).toBe('21:00');
+    expect(lc?.UserActivityProfile?.sampleSize).toBe(5);
+    expect(lc?.UserActivityProfile?.lastLearnedAt).toBe(nowDate.toISOString());
+  });
+
+  it('morning peak が 5〜12 の範囲で推定される', async () => {
+    const store = makeStore();
+    const lifecycleRepo = makeLifecycleRepo(store);
+
+    // JST 8 時に 6 件（morning peak）
+    await makeJstMessages(store, 8, 6);
+
+    const nowDate = new Date(JST_21_UTC_MS + 100 * 24 * 3600 * 1000);
+    await learnUserActivity('u1', 'hiyori', {
+      messageRepo: makeMessageRepo(store),
+      lifecycleRepo,
+      now: () => nowDate,
+      lookbackDays: 200,
+    });
+
+    const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
+    expect(lc?.UserActivityProfile?.morningPeak).toBe('08:00');
+  });
+
+  it('範囲内データなしの場合はデフォルト値（08:00 / 21:00）にフォールバックする', async () => {
+    const store = makeStore();
+    const ulidFactory = () => `ULID-${tick++}`;
+    const messageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+    const lifecycleRepo = makeLifecycleRepo(store);
+
+    // JST 14 時のみ（morning/evening どちらの範囲にも入らない）
+    const utc14 = Date.UTC(2025, 11, 31, 5, 0, 0); // JST 14:00 = UTC 05:00
+    for (let i = 0; i < 5; i++) {
+      tick = utc14 + i * 60000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: `msg ${i}`,
+      });
+    }
+
+    const nowDate = new Date(utc14 + 100 * 24 * 3600 * 1000);
+    await learnUserActivity('u1', 'hiyori', {
+      messageRepo,
+      lifecycleRepo,
+      now: () => nowDate,
+      lookbackDays: 200,
+    });
+
+    const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
+    expect(lc?.UserActivityProfile?.morningPeak).toBe('08:00');
+    expect(lc?.UserActivityProfile?.eveningPeak).toBe('21:00');
+  });
+
+  it('既存 LIFECYCLE の Bedtime/WakeUpTime は保持される', async () => {
+    const store = makeStore();
+    const lifecycleRepo = makeLifecycleRepo(store);
+
+    tick = BASE_NOW_MS;
+    await lifecycleRepo.upsert({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Bedtime: '02:00',
+      WakeUpTime: '10:00',
+    });
+
+    await makeJstMessages(store, 21, 5);
+
+    const nowDate = new Date(JST_21_UTC_MS + 100 * 24 * 3600 * 1000);
+    await learnUserActivity('u1', 'hiyori', {
+      messageRepo: makeMessageRepo(store),
+      lifecycleRepo,
+      now: () => nowDate,
+      lookbackDays: 200,
+    });
+
+    const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
+    expect(lc?.Bedtime).toBe('02:00');
+    expect(lc?.WakeUpTime).toBe('10:00');
+  });
+
+  it('lookbackDays 外のメッセージはカウントされない', async () => {
+    const store = makeStore();
+    const ulidFactory = () => `ULID-${tick++}`;
+    const messageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+    const lifecycleRepo = makeLifecycleRepo(store);
+
+    const oldMs = BASE_NOW_MS - 60 * 24 * 3600 * 1000; // 60 日前
+    for (let i = 0; i < 5; i++) {
+      tick = oldMs + i * 1000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: 'old msg',
+      });
+    }
+
+    const result = await learnUserActivity('u1', 'hiyori', {
+      messageRepo,
+      lifecycleRepo,
+      now: () => new Date(BASE_NOW_MS),
+      lookbackDays: 30, // 30 日以内のみ
+    });
+
+    expect(result).toBe('skipped');
+  });
+});


### PR DESCRIPTION
## 変更の概要

Issue #3329「ユーザー活動時間の学習バッチ（独立 Lambda）」の実装。

ユーザーの過去 30 日間の発話タイムスタンプから JST 時刻ヒストグラムを生成し、  
morning peak（5〜12 時）/ evening peak（17〜翌 2 時）を推定して  
`LIFECYCLE.userActivityProfile` に保存する独立バッチ Lambda。

**主要な変更:**

- `LifecycleEntity` に `UserActivityProfile?`（morningPeak/eveningPeak/sampleSize/lastLearnedAt）を追加
- `lifecycle/histogram.ts` 新規: `buildHourlyHistogram`（Intl.DateTimeFormat で JST 変換）+ `findPeakInRange`（wrap-around 対応）
- `LifecycleRepository` に `updateUserActivityProfile` メソッドを追加（DynamoDB / InMemory 両実装）
- `core/usecases/learn-user-activity.usecase.ts` 新規: サンプル不足（デフォルト 5 件未満）はスキップ
- `batch/handlers/learn-user-activity.ts` / `batch/usecases/learn-user-activity.usecase.ts` 新規: 全ユーザー Scan → core usecase 呼び出し
- `infra/livetalk/lib/batch-stack.ts` 拡張: 独立 Lambda + DLQ + IAM Role + 週次 EventBridge Rule（JST 日曜 03:00）
- `.github/workflows/livetalk-deploy.yml`: `update-function-code` を新 Lambda にも適用

## 関連 Issue

#3329（本 PR は integration → develop の PR ではないため Closes は付けない）

## 変更種別

- [x] 新規機能
- [x] インフラ更新
- [x] CI/CD 更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ 80% 以上を確保）
- [ ] 関連ドキュメントを更新した（tasks/livetalk/design.md の userActivityProfile スキーマは Issue #3329 本文に合わせ sampleSize / lastLearnedAt を追加済み）
- [x] CI/CD 設定を追加・更新した
- [x] ローカルでテストが全て通ることを確認した（core: 616 件、batch: 18 件）
- [x] ビルドエラーがないことを確認した

## テスト内容

### core

| ファイル | 内容 |
|---|---|
| `lifecycle/histogram.test.ts` | 全バケット 0・特定時刻カウント・wrap-around・TZ 差異・同票優先順 等を網羅 |
| `usecases/learn-user-activity.usecase.test.ts` | サンプル不足スキップ・role フィルタ・ピーク保存・デフォルトフォールバック・ルックバック窓 |
| `mappers/lifecycle.mapper.test.ts` | UserActivityProfile roundtrip・フィールド欠落時の動作 |
| `repositories/in-memory-lifecycle.repository.test.ts` | updateUserActivityProfile（新規作成・既存保持・upsert 時プロファイル維持） |
| `repositories/dynamodb-lifecycle.repository.test.ts` | updateUserActivityProfile（DynamoDB PutCommand・既存 Bedtime 保持・エラーラップ） |

### batch

| ファイル | 内容 |
|---|---|
| `handlers/learn-user-activity.test.ts` | 200 正常系・500 異常系・reportErrorEvent 呼び出し確認 |
| `usecases/learn-user-activity.usecase.test.ts` | 0 件・skipped・processed・失敗継続・ページネーション |

## レビューポイント

- `findPeakInRange` の wrap-around 実装（`h % 24`、`toHour=26` で [1]・[2] を探索）
- `upsert` 時に既存 `UserActivityProfile` を保持するよう修正（既存 Bedtime 上書き時にプロファイルが消えないようにした）
- EventBridge cron `weekDay: 'SAT'` の指定が `cron(0 18 ? * SAT *)` に正しくマッピングされるか CDK 側の確認

## 補足事項

- 同一 Docker image 内に `learn-user-activity.handler` エントリポイントを追加（CDK `cmd` で切り替え）
- OpenAI API キーは学習バッチ側の Lambda 環境変数に含めない（DynamoDB read/write + CloudWatch のみ）
- `TZ=Asia/Tokyo` は Lambda 環境変数に設定するが、ヒストグラム計算自体は `Intl.DateTimeFormat` で明示指定しており Lambda TZ 環境変数に依存しない

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgDB1rpeCSHCSH1QoXVs8e)_