### PR TITLE
[Phase 4d] 生活サイクルのユーザー適応（Issue #3330）

### DIFF
--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -62,8 +62,17 @@ export type {
 } from './observability/index.js';
 
 // Lifecycle
-export { resolveLifecycleState, buildHourlyHistogram, findPeakInRange } from './lifecycle/index.js';
-export type { HourHistogram } from './lifecycle/index.js';
+export {
+  resolveLifecycleState,
+  buildHourlyHistogram,
+  findPeakInRange,
+  adaptCharacterSchedule,
+  parseTimeToMinutes,
+  formatMinutesToTime,
+  smoothTime,
+  clampTime,
+} from './lifecycle/index.js';
+export type { HourHistogram, AdaptationOptions } from './lifecycle/index.js';
 export type {
   LifecycleEntity,
   LifecycleKey,

--- a/services/livetalk/core/src/lifecycle/adaptation.ts
+++ b/services/livetalk/core/src/lifecycle/adaptation.ts
@@ -1,0 +1,69 @@
+import type { UserActivityProfile } from '../entities/lifecycle.entity.js';
+import { parseTimeToMinutes, formatMinutesToTime, smoothTime, clampTime } from './time-utils.js';
+
+export interface AdaptationOptions {
+  offsetHours: {
+    /** wakeUpTime = morningPeak - wakeUp 時間（キャラはユーザーより早めに起きる）*/
+    wakeUp: number;
+    /** bedtime = eveningPeak + bedtime 時間（キャラはユーザーより遅めに寝る）*/
+    bedtime: number;
+  };
+  /** smoothing 係数。new = current * (1 - α) + target * α */
+  smoothing: number;
+}
+
+const DEFAULT_ADAPTATION_OPTIONS: AdaptationOptions = {
+  offsetHours: { wakeUp: 1, bedtime: 1.5 },
+  smoothing: 0.3,
+};
+
+// wakeUpTime クランプ範囲: 05:00〜12:00
+const WAKE_UP_CLAMP_MIN = 5 * 60; // 300
+const WAKE_UP_CLAMP_MAX = 12 * 60; // 720
+
+// bedtime クランプ範囲: 21:00〜翌04:00（0時跨ぎ）
+const BEDTIME_CLAMP_MIN = 21 * 60; // 1260
+const BEDTIME_CLAMP_MAX = 4 * 60; // 240
+
+/**
+ * ユーザー活動プロファイルを元に、キャラの就寝/起床時刻を緩やかに適応させる。
+ *
+ * - 完全同期はせず offsetHours 分ズラして独立した存在感を保つ
+ * - smoothing で急激な変化を防ぐ（移動平均的に shift）
+ * - userProfile が未学習（null/undefined）の場合は current をそのまま返す
+ */
+export function adaptCharacterSchedule(
+  current: { bedtime: string; wakeUpTime: string },
+  userProfile: UserActivityProfile | undefined | null,
+  options: AdaptationOptions = DEFAULT_ADAPTATION_OPTIONS
+): { bedtime: string; wakeUpTime: string } {
+  if (!userProfile) {
+    return current;
+  }
+
+  const currentWakeUp = parseTimeToMinutes(current.wakeUpTime);
+  const currentBedtime = parseTimeToMinutes(current.bedtime);
+
+  const morningPeakMin = parseTimeToMinutes(userProfile.morningPeak);
+  const eveningPeakMin = parseTimeToMinutes(userProfile.eveningPeak);
+
+  const targetWakeUp = ((morningPeakMin - options.offsetHours.wakeUp * 60) % 1440 + 1440) % 1440;
+  const targetBedtime = (eveningPeakMin + options.offsetHours.bedtime * 60) % 1440;
+
+  // 移動平均で緩やかに shift（clamp は smooth 後に適用）
+  const newWakeUp = clampTime(
+    smoothTime(currentWakeUp, targetWakeUp, options.smoothing),
+    WAKE_UP_CLAMP_MIN,
+    WAKE_UP_CLAMP_MAX
+  );
+  const newBedtime = clampTime(
+    smoothTime(currentBedtime, targetBedtime, options.smoothing),
+    BEDTIME_CLAMP_MIN,
+    BEDTIME_CLAMP_MAX
+  );
+
+  return {
+    bedtime: formatMinutesToTime(newBedtime),
+    wakeUpTime: formatMinutesToTime(newWakeUp),
+  };
+}

--- a/services/livetalk/core/src/lifecycle/adaptation.ts
+++ b/services/livetalk/core/src/lifecycle/adaptation.ts
@@ -47,7 +47,7 @@ export function adaptCharacterSchedule(
   const morningPeakMin = parseTimeToMinutes(userProfile.morningPeak);
   const eveningPeakMin = parseTimeToMinutes(userProfile.eveningPeak);
 
-  const targetWakeUp = ((morningPeakMin - options.offsetHours.wakeUp * 60) % 1440 + 1440) % 1440;
+  const targetWakeUp = (((morningPeakMin - options.offsetHours.wakeUp * 60) % 1440) + 1440) % 1440;
   const targetBedtime = (eveningPeakMin + options.offsetHours.bedtime * 60) % 1440;
 
   // 移動平均で緩やかに shift（clamp は smooth 後に適用）

--- a/services/livetalk/core/src/lifecycle/index.ts
+++ b/services/livetalk/core/src/lifecycle/index.ts
@@ -1,3 +1,6 @@
 export { resolveLifecycleState } from './state-resolver.js';
 export { buildHourlyHistogram, findPeakInRange } from './histogram.js';
 export type { HourHistogram } from './histogram.js';
+export { adaptCharacterSchedule } from './adaptation.js';
+export type { AdaptationOptions } from './adaptation.js';
+export { parseTimeToMinutes, formatMinutesToTime, smoothTime, clampTime } from './time-utils.js';

--- a/services/livetalk/core/src/lifecycle/time-utils.ts
+++ b/services/livetalk/core/src/lifecycle/time-utils.ts
@@ -1,7 +1,7 @@
 /** "HH:mm" → 0〜1439 の分数に変換する */
 export function parseTimeToMinutes(hhmm: string): number {
   const [h, m] = hhmm.split(':').map(Number);
-  return ((h * 60 + m) % 1440 + 1440) % 1440;
+  return (((h * 60 + m) % 1440) + 1440) % 1440;
 }
 
 /** 0〜1439 の分数（mod 1440 自動適用）を "HH:mm" に変換する */
@@ -22,7 +22,7 @@ export function smoothTime(currentMinutes: number, targetMinutes: number, alpha:
   let diff = targetMinutes - currentMinutes;
   if (diff > 720) diff -= 1440;
   if (diff < -720) diff += 1440;
-  return ((currentMinutes + alpha * diff) % 1440 + 1440) % 1440;
+  return (((currentMinutes + alpha * diff) % 1440) + 1440) % 1440;
 }
 
 /**

--- a/services/livetalk/core/src/lifecycle/time-utils.ts
+++ b/services/livetalk/core/src/lifecycle/time-utils.ts
@@ -1,0 +1,49 @@
+/** "HH:mm" → 0〜1439 の分数に変換する */
+export function parseTimeToMinutes(hhmm: string): number {
+  const [h, m] = hhmm.split(':').map(Number);
+  return ((h * 60 + m) % 1440 + 1440) % 1440;
+}
+
+/** 0〜1439 の分数（mod 1440 自動適用）を "HH:mm" に変換する */
+export function formatMinutesToTime(minutes: number): string {
+  const normalized = ((minutes % 1440) + 1440) % 1440;
+  const h = Math.floor(normalized / 60);
+  const m = Math.round(normalized % 60);
+  const hh = m === 60 ? (h + 1) % 24 : h;
+  const mm = m === 60 ? 0 : m;
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+}
+
+/**
+ * 円環（24h）上で currentMinutes から targetMinutes へ alpha 割合で移動する。
+ * 最短経路（max 720 分）を使うため、0時跨ぎでも正しく補間できる。
+ */
+export function smoothTime(currentMinutes: number, targetMinutes: number, alpha: number): number {
+  let diff = targetMinutes - currentMinutes;
+  if (diff > 720) diff -= 1440;
+  if (diff < -720) diff += 1440;
+  return ((currentMinutes + alpha * diff) % 1440 + 1440) % 1440;
+}
+
+/**
+ * 時刻（分）を [minMinutes, maxMinutes] にクランプする。
+ * minMinutes <= maxMinutes: 通常範囲。
+ * minMinutes > maxMinutes: 0時跨ぎ範囲（例: 21:00〜翌04:00 = [1260, 240]）。
+ */
+export function clampTime(minutes: number, minMinutes: number, maxMinutes: number): number {
+  const normalized = ((minutes % 1440) + 1440) % 1440;
+
+  if (minMinutes <= maxMinutes) {
+    return Math.max(minMinutes, Math.min(maxMinutes, normalized));
+  }
+
+  // 跨ぎ範囲: 有効ゾーンは [minMinutes, 1439] ∪ [0, maxMinutes]
+  if (normalized >= minMinutes || normalized <= maxMinutes) {
+    return normalized;
+  }
+
+  // 範囲外（maxMinutes < normalized < minMinutes）→ 最近傍境界へ
+  const distToMin = minMinutes - normalized; // 前方距離
+  const distToMax = normalized - maxMinutes; // 後方距離
+  return distToMin <= distToMax ? minMinutes : maxMinutes;
+}

--- a/services/livetalk/core/src/repositories/dynamodb-lifecycle.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-lifecycle.repository.ts
@@ -95,4 +95,32 @@ export class DynamoDBLifecycleRepository implements LifecycleRepository {
       throw new DatabaseError(message, error instanceof Error ? error : undefined);
     }
   }
+
+  public async updateSchedule(
+    key: LifecycleKey,
+    schedule: { bedtime: string; wakeUpTime: string }
+  ): Promise<LifecycleEntity> {
+    const now = this.nowMs();
+    const existing = await this.get(key);
+    const entity: LifecycleEntity = {
+      UserID: key.userId,
+      CharacterID: key.characterId,
+      Bedtime: schedule.bedtime,
+      WakeUpTime: schedule.wakeUpTime,
+      ...(existing?.UserActivityProfile !== undefined && {
+        UserActivityProfile: existing.UserActivityProfile,
+      }),
+      CreatedAt: existing?.CreatedAt ?? now,
+      UpdatedAt: now,
+    };
+    try {
+      await this.docClient.send(
+        new PutCommand({ TableName: this.tableName, Item: this.mapper.toItem(entity) })
+      );
+      return entity;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
 }

--- a/services/livetalk/core/src/repositories/in-memory-lifecycle.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-lifecycle.repository.ts
@@ -67,4 +67,25 @@ export class InMemoryLifecycleRepository implements LifecycleRepository {
     this.store.put(this.mapper.toItem(entity));
     return entity;
   }
+
+  public async updateSchedule(
+    key: LifecycleKey,
+    schedule: { bedtime: string; wakeUpTime: string }
+  ): Promise<LifecycleEntity> {
+    const now = this.nowMs();
+    const existing = await this.get(key);
+    const entity: LifecycleEntity = {
+      UserID: key.userId,
+      CharacterID: key.characterId,
+      Bedtime: schedule.bedtime,
+      WakeUpTime: schedule.wakeUpTime,
+      ...(existing?.UserActivityProfile !== undefined && {
+        UserActivityProfile: existing.UserActivityProfile,
+      }),
+      CreatedAt: existing?.CreatedAt ?? now,
+      UpdatedAt: now,
+    };
+    this.store.put(this.mapper.toItem(entity));
+    return entity;
+  }
 }

--- a/services/livetalk/core/src/repositories/lifecycle.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/lifecycle.repository.interface.ts
@@ -24,4 +24,14 @@ export interface LifecycleRepository {
     key: LifecycleKey,
     profile: UserActivityProfile
   ): Promise<LifecycleEntity>;
+
+  /**
+   * キャラの就寝/起床スケジュールを更新する（Phase 4d 適応バッチが使用）。
+   * 既存の UserActivityProfile は保持する。
+   * 既存 LIFECYCLE アイテムがなければデフォルト値で新規作成する。
+   */
+  updateSchedule(
+    key: LifecycleKey,
+    schedule: { bedtime: string; wakeUpTime: string }
+  ): Promise<LifecycleEntity>;
 }

--- a/services/livetalk/core/src/usecases/learn-user-activity.usecase.ts
+++ b/services/livetalk/core/src/usecases/learn-user-activity.usecase.ts
@@ -1,6 +1,7 @@
 import type { LifecycleRepository } from '../repositories/lifecycle.repository.interface.js';
 import type { MessageRepository } from '../repositories/message.repository.interface.js';
 import { buildHourlyHistogram, findPeakInRange } from '../lifecycle/histogram.js';
+import { adaptCharacterSchedule } from '../lifecycle/adaptation.js';
 
 const DEFAULT_MORNING_PEAK = '08:00';
 const DEFAULT_EVENING_PEAK = '21:00';
@@ -54,7 +55,7 @@ export async function learnUserActivity(
   const morningPeak = findPeakInRange(histogram, 5, 12) ?? DEFAULT_MORNING_PEAK;
   const eveningPeak = findPeakInRange(histogram, 17, 26) ?? DEFAULT_EVENING_PEAK;
 
-  await lifecycleRepo.updateUserActivityProfile(
+  const lifecycle = await lifecycleRepo.updateUserActivityProfile(
     { userId, characterId },
     {
       morningPeak,
@@ -63,6 +64,13 @@ export async function learnUserActivity(
       lastLearnedAt: nowDate.toISOString(),
     }
   );
+
+  // Phase 4d: 学習結果を元にキャラのスケジュールを緩やかに適応
+  const adapted = adaptCharacterSchedule(
+    { bedtime: lifecycle.Bedtime, wakeUpTime: lifecycle.WakeUpTime },
+    lifecycle.UserActivityProfile
+  );
+  await lifecycleRepo.updateSchedule({ userId, characterId }, adapted);
 
   return 'learned';
 }

--- a/services/livetalk/core/tests/unit/lifecycle/adaptation.test.ts
+++ b/services/livetalk/core/tests/unit/lifecycle/adaptation.test.ts
@@ -1,9 +1,5 @@
 import { adaptCharacterSchedule } from '../../../src/lifecycle/adaptation.js';
-import {
-  parseTimeToMinutes,
-  formatMinutesToTime,
-  smoothTime,
-} from '../../../src/lifecycle/time-utils.js';
+import { parseTimeToMinutes, smoothTime } from '../../../src/lifecycle/time-utils.js';
 
 const DEFAULT_CURRENT = { bedtime: '01:30', wakeUpTime: '09:30' };
 

--- a/services/livetalk/core/tests/unit/lifecycle/adaptation.test.ts
+++ b/services/livetalk/core/tests/unit/lifecycle/adaptation.test.ts
@@ -1,0 +1,145 @@
+import { adaptCharacterSchedule } from '../../../src/lifecycle/adaptation.js';
+import { parseTimeToMinutes, formatMinutesToTime, smoothTime } from '../../../src/lifecycle/time-utils.js';
+
+const DEFAULT_CURRENT = { bedtime: '01:30', wakeUpTime: '09:30' };
+
+const makeProfile = (morningPeak: string, eveningPeak: string) => ({
+  morningPeak,
+  eveningPeak,
+  sampleSize: 10,
+  lastLearnedAt: '2026-06-01T00:00:00.000Z',
+});
+
+describe('adaptCharacterSchedule', () => {
+  describe('userProfile が null/undefined の場合は current を返す', () => {
+    it('null', () => {
+      expect(adaptCharacterSchedule(DEFAULT_CURRENT, null)).toEqual(DEFAULT_CURRENT);
+    });
+
+    it('undefined', () => {
+      expect(adaptCharacterSchedule(DEFAULT_CURRENT, undefined)).toEqual(DEFAULT_CURRENT);
+    });
+  });
+
+  describe('smoothing=0 のとき current のまま変化しない', () => {
+    it('現在値を保持する', () => {
+      const result = adaptCharacterSchedule(
+        DEFAULT_CURRENT,
+        makeProfile('09:00', '22:00'),
+        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 0 }
+      );
+      expect(result.bedtime).toBe(DEFAULT_CURRENT.bedtime);
+      expect(result.wakeUpTime).toBe(DEFAULT_CURRENT.wakeUpTime);
+    });
+  });
+
+  describe('smoothing=1 のとき target（クランプ後）に収束する', () => {
+    it('通常ユーザー: morningPeak=09:00, eveningPeak=22:00', () => {
+      const result = adaptCharacterSchedule(
+        DEFAULT_CURRENT,
+        makeProfile('09:00', '22:00'),
+        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
+      );
+      // target wakeUpTime = 09:00 - 1h = 08:00（クランプ範囲[05:00,12:00]内）
+      expect(result.wakeUpTime).toBe('08:00');
+      // target bedtime = 22:00 + 1.5h = 23:30（クランプ範囲[21:00,04:00]内）
+      expect(result.bedtime).toBe('23:30');
+    });
+  });
+
+  describe('smoothing が効く（0.3）', () => {
+    it('結果が current と target の間に収まる', () => {
+      const profile = makeProfile('09:00', '22:00');
+      const result = adaptCharacterSchedule(DEFAULT_CURRENT, profile);
+      const currentWake = parseTimeToMinutes(DEFAULT_CURRENT.wakeUpTime);
+      const targetWake = parseTimeToMinutes('08:00');
+      const resultWake = parseTimeToMinutes(result.wakeUpTime);
+
+      // smoothing=0.3: current(570) → target(480) で中間に向かう
+      const expected = smoothTime(currentWake, targetWake, 0.3);
+      expect(resultWake).toBeCloseTo(expected, 0);
+    });
+
+    it('デフォルト設定で wakeUpTime が前方向に shift する', () => {
+      const result = adaptCharacterSchedule(
+        { bedtime: '01:30', wakeUpTime: '09:30' },
+        makeProfile('09:00', '22:00')
+      );
+      // 09:30 → target 08:00、smoothing 0.3 で少し早くなる
+      const resultMin = parseTimeToMinutes(result.wakeUpTime);
+      expect(resultMin).toBeLessThan(parseTimeToMinutes('09:30'));
+      expect(resultMin).toBeGreaterThan(parseTimeToMinutes('08:00'));
+    });
+  });
+
+  describe('クランプ（境界条件）', () => {
+    it('極端な早起きユーザー（morningPeak=04:00）: wakeUpTime は 05:00 にクランプ', () => {
+      // target = 04:00 - 1h = 03:00 → clamp to 05:00
+      const result = adaptCharacterSchedule(
+        DEFAULT_CURRENT,
+        makeProfile('04:00', '21:00'),
+        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
+      );
+      expect(result.wakeUpTime).toBe('05:00');
+    });
+
+    it('極端な夜型ユーザー（morningPeak=14:00）: wakeUpTime は 12:00 にクランプ', () => {
+      // target = 14:00 - 1h = 13:00 → clamp to 12:00
+      const result = adaptCharacterSchedule(
+        DEFAULT_CURRENT,
+        makeProfile('14:00', '23:00'),
+        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
+      );
+      expect(result.wakeUpTime).toBe('12:00');
+    });
+
+    it('深夜のみ活動（eveningPeak=02:00）: bedtime は 04:00 にクランプ', () => {
+      // target = 02:00 + 1.5h = 03:30 → 03:30 は [21:00,04:00] 範囲内
+      const result = adaptCharacterSchedule(
+        DEFAULT_CURRENT,
+        makeProfile('09:00', '02:00'),
+        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
+      );
+      const bedtimeMin = parseTimeToMinutes(result.bedtime);
+      expect(bedtimeMin).toBeLessThanOrEqual(4 * 60);
+    });
+
+    it('夕方早めに終わるユーザー（eveningPeak=19:00）: bedtime は 21:00 にクランプ', () => {
+      // target = 19:00 + 1.5h = 20:30 → [21:00,04:00] 範囲外 → clamp to 21:00
+      const result = adaptCharacterSchedule(
+        DEFAULT_CURRENT,
+        makeProfile('09:00', '19:00'),
+        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
+      );
+      expect(result.bedtime).toBe('21:00');
+    });
+  });
+
+  describe('0時跨ぎ補間', () => {
+    it('bedtime が 23:30 からさらに 01:00 方向に shift する場合、wrap-around で正しく補間', () => {
+      const result = adaptCharacterSchedule(
+        { bedtime: '23:30', wakeUpTime: '09:30' },
+        makeProfile('09:00', '23:00'),
+        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 0.3 }
+      );
+      // target = 23:00 + 1.5h = 00:30 (30min)
+      // current bedtime = 23:30 (1410min), target = 30min
+      // diff = 30 - 1410 = -1380 < -720 → diff += 1440 = 60
+      // smooth = 1410 + 0.3*60 = 1428 = "23:48"
+      const resultMin = parseTimeToMinutes(result.bedtime);
+      expect(resultMin).toBeGreaterThan(parseTimeToMinutes('23:30'));
+    });
+  });
+
+  describe('offsetHours のカスタマイズ', () => {
+    it('offsetHours を 0 にするとユーザーピークに近づく', () => {
+      const result = adaptCharacterSchedule(
+        DEFAULT_CURRENT,
+        makeProfile('08:00', '22:00'),
+        { offsetHours: { wakeUp: 0, bedtime: 0 }, smoothing: 1 }
+      );
+      expect(result.wakeUpTime).toBe('08:00');
+      expect(result.bedtime).toBe('22:00');
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/lifecycle/adaptation.test.ts
+++ b/services/livetalk/core/tests/unit/lifecycle/adaptation.test.ts
@@ -1,5 +1,9 @@
 import { adaptCharacterSchedule } from '../../../src/lifecycle/adaptation.js';
-import { parseTimeToMinutes, formatMinutesToTime, smoothTime } from '../../../src/lifecycle/time-utils.js';
+import {
+  parseTimeToMinutes,
+  formatMinutesToTime,
+  smoothTime,
+} from '../../../src/lifecycle/time-utils.js';
 
 const DEFAULT_CURRENT = { bedtime: '01:30', wakeUpTime: '09:30' };
 
@@ -23,11 +27,10 @@ describe('adaptCharacterSchedule', () => {
 
   describe('smoothing=0 のとき current のまま変化しない', () => {
     it('現在値を保持する', () => {
-      const result = adaptCharacterSchedule(
-        DEFAULT_CURRENT,
-        makeProfile('09:00', '22:00'),
-        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 0 }
-      );
+      const result = adaptCharacterSchedule(DEFAULT_CURRENT, makeProfile('09:00', '22:00'), {
+        offsetHours: { wakeUp: 1, bedtime: 1.5 },
+        smoothing: 0,
+      });
       expect(result.bedtime).toBe(DEFAULT_CURRENT.bedtime);
       expect(result.wakeUpTime).toBe(DEFAULT_CURRENT.wakeUpTime);
     });
@@ -35,11 +38,10 @@ describe('adaptCharacterSchedule', () => {
 
   describe('smoothing=1 のとき target（クランプ後）に収束する', () => {
     it('通常ユーザー: morningPeak=09:00, eveningPeak=22:00', () => {
-      const result = adaptCharacterSchedule(
-        DEFAULT_CURRENT,
-        makeProfile('09:00', '22:00'),
-        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
-      );
+      const result = adaptCharacterSchedule(DEFAULT_CURRENT, makeProfile('09:00', '22:00'), {
+        offsetHours: { wakeUp: 1, bedtime: 1.5 },
+        smoothing: 1,
+      });
       // target wakeUpTime = 09:00 - 1h = 08:00（クランプ範囲[05:00,12:00]内）
       expect(result.wakeUpTime).toBe('08:00');
       // target bedtime = 22:00 + 1.5h = 23:30（クランプ範囲[21:00,04:00]内）
@@ -75,42 +77,38 @@ describe('adaptCharacterSchedule', () => {
   describe('クランプ（境界条件）', () => {
     it('極端な早起きユーザー（morningPeak=04:00）: wakeUpTime は 05:00 にクランプ', () => {
       // target = 04:00 - 1h = 03:00 → clamp to 05:00
-      const result = adaptCharacterSchedule(
-        DEFAULT_CURRENT,
-        makeProfile('04:00', '21:00'),
-        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
-      );
+      const result = adaptCharacterSchedule(DEFAULT_CURRENT, makeProfile('04:00', '21:00'), {
+        offsetHours: { wakeUp: 1, bedtime: 1.5 },
+        smoothing: 1,
+      });
       expect(result.wakeUpTime).toBe('05:00');
     });
 
     it('極端な夜型ユーザー（morningPeak=14:00）: wakeUpTime は 12:00 にクランプ', () => {
       // target = 14:00 - 1h = 13:00 → clamp to 12:00
-      const result = adaptCharacterSchedule(
-        DEFAULT_CURRENT,
-        makeProfile('14:00', '23:00'),
-        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
-      );
+      const result = adaptCharacterSchedule(DEFAULT_CURRENT, makeProfile('14:00', '23:00'), {
+        offsetHours: { wakeUp: 1, bedtime: 1.5 },
+        smoothing: 1,
+      });
       expect(result.wakeUpTime).toBe('12:00');
     });
 
     it('深夜のみ活動（eveningPeak=02:00）: bedtime は 04:00 にクランプ', () => {
       // target = 02:00 + 1.5h = 03:30 → 03:30 は [21:00,04:00] 範囲内
-      const result = adaptCharacterSchedule(
-        DEFAULT_CURRENT,
-        makeProfile('09:00', '02:00'),
-        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
-      );
+      const result = adaptCharacterSchedule(DEFAULT_CURRENT, makeProfile('09:00', '02:00'), {
+        offsetHours: { wakeUp: 1, bedtime: 1.5 },
+        smoothing: 1,
+      });
       const bedtimeMin = parseTimeToMinutes(result.bedtime);
       expect(bedtimeMin).toBeLessThanOrEqual(4 * 60);
     });
 
     it('夕方早めに終わるユーザー（eveningPeak=19:00）: bedtime は 21:00 にクランプ', () => {
       // target = 19:00 + 1.5h = 20:30 → [21:00,04:00] 範囲外 → clamp to 21:00
-      const result = adaptCharacterSchedule(
-        DEFAULT_CURRENT,
-        makeProfile('09:00', '19:00'),
-        { offsetHours: { wakeUp: 1, bedtime: 1.5 }, smoothing: 1 }
-      );
+      const result = adaptCharacterSchedule(DEFAULT_CURRENT, makeProfile('09:00', '19:00'), {
+        offsetHours: { wakeUp: 1, bedtime: 1.5 },
+        smoothing: 1,
+      });
       expect(result.bedtime).toBe('21:00');
     });
   });
@@ -133,11 +131,10 @@ describe('adaptCharacterSchedule', () => {
 
   describe('offsetHours のカスタマイズ', () => {
     it('offsetHours を 0 にするとユーザーピークに近づく', () => {
-      const result = adaptCharacterSchedule(
-        DEFAULT_CURRENT,
-        makeProfile('08:00', '22:00'),
-        { offsetHours: { wakeUp: 0, bedtime: 0 }, smoothing: 1 }
-      );
+      const result = adaptCharacterSchedule(DEFAULT_CURRENT, makeProfile('08:00', '22:00'), {
+        offsetHours: { wakeUp: 0, bedtime: 0 },
+        smoothing: 1,
+      });
       expect(result.wakeUpTime).toBe('08:00');
       expect(result.bedtime).toBe('22:00');
     });

--- a/services/livetalk/core/tests/unit/lifecycle/time-utils.test.ts
+++ b/services/livetalk/core/tests/unit/lifecycle/time-utils.test.ts
@@ -1,0 +1,111 @@
+import {
+  parseTimeToMinutes,
+  formatMinutesToTime,
+  smoothTime,
+  clampTime,
+} from '../../../src/lifecycle/time-utils.js';
+
+describe('parseTimeToMinutes', () => {
+  it.each([
+    ['00:00', 0],
+    ['01:30', 90],
+    ['09:30', 570],
+    ['23:59', 1439],
+    ['12:00', 720],
+    ['21:00', 1260],
+  ])('%s → %i 分', (input, expected) => {
+    expect(parseTimeToMinutes(input)).toBe(expected);
+  });
+});
+
+describe('formatMinutesToTime', () => {
+  it.each([
+    [0, '00:00'],
+    [90, '01:30'],
+    [570, '09:30'],
+    [1439, '23:59'],
+    [720, '12:00'],
+    [1260, '21:00'],
+  ])('%i 分 → %s', (input, expected) => {
+    expect(formatMinutesToTime(input)).toBe(expected);
+  });
+
+  it('1440 は 00:00 に折り返す', () => {
+    expect(formatMinutesToTime(1440)).toBe('00:00');
+  });
+
+  it('負の値は後方からラップする', () => {
+    expect(formatMinutesToTime(-30)).toBe('23:30');
+  });
+});
+
+describe('smoothTime', () => {
+  it('alpha=0 のとき current のまま変化しない', () => {
+    expect(smoothTime(570, 480, 0)).toBe(570);
+  });
+
+  it('alpha=1 のとき target に完全一致する', () => {
+    expect(smoothTime(570, 480, 1)).toBe(480);
+  });
+
+  it('通常補間: 600 から 660 へ alpha=0.3', () => {
+    // diff = 60, 0.3*60=18
+    expect(smoothTime(600, 660, 0.3)).toBe(618);
+  });
+
+  it('0時跨ぎ補間: 23:30(1410) → 01:00(60) alpha=0.3 は前方向に進む', () => {
+    // diff = 60 - 1410 = -1350 < -720 → diff += 1440 = 90
+    // 1410 + 0.3*90 = 1410 + 27 = 1437
+    expect(smoothTime(1410, 60, 0.3)).toBe(1437);
+  });
+
+  it('0時跨ぎ補間: 01:00(60) → 23:00(1380) alpha=0.3 は後方向に進む', () => {
+    // diff = 1380 - 60 = 1320 > 720 → diff -= 1440 = -120
+    // 60 + 0.3*(-120) = 60 - 36 = 24
+    expect(smoothTime(60, 1380, 0.3)).toBe(24);
+  });
+});
+
+describe('clampTime', () => {
+  describe('通常範囲 [300, 720]（05:00〜12:00）', () => {
+    it('範囲内の値はそのまま返す', () => {
+      expect(clampTime(500, 300, 720)).toBe(500);
+    });
+
+    it('下限未満は下限にクランプ', () => {
+      expect(clampTime(200, 300, 720)).toBe(300);
+    });
+
+    it('上限超過は上限にクランプ', () => {
+      expect(clampTime(800, 300, 720)).toBe(720);
+    });
+  });
+
+  describe('0時跨ぎ範囲 [1260, 240]（21:00〜翌04:00）', () => {
+    it('21:00（1260）は範囲内', () => {
+      expect(clampTime(1260, 1260, 240)).toBe(1260);
+    });
+
+    it('23:30（1410）は範囲内', () => {
+      expect(clampTime(1410, 1260, 240)).toBe(1410);
+    });
+
+    it('01:30（90）は範囲内', () => {
+      expect(clampTime(90, 1260, 240)).toBe(90);
+    });
+
+    it('04:00（240）は範囲内', () => {
+      expect(clampTime(240, 1260, 240)).toBe(240);
+    });
+
+    it('08:20（500）は下限 21:00 と上限 04:00 のうち近い 04:00 にクランプ', () => {
+      // distToMin(1260-500=760) > distToMax(500-240=260) → clamp to 240
+      expect(clampTime(500, 1260, 240)).toBe(240);
+    });
+
+    it('15:00（900）は 21:00 に近いのでクランプ', () => {
+      // distToMin(1260-900=360) < distToMax(900-240=660) → clamp to 1260
+      expect(clampTime(900, 1260, 240)).toBe(1260);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-lifecycle.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-lifecycle.repository.test.ts
@@ -174,4 +174,76 @@ describe('DynamoDBLifecycleRepository', () => {
       ).rejects.toBeInstanceOf(DatabaseError);
     });
   });
+
+  describe('updateSchedule', () => {
+    it('Bedtime と WakeUpTime を更新した PutCommand を送る', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        if (cmd instanceof GetCommand) return { Item: undefined };
+        return {};
+      });
+      const repo = new DynamoDBLifecycleRepository(client as never, tableName, () => now);
+      const result = await repo.updateSchedule(
+        { userId: 'u1', characterId: 'hiyori' },
+        { bedtime: '23:48', wakeUpTime: '08:54' }
+      );
+
+      expect(result.Bedtime).toBe('23:48');
+      expect(result.WakeUpTime).toBe('08:54');
+      const put = (sent[1] as PutCommand).input;
+      expect(put.Item?.Bedtime).toBe('23:48');
+      expect(put.Item?.WakeUpTime).toBe('08:54');
+    });
+
+    it('既存の UserActivityProfile を保持する', async () => {
+      const existingProfile = {
+        morningPeak: '09:00',
+        eveningPeak: '22:00',
+        sampleSize: 5,
+        lastLearnedAt: '2026-06-01T00:00:00.000Z',
+      };
+      const existing = {
+        PK: 'USER#u1',
+        SK: 'CHAR#hiyori#LIFECYCLE',
+        Type: 'Lifecycle',
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Bedtime: '01:30',
+        WakeUpTime: '09:30',
+        UserActivityProfile: existingProfile,
+        CreatedAt: 1_600_000_000_000,
+        UpdatedAt: now - 5000,
+      };
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        if (cmd instanceof GetCommand) return { Item: existing };
+        return {};
+      });
+      const repo = new DynamoDBLifecycleRepository(client as never, tableName, () => now);
+      const result = await repo.updateSchedule(
+        { userId: 'u1', characterId: 'hiyori' },
+        { bedtime: '23:48', wakeUpTime: '08:54' }
+      );
+
+      expect(result.UserActivityProfile).toEqual(existingProfile);
+      const put = (sent[1] as PutCommand).input;
+      expect(put.Item?.UserActivityProfile).toEqual(existingProfile);
+    });
+
+    it('Put エラーは DatabaseError でラップする', async () => {
+      const client = makeClient(async (cmd) => {
+        if (cmd instanceof GetCommand) return { Item: undefined };
+        throw new Error('put failure');
+      });
+      const repo = new DynamoDBLifecycleRepository(client as never, tableName, () => now);
+      await expect(
+        repo.updateSchedule(
+          { userId: 'u1', characterId: 'hiyori' },
+          { bedtime: '23:00', wakeUpTime: '08:00' }
+        )
+      ).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-lifecycle.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-lifecycle.repository.test.ts
@@ -167,4 +167,74 @@ describe('InMemoryLifecycleRepository', () => {
       expect(fetched?.UserActivityProfile).toEqual(profile);
     });
   });
+
+  describe('updateSchedule', () => {
+    it('Bedtime と WakeUpTime を更新する', async () => {
+      await repo.upsert({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Bedtime: '01:30',
+        WakeUpTime: '09:30',
+      });
+      now += 1000;
+      const result = await repo.updateSchedule(
+        { userId: 'u1', characterId: 'hiyori' },
+        { bedtime: '23:48', wakeUpTime: '08:54' }
+      );
+
+      expect(result.Bedtime).toBe('23:48');
+      expect(result.WakeUpTime).toBe('08:54');
+
+      const fetched = await repo.get({ userId: 'u1', characterId: 'hiyori' });
+      expect(fetched?.Bedtime).toBe('23:48');
+      expect(fetched?.WakeUpTime).toBe('08:54');
+    });
+
+    it('UserActivityProfile を保持する', async () => {
+      const profile = {
+        morningPeak: '09:00',
+        eveningPeak: '22:00',
+        sampleSize: 5,
+        lastLearnedAt: '2026-06-01T00:00:00.000Z',
+      };
+      await repo.updateUserActivityProfile({ userId: 'u1', characterId: 'hiyori' }, profile);
+      now += 1000;
+      await repo.updateSchedule(
+        { userId: 'u1', characterId: 'hiyori' },
+        { bedtime: '23:00', wakeUpTime: '08:00' }
+      );
+
+      const fetched = await repo.get({ userId: 'u1', characterId: 'hiyori' });
+      expect(fetched?.UserActivityProfile).toEqual(profile);
+    });
+
+    it('既存なしの場合はデフォルト CreatedAt で新規作成する', async () => {
+      const result = await repo.updateSchedule(
+        { userId: 'u1', characterId: 'hiyori' },
+        { bedtime: '23:00', wakeUpTime: '08:00' }
+      );
+
+      expect(result.Bedtime).toBe('23:00');
+      expect(result.WakeUpTime).toBe('08:00');
+      expect(result.CreatedAt).toBe(baseNow);
+    });
+
+    it('CreatedAt は保持され UpdatedAt が更新される', async () => {
+      await repo.upsert({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Bedtime: '01:30',
+        WakeUpTime: '09:30',
+      });
+      now += 5000;
+      await repo.updateSchedule(
+        { userId: 'u1', characterId: 'hiyori' },
+        { bedtime: '23:00', wakeUpTime: '08:00' }
+      );
+
+      const fetched = await repo.get({ userId: 'u1', characterId: 'hiyori' });
+      expect(fetched?.CreatedAt).toBe(baseNow);
+      expect(fetched?.UpdatedAt).toBe(baseNow + 5000);
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -180,7 +180,7 @@ describe('learnUserActivity', () => {
     expect(lc?.UserActivityProfile?.eveningPeak).toBe('21:00');
   });
 
-  it('既存 LIFECYCLE の Bedtime/WakeUpTime は保持される', async () => {
+  it('既存 LIFECYCLE の Bedtime/WakeUpTime は適応方向に shift される（Phase 4d）', async () => {
     const store = makeStore();
     const lifecycleRepo = makeLifecycleRepo(store);
 
@@ -192,6 +192,7 @@ describe('learnUserActivity', () => {
       WakeUpTime: '10:00',
     });
 
+    // JST 21 時に集中 → eveningPeak=21:00、morningPeak=デフォルト 08:00
     await makeJstMessages(store, 21, 5);
 
     const nowDate = new Date(JST_21_UTC_MS + 100 * 24 * 3600 * 1000);
@@ -203,8 +204,64 @@ describe('learnUserActivity', () => {
     });
 
     const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
-    expect(lc?.Bedtime).toBe('02:00');
-    expect(lc?.WakeUpTime).toBe('10:00');
+    // targetBedtime = 22:30、smoothing=0.3 なので 02:00 → 22:30 方向に shift
+    // current=02:00(120min)、diff の最短路は後方向(-210min) → 00:57 付近
+    expect(lc?.Bedtime).not.toBe('02:00'); // 変化している
+    // UserActivityProfile は保持される
+    expect(lc?.UserActivityProfile).toBeDefined();
+    expect(lc?.UserActivityProfile?.eveningPeak).toBe('21:00');
+  });
+
+  describe('Phase 4d: スケジュール適応', () => {
+    it('learned 後に Bedtime/WakeUpTime が shift される', async () => {
+      const store = makeStore();
+      const lifecycleRepo = makeLifecycleRepo(store);
+
+      // 事前に既存ライフサイクルを作成
+      tick = BASE_NOW_MS;
+      await lifecycleRepo.upsert({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Bedtime: '01:30',
+        WakeUpTime: '09:30',
+      });
+
+      // morningPeak=09:00 に集中するメッセージを作成（JST 9時 = UTC 0時）
+      await makeJstMessages(store, 9, 5);
+
+      const nowDate = new Date(JST_21_UTC_MS + 100 * 24 * 3600 * 1000);
+      await learnUserActivity('u1', 'hiyori', {
+        messageRepo: makeMessageRepo(store),
+        lifecycleRepo,
+        now: () => nowDate,
+        lookbackDays: 200,
+      });
+
+      const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
+      // target wakeUpTime = 09:00 - 1h = 08:00; 09:30 より早くなっているはず
+      const wakeUpMin = lc!.WakeUpTime.split(':').reduce((h, m, i) =>
+        i === 0 ? Number(m) * 60 : Number(m) + h, 0);
+      expect(wakeUpMin).toBeLessThan(9 * 60 + 30);
+    });
+
+    it('learned 後に UserActivityProfile が保持される', async () => {
+      const store = makeStore();
+      const lifecycleRepo = makeLifecycleRepo(store);
+
+      await makeJstMessages(store, 21, 5);
+
+      const nowDate = new Date(JST_21_UTC_MS + 100 * 24 * 3600 * 1000);
+      await learnUserActivity('u1', 'hiyori', {
+        messageRepo: makeMessageRepo(store),
+        lifecycleRepo,
+        now: () => nowDate,
+        lookbackDays: 200,
+      });
+
+      const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
+      expect(lc?.UserActivityProfile).toBeDefined();
+      expect(lc?.UserActivityProfile?.eveningPeak).toBe('21:00');
+    });
   });
 
   it('lookbackDays 外のメッセージはカウントされない', async () => {

--- a/services/livetalk/core/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -239,8 +239,10 @@ describe('learnUserActivity', () => {
 
       const lc = await lifecycleRepo.get({ userId: 'u1', characterId: 'hiyori' });
       // target wakeUpTime = 09:00 - 1h = 08:00; 09:30 より早くなっているはず
-      const wakeUpMin = lc!.WakeUpTime.split(':').reduce((h, m, i) =>
-        i === 0 ? Number(m) * 60 : Number(m) + h, 0);
+      const wakeUpMin = lc!.WakeUpTime.split(':').reduce(
+        (h, m, i) => (i === 0 ? Number(m) * 60 : Number(m) + h),
+        0
+      );
       expect(wakeUpMin).toBeLessThan(9 * 60 + 30);
     });
 


### PR DESCRIPTION
## 変更の概要

Phase 4c で学習した `userActivityProfile`（morningPeak / eveningPeak）を使って、キャラの就寝・起床時刻をユーザーの生活リズムに緩やかに適応させる。

- 完全同期はせず offsetHours 分ズラし、キャラの独立した存在感を保つ
- 移動平均（smoothing=0.3）で急激な変化を防ぐ
- 境界クランプ（wakeUpTime: 05:00〜12:00、bedtime: 21:00〜翌04:00）で極端な値を防止
- 新規 Lambda は不要。Phase 4c のバッチ実行時に自動適応

## 関連 Issue

関連 Issue: #3330（Phase 4 最終サブ Issue）

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した
- [x] ローカルでテストが全て通ることを確認した（665 tests passed）
- [x] ビルドエラーがないことを確認した

## テスト内容

### 新規テストファイル

- `tests/unit/lifecycle/time-utils.test.ts`（28 ケース）
  - `parseTimeToMinutes` / `formatMinutesToTime`：HH:mm ↔ 分換算、wrap-around
  - `smoothTime`：0時跨ぎ最短経路補間
  - `clampTime`：通常範囲・0時跨ぎ範囲両方

- `tests/unit/lifecycle/adaptation.test.ts`（12 ケース）
  - null/undefined プロファイル時は current を返す
  - smoothing=0 で変化なし、smoothing=1 でターゲットに収束
  - 極端な早起き・夜型・深夜活動のクランプ
  - 0時跨ぎ補間の正確性

### 既存テスト更新

- `in-memory-lifecycle.repository.test.ts`：`updateSchedule` メソッドのテストを追加
- `dynamodb-lifecycle.repository.test.ts`：`updateSchedule` メソッドのテストを追加
- `learn-user-activity.usecase.test.ts`：Phase 4d の適応ステップのテスト追加＋既存テストを Phase 4d 挙動に合わせて更新

## レビューポイント

- **smoothTime の最短経路ロジック**（`time-utils.ts:23-27`）：diff > 720 で反転する設計。0時を跨ぐ bedtime（例: 23:30 → 01:00）が正しく補間されることを `adaptation.test.ts` でカバー
- **clampTime の跨ぎ範囲処理**（`time-utils.ts:41-49`）：21:00〜04:00 の範囲で範囲外の値を最近傍境界にクランプ
- **clamp を smoothing 後に適用**（`adaptation.ts:46-55`）：smoothing 前にクランプすると毎回ターゲットへ寄り続ける挙動になるため、smooth → clamp の順にしている
- **既存テスト更新**（`learn-user-activity.usecase.test.ts:183`）：「Bedtime/WakeUpTime が保持される」テストを「適応方向に shift される」に変更。Phase 4d で意図的に変更される仕様に合わせた

## 補足事項

- offsetHours（wakeUp: 1, bedtime: 1.5）と smoothing（0.3）は仮値。実機で違和感あれば調整
- Phase 4d 完了により Phase 4（#3187）が完了となる

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwKQdudKFQ3BiSjMuakoFE)_