### PR TITLE
[Phase 5a] 勉強バッチ（Web リサーチ → 知識化）を実装（Issue #3343）

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -413,7 +413,8 @@ jobs:
 
           for FN in \
             "nagiyu-livetalk-batch-compress-$ENVIRONMENT" \
-            "nagiyu-livetalk-batch-learn-user-activity-$ENVIRONMENT"; do
+            "nagiyu-livetalk-batch-learn-user-activity-$ENVIRONMENT" \
+            "nagiyu-livetalk-batch-study-$ENVIRONMENT"; do
 
             aws lambda update-function-code \
               --function-name "$FN" \
@@ -518,6 +519,7 @@ jobs:
             echo "- **Latest tag**: same digest also pushed as \`:latest\`"
             echo "- **Batch Lambda（圧縮）**: \`nagiyu-livetalk-batch-compress-$ENVIRONMENT\`（EventBridge 日次 JST 03:00）"
             echo "- **Batch Lambda（学習）**: \`nagiyu-livetalk-batch-learn-user-activity-$ENVIRONMENT\`（EventBridge 週次 JST 日曜 03:00）"
+            echo "- **Batch Lambda（勉強）**: \`nagiyu-livetalk-batch-study-$ENVIRONMENT\`（EventBridge 毎時）"
             echo "- **ALB DNS**: \`$ALB_DNS\`"
             echo "- **Custom Domain**: https://$CUSTOM_DOMAIN"
             echo ""

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ infra/**/*.d.ts
 
 # Yarn (このプロジェクトはnpmを使用)
 yarn.lock
+
+# Claude Code 内部状態（ワークツリー・セッションキャッシュ等）
+.claude/

--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -181,6 +181,70 @@ export class LiveTalkBatchStack extends cdk.Stack {
       })
     );
 
+    // ---- 勉強バッチ（Phase 5a / Issue #3343）----
+
+    // 勉強バッチ専用 DLQ
+    const studyDlq = new sqs.Queue(this, 'StudyDlq', {
+      queueName: `nagiyu-livetalk-study-dlq-${environment}`,
+      retentionPeriod: cdk.Duration.days(7),
+    });
+
+    // 勉強バッチ専用 IAM Role（OpenAI 権限が必要）
+    const studyRole = new iam.Role(this, 'StudyExecutionRole', {
+      roleName: `nagiyu-livetalk-study-role-${environment}`,
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+      ],
+    });
+    dynamoTable.grantReadWriteData(studyRole);
+    studyDlq.grantSendMessages(studyRole);
+    grantErrorEventsWrite(this, studyRole, environment);
+
+    // 勉強バッチ Lambda
+    const studyFunction = new lambda.Function(this, 'StudyFunction', {
+      functionName: `nagiyu-livetalk-batch-study-${environment}`,
+      runtime: lambda.Runtime.FROM_IMAGE,
+      code: lambda.Code.fromEcrImage(batchRepository, {
+        tagOrDigest: 'latest',
+        cmd: ['services/livetalk/batch/dist/src/handlers/study.handler'],
+      }),
+      handler: lambda.Handler.FROM_IMAGE,
+      role: studyRole,
+      memorySize: 512,
+      timeout: cdk.Duration.minutes(15),
+      environment: {
+        NODE_ENV: environment,
+        DYNAMODB_TABLE_NAME: dynamoTableName,
+        OPENAI_API_KEY: openAiApiKey,
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
+        TZ: 'Asia/Tokyo',
+      },
+      deadLetterQueue: studyDlq,
+      tracing: lambda.Tracing.ACTIVE,
+      logRetention: logs.RetentionDays.ONE_MONTH,
+    });
+
+    // EventBridge: 毎時 0 分に実行（高頻度、ユーザーごとに判定で間引く）
+    const hourlyStudyRule = new events.Rule(this, 'HourlyStudyRule', {
+      ruleName: `livetalk-batch-study-${environment}`,
+      description: 'LiveTalk 勉強バッチ（毎時 JST）',
+      schedule: events.Schedule.cron({
+        minute: '0',
+        hour: '*',
+        day: '*',
+        month: '*',
+        year: '*',
+      }),
+    });
+    hourlyStudyRule.addTarget(
+      new targets.LambdaFunction(studyFunction, {
+        deadLetterQueue: studyDlq,
+        maxEventAge: cdk.Duration.hours(1),
+        retryAttempts: 1,
+      })
+    );
+
     // タグ
     cdk.Tags.of(this).add('Application', 'nagiyu');
     cdk.Tags.of(this).add('Service', 'livetalk');
@@ -206,6 +270,16 @@ export class LiveTalkBatchStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'LearnActivityDlqUrl', {
       value: learnActivityDlq.queueUrl,
       description: 'LiveTalk Learn User Activity DLQ URL',
+    });
+
+    new cdk.CfnOutput(this, 'StudyFunctionArn', {
+      value: studyFunction.functionArn,
+      description: 'LiveTalk Study Lambda Function ARN',
+    });
+
+    new cdk.CfnOutput(this, 'StudyDlqUrl', {
+      value: studyDlq.queueUrl,
+      description: 'LiveTalk Study DLQ URL',
     });
   }
 }

--- a/infra/livetalk/tests/unit/batch-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-stack.test.js
@@ -94,9 +94,9 @@ describe('LiveTalkBatchStack', () => {
     expect(vars.OPENAI_API_KEY).toBeUndefined();
   });
 
-  it('EventBridge ルールを 2 つ作成する（日次圧縮 + 週次学習）', () => {
+  it('EventBridge ルールを 3 つ作成する（日次圧縮 + 週次学習 + 毎時勉強）', () => {
     const { template } = synth();
-    template.resourceCountIs('AWS::Events::Rule', 2);
+    template.resourceCountIs('AWS::Events::Rule', 3);
   });
 
   it('圧縮バッチの EventBridge スケジュールは cron(0 18 * * ? *)', () => {
@@ -113,9 +113,9 @@ describe('LiveTalkBatchStack', () => {
     });
   });
 
-  it('SQS DLQ を 2 つ作成する（圧縮 + 学習で分離）', () => {
+  it('SQS DLQ を 3 つ作成する（圧縮 + 学習 + 勉強で分離）', () => {
     const { template } = synth();
-    template.resourceCountIs('AWS::SQS::Queue', 2);
+    template.resourceCountIs('AWS::SQS::Queue', 3);
   });
 
   it('Lambda 実行ロールを作成する', () => {
@@ -131,6 +131,33 @@ describe('LiveTalkBatchStack', () => {
     });
   });
 
+  it('勉強バッチ用 Lambda 関数が存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: Match.stringLikeRegexp('livetalk-batch-study'),
+    });
+  });
+
+  it('勉強バッチ Lambda 環境変数に TZ=Asia/Tokyo と OPENAI_API_KEY が含まれる', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: Match.stringLikeRegexp('livetalk-batch-study'),
+      Environment: {
+        Variables: Match.objectLike({
+          TZ: 'Asia/Tokyo',
+          OPENAI_API_KEY: 'PLACEHOLDER_KEY',
+        }),
+      },
+    });
+  });
+
+  it('勉強バッチの EventBridge スケジュールは毎時（cron(0 * * * ? *)）', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: 'cron(0 * * * ? *)',
+    });
+  });
+
   it('BatchFunctionArn を Outputs に出力する', () => {
     const { template } = synth();
     template.hasOutput('BatchFunctionArn', Match.anyValue());
@@ -139,6 +166,11 @@ describe('LiveTalkBatchStack', () => {
   it('LearnActivityFunctionArn を Outputs に出力する', () => {
     const { template } = synth();
     template.hasOutput('LearnActivityFunctionArn', Match.anyValue());
+  });
+
+  it('StudyFunctionArn を Outputs に出力する', () => {
+    const { template } = synth();
+    template.hasOutput('StudyFunctionArn', Match.anyValue());
   });
 
   it('prod 環境でも正しく生成する', () => {

--- a/services/livetalk/batch/src/handlers/study.ts
+++ b/services/livetalk/batch/src/handlers/study.ts
@@ -1,0 +1,91 @@
+import { logger, toErrorMessage } from '@nagiyu/common';
+import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
+import {
+  DynamoDBInterestRepository,
+  DynamoDBKnowledgeRepository,
+  DynamoDBLifecycleRepository,
+  OpenAIResearchClient,
+  defaultUlidFactory,
+} from '@nagiyu/livetalk-core';
+import { studyAllUsers } from '../usecases/study.usecase.js';
+
+const SERVICE_ID = 'livetalk';
+
+export interface ScheduledEvent {
+  version: string;
+  id: string;
+  'detail-type': string;
+  source: string;
+  account: string;
+  time: string;
+  region: string;
+  resources: string[];
+  detail: Record<string, unknown>;
+}
+
+export interface HandlerResponse {
+  statusCode: number;
+  body: string;
+}
+
+export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
+  logger.info('[study] バッチ開始', {
+    eventId: event.id,
+    eventTime: event.time,
+  });
+
+  try {
+    const docClient = getDynamoDBDocumentClient();
+    const tableName = getTableName();
+    const apiKey = process.env.OPENAI_API_KEY ?? '';
+
+    const lifecycleRepo = new DynamoDBLifecycleRepository(docClient, tableName);
+    const interestRepo = new DynamoDBInterestRepository(docClient, tableName);
+    const knowledgeRepo = new DynamoDBKnowledgeRepository(docClient, tableName);
+    const researchClient = new OpenAIResearchClient({ apiKey });
+
+    const result = await studyAllUsers({
+      docClient,
+      tableName,
+      lifecycleRepo,
+      interestRepo,
+      knowledgeRepo,
+      researchClient,
+      ulidFactory: defaultUlidFactory,
+    });
+
+    logger.info('[study] バッチ完了', {
+      eventId: event.id,
+      ...result,
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: '勉強バッチが正常に完了しました',
+        ...result,
+      }),
+    };
+  } catch (error) {
+    const errorMessage = toErrorMessage(error);
+    logger.error('[study] バッチ失敗', {
+      eventId: event.id,
+      error: errorMessage,
+    });
+    await reportErrorEvent({
+      serviceId: SERVICE_ID,
+      severity: 'error',
+      title: '勉強バッチ: 致命的エラー',
+      message: errorMessage,
+      context: { eventId: event.id },
+    });
+
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: '勉強バッチでエラーが発生しました',
+        error: errorMessage,
+      }),
+    };
+  }
+}

--- a/services/livetalk/batch/src/index.ts
+++ b/services/livetalk/batch/src/index.ts
@@ -11,3 +11,10 @@ export type {
   LearnAllUserActivitiesParams,
   LearnAllUserActivitiesResult,
 } from './usecases/learn-user-activity.usecase.js';
+
+export { handler as studyHandler } from './handlers/study.js';
+export { studyAllUsers } from './usecases/study.usecase.js';
+export type {
+  StudyAllUsersParams,
+  StudyAllUsersResult,
+} from './usecases/study.usecase.js';

--- a/services/livetalk/batch/src/index.ts
+++ b/services/livetalk/batch/src/index.ts
@@ -14,7 +14,4 @@ export type {
 
 export { handler as studyHandler } from './handlers/study.js';
 export { studyAllUsers } from './usecases/study.usecase.js';
-export type {
-  StudyAllUsersParams,
-  StudyAllUsersResult,
-} from './usecases/study.usecase.js';
+export type { StudyAllUsersParams, StudyAllUsersResult } from './usecases/study.usecase.js';

--- a/services/livetalk/batch/src/usecases/study.usecase.ts
+++ b/services/livetalk/batch/src/usecases/study.usecase.ts
@@ -35,9 +35,7 @@ export interface StudyAllUsersResult {
  * 各ユーザーについて shouldStudyNow 判定を行い、該当ユーザーのみ
  * Web リサーチ → 知識ベース保存を実行する（空振りコスト最小化）。
  */
-export async function studyAllUsers(
-  params: StudyAllUsersParams
-): Promise<StudyAllUsersResult> {
+export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyAllUsersResult> {
   const {
     docClient,
     tableName,

--- a/services/livetalk/batch/src/usecases/study.usecase.ts
+++ b/services/livetalk/batch/src/usecases/study.usecase.ts
@@ -1,0 +1,131 @@
+import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { logger, toErrorMessage } from '@nagiyu/common';
+import {
+  DEFAULT_CHARACTER_ID,
+  hiyori,
+  studyForUser,
+  type InterestRepository,
+  type KnowledgeRepository,
+  type LifecycleRepository,
+  type UlidFactory,
+} from '@nagiyu/livetalk-core';
+import type { IResearchClient } from '@nagiyu/livetalk-core';
+
+export interface StudyAllUsersParams {
+  docClient: DynamoDBDocumentClient;
+  tableName: string;
+  lifecycleRepo: LifecycleRepository;
+  interestRepo: InterestRepository;
+  knowledgeRepo: KnowledgeRepository;
+  researchClient: IResearchClient;
+  ulidFactory?: UlidFactory;
+  now?: () => Date;
+}
+
+export interface StudyAllUsersResult {
+  studiedUsers: number;
+  skippedUsers: number;
+  failedUsers: number;
+  failedUserIds: string[];
+}
+
+/**
+ * 全アクティブユーザーに対して勉強バッチを実行する。
+ *
+ * 各ユーザーについて shouldStudyNow 判定を行い、該当ユーザーのみ
+ * Web リサーチ → 知識ベース保存を実行する（空振りコスト最小化）。
+ */
+export async function studyAllUsers(
+  params: StudyAllUsersParams
+): Promise<StudyAllUsersResult> {
+  const {
+    docClient,
+    tableName,
+    lifecycleRepo,
+    interestRepo,
+    knowledgeRepo,
+    researchClient,
+    ulidFactory,
+    now,
+  } = params;
+
+  const userIds = await scanAllUserIds(docClient, tableName);
+
+  logger.info('[studyAllUsers] ユーザー一覧取得完了', { userCount: userIds.length });
+
+  const result: StudyAllUsersResult = {
+    studiedUsers: 0,
+    skippedUsers: 0,
+    failedUsers: 0,
+    failedUserIds: [],
+  };
+
+  for (const userId of userIds) {
+    try {
+      const lifecycle = await lifecycleRepo.get({
+        userId,
+        characterId: DEFAULT_CHARACTER_ID,
+      });
+
+      if (!lifecycle) {
+        result.skippedUsers++;
+        continue;
+      }
+
+      const outcome = await studyForUser(userId, DEFAULT_CHARACTER_ID, {
+        knowledgeRepo,
+        interestRepo,
+        researchClient,
+        character: hiyori,
+        lifecycle,
+        ulidFactory,
+        now,
+      });
+
+      if (outcome.outcome === 'skipped') {
+        result.skippedUsers++;
+      } else {
+        result.studiedUsers++;
+      }
+    } catch (error) {
+      logger.error('[studyAllUsers] ユーザー処理失敗', {
+        userId,
+        error: toErrorMessage(error),
+      });
+      result.failedUsers++;
+      result.failedUserIds.push(userId);
+    }
+  }
+
+  logger.info('[studyAllUsers] 全ユーザー処理完了', { ...result });
+  return result;
+}
+
+async function scanAllUserIds(
+  docClient: DynamoDBDocumentClient,
+  tableName: string
+): Promise<string[]> {
+  const userIds: string[] = [];
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+  do {
+    const command = new ScanCommand({
+      TableName: tableName,
+      FilterExpression: '#type = :profile',
+      ExpressionAttributeNames: { '#type': 'Type' },
+      ExpressionAttributeValues: { ':profile': 'Profile' },
+      ProjectionExpression: 'UserID',
+      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
+    });
+
+    const response = await docClient.send(command);
+    for (const item of response.Items ?? []) {
+      if (typeof item.UserID === 'string' && item.UserID) {
+        userIds.push(item.UserID);
+      }
+    }
+    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastEvaluatedKey !== undefined);
+
+  return userIds;
+}

--- a/services/livetalk/batch/tests/unit/handlers/study.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/study.test.ts
@@ -1,0 +1,67 @@
+import type { ScheduledEvent } from '../../../src/handlers/study.js';
+
+jest.mock('@nagiyu/aws', () => ({
+  getDynamoDBDocumentClient: jest.fn(() => ({})),
+  getTableName: jest.fn(() => 'test-table'),
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@nagiyu/livetalk-core', () => ({
+  DynamoDBLifecycleRepository: jest.fn(),
+  DynamoDBInterestRepository: jest.fn(),
+  DynamoDBKnowledgeRepository: jest.fn(),
+  OpenAIResearchClient: jest.fn(),
+  defaultUlidFactory: jest.fn(),
+}));
+
+const mockStudyAll = jest.fn();
+jest.mock('../../../src/usecases/study.usecase.js', () => ({
+  studyAllUsers: (...args: unknown[]) => mockStudyAll(...args),
+}));
+
+const makeEvent = (overrides: Partial<ScheduledEvent> = {}): ScheduledEvent => ({
+  version: '0',
+  id: 'event-001',
+  'detail-type': 'Scheduled Event',
+  source: 'aws.events',
+  account: '123456789012',
+  time: '2026-06-01T00:00:00Z',
+  region: 'us-east-1',
+  resources: [],
+  detail: {},
+  ...overrides,
+});
+
+describe('study handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('正常処理時に 200 を返す', async () => {
+    mockStudyAll.mockResolvedValue({
+      studiedUsers: 2,
+      skippedUsers: 3,
+      failedUsers: 0,
+      failedUserIds: [],
+    });
+
+    const { handler } = await import('../../../src/handlers/study.js');
+    const response = await handler(makeEvent());
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.studiedUsers).toBe(2);
+    expect(body.skippedUsers).toBe(3);
+  });
+
+  it('例外発生時に 500 を返す', async () => {
+    mockStudyAll.mockRejectedValue(new Error('DynamoDB 障害'));
+
+    const { handler } = await import('../../../src/handlers/study.js');
+    const response = await handler(makeEvent());
+
+    expect(response.statusCode).toBe(500);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain('DynamoDB 障害');
+  });
+});

--- a/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
@@ -1,0 +1,97 @@
+import { ScanCommand } from '@aws-sdk/lib-dynamodb';
+
+jest.mock('@nagiyu/livetalk-core', () => ({
+  DEFAULT_CHARACTER_ID: 'hiyori',
+  hiyori: {
+    id: 'hiyori',
+    displayName: '桃瀬ひより',
+    personality: {
+      basePrompt: '',
+      speechStyle: '優しい口調',
+      preferences: { likes: [], dislikes: [] },
+    },
+    voiceConfig: { speakerId: 14 },
+    license: { displayText: '', creditName: '' },
+  },
+  studyForUser: jest.fn(),
+}));
+
+const mockStudyForUser = jest.requireMock('@nagiyu/livetalk-core').studyForUser as jest.Mock;
+
+describe('studyAllUsers', () => {
+  const mockDocClient = {
+    send: jest.fn(),
+  };
+
+  const makeParams = (overrides = {}) => ({
+    docClient: mockDocClient as never,
+    tableName: 'test-table',
+    lifecycleRepo: {
+      get: jest.fn().mockResolvedValue({
+        Bedtime: '01:30',
+        WakeUpTime: '09:30',
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        CreatedAt: 0,
+        UpdatedAt: 0,
+      }),
+    } as never,
+    interestRepo: {} as never,
+    knowledgeRepo: {} as never,
+    researchClient: {} as never,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDocClient.send.mockResolvedValue({
+      Items: [{ UserID: 'u1' }, { UserID: 'u2' }],
+    });
+  });
+
+  it('全ユーザーをループして studyForUser を呼ぶ', async () => {
+    mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams());
+
+    expect(result.studiedUsers).toBe(2);
+    expect(result.skippedUsers).toBe(0);
+    expect(result.failedUsers).toBe(0);
+    expect(mockStudyForUser).toHaveBeenCalledTimes(2);
+  });
+
+  it('studyForUser がスキップを返したユーザーをカウント', async () => {
+    mockStudyForUser
+      .mockResolvedValueOnce({ outcome: 'studied', savedCount: 1 })
+      .mockResolvedValueOnce({ outcome: 'skipped', skipReason: 'テスト' });
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams());
+
+    expect(result.studiedUsers).toBe(1);
+    expect(result.skippedUsers).toBe(1);
+  });
+
+  it('lifecycle が null のユーザーはスキップ', async () => {
+    const lifecycleRepo = {
+      get: jest.fn().mockResolvedValue(null),
+    };
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams({ lifecycleRepo: lifecycleRepo as never }));
+
+    expect(result.skippedUsers).toBe(2);
+    expect(mockStudyForUser).not.toHaveBeenCalled();
+  });
+
+  it('studyForUser が throw したユーザーは failedUsers にカウント', async () => {
+    mockStudyForUser.mockRejectedValue(new Error('DynamoDB エラー'));
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams());
+
+    expect(result.failedUsers).toBe(2);
+    expect(result.failedUserIds).toEqual(['u1', 'u2']);
+  });
+});

--- a/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
@@ -1,5 +1,3 @@
-import { ScanCommand } from '@aws-sdk/lib-dynamodb';
-
 jest.mock('@nagiyu/livetalk-core', () => ({
   DEFAULT_CHARACTER_ID: 'hiyori',
   hiyori: {

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -132,3 +132,49 @@ export const PROMOTION_SIMILARITY_THRESHOLD = 0.5;
  * 過剰統合（無関係カテゴリの誤統合）を避けるため Memory 昇格よりは厳しめに設定する。
  */
 export const INTEREST_DEDUP_SIMILARITY_THRESHOLD = 0.85;
+
+/**
+ * 勉強バッチ: 1 実行あたりに発行する検索クエリの最大数（暴走防止）。
+ */
+export const STUDY_MAX_QUERIES_PER_RUN = 3;
+
+/**
+ * 勉強バッチ: 前回勉強からの最短間隔（時間）。
+ * この時間が経過していない場合は勉強をスキップする。
+ */
+export const STUDY_MIN_INTERVAL_HOURS = 6;
+
+/**
+ * 勉強バッチ: ユーザーのピーク活動時間帯を避けるウィンドウ（時間）。
+ * morningPeak / eveningPeak の前後この時間内はユーザーが活動中とみなしてスキップ。
+ */
+export const STUDY_INACTIVE_WINDOW_HOURS = 2;
+
+/**
+ * 勉強バッチ: 品質が低い（要約が短すぎる）と判定する文字数閾値。
+ * summary がこの文字数未満の場合は保存しない。
+ */
+export const STUDY_MIN_SUMMARY_LENGTH = 50;
+
+/**
+ * 勉強バッチ: 1 実行あたりに発行する検索クエリの最大数（暴走防止）。
+ */
+export const STUDY_MAX_QUERIES_PER_RUN = 3;
+
+/**
+ * 勉強バッチ: 前回勉強からの最短間隔（時間）。
+ * この時間が経過していない場合は勉強をスキップする。
+ */
+export const STUDY_MIN_INTERVAL_HOURS = 6;
+
+/**
+ * 勉強バッチ: ユーザーのピーク活動時間帯を避けるウィンドウ（時間）。
+ * morningPeak / eveningPeak の前後この時間内はユーザーが活動中とみなしてスキップ。
+ */
+export const STUDY_INACTIVE_WINDOW_HOURS = 2;
+
+/**
+ * 勉強バッチ: 品質が低い（要約が短すぎる）と判定する文字数閾値。
+ * summary がこの文字数未満の場合は保存しない。
+ */
+export const STUDY_MIN_SUMMARY_LENGTH = 50;

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -155,26 +155,3 @@ export const STUDY_INACTIVE_WINDOW_HOURS = 2;
  * summary がこの文字数未満の場合は保存しない。
  */
 export const STUDY_MIN_SUMMARY_LENGTH = 50;
-
-/**
- * 勉強バッチ: 1 実行あたりに発行する検索クエリの最大数（暴走防止）。
- */
-export const STUDY_MAX_QUERIES_PER_RUN = 3;
-
-/**
- * 勉強バッチ: 前回勉強からの最短間隔（時間）。
- * この時間が経過していない場合は勉強をスキップする。
- */
-export const STUDY_MIN_INTERVAL_HOURS = 6;
-
-/**
- * 勉強バッチ: ユーザーのピーク活動時間帯を避けるウィンドウ（時間）。
- * morningPeak / eveningPeak の前後この時間内はユーザーが活動中とみなしてスキップ。
- */
-export const STUDY_INACTIVE_WINDOW_HOURS = 2;
-
-/**
- * 勉強バッチ: 品質が低い（要約が短すぎる）と判定する文字数閾値。
- * summary がこの文字数未満の場合は保存しない。
- */
-export const STUDY_MIN_SUMMARY_LENGTH = 50;

--- a/services/livetalk/core/src/entities/knowledge.entity.ts
+++ b/services/livetalk/core/src/entities/knowledge.entity.ts
@@ -1,0 +1,33 @@
+/**
+ * キャラが Web リサーチで獲得した知識。
+ *
+ * Phase 5a（#3343）勉強バッチが書き込む。
+ * DynamoDB SK: `CHAR#<charId>#KNOWLEDGE#<ulid>`
+ */
+export interface KnowledgeEntity {
+  UserID: string;
+  CharacterID: string;
+  /** ULID（時系列ソート可能） */
+  KnowledgeID: string;
+  /** 検索トピック */
+  Topic: string;
+  /** キャラ目線の要約 */
+  Summary: string;
+  /** 参照した URL 一覧 */
+  SourceUrls: string[];
+  /** キャラのコメント（短い一言） */
+  RawComment: string;
+  /** 紐付く興味カテゴリ名 */
+  RelatedCategory: string;
+  CreatedAt: number;
+  /** 任意 TTL（Unix 秒）。未設定なら永続 */
+  Ttl?: number;
+}
+
+export interface KnowledgeKey {
+  userId: string;
+  characterId: string;
+  knowledgeId: string;
+}
+
+export type CreateKnowledgeInput = Omit<KnowledgeEntity, 'CreatedAt'>;

--- a/services/livetalk/core/src/entities/knowledge.entity.ts
+++ b/services/livetalk/core/src/entities/knowledge.entity.ts
@@ -20,6 +20,7 @@ export interface KnowledgeEntity {
   /** 紐付く興味カテゴリ名 */
   RelatedCategory: string;
   CreatedAt: number;
+  UpdatedAt: number;
   /** 任意 TTL（Unix 秒）。未設定なら永続 */
   Ttl?: number;
 }
@@ -30,4 +31,4 @@ export interface KnowledgeKey {
   knowledgeId: string;
 }
 
-export type CreateKnowledgeInput = Omit<KnowledgeEntity, 'CreatedAt'>;
+export type CreateKnowledgeInput = Omit<KnowledgeEntity, 'CreatedAt' | 'UpdatedAt'>;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -213,10 +213,7 @@ export type { KnowledgeRepository } from './repositories/knowledge.repository.in
 export { InMemoryKnowledgeRepository } from './repositories/in-memory-knowledge.repository.js';
 export { DynamoDBKnowledgeRepository } from './repositories/dynamodb-knowledge.repository.js';
 export { KnowledgeMapper } from './mappers/knowledge.mapper.js';
-export {
-  buildKnowledgeSK,
-  buildKnowledgeSKPrefix,
-} from './mappers/keys.js';
+export { buildKnowledgeSK, buildKnowledgeSKPrefix } from './mappers/keys.js';
 
 // Token counter
 export {

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -101,6 +101,14 @@ export {
   type LearnUserActivityParams,
 } from './usecases/learn-user-activity.usecase.js';
 
+// Research（Phase 5a）
+export type { IResearchClient, ResearchResult } from './research/index.js';
+export {
+  OpenAIResearchClient,
+  RESEARCH_ERROR_MESSAGES,
+  type OpenAIResearchClientOptions,
+} from './research/index.js';
+
 // Entities
 export type {
   MemoryEntity,
@@ -195,6 +203,21 @@ export { InMemorySafetyEventRepository } from './repositories/in-memory-safety-e
 export { InMemoryInterestRepository } from './repositories/in-memory-interest.repository.js';
 export { DynamoDBInterestRepository } from './repositories/dynamodb-interest.repository.js';
 
+// Knowledge（Phase 5a）
+export type {
+  KnowledgeEntity,
+  KnowledgeKey,
+  CreateKnowledgeInput,
+} from './entities/knowledge.entity.js';
+export type { KnowledgeRepository } from './repositories/knowledge.repository.interface.js';
+export { InMemoryKnowledgeRepository } from './repositories/in-memory-knowledge.repository.js';
+export { DynamoDBKnowledgeRepository } from './repositories/dynamodb-knowledge.repository.js';
+export { KnowledgeMapper } from './mappers/knowledge.mapper.js';
+export {
+  buildKnowledgeSK,
+  buildKnowledgeSKPrefix,
+} from './mappers/keys.js';
+
 // Token counter
 export {
   TiktokenCounter,
@@ -220,4 +243,16 @@ export {
   AFFECTION_TIME_CONTINUITY_BONUS,
   AFFECTION_BIDIRECTIONALITY_WEIGHT,
   INTEREST_DEDUP_SIMILARITY_THRESHOLD,
+  STUDY_MAX_QUERIES_PER_RUN,
+  STUDY_MIN_INTERVAL_HOURS,
+  STUDY_INACTIVE_WINDOW_HOURS,
+  STUDY_MIN_SUMMARY_LENGTH,
 } from './constants.js';
+
+// Study usecase（Phase 5a）
+export {
+  studyForUser,
+  shouldStudyNow,
+  type StudyForUserParams,
+  type StudyForUserResult,
+} from './usecases/study.usecase.js';

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -91,3 +91,11 @@ export function buildInterestSK(characterId: string, category: string): string {
 export function buildLifecycleSK(characterId: string): string {
   return `CHAR#${characterId}#LIFECYCLE`;
 }
+
+export function buildKnowledgeSKPrefix(characterId: string): string {
+  return `CHAR#${characterId}#KNOWLEDGE#`;
+}
+
+export function buildKnowledgeSK(characterId: string, knowledgeId: string): string {
+  return `${buildKnowledgeSKPrefix(characterId)}${knowledgeId}`;
+}

--- a/services/livetalk/core/src/mappers/knowledge.mapper.ts
+++ b/services/livetalk/core/src/mappers/knowledge.mapper.ts
@@ -1,0 +1,64 @@
+import {
+  validateNumberField,
+  validateStringField,
+  validateTimestampField,
+  type DynamoDBItem,
+  type EntityMapper,
+} from '@nagiyu/aws';
+import type { KnowledgeEntity, KnowledgeKey } from '../entities/knowledge.entity.js';
+import { buildKnowledgeSK, buildUserPK } from './keys.js';
+
+export class KnowledgeMapper implements EntityMapper<KnowledgeEntity, KnowledgeKey> {
+  public readonly entityType = 'Knowledge';
+
+  public toItem(entity: KnowledgeEntity): DynamoDBItem {
+    const { pk, sk } = this.buildKeys({
+      userId: entity.UserID,
+      characterId: entity.CharacterID,
+      knowledgeId: entity.KnowledgeID,
+    });
+    const item: DynamoDBItem = {
+      PK: pk,
+      SK: sk,
+      Type: this.entityType,
+      UserID: entity.UserID,
+      CharacterID: entity.CharacterID,
+      KnowledgeID: entity.KnowledgeID,
+      Topic: entity.Topic,
+      Summary: entity.Summary,
+      SourceUrls: entity.SourceUrls,
+      RawComment: entity.RawComment,
+      RelatedCategory: entity.RelatedCategory,
+      CreatedAt: entity.CreatedAt,
+    };
+    if (entity.Ttl !== undefined) {
+      item.Ttl = entity.Ttl;
+    }
+    return item;
+  }
+
+  public toEntity(item: DynamoDBItem): KnowledgeEntity {
+    const entity: KnowledgeEntity = {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
+      KnowledgeID: validateStringField(item.KnowledgeID, 'KnowledgeID'),
+      Topic: validateStringField(item.Topic, 'Topic'),
+      Summary: validateStringField(item.Summary, 'Summary'),
+      SourceUrls: Array.isArray(item.SourceUrls) ? (item.SourceUrls as string[]) : [],
+      RawComment: validateStringField(item.RawComment, 'RawComment'),
+      RelatedCategory: validateStringField(item.RelatedCategory, 'RelatedCategory'),
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+    };
+    if (item.Ttl !== undefined) {
+      entity.Ttl = validateNumberField(item.Ttl, 'Ttl');
+    }
+    return entity;
+  }
+
+  public buildKeys(key: KnowledgeKey): { pk: string; sk: string } {
+    return {
+      pk: buildUserPK(key.userId),
+      sk: buildKnowledgeSK(key.characterId, key.knowledgeId),
+    };
+  }
+}

--- a/services/livetalk/core/src/mappers/knowledge.mapper.ts
+++ b/services/livetalk/core/src/mappers/knowledge.mapper.ts
@@ -30,6 +30,7 @@ export class KnowledgeMapper implements EntityMapper<KnowledgeEntity, KnowledgeK
       RawComment: entity.RawComment,
       RelatedCategory: entity.RelatedCategory,
       CreatedAt: entity.CreatedAt,
+      UpdatedAt: entity.UpdatedAt,
     };
     if (entity.Ttl !== undefined) {
       item.Ttl = entity.Ttl;
@@ -48,6 +49,7 @@ export class KnowledgeMapper implements EntityMapper<KnowledgeEntity, KnowledgeK
       RawComment: validateStringField(item.RawComment, 'RawComment'),
       RelatedCategory: validateStringField(item.RelatedCategory, 'RelatedCategory'),
       CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
     };
     if (item.Ttl !== undefined) {
       entity.Ttl = validateNumberField(item.Ttl, 'Ttl');

--- a/services/livetalk/core/src/repositories/dynamodb-knowledge.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-knowledge.repository.ts
@@ -24,7 +24,7 @@ export class DynamoDBKnowledgeRepository implements KnowledgeRepository {
 
   public async put(input: CreateKnowledgeInput): Promise<KnowledgeEntity> {
     const now = this.nowMs();
-    const entity: KnowledgeEntity = { ...input, CreatedAt: now };
+    const entity: KnowledgeEntity = { ...input, CreatedAt: now, UpdatedAt: now };
     try {
       await this.docClient.send(
         new PutCommand({ TableName: this.tableName, Item: this.mapper.toItem(entity) })

--- a/services/livetalk/core/src/repositories/dynamodb-knowledge.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-knowledge.repository.ts
@@ -1,13 +1,6 @@
-import {
-  PutCommand,
-  QueryCommand,
-  type DynamoDBDocumentClient,
-} from '@aws-sdk/lib-dynamodb';
+import { PutCommand, QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
-import type {
-  CreateKnowledgeInput,
-  KnowledgeEntity,
-} from '../entities/knowledge.entity.js';
+import type { CreateKnowledgeInput, KnowledgeEntity } from '../entities/knowledge.entity.js';
 import { KnowledgeMapper } from '../mappers/knowledge.mapper.js';
 import { buildKnowledgeSKPrefix, buildUserPK } from '../mappers/keys.js';
 import type { KnowledgeRepository } from './knowledge.repository.interface.js';
@@ -43,11 +36,7 @@ export class DynamoDBKnowledgeRepository implements KnowledgeRepository {
     }
   }
 
-  public async list(
-    userId: string,
-    characterId: string,
-    limit = 100
-  ): Promise<KnowledgeEntity[]> {
+  public async list(userId: string, characterId: string, limit = 100): Promise<KnowledgeEntity[]> {
     const pk = buildUserPK(userId);
     const prefix = buildKnowledgeSKPrefix(characterId);
     const results: KnowledgeEntity[] = [];

--- a/services/livetalk/core/src/repositories/dynamodb-knowledge.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-knowledge.repository.ts
@@ -1,0 +1,110 @@
+import {
+  PutCommand,
+  QueryCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
+import type {
+  CreateKnowledgeInput,
+  KnowledgeEntity,
+} from '../entities/knowledge.entity.js';
+import { KnowledgeMapper } from '../mappers/knowledge.mapper.js';
+import { buildKnowledgeSKPrefix, buildUserPK } from '../mappers/keys.js';
+import type { KnowledgeRepository } from './knowledge.repository.interface.js';
+
+export class DynamoDBKnowledgeRepository implements KnowledgeRepository {
+  private readonly mapper: KnowledgeMapper;
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly nowMs: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.nowMs = nowMs;
+    this.mapper = new KnowledgeMapper();
+  }
+
+  public async put(input: CreateKnowledgeInput): Promise<KnowledgeEntity> {
+    const now = this.nowMs();
+    const entity: KnowledgeEntity = { ...input, CreatedAt: now };
+    try {
+      await this.docClient.send(
+        new PutCommand({ TableName: this.tableName, Item: this.mapper.toItem(entity) })
+      );
+      return entity;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async list(
+    userId: string,
+    characterId: string,
+    limit = 100
+  ): Promise<KnowledgeEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildKnowledgeSKPrefix(characterId);
+    const results: KnowledgeEntity[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: { ':pk': pk, ':prefix': prefix },
+            ScanIndexForward: false,
+            Limit: limit,
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        results.push(this.mapper.toEntity(raw as unknown as DynamoDBItem));
+      }
+
+      if (!result.LastEvaluatedKey || results.length >= limit) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return results;
+  }
+
+  public async getLatest(userId: string, characterId: string): Promise<KnowledgeEntity | null> {
+    const pk = buildUserPK(userId);
+    const prefix = buildKnowledgeSKPrefix(characterId);
+
+    try {
+      const result = await this.docClient.send(
+        new QueryCommand({
+          TableName: this.tableName,
+          KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+          ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+          ExpressionAttributeValues: { ':pk': pk, ':prefix': prefix },
+          ScanIndexForward: false,
+          Limit: 1,
+        })
+      );
+
+      const item = result.Items?.[0];
+      if (!item) return null;
+      return this.mapper.toEntity(item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-knowledge.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-knowledge.repository.ts
@@ -17,7 +17,7 @@ export class InMemoryKnowledgeRepository implements KnowledgeRepository {
 
   public async put(input: CreateKnowledgeInput): Promise<KnowledgeEntity> {
     const now = this.nowMs();
-    const entity: KnowledgeEntity = { ...input, CreatedAt: now };
+    const entity: KnowledgeEntity = { ...input, CreatedAt: now, UpdatedAt: now };
     this.store.put(this.mapper.toItem(entity));
     return entity;
   }

--- a/services/livetalk/core/src/repositories/in-memory-knowledge.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-knowledge.repository.ts
@@ -1,0 +1,47 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import type {
+  CreateKnowledgeInput,
+  KnowledgeEntity,
+} from '../entities/knowledge.entity.js';
+import { KnowledgeMapper } from '../mappers/knowledge.mapper.js';
+import { buildKnowledgeSKPrefix, buildUserPK } from '../mappers/keys.js';
+import type { KnowledgeRepository } from './knowledge.repository.interface.js';
+
+export class InMemoryKnowledgeRepository implements KnowledgeRepository {
+  private readonly mapper: KnowledgeMapper;
+  private readonly store: InMemorySingleTableStore;
+  private readonly nowMs: () => number;
+
+  constructor(store: InMemorySingleTableStore, nowMs: () => number = () => Date.now()) {
+    this.store = store;
+    this.nowMs = nowMs;
+    this.mapper = new KnowledgeMapper();
+  }
+
+  public async put(input: CreateKnowledgeInput): Promise<KnowledgeEntity> {
+    const now = this.nowMs();
+    const entity: KnowledgeEntity = { ...input, CreatedAt: now };
+    this.store.put(this.mapper.toItem(entity));
+    return entity;
+  }
+
+  public async list(userId: string, characterId: string, limit = 100): Promise<KnowledgeEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildKnowledgeSKPrefix(characterId);
+    // store.query に limit を渡さず全件取得し、CreatedAt 降順でソート後に limit を適用する。
+    // InMemorySingleTableStore は挿入順で返すため、先に limit を適用すると
+    // 最新アイテムが取りこぼされる可能性がある。
+    const result = this.store.query(
+      { pk, sk: { operator: 'begins_with', value: prefix } }
+    );
+    return result.items
+      .map((item) => this.mapper.toEntity(item))
+      .sort((a, b) => b.CreatedAt - a.CreatedAt)
+      .slice(0, limit);
+  }
+
+  public async getLatest(userId: string, characterId: string): Promise<KnowledgeEntity | null> {
+    const all = await this.list(userId, characterId, 1);
+    return all[0] ?? null;
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-knowledge.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-knowledge.repository.ts
@@ -1,8 +1,5 @@
 import { InMemorySingleTableStore } from '@nagiyu/aws';
-import type {
-  CreateKnowledgeInput,
-  KnowledgeEntity,
-} from '../entities/knowledge.entity.js';
+import type { CreateKnowledgeInput, KnowledgeEntity } from '../entities/knowledge.entity.js';
 import { KnowledgeMapper } from '../mappers/knowledge.mapper.js';
 import { buildKnowledgeSKPrefix, buildUserPK } from '../mappers/keys.js';
 import type { KnowledgeRepository } from './knowledge.repository.interface.js';
@@ -31,9 +28,7 @@ export class InMemoryKnowledgeRepository implements KnowledgeRepository {
     // store.query に limit を渡さず全件取得し、CreatedAt 降順でソート後に limit を適用する。
     // InMemorySingleTableStore は挿入順で返すため、先に limit を適用すると
     // 最新アイテムが取りこぼされる可能性がある。
-    const result = this.store.query(
-      { pk, sk: { operator: 'begins_with', value: prefix } }
-    );
+    const result = this.store.query({ pk, sk: { operator: 'begins_with', value: prefix } });
     return result.items
       .map((item) => this.mapper.toEntity(item))
       .sort((a, b) => b.CreatedAt - a.CreatedAt)

--- a/services/livetalk/core/src/repositories/knowledge.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/knowledge.repository.interface.ts
@@ -1,0 +1,11 @@
+import type {
+  CreateKnowledgeInput,
+  KnowledgeEntity,
+} from '../entities/knowledge.entity.js';
+
+export interface KnowledgeRepository {
+  put(input: CreateKnowledgeInput): Promise<KnowledgeEntity>;
+  list(userId: string, characterId: string, limit?: number): Promise<KnowledgeEntity[]>;
+  /** 最新の Knowledge を 1 件返す。なければ null。 */
+  getLatest(userId: string, characterId: string): Promise<KnowledgeEntity | null>;
+}

--- a/services/livetalk/core/src/repositories/knowledge.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/knowledge.repository.interface.ts
@@ -1,7 +1,4 @@
-import type {
-  CreateKnowledgeInput,
-  KnowledgeEntity,
-} from '../entities/knowledge.entity.js';
+import type { CreateKnowledgeInput, KnowledgeEntity } from '../entities/knowledge.entity.js';
 
 export interface KnowledgeRepository {
   put(input: CreateKnowledgeInput): Promise<KnowledgeEntity>;

--- a/services/livetalk/core/src/research/index.ts
+++ b/services/livetalk/core/src/research/index.ts
@@ -1,0 +1,6 @@
+export type { IResearchClient, ResearchResult } from './types.js';
+export {
+  OpenAIResearchClient,
+  RESEARCH_ERROR_MESSAGES,
+  type OpenAIResearchClientOptions,
+} from './openai-research-client.js';

--- a/services/livetalk/core/src/research/openai-research-client.ts
+++ b/services/livetalk/core/src/research/openai-research-client.ts
@@ -1,0 +1,116 @@
+import OpenAI from 'openai';
+import { zodTextFormat } from 'openai/helpers/zod';
+import { z } from 'zod';
+import { withRetry } from '@nagiyu/common';
+import type { CharacterDefinition } from '../characters/types.js';
+import type { IResearchClient, ResearchResult } from './types.js';
+
+const RESEARCH_MODEL = 'gpt-5-mini';
+const MAX_RETRIES = 3;
+const REQUEST_TIMEOUT_MS = 120_000;
+
+export const RESEARCH_ERROR_MESSAGES = {
+  EMPTY_API_KEY: 'OpenAI API キーが指定されていません',
+  INVALID_RESPONSE: 'Web リサーチの応答が不正です',
+  TIMEOUT: 'OpenAI Web リサーチ API がタイムアウトしました',
+} as const;
+
+const researchResultSchema = z.object({
+  topic: z.string(),
+  summary: z.string(),
+  sourceUrls: z.array(z.string()),
+  rawComment: z.string(),
+});
+
+export interface OpenAIResearchClientOptions {
+  apiKey?: string;
+  client?: OpenAI;
+  model?: string;
+}
+
+export class OpenAIResearchClient implements IResearchClient {
+  private readonly client: OpenAI;
+  private readonly model: string;
+
+  constructor(options: OpenAIResearchClientOptions = {}) {
+    if (options.client) {
+      this.client = options.client;
+    } else {
+      if (!options.apiKey) {
+        throw new Error(RESEARCH_ERROR_MESSAGES.EMPTY_API_KEY);
+      }
+      this.client = new OpenAI({ apiKey: options.apiKey, maxRetries: 0 });
+    }
+    this.model = options.model ?? RESEARCH_MODEL;
+  }
+
+  public async research(query: string, character: CharacterDefinition): Promise<ResearchResult> {
+    const response = await withRetry(
+      async () =>
+        withTimeout(
+          this.client.responses.parse({
+            model: this.model,
+            stream: false,
+            tools: [{ type: 'web_search' }],
+            tool_choice: 'required',
+            text: { format: zodTextFormat(researchResultSchema, 'livetalk_research') },
+            input: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'input_text',
+                    text: buildPrompt(query, character),
+                  },
+                ],
+              },
+            ],
+          }),
+          REQUEST_TIMEOUT_MS
+        ),
+      { maxRetries: MAX_RETRIES }
+    );
+
+    if (!response.output_parsed) {
+      throw new Error(RESEARCH_ERROR_MESSAGES.INVALID_RESPONSE);
+    }
+
+    return response.output_parsed;
+  }
+}
+
+function buildPrompt(query: string, character: CharacterDefinition): string {
+  const likes = character.personality.preferences.likes.join('、');
+  return [
+    `あなたは「${character.displayName}」です。`,
+    `口調・性格：${character.personality.speechStyle}`,
+    `好きなもの：${likes}`,
+    '',
+    `「${query}」について必ず Web 検索し、${character.displayName} らしい視点で内容を要約してください。`,
+    '',
+    '返す項目（JSON）:',
+    '- topic: 検索したトピックを 1〜2 文で説明',
+    '- summary: キャラクター目線の要約（200 文字以上）',
+    '- sourceUrls: 参照した URL のリスト（空の場合は空配列）',
+    `- rawComment: ${character.displayName} として一言コメント（50〜100 文字、上記の口調で）`,
+  ].join('\n');
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(RESEARCH_ERROR_MESSAGES.TIMEOUT));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/services/livetalk/core/src/research/types.ts
+++ b/services/livetalk/core/src/research/types.ts
@@ -1,0 +1,19 @@
+import type { CharacterDefinition } from '../characters/types.js';
+
+export interface ResearchResult {
+  topic: string;
+  /** キャラ目線の要約 */
+  summary: string;
+  sourceUrls: string[];
+  /** キャラのコメント（短い一言） */
+  rawComment: string;
+}
+
+/**
+ * Web リサーチクライアントの抽象インターフェース。
+ *
+ * 現在は OpenAI Web Search 実装のみ。将来 Brave Search 等に差し替え可能。
+ */
+export interface IResearchClient {
+  research(query: string, character: CharacterDefinition): Promise<ResearchResult>;
+}

--- a/services/livetalk/core/src/usecases/study.usecase.ts
+++ b/services/livetalk/core/src/usecases/study.usecase.ts
@@ -140,7 +140,10 @@ export function shouldStudyNow(
   const profile = lifecycle.UserActivityProfile;
   if (profile) {
     const currentHour = now.getHours();
-    if (isNearPeak(currentHour, profile.morningPeak) || isNearPeak(currentHour, profile.eveningPeak)) {
+    if (
+      isNearPeak(currentHour, profile.morningPeak) ||
+      isNearPeak(currentHour, profile.eveningPeak)
+    ) {
       return { result: false, reason: 'ユーザーのピーク活動時間帯' };
     }
   }

--- a/services/livetalk/core/src/usecases/study.usecase.ts
+++ b/services/livetalk/core/src/usecases/study.usecase.ts
@@ -1,0 +1,164 @@
+import { logger } from '@nagiyu/common';
+import type { CharacterDefinition } from '../characters/types.js';
+import {
+  STUDY_MAX_QUERIES_PER_RUN,
+  STUDY_MIN_INTERVAL_HOURS,
+  STUDY_INACTIVE_WINDOW_HOURS,
+  STUDY_MIN_SUMMARY_LENGTH,
+} from '../constants.js';
+import type { LifecycleEntity } from '../entities/lifecycle.entity.js';
+import type { KnowledgeRepository } from '../repositories/knowledge.repository.interface.js';
+import type { InterestRepository } from '../repositories/interest.repository.interface.js';
+import { resolveLifecycleState } from '../lifecycle/state-resolver.js';
+import type { IResearchClient } from '../research/types.js';
+import type { UlidFactory } from '../lib/ulid.js';
+import { defaultUlidFactory } from '../lib/ulid.js';
+
+export interface StudyForUserParams {
+  knowledgeRepo: KnowledgeRepository;
+  interestRepo: InterestRepository;
+  researchClient: IResearchClient;
+  character: CharacterDefinition;
+  lifecycle: LifecycleEntity;
+  ulidFactory?: UlidFactory;
+  now?: () => Date;
+  maxQueriesPerRun?: number;
+}
+
+export interface StudyForUserResult {
+  outcome: 'studied' | 'skipped';
+  skipReason?: string;
+  savedCount?: number;
+}
+
+/**
+ * 1 ユーザー × 1 キャラの勉強バッチ（Web リサーチ → 知識ベース保存）。
+ *
+ * 実施判定：
+ * 1. キャラが起床中（lifecycle の Bedtime/WakeUpTime）
+ * 2. ユーザーが非活動時間帯（activityProfile のピーク前後 STUDY_INACTIVE_WINDOW_HOURS を避ける）
+ * 3. 前回勉強から STUDY_MIN_INTERVAL_HOURS 以上経過
+ */
+export async function studyForUser(
+  userId: string,
+  characterId: string,
+  params: StudyForUserParams
+): Promise<StudyForUserResult> {
+  const {
+    knowledgeRepo,
+    interestRepo,
+    researchClient,
+    character,
+    lifecycle,
+    ulidFactory = defaultUlidFactory,
+    now = () => new Date(),
+    maxQueriesPerRun = STUDY_MAX_QUERIES_PER_RUN,
+  } = params;
+
+  const nowDate = now();
+
+  // 前回勉強時刻を取得
+  const latestKnowledge = await knowledgeRepo.getLatest(userId, characterId);
+  const lastStudiedAt = latestKnowledge?.CreatedAt;
+
+  const shouldStudy = shouldStudyNow(lifecycle, lastStudiedAt, nowDate);
+  if (!shouldStudy.result) {
+    return { outcome: 'skipped', skipReason: shouldStudy.reason };
+  }
+
+  // 興味カテゴリを weight 降順で取得
+  const categories = await interestRepo.list(userId, characterId);
+  if (categories.length === 0) {
+    return { outcome: 'skipped', skipReason: '興味カテゴリが未登録' };
+  }
+
+  const sorted = [...categories].sort((a, b) => b.Weight - a.Weight);
+  const targets = sorted.slice(0, maxQueriesPerRun);
+
+  let savedCount = 0;
+
+  for (const cat of targets) {
+    const query = buildSearchQuery(cat.Category);
+    try {
+      const result = await researchClient.research(query, character);
+
+      if (result.summary.length < STUDY_MIN_SUMMARY_LENGTH) {
+        logger.warn('[study] 品質が低いため保存をスキップ', {
+          userId,
+          characterId,
+          category: cat.Category,
+          summaryLength: result.summary.length,
+        });
+        continue;
+      }
+
+      await knowledgeRepo.put({
+        UserID: userId,
+        CharacterID: characterId,
+        KnowledgeID: ulidFactory(),
+        Topic: result.topic,
+        Summary: result.summary,
+        SourceUrls: result.sourceUrls,
+        RawComment: result.rawComment,
+        RelatedCategory: cat.Category,
+      });
+      savedCount++;
+    } catch (err) {
+      logger.warn('[study] リサーチ失敗', {
+        userId,
+        characterId,
+        category: cat.Category,
+        err,
+      });
+    }
+  }
+
+  return { outcome: 'studied', savedCount };
+}
+
+function buildSearchQuery(category: string): string {
+  return `${category} 最新情報`;
+}
+
+interface ShouldStudyDecision {
+  result: boolean;
+  reason?: string;
+}
+
+export function shouldStudyNow(
+  lifecycle: LifecycleEntity,
+  lastStudiedAt: number | undefined,
+  now: Date
+): ShouldStudyDecision {
+  // 1. キャラが起床中か
+  const state = resolveLifecycleState(now, lifecycle.Bedtime, lifecycle.WakeUpTime);
+  if (state !== 'awake') {
+    return { result: false, reason: 'キャラが就寝中' };
+  }
+
+  // 2. ユーザーのピーク活動時間帯を避ける
+  const profile = lifecycle.UserActivityProfile;
+  if (profile) {
+    const currentHour = now.getHours();
+    if (isNearPeak(currentHour, profile.morningPeak) || isNearPeak(currentHour, profile.eveningPeak)) {
+      return { result: false, reason: 'ユーザーのピーク活動時間帯' };
+    }
+  }
+
+  // 3. 前回勉強からの経過時間
+  if (lastStudiedAt !== undefined) {
+    const hoursSince = (now.getTime() - lastStudiedAt) / (1000 * 60 * 60);
+    if (hoursSince < STUDY_MIN_INTERVAL_HOURS) {
+      return { result: false, reason: `前回勉強から ${STUDY_MIN_INTERVAL_HOURS} 時間未満` };
+    }
+  }
+
+  return { result: true };
+}
+
+function isNearPeak(currentHour: number, peakTime: string): boolean {
+  const peakHour = parseInt(peakTime.split(':')[0], 10);
+  const diff = Math.abs(currentHour - peakHour);
+  const circularDiff = Math.min(diff, 24 - diff);
+  return circularDiff <= STUDY_INACTIVE_WINDOW_HOURS;
+}

--- a/services/livetalk/core/tests/unit/mappers/knowledge.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/knowledge.mapper.test.ts
@@ -1,0 +1,46 @@
+import { KnowledgeMapper } from '../../../src/mappers/knowledge.mapper.js';
+
+describe('KnowledgeMapper', () => {
+  const mapper = new KnowledgeMapper();
+
+  const entity = {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    KnowledgeID: 'ulid-001',
+    Topic: 'テスト',
+    Summary: 'テスト要約',
+    SourceUrls: ['https://example.com'],
+    RawComment: 'コメント',
+    RelatedCategory: 'テスト',
+    CreatedAt: 1_700_000_000_000,
+  };
+
+  it('buildKeys は正しい PK/SK を生成する', () => {
+    const { pk, sk } = mapper.buildKeys({
+      userId: 'u1',
+      characterId: 'hiyori',
+      knowledgeId: 'ulid-001',
+    });
+    expect(pk).toBe('USER#u1');
+    expect(sk).toBe('CHAR#hiyori#KNOWLEDGE#ulid-001');
+  });
+
+  it('toItem / toEntity のラウンドトリップが成立する', () => {
+    const item = mapper.toItem(entity);
+    const restored = mapper.toEntity(item);
+    expect(restored).toEqual(entity);
+  });
+
+  it('Ttl が undefined の場合は item に含まれない', () => {
+    const item = mapper.toItem(entity);
+    expect(item.Ttl).toBeUndefined();
+  });
+
+  it('Ttl が設定されている場合は item に含まれる', () => {
+    const withTtl = { ...entity, Ttl: 9999 };
+    const item = mapper.toItem(withTtl);
+    const restored = mapper.toEntity(item);
+    expect(item.Ttl).toBe(9999);
+    expect(restored.Ttl).toBe(9999);
+  });
+});

--- a/services/livetalk/core/tests/unit/mappers/knowledge.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/knowledge.mapper.test.ts
@@ -13,6 +13,7 @@ describe('KnowledgeMapper', () => {
     RawComment: 'コメント',
     RelatedCategory: 'テスト',
     CreatedAt: 1_700_000_000_000,
+    UpdatedAt: 1_700_000_000_000,
   };
 
   it('buildKeys は正しい PK/SK を生成する', () => {

--- a/services/livetalk/core/tests/unit/repositories/in-memory-knowledge.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-knowledge.repository.test.ts
@@ -13,10 +13,18 @@ describe('InMemoryKnowledgeRepository', () => {
     repo = new InMemoryKnowledgeRepository(store, () => now);
   });
 
-  const makeInput = (overrides: Partial<{
-    UserID: string; CharacterID: string; KnowledgeID: string; Topic: string;
-    Summary: string; SourceUrls: string[]; RawComment: string; RelatedCategory: string;
-  }> = {}) => ({
+  const makeInput = (
+    overrides: Partial<{
+      UserID: string;
+      CharacterID: string;
+      KnowledgeID: string;
+      Topic: string;
+      Summary: string;
+      SourceUrls: string[];
+      RawComment: string;
+      RelatedCategory: string;
+    }> = {}
+  ) => ({
     UserID: 'u1',
     CharacterID: 'hiyori',
     KnowledgeID: 'ulid-001',

--- a/services/livetalk/core/tests/unit/repositories/in-memory-knowledge.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-knowledge.repository.test.ts
@@ -1,0 +1,75 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryKnowledgeRepository } from '../../../src/repositories/in-memory-knowledge.repository.js';
+
+describe('InMemoryKnowledgeRepository', () => {
+  const baseNow = 1_700_000_000_000;
+  let now = baseNow;
+  let store: InMemorySingleTableStore;
+  let repo: InMemoryKnowledgeRepository;
+
+  beforeEach(() => {
+    store = new InMemorySingleTableStore();
+    now = baseNow;
+    repo = new InMemoryKnowledgeRepository(store, () => now);
+  });
+
+  const makeInput = (overrides: Partial<{
+    UserID: string; CharacterID: string; KnowledgeID: string; Topic: string;
+    Summary: string; SourceUrls: string[]; RawComment: string; RelatedCategory: string;
+  }> = {}) => ({
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    KnowledgeID: 'ulid-001',
+    Topic: 'コーヒーの効能',
+    Summary: 'コーヒーには覚醒効果があります。'.repeat(5),
+    SourceUrls: ['https://example.com'],
+    RawComment: '面白い！',
+    RelatedCategory: 'コーヒー',
+    ...overrides,
+  });
+
+  it('put で新規作成できる', async () => {
+    const item = await repo.put(makeInput());
+    expect(item.UserID).toBe('u1');
+    expect(item.KnowledgeID).toBe('ulid-001');
+    expect(item.CreatedAt).toBe(baseNow);
+  });
+
+  it('list でキャラ単位の全件を返す（CreatedAt 降順）', async () => {
+    await repo.put(makeInput({ KnowledgeID: 'ulid-001' }));
+    now += 1000;
+    await repo.put(makeInput({ KnowledgeID: 'ulid-002' }));
+    await repo.put(makeInput({ UserID: 'u2', KnowledgeID: 'ulid-003' }));
+
+    const list = await repo.list('u1', 'hiyori');
+    expect(list).toHaveLength(2);
+    expect(list[0].KnowledgeID).toBe('ulid-002');
+    expect(list[1].KnowledgeID).toBe('ulid-001');
+  });
+
+  it('list は limit を超えない', async () => {
+    for (let i = 0; i < 5; i++) {
+      await repo.put(makeInput({ KnowledgeID: `ulid-00${i}` }));
+      now += 100;
+    }
+    const list = await repo.list('u1', 'hiyori', 3);
+    expect(list).toHaveLength(3);
+  });
+
+  it('getLatest は最新 1 件を返す', async () => {
+    await repo.put(makeInput({ KnowledgeID: 'ulid-001' }));
+    now += 1000;
+    await repo.put(makeInput({ KnowledgeID: 'ulid-002' }));
+
+    const latest = await repo.getLatest('u1', 'hiyori');
+    expect(latest?.KnowledgeID).toBe('ulid-002');
+  });
+
+  it('getLatest は件数ゼロで null を返す', async () => {
+    expect(await repo.getLatest('u1', 'hiyori')).toBeNull();
+  });
+
+  it('list は未登録ユーザーに対して空配列を返す', async () => {
+    expect(await repo.list('unknown', 'hiyori')).toHaveLength(0);
+  });
+});

--- a/services/livetalk/core/tests/unit/research/openai-research-client.test.ts
+++ b/services/livetalk/core/tests/unit/research/openai-research-client.test.ts
@@ -1,0 +1,62 @@
+import OpenAI from 'openai';
+import { OpenAIResearchClient, RESEARCH_ERROR_MESSAGES } from '../../../src/research/openai-research-client.js';
+import type { CharacterDefinition } from '../../../src/characters/types.js';
+
+const character: CharacterDefinition = {
+  id: 'hiyori',
+  displayName: '桃瀬ひより',
+  personality: {
+    basePrompt: '',
+    speechStyle: '優しい口調',
+    preferences: { likes: ['コーヒー'], dislikes: [] },
+  },
+  voiceConfig: { speakerId: 14 },
+  license: { displayText: '', creditName: '' },
+};
+
+describe('OpenAIResearchClient', () => {
+  it('apiKey なしで初期化すると例外', () => {
+    expect(() => new OpenAIResearchClient({})).toThrow(
+      RESEARCH_ERROR_MESSAGES.EMPTY_API_KEY
+    );
+  });
+
+  it('client 注入で初期化できる', () => {
+    const mockClient = {} as OpenAI;
+    expect(() => new OpenAIResearchClient({ client: mockClient })).not.toThrow();
+  });
+
+  it('output_parsed が null の場合 INVALID_RESPONSE を throw する', async () => {
+    const mockParse = jest.fn().mockResolvedValue({ output_parsed: null });
+    const mockClient = {
+      responses: { parse: mockParse },
+    } as unknown as OpenAI;
+
+    const researchClient = new OpenAIResearchClient({ client: mockClient });
+    await expect(researchClient.research('テスト', character)).rejects.toThrow(
+      RESEARCH_ERROR_MESSAGES.INVALID_RESPONSE
+    );
+  });
+
+  it('正常ケースで ResearchResult が返る', async () => {
+    const expected = {
+      topic: 'コーヒー',
+      summary: 'コーヒーの説明。'.repeat(10),
+      sourceUrls: ['https://example.com'],
+      rawComment: 'コメント',
+    };
+    const mockParse = jest.fn().mockResolvedValue({ output_parsed: expected });
+    const mockClient = { responses: { parse: mockParse } } as unknown as OpenAI;
+
+    const researchClient = new OpenAIResearchClient({ client: mockClient });
+    const result = await researchClient.research('コーヒー', character);
+
+    expect(result).toEqual(expected);
+    expect(mockParse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [{ type: 'web_search' }],
+        tool_choice: 'required',
+      })
+    );
+  });
+});

--- a/services/livetalk/core/tests/unit/research/openai-research-client.test.ts
+++ b/services/livetalk/core/tests/unit/research/openai-research-client.test.ts
@@ -1,5 +1,8 @@
 import OpenAI from 'openai';
-import { OpenAIResearchClient, RESEARCH_ERROR_MESSAGES } from '../../../src/research/openai-research-client.js';
+import {
+  OpenAIResearchClient,
+  RESEARCH_ERROR_MESSAGES,
+} from '../../../src/research/openai-research-client.js';
 import type { CharacterDefinition } from '../../../src/characters/types.js';
 
 const character: CharacterDefinition = {
@@ -16,9 +19,7 @@ const character: CharacterDefinition = {
 
 describe('OpenAIResearchClient', () => {
   it('apiKey なしで初期化すると例外', () => {
-    expect(() => new OpenAIResearchClient({})).toThrow(
-      RESEARCH_ERROR_MESSAGES.EMPTY_API_KEY
-    );
+    expect(() => new OpenAIResearchClient({})).toThrow(RESEARCH_ERROR_MESSAGES.EMPTY_API_KEY);
   });
 
   it('client 注入で初期化できる', () => {

--- a/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
@@ -1,0 +1,215 @@
+import type { LifecycleEntity } from '../../../src/entities/lifecycle.entity.js';
+import { shouldStudyNow, studyForUser } from '../../../src/usecases/study.usecase.js';
+import type { KnowledgeRepository } from '../../../src/repositories/knowledge.repository.interface.js';
+import type { InterestRepository } from '../../../src/repositories/interest.repository.interface.js';
+import type { IResearchClient } from '../../../src/research/types.js';
+import type { CharacterDefinition } from '../../../src/characters/types.js';
+import { STUDY_MIN_INTERVAL_HOURS, STUDY_MIN_SUMMARY_LENGTH } from '../../../src/constants.js';
+
+const makeLifecycle = (overrides: Partial<LifecycleEntity> = {}): LifecycleEntity => ({
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  Bedtime: '01:30',
+  WakeUpTime: '09:30',
+  CreatedAt: 1_700_000_000_000,
+  UpdatedAt: 1_700_000_000_000,
+  ...overrides,
+});
+
+const character: CharacterDefinition = {
+  id: 'hiyori',
+  displayName: '桃瀬ひより',
+  personality: {
+    basePrompt: '',
+    speechStyle: '優しい口調',
+    preferences: { likes: ['コーヒー'], dislikes: [] },
+  },
+  voiceConfig: { speakerId: 14 },
+  license: { displayText: '', creditName: '' },
+};
+
+describe('shouldStudyNow', () => {
+  // 14:00 ローカル時刻（起床中 = Bedtime 01:30〜WakeUpTime 09:30 以外、ピーク外）
+  const awakeNonPeak = new Date(2026, 5, 1, 14, 0, 0);
+
+  it('起床中かつ非ピーク時間は true', () => {
+    const result = shouldStudyNow(makeLifecycle(), undefined, awakeNonPeak);
+    expect(result.result).toBe(true);
+  });
+
+  it('就寝中は false', () => {
+    // 03:00 ローカル時刻 = 就寝時間（Bedtime 01:30〜WakeUpTime 09:30）
+    const sleeping = new Date(2026, 4, 31, 3, 0, 0);
+    const result = shouldStudyNow(makeLifecycle(), undefined, sleeping);
+    expect(result.result).toBe(false);
+    expect(result.reason).toContain('就寝中');
+  });
+
+  it('ピーク活動時間帯はスキップ', () => {
+    const lifecycle = makeLifecycle({
+      UserActivityProfile: {
+        morningPeak: '14:00',
+        eveningPeak: '21:00',
+        sampleSize: 10,
+        lastLearnedAt: '2026-06-01T00:00:00Z',
+      },
+    });
+    // 14:00 ローカル時刻 は morningPeak '14:00' の ±2 時間内なのでスキップ
+    const result = shouldStudyNow(lifecycle, undefined, awakeNonPeak);
+    expect(result.result).toBe(false);
+    expect(result.reason).toContain('ピーク');
+  });
+
+  it('前回勉強から STUDY_MIN_INTERVAL_HOURS 未満はスキップ', () => {
+    const nowMs = awakeNonPeak.getTime();
+    const recentStudy = nowMs - (STUDY_MIN_INTERVAL_HOURS - 1) * 60 * 60 * 1000;
+    const result = shouldStudyNow(makeLifecycle(), recentStudy, awakeNonPeak);
+    expect(result.result).toBe(false);
+  });
+
+  it('前回勉強から STUDY_MIN_INTERVAL_HOURS 以上経過していれば true', () => {
+    const nowMs = awakeNonPeak.getTime();
+    const oldStudy = nowMs - (STUDY_MIN_INTERVAL_HOURS + 1) * 60 * 60 * 1000;
+    const result = shouldStudyNow(makeLifecycle(), oldStudy, awakeNonPeak);
+    expect(result.result).toBe(true);
+  });
+
+  it('UserActivityProfile がない場合はピーク判定をスキップ', () => {
+    const lifecycle = makeLifecycle({ UserActivityProfile: undefined });
+    const result = shouldStudyNow(lifecycle, undefined, awakeNonPeak);
+    expect(result.result).toBe(true);
+  });
+});
+
+describe('studyForUser', () => {
+  // 14:00 ローカル時刻（起床中）
+  const awakeNonPeak = new Date(2026, 5, 1, 14, 0, 0);
+
+  const makeKnowledgeRepo = (): jest.Mocked<KnowledgeRepository> => ({
+    put: jest.fn().mockImplementation(async (input) => ({ ...input, CreatedAt: Date.now() })),
+    list: jest.fn().mockResolvedValue([]),
+    getLatest: jest.fn().mockResolvedValue(null),
+  });
+
+  const makeInterestRepo = (): jest.Mocked<InterestRepository> => ({
+    get: jest.fn(),
+    list: jest.fn().mockResolvedValue([
+      { UserID: 'u1', CharacterID: 'hiyori', Category: 'コーヒー', Weight: 10, CreatedAt: 0, UpdatedAt: 0 },
+    ]),
+    put: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  });
+
+  const makeResearchClient = (): jest.Mocked<IResearchClient> => ({
+    research: jest.fn().mockResolvedValue({
+      topic: 'コーヒーの効能',
+      summary: 'コーヒーには多くの健康効果があります。'.repeat(5),
+      sourceUrls: ['https://example.com'],
+      rawComment: '美味しいね！',
+    }),
+  });
+
+  it('実施判定が通れば研究が実行される', async () => {
+    const knowledgeRepo = makeKnowledgeRepo();
+    const interestRepo = makeInterestRepo();
+    const researchClient = makeResearchClient();
+
+    const result = await studyForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      interestRepo,
+      researchClient,
+      character,
+      lifecycle: makeLifecycle(),
+      ulidFactory: () => 'test-ulid',
+      now: () => awakeNonPeak,
+    });
+
+    expect(result.outcome).toBe('studied');
+    expect(result.savedCount).toBeGreaterThan(0);
+    expect(knowledgeRepo.put).toHaveBeenCalled();
+  });
+
+  it('就寝中はスキップ', async () => {
+    // 03:00 ローカル時刻 = 就寝中
+    const sleeping = new Date(2026, 4, 31, 3, 0, 0);
+    const result = await studyForUser('u1', 'hiyori', {
+      knowledgeRepo: makeKnowledgeRepo(),
+      interestRepo: makeInterestRepo(),
+      researchClient: makeResearchClient(),
+      character,
+      lifecycle: makeLifecycle(),
+      now: () => sleeping,
+    });
+    expect(result.outcome).toBe('skipped');
+  });
+
+  it('興味カテゴリが空ならスキップ', async () => {
+    const interestRepo = makeInterestRepo();
+    interestRepo.list.mockResolvedValue([]);
+
+    const result = await studyForUser('u1', 'hiyori', {
+      knowledgeRepo: makeKnowledgeRepo(),
+      interestRepo,
+      researchClient: makeResearchClient(),
+      character,
+      lifecycle: makeLifecycle(),
+      now: () => awakeNonPeak,
+    });
+    expect(result.outcome).toBe('skipped');
+  });
+
+  it(`要約が ${STUDY_MIN_SUMMARY_LENGTH} 文字未満の場合は保存しない`, async () => {
+    const researchClient = makeResearchClient();
+    researchClient.research.mockResolvedValue({
+      topic: 'トピック',
+      summary: '短い',
+      sourceUrls: [],
+      rawComment: 'コメント',
+    });
+
+    const knowledgeRepo = makeKnowledgeRepo();
+    await studyForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      interestRepo: makeInterestRepo(),
+      researchClient,
+      character,
+      lifecycle: makeLifecycle(),
+      now: () => awakeNonPeak,
+    });
+
+    expect(knowledgeRepo.put).not.toHaveBeenCalled();
+  });
+
+  it('リサーチ失敗でも他カテゴリを継続する（fail-warn）', async () => {
+    const interestRepo = makeInterestRepo();
+    interestRepo.list.mockResolvedValue([
+      { UserID: 'u1', CharacterID: 'hiyori', Category: 'コーヒー', Weight: 10, CreatedAt: 0, UpdatedAt: 0 },
+      { UserID: 'u1', CharacterID: 'hiyori', Category: 'アニメ', Weight: 5, CreatedAt: 0, UpdatedAt: 0 },
+    ]);
+
+    const researchClient = makeResearchClient();
+    researchClient.research
+      .mockRejectedValueOnce(new Error('API エラー'))
+      .mockResolvedValueOnce({
+        topic: 'アニメの話題',
+        summary: 'アニメに関する情報です。'.repeat(5),
+        sourceUrls: [],
+        rawComment: '面白そう！',
+      });
+
+    const knowledgeRepo = makeKnowledgeRepo();
+    const result = await studyForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      interestRepo,
+      researchClient,
+      character,
+      lifecycle: makeLifecycle(),
+      ulidFactory: () => 'test-ulid',
+      now: () => awakeNonPeak,
+    });
+
+    expect(result.outcome).toBe('studied');
+    expect(knowledgeRepo.put).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
@@ -94,7 +94,14 @@ describe('studyForUser', () => {
   const makeInterestRepo = (): jest.Mocked<InterestRepository> => ({
     get: jest.fn(),
     list: jest.fn().mockResolvedValue([
-      { UserID: 'u1', CharacterID: 'hiyori', Category: 'コーヒー', Weight: 10, CreatedAt: 0, UpdatedAt: 0 },
+      {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Category: 'コーヒー',
+        Weight: 10,
+        CreatedAt: 0,
+        UpdatedAt: 0,
+      },
     ]),
     put: jest.fn(),
     update: jest.fn(),
@@ -184,19 +191,31 @@ describe('studyForUser', () => {
   it('リサーチ失敗でも他カテゴリを継続する（fail-warn）', async () => {
     const interestRepo = makeInterestRepo();
     interestRepo.list.mockResolvedValue([
-      { UserID: 'u1', CharacterID: 'hiyori', Category: 'コーヒー', Weight: 10, CreatedAt: 0, UpdatedAt: 0 },
-      { UserID: 'u1', CharacterID: 'hiyori', Category: 'アニメ', Weight: 5, CreatedAt: 0, UpdatedAt: 0 },
+      {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Category: 'コーヒー',
+        Weight: 10,
+        CreatedAt: 0,
+        UpdatedAt: 0,
+      },
+      {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Category: 'アニメ',
+        Weight: 5,
+        CreatedAt: 0,
+        UpdatedAt: 0,
+      },
     ]);
 
     const researchClient = makeResearchClient();
-    researchClient.research
-      .mockRejectedValueOnce(new Error('API エラー'))
-      .mockResolvedValueOnce({
-        topic: 'アニメの話題',
-        summary: 'アニメに関する情報です。'.repeat(5),
-        sourceUrls: [],
-        rawComment: '面白そう！',
-      });
+    researchClient.research.mockRejectedValueOnce(new Error('API エラー')).mockResolvedValueOnce({
+      topic: 'アニメの話題',
+      summary: 'アニメに関する情報です。'.repeat(5),
+      sourceUrls: [],
+      rawComment: '面白そう！',
+    });
 
     const knowledgeRepo = makeKnowledgeRepo();
     const result = await studyForUser('u1', 'hiyori', {


### PR DESCRIPTION
## 変更の概要

リブトーク Phase 5a（Issue #3343）の勉強バッチを実装。キャラが裏で Web リサーチして知識ベースに溜める定期バッチ（Lambda + EventBridge 毎時）。

- **IResearchClient 抽象化**：将来 Brave Search 等への差し替えを可能にする抽象レイヤー
- **OpenAIResearchClient**：Stock Tracker パターン（`responses.parse` + `tools:[{type:'web_search'}]`）で「検索 → キャラ目線要約 → 構造化出力」を 1 API で完結
- **実施判定（shouldStudyNow）**：① キャラが起床中 ② ユーザーのピーク活動時間帯を避ける ③ 前回から N 時間経過
- **知識ベース（KnowledgeEntity）**：DynamoDB SK `CHAR#<charId>#KNOWLEDGE#<ulid>` に保存
- **OpenAI 呼び出し回数ガード**：`STUDY_MAX_QUERIES_PER_RUN = 3`（1 実行あたり上限）

## 関連 Issue

Issue #3343（Integration PR マージ後にクローズ予定）

## 変更種別

- [x] 新規機能
- [x] インフラ更新
- [x] CI/CD 更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] CI/CD 設定を追加・更新した（workflow の Lambda 更新ループに study 追加）
- [x] ローカルでテストが全て通ることを確認した（core: 700 件、batch: 24 件）

## テスト内容

| ファイル | 内容 |
|---|---|
| `core/tests/unit/research/openai-research-client.test.ts` | APIキー未指定エラー・output_parsed=null エラー・正常ケース・tools パラメータ確認 |
| `core/tests/unit/usecases/study.usecase.test.ts` | shouldStudyNow（就寝中・ピーク中・間隔不足・通過条件）、studyForUser（実行・スキップ・品質フィルタ・fail-warn） |
| `core/tests/unit/repositories/in-memory-knowledge.repository.test.ts` | put / list（降順・limit）/ getLatest / 空配列 |
| `core/tests/unit/mappers/knowledge.mapper.test.ts` | buildKeys / ラウンドトリップ / Ttl あり/なし |
| `batch/tests/unit/usecases/study.usecase.test.ts` | 全ユーザー処理・スキップ・lifecycle=null・例外 |
| `batch/tests/unit/handlers/study.test.ts` | 200 正常 / 500 エラー |

## レビューポイント

- `shouldStudyNow` の「ピーク活動時間帯を避ける」ロジック（`STUDY_INACTIVE_WINDOW_HOURS = 2`）：前後 2 時間の判定が適切か確認をお願いします
- `STUDY_MAX_QUERIES_PER_RUN = 3`：コスト観点でこの上限が妥当か確認をお願いします
- `STUDY_MIN_INTERVAL_HOURS = 6`：1日4回まで勉強する設定。多すぎ/少なすぎないか確認をお願いします
- `batch-stack.ts` の study Lambda は既存の compress / learn-activity と同じ ECR イメージを参照（handler の cmd だけ変えるパターン）

## 補足事項

- `in-memory-knowledge.repository.ts` の `list()` は全件取得後に `.sort().slice(0, limit)` を適用（`InMemorySingleTableStore.query` が挿入順返却のため、limit 先行適用だと最新件が取りこぼされる）
- `.gitignore` に `.claude/` を追加（Claude Code 内部ワークツリーをトラッキング対象外に）

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1ZhxdHNQ36ZgGz5EkPdez)_