### PR TITLE
[Feature] [リブトーク Phase 5b] 「勉強しておくね」強制ゲート（#3344）

### DIFF
--- a/services/livetalk/core/src/characters/prompt-builder.ts
+++ b/services/livetalk/core/src/characters/prompt-builder.ts
@@ -1,6 +1,7 @@
 import type { CharacterDefinition } from './types.js';
 import type { MessageEntity } from '../entities/message.entity.js';
 import type { MemoryEntity } from '../entities/memory.entity.js';
+import type { KnowledgeEntity } from '../entities/knowledge.entity.js';
 import type { ChatMessage } from '../llm-client/types.js';
 import type { RetrievedMemory } from '../memory/types.js';
 import type { LifecycleState } from '../entities/lifecycle.entity.js';
@@ -32,7 +33,8 @@ export function buildSystemPrompt(
   retrievedMemories: RetrievedMemory[] = [],
   summaryText?: string,
   newLearnings?: MemoryEntity[],
-  lifecycleState?: LifecycleState
+  lifecycleState?: LifecycleState,
+  knowledgeContext?: KnowledgeEntity[]
 ): string {
   const { personality, displayName } = character;
   const timeOfDay = getTimeOfDay(now);
@@ -56,8 +58,9 @@ export function buildSystemPrompt(
   const hasMemories = retrievedMemories.length > 0;
   const hasNewLearnings = newLearnings !== undefined && newLearnings.length > 0;
   const isSleeping = lifecycleState === 'sleeping';
+  const hasKnowledge = knowledgeContext !== undefined && knowledgeContext.length > 0;
 
-  if (!hasSummary && !hasMemories && !hasNewLearnings && !isSleeping) return base;
+  if (!hasSummary && !hasMemories && !hasNewLearnings && !isSleeping && !hasKnowledge) return base;
 
   const sections: string[] = [base];
 
@@ -81,6 +84,15 @@ export function buildSystemPrompt(
     );
   }
 
+  if (hasKnowledge) {
+    const knowledgeSection = knowledgeContext!
+      .map((k) => `- ${k.Topic}：${k.Summary}${k.RawComment ? `（${k.RawComment}）` : ''}`)
+      .join('\n');
+    sections.push(
+      `この前調べたこと：\n${knowledgeSection}\n\n調べた内容について「この前の話なんだけど」「気になって調べちゃったんだよね」など、自然に会話に絡めてください。`
+    );
+  }
+
   return sections.join('\n\n');
 }
 
@@ -100,7 +112,8 @@ export function buildChatMessages(
   retrievedMemories: RetrievedMemory[] = [],
   summaryText?: string,
   newLearnings?: MemoryEntity[],
-  lifecycleState?: LifecycleState
+  lifecycleState?: LifecycleState,
+  knowledgeContext?: KnowledgeEntity[]
 ): ChatMessage[] {
   const systemPrompt = buildSystemPrompt(
     character,
@@ -108,7 +121,8 @@ export function buildChatMessages(
     retrievedMemories,
     summaryText,
     newLearnings,
-    lifecycleState
+    lifecycleState,
+    knowledgeContext
   );
   const messages: ChatMessage[] = [{ role: 'system', content: systemPrompt }];
 

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -155,3 +155,14 @@ export const STUDY_INACTIVE_WINDOW_HOURS = 2;
  * summary がこの文字数未満の場合は保存しない。
  */
 export const STUDY_MIN_SUMMARY_LENGTH = 50;
+
+/**
+ * StudyTopic に付与する DynamoDB TTL（秒）。30 日後に自動削除。
+ */
+export const STUDY_TOPIC_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * 知識ゲート経由で登録された StudyTopic の優先度。
+ * 通常の勉強バッチ（Priority=1）より高くして先に処理させる。
+ */
+export const STUDY_TOPIC_GATE_PRIORITY = 10;

--- a/services/livetalk/core/src/entities/study-topic.entity.ts
+++ b/services/livetalk/core/src/entities/study-topic.entity.ts
@@ -1,0 +1,35 @@
+/**
+ * 会話中に「勉強しておくね」と返したトピックのキュー。
+ *
+ * Phase 5b（#3344）chat-usecase の知識ゲートが書き込む。
+ * 勉強バッチ（Phase 5a）がこのキューを優先的に処理する。
+ * DynamoDB SK: `CHAR#<charId>#STUDY#<ulid>`
+ */
+export interface StudyTopicEntity {
+  UserID: string;
+  CharacterID: string;
+  /** ULID（時系列ソート可能） */
+  TopicID: string;
+  /** 勉強が必要と判定されたトピック名 */
+  Topic: string;
+  /**
+   * 優先度（高いほど先に処理）。
+   * 強制ゲート経由は priority=10、通常勉強は 1。
+   */
+  Priority: number;
+  Status: 'pending' | 'in_progress' | 'done';
+  CreatedAt: number;
+  UpdatedAt: number;
+  /** TTL（Unix 秒）。30 日後に自動削除 */
+  Ttl?: number;
+}
+
+export interface StudyTopicKey {
+  userId: string;
+  characterId: string;
+  topicId: string;
+}
+
+export type CreateStudyTopicInput = Omit<StudyTopicEntity, 'CreatedAt' | 'UpdatedAt'>;
+export type UpdateStudyTopicInput = Pick<StudyTopicEntity, 'UserID' | 'CharacterID' | 'TopicID' | 'Status' | 'Priority'> &
+  Partial<Pick<StudyTopicEntity, 'Ttl'>>;

--- a/services/livetalk/core/src/entities/study-topic.entity.ts
+++ b/services/livetalk/core/src/entities/study-topic.entity.ts
@@ -31,5 +31,8 @@ export interface StudyTopicKey {
 }
 
 export type CreateStudyTopicInput = Omit<StudyTopicEntity, 'CreatedAt' | 'UpdatedAt'>;
-export type UpdateStudyTopicInput = Pick<StudyTopicEntity, 'UserID' | 'CharacterID' | 'TopicID' | 'Status' | 'Priority'> &
+export type UpdateStudyTopicInput = Pick<
+  StudyTopicEntity,
+  'UserID' | 'CharacterID' | 'TopicID' | 'Status' | 'Priority'
+> &
   Partial<Pick<StudyTopicEntity, 'Ttl'>>;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -215,6 +215,28 @@ export { DynamoDBKnowledgeRepository } from './repositories/dynamodb-knowledge.r
 export { KnowledgeMapper } from './mappers/knowledge.mapper.js';
 export { buildKnowledgeSK, buildKnowledgeSKPrefix } from './mappers/keys.js';
 
+// StudyTopic（Phase 5b / #3344）
+export type {
+  StudyTopicEntity,
+  StudyTopicKey,
+  CreateStudyTopicInput,
+  UpdateStudyTopicInput,
+} from './entities/study-topic.entity.js';
+export type { StudyTopicRepository } from './repositories/study-topic.repository.interface.js';
+export { InMemoryStudyTopicRepository } from './repositories/in-memory-study-topic.repository.js';
+export { DynamoDBStudyTopicRepository } from './repositories/dynamodb-study-topic.repository.js';
+export { StudyTopicMapper } from './mappers/study-topic.mapper.js';
+export { buildStudyTopicSK, buildStudyTopicSKPrefix } from './mappers/keys.js';
+
+// 知識ゲート（Phase 5b / #3344）
+export {
+  searchKnowledge,
+  classifyTopic,
+  evaluateKnowledgeGate,
+  type KnowledgeGateResult,
+} from './study/knowledge-gate.js';
+export { buildStudyDeferralMessage } from './study/templates.js';
+
 // Token counter
 export {
   TiktokenCounter,
@@ -244,6 +266,8 @@ export {
   STUDY_MIN_INTERVAL_HOURS,
   STUDY_INACTIVE_WINDOW_HOURS,
   STUDY_MIN_SUMMARY_LENGTH,
+  STUDY_TOPIC_TTL_SECONDS,
+  STUDY_TOPIC_GATE_PRIORITY,
 } from './constants.js';
 
 // Study usecase（Phase 5a）

--- a/services/livetalk/core/src/llm-client/schemas/index.ts
+++ b/services/livetalk/core/src/llm-client/schemas/index.ts
@@ -6,3 +6,6 @@ export type { CorrectionResponseRaw } from './correction.schema.js';
 
 export { ConfirmationResponseSchema } from './confirmation.schema.js';
 export type { ConfirmationResponseRaw } from './confirmation.schema.js';
+
+export { KnowledgeGateSchema } from './knowledge-gate.schema.js';
+export type { KnowledgeGateRaw } from './knowledge-gate.schema.js';

--- a/services/livetalk/core/src/llm-client/schemas/knowledge-gate.schema.ts
+++ b/services/livetalk/core/src/llm-client/schemas/knowledge-gate.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+/**
+ * `study/knowledge-gate.ts` の `classifyTopic` 向け Structured Outputs スキーマ。
+ *
+ * needsStudy=true: 時事・ユーザー固有・ニッチな情報で知識ベースへの蓄積が必要
+ * needsStudy=false: 一般常識・キャラ嗜好範囲内で即答できる
+ *
+ * @see Issue #3344
+ */
+export const KnowledgeGateSchema = z.object({
+  needsStudy: z.boolean(),
+  /** LLM が正規化したトピック名（登録・検索に使う短い名詞句） */
+  normalizedTopic: z.string(),
+});
+
+export type KnowledgeGateRaw = z.infer<typeof KnowledgeGateSchema>;

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -99,3 +99,11 @@ export function buildKnowledgeSKPrefix(characterId: string): string {
 export function buildKnowledgeSK(characterId: string, knowledgeId: string): string {
   return `${buildKnowledgeSKPrefix(characterId)}${knowledgeId}`;
 }
+
+export function buildStudyTopicSKPrefix(characterId: string): string {
+  return `CHAR#${characterId}#STUDY#`;
+}
+
+export function buildStudyTopicSK(characterId: string, topicId: string): string {
+  return `${buildStudyTopicSKPrefix(characterId)}${topicId}`;
+}

--- a/services/livetalk/core/src/mappers/study-topic.mapper.ts
+++ b/services/livetalk/core/src/mappers/study-topic.mapper.ts
@@ -1,0 +1,63 @@
+import {
+  validateNumberField,
+  validateStringField,
+  validateTimestampField,
+  type DynamoDBItem,
+  type EntityMapper,
+} from '@nagiyu/aws';
+import type { StudyTopicEntity, StudyTopicKey } from '../entities/study-topic.entity.js';
+import { buildStudyTopicSK, buildUserPK } from './keys.js';
+
+export class StudyTopicMapper implements EntityMapper<StudyTopicEntity, StudyTopicKey> {
+  public readonly entityType = 'StudyTopic';
+
+  public toItem(entity: StudyTopicEntity): DynamoDBItem {
+    const { pk, sk } = this.buildKeys({
+      userId: entity.UserID,
+      characterId: entity.CharacterID,
+      topicId: entity.TopicID,
+    });
+    const item: DynamoDBItem = {
+      PK: pk,
+      SK: sk,
+      Type: this.entityType,
+      UserID: entity.UserID,
+      CharacterID: entity.CharacterID,
+      TopicID: entity.TopicID,
+      Topic: entity.Topic,
+      Priority: entity.Priority,
+      Status: entity.Status,
+      CreatedAt: entity.CreatedAt,
+      UpdatedAt: entity.UpdatedAt,
+    };
+    if (entity.Ttl !== undefined) {
+      item.Ttl = entity.Ttl;
+    }
+    return item;
+  }
+
+  public toEntity(item: DynamoDBItem): StudyTopicEntity {
+    const status = validateStringField(item.Status, 'Status');
+    const entity: StudyTopicEntity = {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
+      TopicID: validateStringField(item.TopicID, 'TopicID'),
+      Topic: validateStringField(item.Topic, 'Topic'),
+      Priority: validateNumberField(item.Priority, 'Priority'),
+      Status: status as StudyTopicEntity['Status'],
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
+    };
+    if (item.Ttl !== undefined) {
+      entity.Ttl = validateNumberField(item.Ttl, 'Ttl');
+    }
+    return entity;
+  }
+
+  public buildKeys(key: StudyTopicKey): { pk: string; sk: string } {
+    return {
+      pk: buildUserPK(key.userId),
+      sk: buildStudyTopicSK(key.characterId, key.topicId),
+    };
+  }
+}

--- a/services/livetalk/core/src/repositories/dynamodb-study-topic.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-study-topic.repository.ts
@@ -1,0 +1,149 @@
+import {
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
+import type {
+  CreateStudyTopicInput,
+  StudyTopicEntity,
+  UpdateStudyTopicInput,
+} from '../entities/study-topic.entity.js';
+import { StudyTopicMapper } from '../mappers/study-topic.mapper.js';
+import { buildStudyTopicSK, buildStudyTopicSKPrefix, buildUserPK } from '../mappers/keys.js';
+import type { StudyTopicRepository } from './study-topic.repository.interface.js';
+
+export class DynamoDBStudyTopicRepository implements StudyTopicRepository {
+  private readonly mapper: StudyTopicMapper;
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly nowMs: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.nowMs = nowMs;
+    this.mapper = new StudyTopicMapper();
+  }
+
+  public async put(input: CreateStudyTopicInput): Promise<StudyTopicEntity> {
+    const now = this.nowMs();
+    const entity: StudyTopicEntity = { ...input, CreatedAt: now, UpdatedAt: now };
+    try {
+      await this.docClient.send(
+        new PutCommand({ TableName: this.tableName, Item: this.mapper.toItem(entity) })
+      );
+      return entity;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async listByStatus(
+    userId: string,
+    characterId: string,
+    status?: StudyTopicEntity['Status']
+  ): Promise<StudyTopicEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildStudyTopicSKPrefix(characterId);
+    const results: StudyTopicEntity[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: { ':pk': pk, ':prefix': prefix },
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        const entity = this.mapper.toEntity(raw as unknown as DynamoDBItem);
+        if (status === undefined || entity.Status === status) {
+          results.push(entity);
+        }
+      }
+
+      if (!result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return results.sort((a, b) => b.Priority - a.Priority || a.CreatedAt - b.CreatedAt);
+  }
+
+  public async updateStatus(input: UpdateStudyTopicInput): Promise<StudyTopicEntity> {
+    const pk = buildUserPK(input.UserID);
+    const sk = buildStudyTopicSK(input.CharacterID, input.TopicID);
+    const now = this.nowMs();
+
+    const expressionParts = [
+      '#status = :status',
+      '#priority = :priority',
+      '#updatedAt = :updatedAt',
+    ];
+    const expressionAttributeNames: Record<string, string> = {
+      '#status': 'Status',
+      '#priority': 'Priority',
+      '#updatedAt': 'UpdatedAt',
+    };
+    const expressionAttributeValues: Record<string, unknown> = {
+      ':status': input.Status,
+      ':priority': input.Priority,
+      ':updatedAt': now,
+    };
+
+    if (input.Ttl !== undefined) {
+      expressionParts.push('#ttl = :ttl');
+      expressionAttributeNames['#ttl'] = 'Ttl';
+      expressionAttributeValues[':ttl'] = input.Ttl;
+    }
+
+    try {
+      const result = await this.docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+          UpdateExpression: `SET ${expressionParts.join(', ')}`,
+          ExpressionAttributeNames: expressionAttributeNames,
+          ExpressionAttributeValues: expressionAttributeValues,
+          ReturnValues: 'ALL_NEW',
+        })
+      );
+      return this.mapper.toEntity(result.Attributes as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async findPendingByTopic(
+    userId: string,
+    characterId: string,
+    topic: string
+  ): Promise<StudyTopicEntity | null> {
+    const all = await this.listByStatus(userId, characterId);
+    const normalizedTopic = topic.toLowerCase();
+    return (
+      all.find(
+        (e) =>
+          (e.Status === 'pending' || e.Status === 'in_progress') &&
+          e.Topic.toLowerCase() === normalizedTopic
+      ) ?? null
+    );
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-study-topic.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-study-topic.repository.ts
@@ -1,0 +1,84 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import type {
+  CreateStudyTopicInput,
+  StudyTopicEntity,
+  UpdateStudyTopicInput,
+} from '../entities/study-topic.entity.js';
+import { StudyTopicMapper } from '../mappers/study-topic.mapper.js';
+import { buildStudyTopicSKPrefix, buildUserPK } from '../mappers/keys.js';
+import type { StudyTopicRepository } from './study-topic.repository.interface.js';
+
+export class InMemoryStudyTopicRepository implements StudyTopicRepository {
+  private readonly mapper: StudyTopicMapper;
+  private readonly store: InMemorySingleTableStore;
+  private readonly nowMs: () => number;
+
+  constructor(store: InMemorySingleTableStore, nowMs: () => number = () => Date.now()) {
+    this.store = store;
+    this.nowMs = nowMs;
+    this.mapper = new StudyTopicMapper();
+  }
+
+  public async put(input: CreateStudyTopicInput): Promise<StudyTopicEntity> {
+    const now = this.nowMs();
+    const entity: StudyTopicEntity = { ...input, CreatedAt: now, UpdatedAt: now };
+    this.store.put(this.mapper.toItem(entity));
+    return entity;
+  }
+
+  public async listByStatus(
+    userId: string,
+    characterId: string,
+    status?: StudyTopicEntity['Status']
+  ): Promise<StudyTopicEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildStudyTopicSKPrefix(characterId);
+    const result = this.store.query({ pk, sk: { operator: 'begins_with', value: prefix } });
+    const items = result.items
+      .map((item) => this.mapper.toEntity(item))
+      .filter((e) => status === undefined || e.Status === status)
+      .sort((a, b) => b.Priority - a.Priority || a.CreatedAt - b.CreatedAt);
+    return items;
+  }
+
+  public async updateStatus(input: UpdateStudyTopicInput): Promise<StudyTopicEntity> {
+    const pk = buildUserPK(input.UserID);
+    const prefix = buildStudyTopicSKPrefix(input.CharacterID);
+    const result = this.store.query({ pk, sk: { operator: 'begins_with', value: prefix } });
+    const found = result.items
+      .map((item) => this.mapper.toEntity(item))
+      .find((e) => e.TopicID === input.TopicID);
+
+    if (!found) {
+      throw new Error(`StudyTopic not found: ${input.TopicID}`);
+    }
+
+    const updated: StudyTopicEntity = {
+      ...found,
+      Status: input.Status,
+      Priority: input.Priority,
+      UpdatedAt: this.nowMs(),
+    };
+    if (input.Ttl !== undefined) {
+      updated.Ttl = input.Ttl;
+    }
+    this.store.put(this.mapper.toItem(updated));
+    return updated;
+  }
+
+  public async findPendingByTopic(
+    userId: string,
+    characterId: string,
+    topic: string
+  ): Promise<StudyTopicEntity | null> {
+    const all = await this.listByStatus(userId, characterId);
+    const normalizedTopic = topic.toLowerCase();
+    return (
+      all.find(
+        (e) =>
+          (e.Status === 'pending' || e.Status === 'in_progress') &&
+          e.Topic.toLowerCase() === normalizedTopic
+      ) ?? null
+    );
+  }
+}

--- a/services/livetalk/core/src/repositories/study-topic.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/study-topic.repository.interface.ts
@@ -1,0 +1,23 @@
+import type {
+  CreateStudyTopicInput,
+  StudyTopicEntity,
+  UpdateStudyTopicInput,
+} from '../entities/study-topic.entity.js';
+
+export interface StudyTopicRepository {
+  put(input: CreateStudyTopicInput): Promise<StudyTopicEntity>;
+  /** Status でフィルタして Priority 降順で返す。未指定時は全件。 */
+  listByStatus(
+    userId: string,
+    characterId: string,
+    status?: StudyTopicEntity['Status']
+  ): Promise<StudyTopicEntity[]>;
+  /** Status / Priority を更新する */
+  updateStatus(input: UpdateStudyTopicInput): Promise<StudyTopicEntity>;
+  /** 同じ Topic が pending / in_progress で既に存在するか確認する（重複登録防止） */
+  findPendingByTopic(
+    userId: string,
+    characterId: string,
+    topic: string
+  ): Promise<StudyTopicEntity | null>;
+}

--- a/services/livetalk/core/src/study/index.ts
+++ b/services/livetalk/core/src/study/index.ts
@@ -1,0 +1,7 @@
+export {
+  searchKnowledge,
+  classifyTopic,
+  evaluateKnowledgeGate,
+  type KnowledgeGateResult,
+} from './knowledge-gate.js';
+export { buildStudyDeferralMessage } from './templates.js';

--- a/services/livetalk/core/src/study/knowledge-gate.ts
+++ b/services/livetalk/core/src/study/knowledge-gate.ts
@@ -1,0 +1,121 @@
+import type { ILLMClient } from '../llm-client/types.js';
+import type { KnowledgeEntity } from '../entities/knowledge.entity.js';
+import { KnowledgeGateSchema } from '../llm-client/schemas/knowledge-gate.schema.js';
+
+/** 知識ゲートのキーワード照合に使う最小スコア（トークン一致数） */
+const KEYWORD_MATCH_MIN_TOKENS = 1;
+
+/**
+ * テキストをスペース・句読点・日本語分かち書き相当でトークン分割する。
+ * 外部ライブラリ不要のシンプル実装。
+ */
+function tokenize(text: string): Set<string> {
+  const tokens = text
+    .toLowerCase()
+    .split(/[\s、。，．　！？!?「」『』【】・\-_,./]+/)
+    .filter((t) => t.length >= 2);
+  return new Set(tokens);
+}
+
+/**
+ * ユーザー入力と Knowledge の Topic/Summary を照合してヒット件数を返す（純粋関数）。
+ *
+ * ヒット判定: userText のトークンが Topic または Summary の文字列に 1 件以上含まれる。
+ */
+export function searchKnowledge(userText: string, knowledge: KnowledgeEntity[]): KnowledgeEntity[] {
+  if (knowledge.length === 0) return [];
+  const userTokens = tokenize(userText);
+  if (userTokens.size === 0) return [];
+
+  return knowledge.filter((k) => {
+    const target = `${k.Topic} ${k.Summary}`.toLowerCase();
+    let matchCount = 0;
+    for (const token of userTokens) {
+      if (target.includes(token)) {
+        matchCount++;
+        if (matchCount >= KEYWORD_MATCH_MIN_TOKENS) return true;
+      }
+    }
+    return false;
+  });
+}
+
+/**
+ * ユーザー入力が「勉強が必要なトピック」かを安価な LLM 分類で判定する。
+ *
+ * needsStudy=true の条件:
+ * - 時事・ニュース・最新情報（キャラが知らない可能性が高い）
+ * - ユーザー固有の話題（家族・職場・趣味の詳細など）
+ * - ニッチな専門知識でキャラの嗜好範囲外
+ *
+ * needsStudy=false の条件:
+ * - 一般常識（歴史・地理・科学の基礎など）
+ * - キャラの嗜好・プロフィール範囲内（好きなもの・苦手なもの）
+ * - 日常会話・感情表現・雑談
+ */
+export async function classifyTopic(
+  userText: string,
+  characterName: string,
+  llmClient: ILLMClient
+): Promise<{ needsStudy: boolean; normalizedTopic: string }> {
+  const messages = [
+    {
+      role: 'system' as const,
+      content: `あなたはAIコンパニオン「${characterName}」のトピック分類器です。
+ユーザーの発言から「${characterName}が勉強して調べる必要があるトピック」かを判定してください。
+
+needsStudy=true にするケース:
+- 時事・最新ニュース・直近のイベント
+- ユーザー固有の人物・場所・体験の詳細
+- ニッチな専門知識で${characterName}の嗜好範囲外
+
+needsStudy=false にするケース:
+- 一般常識（歴史・科学・地理の基本）
+- 日常会話・感情表現・雑談・相談
+- キャラへの質問（性格・好き嫌い）
+- 挨拶・依頼・感想
+
+normalizedTopic: 話題を表す短い名詞句（例: "モンハン新作", "ユーザーの新しい職場"）。
+needsStudy=false の場合でも適切な値を返してください。`,
+    },
+    {
+      role: 'user' as const,
+      content: userText,
+    },
+  ];
+
+  return llmClient.chatStructured(messages, KnowledgeGateSchema, {
+    purpose: 'classify',
+  });
+}
+
+/** 知識ゲートの評価結果 */
+export type KnowledgeGateResult =
+  | { kind: 'knowledge_hit'; knowledge: KnowledgeEntity[] }
+  | { kind: 'study'; normalizedTopic: string }
+  | { kind: 'normal' };
+
+/**
+ * 知識ゲートの最終判定（コード側で gating）。
+ *
+ * フロー:
+ *   1. 知識ベースをキーワード照合 → ヒット → knowledge_hit
+ *   2. LLM 分類（needsStudy=true → study / false → normal）
+ */
+export async function evaluateKnowledgeGate(
+  userText: string,
+  characterName: string,
+  knowledge: KnowledgeEntity[],
+  llmClient: ILLMClient
+): Promise<KnowledgeGateResult> {
+  const hits = searchKnowledge(userText, knowledge);
+  if (hits.length > 0) {
+    return { kind: 'knowledge_hit', knowledge: hits };
+  }
+
+  const classification = await classifyTopic(userText, characterName, llmClient);
+  if (classification.needsStudy) {
+    return { kind: 'study', normalizedTopic: classification.normalizedTopic };
+  }
+  return { kind: 'normal' };
+}

--- a/services/livetalk/core/src/study/knowledge-gate.ts
+++ b/services/livetalk/core/src/study/knowledge-gate.ts
@@ -12,7 +12,7 @@ const KEYWORD_MATCH_MIN_TOKENS = 1;
 function tokenize(text: string): Set<string> {
   const tokens = text
     .toLowerCase()
-    .split(/[\s、。，．　！？!?「」『』【】・\-_,./]+/)
+    .split(/[\s、。，．\u3000！？!?「」『』【】・\-_,./]+/)
     .filter((t) => t.length >= 2);
   return new Set(tokens);
 }

--- a/services/livetalk/core/src/study/templates.ts
+++ b/services/livetalk/core/src/study/templates.ts
@@ -1,0 +1,21 @@
+/**
+ * 「勉強しておくね」応答テンプレート（Phase 5b / Issue #3344）。
+ *
+ * 知識ゲートで「needsStudy=true」と判定されたトピックに対して
+ * キャラ口調で返す固定テンプレート。LLM をバイパスして送出する。
+ */
+
+const STUDY_DEFERRAL_MESSAGES = [
+  'ちょっとそこまでは知らないかも…。気になったから、ちゃんと勉強しておくね！次に話すときまでに調べてくる！',
+  'うーん、それは私にはまだわからないな…。勉強しておくから、また今度教えてあげる！',
+  'そこまでは把握してないかも…ごめんね。次までにちゃんと調べておくよ！',
+];
+
+/**
+ * 「勉強しておくね」テンプレートメッセージを返す。
+ * 現在時刻のミリ秒で選択する（テスト時は nowMs=0 で 0 番目）。
+ */
+export function buildStudyDeferralMessage(nowMs?: number): string {
+  const idx = nowMs !== undefined ? nowMs % STUDY_DEFERRAL_MESSAGES.length : 0;
+  return STUDY_DEFERRAL_MESSAGES[idx];
+}

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -327,7 +327,9 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
 
   // 3.6. 知識ゲート（Phase 5b / Issue #3344）
   // knowledgeRepository が指定されている場合のみ実行（未指定時は従来フローで継続）
-  let knowledgeContextForPrompt: import('../entities/knowledge.entity.js').KnowledgeEntity[] | undefined;
+  let knowledgeContextForPrompt:
+    | import('../entities/knowledge.entity.js').KnowledgeEntity[]
+    | undefined;
   if (knowledgeRepository) {
     try {
       const allKnowledge = await knowledgeRepository.list(userId, characterId);

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -9,6 +9,8 @@ import type { MemoryRepository } from '../repositories/memory.repository.interfa
 import type { MemorySummaryRepository } from '../repositories/memory-summary.repository.interface.js';
 import type { MessageRepository } from '../repositories/message.repository.interface.js';
 import type { SafetyEventRepository } from '../repositories/safety-event.repository.interface.js';
+import type { KnowledgeRepository } from '../repositories/knowledge.repository.interface.js';
+import type { StudyTopicRepository } from '../repositories/study-topic.repository.interface.js';
 import type { CharacterDefinition } from '../characters/types.js';
 import type { MemoryEntity } from '../entities/memory.entity.js';
 import type { MessageEntity } from '../entities/message.entity.js';
@@ -24,6 +26,8 @@ import {
   MEMORY_CATEGORY_CAP,
   MEMORY_COOLDOWN_MS,
   MEMORY_MAX_TIER_B,
+  STUDY_TOPIC_TTL_SECONDS,
+  STUDY_TOPIC_GATE_PRIORITY,
 } from '../constants.js';
 import { detectSafetyRisk } from '../safety/detector.js';
 import { buildModerationReplacementMessage, buildSafetyMessage } from '../safety/templates.js';
@@ -39,6 +43,9 @@ import {
   emitChatMetricsLog,
   emitChatMetricsEMF,
 } from '../observability/metrics.js';
+import { evaluateKnowledgeGate } from '../study/knowledge-gate.js';
+import { buildStudyDeferralMessage } from '../study/templates.js';
+import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
 
 /**
  * /api/chat ストリーミングレスポンスの各イベント型。
@@ -86,6 +93,15 @@ export interface ChatUseCaseParams {
   memorySummaryRepository?: MemorySummaryRepository;
   /** Lifecycle リポジトリ。未指定時はデフォルト就寝スケジュールで判定する */
   lifecycleRepository?: LifecycleRepository;
+  /**
+   * 知識ゲート（Phase 5b）。未指定時はゲートをスキップして従来フローで継続する。
+   * 指定時は KNOWLEDGE を検索し、ヒット無し+要勉強なら LLM をバイパスして STUDY_TOPIC を登録する。
+   */
+  knowledgeRepository?: KnowledgeRepository;
+  /** StudyTopic リポジトリ。knowledgeRepository 指定時に study 分岐で使用する */
+  studyTopicRepository?: StudyTopicRepository;
+  /** ULID ファクトリ。テスト時に差し替え可能。未指定時はデフォルト実装 */
+  ulidFactory?: UlidFactory;
 }
 
 type SynthesisResult = { index: number; text: string; audio: string | null; elapsedMs: number };
@@ -202,6 +218,9 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     characterStateRepository,
     memorySummaryRepository,
     lifecycleRepository,
+    knowledgeRepository,
+    studyTopicRepository,
+    ulidFactory = defaultUlidFactory,
   } = params;
 
   const chatStart = performance.now();
@@ -306,6 +325,78 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
   // 3.5. lifecycle event を emit（UI がモデル目パラメータを即座に反映できるよう通常フロー先頭で送出）
   yield { type: 'lifecycle', state: lifecycleState };
 
+  // 3.6. 知識ゲート（Phase 5b / Issue #3344）
+  // knowledgeRepository が指定されている場合のみ実行（未指定時は従来フローで継続）
+  let knowledgeContextForPrompt: import('../entities/knowledge.entity.js').KnowledgeEntity[] | undefined;
+  if (knowledgeRepository) {
+    try {
+      const allKnowledge = await knowledgeRepository.list(userId, characterId);
+      const gateResult = await evaluateKnowledgeGate(
+        userText,
+        character.displayName,
+        allKnowledge,
+        llmClient
+      );
+
+      if (gateResult.kind === 'study') {
+        // STUDY_TOPIC 登録（fail-warn: 登録失敗でも応答は継続）
+        if (studyTopicRepository) {
+          try {
+            const existingTopic = await studyTopicRepository.findPendingByTopic(
+              userId,
+              characterId,
+              gateResult.normalizedTopic
+            );
+            if (!existingTopic) {
+              const ttlUnixSec = Math.floor(Date.now() / 1000) + STUDY_TOPIC_TTL_SECONDS;
+              await studyTopicRepository.put({
+                UserID: userId,
+                CharacterID: characterId,
+                TopicID: ulidFactory(),
+                Topic: gateResult.normalizedTopic,
+                Priority: STUDY_TOPIC_GATE_PRIORITY,
+                Status: 'pending',
+                Ttl: ttlUnixSec,
+              });
+            }
+          } catch (err) {
+            logger.warn('[chat-usecase] StudyTopic の登録に失敗しました（スキップして継続）', {
+              err,
+            });
+          }
+        }
+
+        // LLM をバイパスしてキャラ口調テンプレ応答を送出
+        const studyMessage = buildStudyDeferralMessage(Date.now());
+        yield* streamSafetyText(studyMessage, voiceClient, character.voiceConfig.speakerId);
+
+        // アシスタントメッセージとして保存
+        try {
+          await messageRepository.create({
+            UserID: userId,
+            CharacterID: characterId,
+            Role: 'assistant',
+            Text: studyMessage,
+          });
+        } catch (err) {
+          logger.error('[chat-usecase] 勉強応答メッセージの保存に失敗しました', { err });
+        }
+
+        yield { type: 'done' };
+        return;
+      }
+
+      if (gateResult.kind === 'knowledge_hit') {
+        // 知識を prompt context に注入して通常応答へ
+        knowledgeContextForPrompt = gateResult.knowledge;
+      }
+      // kind === 'normal' は通常フローで継続（何もしない）
+    } catch (err) {
+      // fail-warn: ゲートエラーは通常フローで継続
+      logger.warn('[chat-usecase] 知識ゲートの評価に失敗しました（通常フローで継続）', { err });
+    }
+  }
+
   // 4. Memory retrieve（fail-warn: エラー時は空配列で継続）
   let retrievedMemories: RetrievedMemory[] = [];
   if (memoryRetriever) {
@@ -384,7 +475,8 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     retrievedMemories,
     undefined,
     newLearnings.length > 0 ? newLearnings : undefined,
-    lifecycleState
+    lifecycleState,
+    knowledgeContextForPrompt
   );
 
   // プロンプトトークン内訳を計算（best-effort）

--- a/services/livetalk/core/src/usecases/study.usecase.ts
+++ b/services/livetalk/core/src/usecases/study.usecase.ts
@@ -9,6 +9,7 @@ import {
 import type { LifecycleEntity } from '../entities/lifecycle.entity.js';
 import type { KnowledgeRepository } from '../repositories/knowledge.repository.interface.js';
 import type { InterestRepository } from '../repositories/interest.repository.interface.js';
+import type { StudyTopicRepository } from '../repositories/study-topic.repository.interface.js';
 import { resolveLifecycleState } from '../lifecycle/state-resolver.js';
 import type { IResearchClient } from '../research/types.js';
 import type { UlidFactory } from '../lib/ulid.js';
@@ -23,6 +24,11 @@ export interface StudyForUserParams {
   ulidFactory?: UlidFactory;
   now?: () => Date;
   maxQueriesPerRun?: number;
+  /**
+   * StudyTopic リポジトリ（Phase 5b）。
+   * 指定された場合、通常の興味カテゴリ処理の前に pending の STUDY_TOPIC を優先処理する。
+   */
+  studyTopicRepo?: StudyTopicRepository;
 }
 
 export interface StudyForUserResult {
@@ -53,6 +59,7 @@ export async function studyForUser(
     ulidFactory = defaultUlidFactory,
     now = () => new Date(),
     maxQueriesPerRun = STUDY_MAX_QUERIES_PER_RUN,
+    studyTopicRepo,
   } = params;
 
   const nowDate = now();
@@ -66,50 +73,117 @@ export async function studyForUser(
     return { outcome: 'skipped', skipReason: shouldStudy.reason };
   }
 
-  // 興味カテゴリを weight 降順で取得
-  const categories = await interestRepo.list(userId, characterId);
-  if (categories.length === 0) {
-    return { outcome: 'skipped', skipReason: '興味カテゴリが未登録' };
-  }
-
-  const sorted = [...categories].sort((a, b) => b.Weight - a.Weight);
-  const targets = sorted.slice(0, maxQueriesPerRun);
-
   let savedCount = 0;
 
-  for (const cat of targets) {
-    const query = buildSearchQuery(cat.Category);
-    try {
-      const result = await researchClient.research(query, character);
+  // STUDY_TOPIC の pending を優先処理（Phase 5b）
+  if (studyTopicRepo) {
+    const pendingTopics = await studyTopicRepo.listByStatus(userId, characterId, 'pending');
+    for (const studyTopic of pendingTopics) {
+      if (savedCount >= maxQueriesPerRun) break;
+      try {
+        await studyTopicRepo.updateStatus({
+          UserID: userId,
+          CharacterID: characterId,
+          TopicID: studyTopic.TopicID,
+          Status: 'in_progress',
+          Priority: studyTopic.Priority,
+        });
 
-      if (result.summary.length < STUDY_MIN_SUMMARY_LENGTH) {
-        logger.warn('[study] 品質が低いため保存をスキップ', {
+        const result = await researchClient.research(studyTopic.Topic, character);
+
+        if (result.summary.length < STUDY_MIN_SUMMARY_LENGTH) {
+          logger.warn('[study] STUDY_TOPIC: 品質が低いため保存をスキップ', {
+            userId,
+            characterId,
+            topic: studyTopic.Topic,
+            summaryLength: result.summary.length,
+          });
+          await studyTopicRepo.updateStatus({
+            UserID: userId,
+            CharacterID: characterId,
+            TopicID: studyTopic.TopicID,
+            Status: 'done',
+            Priority: studyTopic.Priority,
+          });
+          continue;
+        }
+
+        await knowledgeRepo.put({
+          UserID: userId,
+          CharacterID: characterId,
+          KnowledgeID: ulidFactory(),
+          Topic: result.topic,
+          Summary: result.summary,
+          SourceUrls: result.sourceUrls,
+          RawComment: result.rawComment,
+          RelatedCategory: studyTopic.Topic,
+        });
+
+        await studyTopicRepo.updateStatus({
+          UserID: userId,
+          CharacterID: characterId,
+          TopicID: studyTopic.TopicID,
+          Status: 'done',
+          Priority: studyTopic.Priority,
+        });
+        savedCount++;
+      } catch (err) {
+        logger.warn('[study] STUDY_TOPIC リサーチ失敗', {
+          userId,
+          characterId,
+          topic: studyTopic.Topic,
+          err,
+        });
+        // in_progress のまま次回バッチで再試行
+      }
+    }
+  }
+
+  // 通常の興味カテゴリ処理（残り枠がある場合）
+  const remainingQuota = maxQueriesPerRun - savedCount;
+  if (remainingQuota > 0) {
+    const categories = await interestRepo.list(userId, characterId);
+    if (categories.length === 0 && savedCount === 0) {
+      return { outcome: 'skipped', skipReason: '興味カテゴリが未登録' };
+    }
+
+    const sorted = [...categories].sort((a, b) => b.Weight - a.Weight);
+    const targets = sorted.slice(0, remainingQuota);
+
+    for (const cat of targets) {
+      const query = buildSearchQuery(cat.Category);
+      try {
+        const result = await researchClient.research(query, character);
+
+        if (result.summary.length < STUDY_MIN_SUMMARY_LENGTH) {
+          logger.warn('[study] 品質が低いため保存をスキップ', {
+            userId,
+            characterId,
+            category: cat.Category,
+            summaryLength: result.summary.length,
+          });
+          continue;
+        }
+
+        await knowledgeRepo.put({
+          UserID: userId,
+          CharacterID: characterId,
+          KnowledgeID: ulidFactory(),
+          Topic: result.topic,
+          Summary: result.summary,
+          SourceUrls: result.sourceUrls,
+          RawComment: result.rawComment,
+          RelatedCategory: cat.Category,
+        });
+        savedCount++;
+      } catch (err) {
+        logger.warn('[study] リサーチ失敗', {
           userId,
           characterId,
           category: cat.Category,
-          summaryLength: result.summary.length,
+          err,
         });
-        continue;
       }
-
-      await knowledgeRepo.put({
-        UserID: userId,
-        CharacterID: characterId,
-        KnowledgeID: ulidFactory(),
-        Topic: result.topic,
-        Summary: result.summary,
-        SourceUrls: result.sourceUrls,
-        RawComment: result.rawComment,
-        RelatedCategory: cat.Category,
-      });
-      savedCount++;
-    } catch (err) {
-      logger.warn('[study] リサーチ失敗', {
-        userId,
-        characterId,
-        category: cat.Category,
-        err,
-      });
     }
   }
 

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-study-topic.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-study-topic.repository.test.ts
@@ -1,6 +1,5 @@
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { DynamoDBStudyTopicRepository } from '../../../src/repositories/dynamodb-study-topic.repository.js';
-import type { StudyTopicEntity } from '../../../src/entities/study-topic.entity.js';
 
 const TABLE = 'nagiyu-livetalk-test';
 const FIXED_NOW = 1_700_000_000_000;

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-study-topic.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-study-topic.repository.test.ts
@@ -1,0 +1,261 @@
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBStudyTopicRepository } from '../../../src/repositories/dynamodb-study-topic.repository.js';
+import type { StudyTopicEntity } from '../../../src/entities/study-topic.entity.js';
+
+const TABLE = 'nagiyu-livetalk-test';
+const FIXED_NOW = 1_700_000_000_000;
+
+function makeDocClient(mockSend: jest.Mock) {
+  return { send: mockSend } as unknown as DynamoDBDocumentClient;
+}
+
+function makeRepo(mockSend: jest.Mock) {
+  return new DynamoDBStudyTopicRepository(makeDocClient(mockSend), TABLE, () => FIXED_NOW);
+}
+
+function makeItemRaw(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    PK: 'USER#u1',
+    SK: 'CHAR#hiyori#STUDY#tp1',
+    Type: 'StudyTopic',
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    TopicID: 'tp1',
+    Topic: 'モンスターハンター',
+    Priority: 10,
+    Status: 'pending',
+    CreatedAt: FIXED_NOW,
+    UpdatedAt: FIXED_NOW,
+    ...overrides,
+  };
+}
+
+describe('DynamoDBStudyTopicRepository', () => {
+  describe('put()', () => {
+    it('PutCommand で DynamoDB に書き込み、エンティティを返す', async () => {
+      const mockSend = jest.fn().mockResolvedValue({});
+      const repo = makeRepo(mockSend);
+
+      const entity = await repo.put({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        TopicID: 'tp1',
+        Topic: 'モンスターハンター',
+        Priority: 10,
+        Status: 'pending',
+      });
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(entity.UserID).toBe('u1');
+      expect(entity.TopicID).toBe('tp1');
+      expect(entity.Status).toBe('pending');
+      expect(entity.CreatedAt).toBe(FIXED_NOW);
+    });
+
+    it('TTL 付きで保存できる', async () => {
+      const mockSend = jest.fn().mockResolvedValue({});
+      const repo = makeRepo(mockSend);
+      const ttl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+
+      const entity = await repo.put({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        TopicID: 'tp1',
+        Topic: 'テスト',
+        Priority: 5,
+        Status: 'pending',
+        Ttl: ttl,
+      });
+
+      expect(entity.Ttl).toBe(ttl);
+    });
+
+    it('DynamoDB エラー → DatabaseError', async () => {
+      const mockSend = jest.fn().mockRejectedValue(new Error('DB down'));
+      const repo = makeRepo(mockSend);
+
+      await expect(
+        repo.put({
+          UserID: 'u1',
+          CharacterID: 'hiyori',
+          TopicID: 'tp1',
+          Topic: 'テスト',
+          Priority: 1,
+          Status: 'pending',
+        })
+      ).rejects.toMatchObject({ name: 'DatabaseError' });
+    });
+  });
+
+  describe('listByStatus()', () => {
+    it('全件取得（status 未指定）', async () => {
+      const mockSend = jest.fn().mockResolvedValue({
+        Items: [makeItemRaw(), makeItemRaw({ SK: 'CHAR#hiyori#STUDY#tp2', TopicID: 'tp2', Status: 'done' })],
+      });
+      const repo = makeRepo(mockSend);
+
+      const items = await repo.listByStatus('u1', 'hiyori');
+      expect(items).toHaveLength(2);
+    });
+
+    it('pending のみ取得', async () => {
+      const mockSend = jest.fn().mockResolvedValue({
+        Items: [
+          makeItemRaw({ Status: 'pending' }),
+          makeItemRaw({ SK: 'CHAR#hiyori#STUDY#tp2', TopicID: 'tp2', Status: 'done' }),
+        ],
+      });
+      const repo = makeRepo(mockSend);
+
+      const items = await repo.listByStatus('u1', 'hiyori', 'pending');
+      expect(items).toHaveLength(1);
+      expect(items[0].Status).toBe('pending');
+    });
+
+    it('Priority 降順でソートされる', async () => {
+      const mockSend = jest.fn().mockResolvedValue({
+        Items: [
+          makeItemRaw({ TopicID: 'tp1', Priority: 1 }),
+          makeItemRaw({ SK: 'CHAR#hiyori#STUDY#tp2', TopicID: 'tp2', Priority: 10 }),
+        ],
+      });
+      const repo = makeRepo(mockSend);
+
+      const items = await repo.listByStatus('u1', 'hiyori');
+      expect(items[0].Priority).toBe(10);
+    });
+
+    it('ページネーション（LastEvaluatedKey）を処理する', async () => {
+      const mockSend = jest
+        .fn()
+        .mockResolvedValueOnce({
+          Items: [makeItemRaw()],
+          LastEvaluatedKey: { PK: 'USER#u1', SK: 'CHAR#hiyori#STUDY#tp1' },
+        })
+        .mockResolvedValueOnce({
+          Items: [makeItemRaw({ SK: 'CHAR#hiyori#STUDY#tp2', TopicID: 'tp2' })],
+        });
+      const repo = makeRepo(mockSend);
+
+      const items = await repo.listByStatus('u1', 'hiyori');
+      expect(items).toHaveLength(2);
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('DynamoDB エラー → DatabaseError', async () => {
+      const mockSend = jest.fn().mockRejectedValue(new Error('query failed'));
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.listByStatus('u1', 'hiyori')).rejects.toMatchObject({
+        name: 'DatabaseError',
+      });
+    });
+
+    it('Items が undefined の場合は空配列', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ Items: undefined });
+      const repo = makeRepo(mockSend);
+
+      const items = await repo.listByStatus('u1', 'hiyori');
+      expect(items).toHaveLength(0);
+    });
+  });
+
+  describe('updateStatus()', () => {
+    it('UpdateCommand で Status を更新し、エンティティを返す', async () => {
+      const updatedRaw = makeItemRaw({ Status: 'done', UpdatedAt: FIXED_NOW + 1000 });
+      const mockSend = jest.fn().mockResolvedValue({ Attributes: updatedRaw });
+      const repo = makeRepo(mockSend);
+
+      const result = await repo.updateStatus({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        TopicID: 'tp1',
+        Status: 'done',
+        Priority: 10,
+      });
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(result.Status).toBe('done');
+    });
+
+    it('TTL 付きで更新できる', async () => {
+      const ttl = Math.floor(Date.now() / 1000) + 86400;
+      const updatedRaw = makeItemRaw({ Status: 'done', Ttl: ttl });
+      const mockSend = jest.fn().mockResolvedValue({ Attributes: updatedRaw });
+      const repo = makeRepo(mockSend);
+
+      const result = await repo.updateStatus({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        TopicID: 'tp1',
+        Status: 'done',
+        Priority: 10,
+        Ttl: ttl,
+      });
+
+      expect(result.Ttl).toBe(ttl);
+    });
+
+    it('DynamoDB エラー → DatabaseError', async () => {
+      const mockSend = jest.fn().mockRejectedValue(new Error('update failed'));
+      const repo = makeRepo(mockSend);
+
+      await expect(
+        repo.updateStatus({
+          UserID: 'u1',
+          CharacterID: 'hiyori',
+          TopicID: 'tp1',
+          Status: 'done',
+          Priority: 1,
+        })
+      ).rejects.toMatchObject({ name: 'DatabaseError' });
+    });
+  });
+
+  describe('findPendingByTopic()', () => {
+    it('pending のトピックが見つかる', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ Items: [makeItemRaw({ Status: 'pending' })] });
+      const repo = makeRepo(mockSend);
+
+      const found = await repo.findPendingByTopic('u1', 'hiyori', 'モンスターハンター');
+      expect(found).not.toBeNull();
+      expect(found!.TopicID).toBe('tp1');
+    });
+
+    it('in_progress のトピックも見つかる（重複防止対象）', async () => {
+      const mockSend = jest.fn().mockResolvedValue({
+        Items: [makeItemRaw({ Status: 'in_progress' })],
+      });
+      const repo = makeRepo(mockSend);
+
+      const found = await repo.findPendingByTopic('u1', 'hiyori', 'モンスターハンター');
+      expect(found).not.toBeNull();
+    });
+
+    it('done のトピックは見つからない', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ Items: [makeItemRaw({ Status: 'done' })] });
+      const repo = makeRepo(mockSend);
+
+      const found = await repo.findPendingByTopic('u1', 'hiyori', 'モンスターハンター');
+      expect(found).toBeNull();
+    });
+
+    it('大文字小文字を無視してマッチ', async () => {
+      const mockSend = jest.fn().mockResolvedValue({
+        Items: [makeItemRaw({ Topic: 'JavaScript', Status: 'pending' })],
+      });
+      const repo = makeRepo(mockSend);
+
+      const found = await repo.findPendingByTopic('u1', 'hiyori', 'javascript');
+      expect(found).not.toBeNull();
+    });
+
+    it('一致しない場合は null', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ Items: [makeItemRaw({ Status: 'pending' })] });
+      const repo = makeRepo(mockSend);
+
+      const found = await repo.findPendingByTopic('u1', 'hiyori', '存在しないトピック');
+      expect(found).toBeNull();
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-study-topic.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-study-topic.repository.test.ts
@@ -90,7 +90,10 @@ describe('DynamoDBStudyTopicRepository', () => {
   describe('listByStatus()', () => {
     it('全件取得（status 未指定）', async () => {
       const mockSend = jest.fn().mockResolvedValue({
-        Items: [makeItemRaw(), makeItemRaw({ SK: 'CHAR#hiyori#STUDY#tp2', TopicID: 'tp2', Status: 'done' })],
+        Items: [
+          makeItemRaw(),
+          makeItemRaw({ SK: 'CHAR#hiyori#STUDY#tp2', TopicID: 'tp2', Status: 'done' }),
+        ],
       });
       const repo = makeRepo(mockSend);
 

--- a/services/livetalk/core/tests/unit/repositories/in-memory-study-topic.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-study-topic.repository.test.ts
@@ -1,0 +1,148 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryStudyTopicRepository } from '../../../src/repositories/in-memory-study-topic.repository.js';
+import type { CreateStudyTopicInput } from '../../../src/entities/study-topic.entity.js';
+
+const baseNow = 1_700_000_000_000;
+
+function makeInput(overrides: Partial<CreateStudyTopicInput> = {}): CreateStudyTopicInput {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    TopicID: 'tp1',
+    Topic: 'モンスターハンター',
+    Priority: 10,
+    Status: 'pending',
+    ...overrides,
+  };
+}
+
+describe('InMemoryStudyTopicRepository', () => {
+  let now: number;
+  let store: InMemorySingleTableStore;
+  let repo: InMemoryStudyTopicRepository;
+
+  beforeEach(() => {
+    store = new InMemorySingleTableStore();
+    now = baseNow;
+    repo = new InMemoryStudyTopicRepository(store, () => now);
+  });
+
+  // ── put ──
+
+  it('put で新規登録できる', async () => {
+    const item = await repo.put(makeInput());
+    expect(item.UserID).toBe('u1');
+    expect(item.Topic).toBe('モンスターハンター');
+    expect(item.Status).toBe('pending');
+    expect(item.CreatedAt).toBe(baseNow);
+    expect(item.UpdatedAt).toBe(baseNow);
+  });
+
+  it('put で TTL を保存できる', async () => {
+    const ttl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+    const item = await repo.put(makeInput({ Ttl: ttl }));
+    expect(item.Ttl).toBe(ttl);
+  });
+
+  // ── listByStatus ──
+
+  it('listByStatus: status 未指定で全件取得', async () => {
+    await repo.put(makeInput({ TopicID: 'tp1', Status: 'pending' }));
+    await repo.put(makeInput({ TopicID: 'tp2', Status: 'done' }));
+    const all = await repo.listByStatus('u1', 'hiyori');
+    expect(all).toHaveLength(2);
+  });
+
+  it('listByStatus: pending のみ取得', async () => {
+    await repo.put(makeInput({ TopicID: 'tp1', Status: 'pending' }));
+    await repo.put(makeInput({ TopicID: 'tp2', Status: 'done' }));
+    const pending = await repo.listByStatus('u1', 'hiyori', 'pending');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].TopicID).toBe('tp1');
+  });
+
+  it('listByStatus: Priority 降順でソートされる', async () => {
+    await repo.put(makeInput({ TopicID: 'tp1', Priority: 1, Status: 'pending' }));
+    await repo.put(makeInput({ TopicID: 'tp2', Priority: 10, Status: 'pending' }));
+    const items = await repo.listByStatus('u1', 'hiyori', 'pending');
+    expect(items[0].TopicID).toBe('tp2'); // Priority 10 が先
+    expect(items[1].TopicID).toBe('tp1');
+  });
+
+  it('listByStatus: 同 Priority は CreatedAt 昇順', async () => {
+    now = baseNow;
+    await repo.put(makeInput({ TopicID: 'tp1', Priority: 5, Status: 'pending' }));
+    now = baseNow + 1000;
+    await repo.put(makeInput({ TopicID: 'tp2', Priority: 5, Status: 'pending' }));
+    const items = await repo.listByStatus('u1', 'hiyori', 'pending');
+    expect(items[0].TopicID).toBe('tp1'); // CreatedAt が早い方が先
+  });
+
+  it('listByStatus: 別ユーザーは混入しない', async () => {
+    await repo.put(makeInput({ UserID: 'u1', TopicID: 'tp1' }));
+    await repo.put(makeInput({ UserID: 'u2', TopicID: 'tp2' }));
+    const u1Items = await repo.listByStatus('u1', 'hiyori', 'pending');
+    expect(u1Items).toHaveLength(1);
+    expect(u1Items[0].UserID).toBe('u1');
+  });
+
+  // ── updateStatus ──
+
+  it('updateStatus で Status を変更できる', async () => {
+    await repo.put(makeInput({ TopicID: 'tp1', Status: 'pending' }));
+    now = baseNow + 5000;
+    const updated = await repo.updateStatus({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      TopicID: 'tp1',
+      Status: 'done',
+      Priority: 10,
+    });
+    expect(updated.Status).toBe('done');
+    expect(updated.UpdatedAt).toBe(baseNow + 5000);
+  });
+
+  it('updateStatus: 存在しない TopicID は例外', async () => {
+    await expect(
+      repo.updateStatus({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        TopicID: 'nonexistent',
+        Status: 'done',
+        Priority: 1,
+      })
+    ).rejects.toThrow();
+  });
+
+  // ── findPendingByTopic ──
+
+  it('pending のトピックが見つかる', async () => {
+    await repo.put(makeInput({ TopicID: 'tp1', Topic: 'モンハン', Status: 'pending' }));
+    const found = await repo.findPendingByTopic('u1', 'hiyori', 'モンハン');
+    expect(found).not.toBeNull();
+    expect(found!.TopicID).toBe('tp1');
+  });
+
+  it('in_progress のトピックも見つかる（重複防止対象）', async () => {
+    await repo.put(makeInput({ TopicID: 'tp1', Topic: 'モンハン', Status: 'in_progress' }));
+    const found = await repo.findPendingByTopic('u1', 'hiyori', 'モンハン');
+    expect(found).not.toBeNull();
+  });
+
+  it('done のトピックは見つからない', async () => {
+    await repo.put(makeInput({ TopicID: 'tp1', Topic: 'モンハン', Status: 'done' }));
+    const found = await repo.findPendingByTopic('u1', 'hiyori', 'モンハン');
+    expect(found).toBeNull();
+  });
+
+  it('大文字小文字を無視してマッチ', async () => {
+    await repo.put(makeInput({ TopicID: 'tp1', Topic: 'JavaScript', Status: 'pending' }));
+    const found = await repo.findPendingByTopic('u1', 'hiyori', 'javascript');
+    expect(found).not.toBeNull();
+  });
+
+  it('存在しないトピックは null を返す', async () => {
+    const found = await repo.findPendingByTopic('u1', 'hiyori', '存在しない');
+    expect(found).toBeNull();
+  });
+});

--- a/services/livetalk/core/tests/unit/study/knowledge-gate.test.ts
+++ b/services/livetalk/core/tests/unit/study/knowledge-gate.test.ts
@@ -26,7 +26,9 @@ function makeKnowledge(overrides: Partial<KnowledgeEntity> = {}): KnowledgeEntit
 
 function makeLLMClient(result: { needsStudy: boolean; normalizedTopic: string }): ILLMClient {
   return {
-    chatStream: jest.fn(async function* () { yield ''; }),
+    chatStream: jest.fn(async function* () {
+      yield '';
+    }),
     chatComplete: jest.fn(),
     chatStructured: jest.fn(async () => result) as unknown as ILLMClient['chatStructured'],
     summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
@@ -66,7 +68,11 @@ describe('searchKnowledge', () => {
   it('複数 knowledge から複数ヒット', () => {
     const k1 = makeKnowledge({ KnowledgeID: 'k1', Topic: 'モンハン', Summary: 'ゲーム' });
     const k2 = makeKnowledge({ KnowledgeID: 'k2', Topic: 'コーヒー', Summary: '飲み物' });
-    const k3 = makeKnowledge({ KnowledgeID: 'k3', Topic: 'モンスターハンター最新', Summary: 'ゲーム情報' });
+    const k3 = makeKnowledge({
+      KnowledgeID: 'k3',
+      Topic: 'モンスターハンター最新',
+      Summary: 'ゲーム情報',
+    });
     const hits = searchKnowledge('モンハン', [k1, k2, k3]);
     expect(hits).toHaveLength(1);
     expect(hits[0].KnowledgeID).toBe('k1');

--- a/services/livetalk/core/tests/unit/study/knowledge-gate.test.ts
+++ b/services/livetalk/core/tests/unit/study/knowledge-gate.test.ts
@@ -1,0 +1,170 @@
+import {
+  searchKnowledge,
+  classifyTopic,
+  evaluateKnowledgeGate,
+} from '../../../src/study/knowledge-gate.js';
+import type { KnowledgeEntity } from '../../../src/entities/knowledge.entity.js';
+import type { ILLMClient } from '../../../src/llm-client/types.js';
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────
+
+function makeKnowledge(overrides: Partial<KnowledgeEntity> = {}): KnowledgeEntity {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    KnowledgeID: 'k1',
+    Topic: 'モンスターハンター',
+    Summary: 'カプコンのアクションRPGシリーズ。最新作はワイルズ。',
+    SourceUrls: [],
+    RawComment: '面白そう！',
+    RelatedCategory: 'ゲーム',
+    CreatedAt: 1_700_000_000_000,
+    UpdatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeLLMClient(result: { needsStudy: boolean; normalizedTopic: string }): ILLMClient {
+  return {
+    chatStream: jest.fn(async function* () { yield ''; }),
+    chatComplete: jest.fn(),
+    chatStructured: jest.fn(async () => result) as unknown as ILLMClient['chatStructured'],
+    summarize: jest.fn(async () => ({ mergedSummary: '', newMemoryCandidates: [] })),
+  };
+}
+
+// ── searchKnowledge ───────────────────────────────────────────────────────
+
+describe('searchKnowledge', () => {
+  it('空の knowledge 配列は空を返す', () => {
+    expect(searchKnowledge('モンハン', [])).toEqual([]);
+  });
+
+  it('Topic に一致するトークンがある場合はヒット', () => {
+    const k = makeKnowledge({ Topic: 'モンスターハンターワイルズ', Summary: '新作アクションRPG' });
+    const hits = searchKnowledge('モンスターハンター', [k]);
+    expect(hits).toHaveLength(1);
+  });
+
+  it('Summary に一致するトークンがある場合はヒット', () => {
+    const k = makeKnowledge({ Topic: 'ゲーム情報', Summary: 'モンスターハンターの最新情報' });
+    const hits = searchKnowledge('モンスターハンター', [k]);
+    expect(hits).toHaveLength(1);
+  });
+
+  it('一致しないトークンはヒットしない', () => {
+    const k = makeKnowledge({ Topic: 'コーヒー豆', Summary: 'エチオピア産の豆が人気' });
+    expect(searchKnowledge('モンスターハンター', [k])).toHaveLength(0);
+  });
+
+  it('1文字以下のトークンは除外される（ノイズ防止）', () => {
+    const k = makeKnowledge({ Topic: 'を情報', Summary: 'の内容' });
+    // "を" "の" は1文字なのでトークンにならない
+    expect(searchKnowledge('を の', [k])).toHaveLength(0);
+  });
+
+  it('複数 knowledge から複数ヒット', () => {
+    const k1 = makeKnowledge({ KnowledgeID: 'k1', Topic: 'モンハン', Summary: 'ゲーム' });
+    const k2 = makeKnowledge({ KnowledgeID: 'k2', Topic: 'コーヒー', Summary: '飲み物' });
+    const k3 = makeKnowledge({ KnowledgeID: 'k3', Topic: 'モンスターハンター最新', Summary: 'ゲーム情報' });
+    const hits = searchKnowledge('モンハン', [k1, k2, k3]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].KnowledgeID).toBe('k1');
+  });
+
+  it('大文字小文字の違いを無視してマッチ', () => {
+    const k = makeKnowledge({ Topic: 'JavaScript', Summary: 'プログラミング言語' });
+    const hits = searchKnowledge('javascript', [k]);
+    expect(hits).toHaveLength(1);
+  });
+
+  it('userText が空の場合は空を返す', () => {
+    const k = makeKnowledge();
+    expect(searchKnowledge('', [k])).toHaveLength(0);
+  });
+});
+
+// ── classifyTopic ─────────────────────────────────────────────────────────
+
+describe('classifyTopic', () => {
+  it('needsStudy=true を返す場合（時事・ニッチ）', async () => {
+    const llm = makeLLMClient({ needsStudy: true, normalizedTopic: '最新ニュース' });
+    const result = await classifyTopic('最新ニュース教えて', 'ひより', llm);
+    expect(result.needsStudy).toBe(true);
+    expect(result.normalizedTopic).toBe('最新ニュース');
+  });
+
+  it('needsStudy=false を返す場合（一般常識）', async () => {
+    const llm = makeLLMClient({ needsStudy: false, normalizedTopic: '日本の首都' });
+    const result = await classifyTopic('日本の首都ってどこ？', 'ひより', llm);
+    expect(result.needsStudy).toBe(false);
+  });
+
+  it('chatStructured を purpose=classify で呼び出す', async () => {
+    const llm = makeLLMClient({ needsStudy: false, normalizedTopic: '挨拶' });
+    await classifyTopic('おはよう', 'ひより', llm);
+    expect(llm.chatStructured).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ role: 'user', content: 'おはよう' })]),
+      expect.anything(),
+      expect.objectContaining({ purpose: 'classify' })
+    );
+  });
+});
+
+// ── evaluateKnowledgeGate ─────────────────────────────────────────────────
+
+describe('evaluateKnowledgeGate', () => {
+  it('知識ベースにヒットすれば knowledge_hit を返す', async () => {
+    const k = makeKnowledge({ Topic: 'モンスターハンター', Summary: 'カプコンのゲーム' });
+    const llm = makeLLMClient({ needsStudy: true, normalizedTopic: 'モンハン' });
+    const result = await evaluateKnowledgeGate('モンスターハンター', 'ひより', [k], llm);
+    expect(result.kind).toBe('knowledge_hit');
+    // LLM は呼ばれない（ヒット時は即返却）
+    expect(llm.chatStructured).not.toHaveBeenCalled();
+  });
+
+  it('knowledge_hit 時に一致した knowledge を含む', async () => {
+    const k = makeKnowledge({ KnowledgeID: 'k1', Topic: 'モンスターハンター' });
+    const llm = makeLLMClient({ needsStudy: false, normalizedTopic: 'x' });
+    const result = await evaluateKnowledgeGate('モンスターハンター', 'ひより', [k], llm);
+    if (result.kind !== 'knowledge_hit') throw new Error('unexpected');
+    expect(result.knowledge[0].KnowledgeID).toBe('k1');
+  });
+
+  it('ヒットなし + needsStudy=true → study を返す', async () => {
+    const llm = makeLLMClient({ needsStudy: true, normalizedTopic: '最新アニメ' });
+    const result = await evaluateKnowledgeGate('最新アニメ教えて', 'ひより', [], llm);
+    expect(result.kind).toBe('study');
+    if (result.kind !== 'study') throw new Error('unexpected');
+    expect(result.normalizedTopic).toBe('最新アニメ');
+  });
+
+  it('ヒットなし + needsStudy=false → normal を返す', async () => {
+    const llm = makeLLMClient({ needsStudy: false, normalizedTopic: '挨拶' });
+    const result = await evaluateKnowledgeGate('おはよう！', 'ひより', [], llm);
+    expect(result.kind).toBe('normal');
+  });
+
+  it('知識ベースが空 + needsStudy=true → study を返す', async () => {
+    const llm = makeLLMClient({ needsStudy: true, normalizedTopic: 'ユーザー固有の話題' });
+    const result = await evaluateKnowledgeGate('私の実家の近くのラーメン屋', 'ひより', [], llm);
+    expect(result.kind).toBe('study');
+  });
+
+  it('知識ベースにヒットする場合は LLM 分類を呼ばない（コード側で gating）', async () => {
+    const k = makeKnowledge({ Topic: 'モンスターハンター' });
+    const llm = makeLLMClient({ needsStudy: true, normalizedTopic: 'x' });
+    await evaluateKnowledgeGate('モンスターハンター', 'ひより', [k], llm);
+    expect(llm.chatStructured).not.toHaveBeenCalled();
+  });
+
+  it('複数 knowledge があり一致するものだけ返す', async () => {
+    const k1 = makeKnowledge({ KnowledgeID: 'k1', Topic: 'モンハン', Summary: 'ゲーム' });
+    const k2 = makeKnowledge({ KnowledgeID: 'k2', Topic: 'コーヒー豆', Summary: '飲み物の話' });
+    const llm = makeLLMClient({ needsStudy: false, normalizedTopic: 'x' });
+    const result = await evaluateKnowledgeGate('コーヒー', 'ひより', [k1, k2], llm);
+    expect(result.kind).toBe('knowledge_hit');
+    if (result.kind !== 'knowledge_hit') throw new Error('unexpected');
+    expect(result.knowledge.map((k) => k.KnowledgeID)).toEqual(['k2']);
+  });
+});

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -5,11 +5,17 @@ import type { IVoiceClient } from '../../../src/voicevox/types.js';
 import type { MemoryRepository } from '../../../src/repositories/memory.repository.interface.js';
 import type { MessageRepository } from '../../../src/repositories/message.repository.interface.js';
 import type { SafetyEventRepository } from '../../../src/repositories/safety-event.repository.interface.js';
+import type { KnowledgeRepository } from '../../../src/repositories/knowledge.repository.interface.js';
+import type { StudyTopicRepository } from '../../../src/repositories/study-topic.repository.interface.js';
 import type { MessageEntity } from '../../../src/entities/message.entity.js';
 import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
+import type { KnowledgeEntity } from '../../../src/entities/knowledge.entity.js';
 import type { SafetyEventEntity } from '../../../src/entities/safety-event.entity.js';
 import type { IModerationClient, ModerationResult } from '../../../src/safety/types.js';
 import type { IMemoryRetriever, RetrievedMemory } from '../../../src/memory/types.js';
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryKnowledgeRepository } from '../../../src/repositories/in-memory-knowledge.repository.js';
+import { InMemoryStudyTopicRepository } from '../../../src/repositories/in-memory-study-topic.repository.js';
 
 // ── ヘルパー ──────────────────────────────────────────────────────────────
 
@@ -1213,6 +1219,272 @@ describe('runChatUseCase', () => {
       );
 
       expect(events[events.length - 1]).toEqual({ type: 'done' });
+    });
+  });
+
+  // ── 知識ゲート（Phase 5b / Issue #3344）────────────────────────────────
+
+  describe('知識ゲート', () => {
+    function makeKnowledge(topic: string, summary: string): KnowledgeEntity {
+      return {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        KnowledgeID: 'k1',
+        Topic: topic,
+        Summary: summary,
+        SourceUrls: [],
+        RawComment: '',
+        RelatedCategory: 'ゲーム',
+        CreatedAt: 1_700_000_000_000,
+        UpdatedAt: 1_700_000_000_000,
+      };
+    }
+
+    function makeKnowledgeRepo(knowledge: KnowledgeEntity[] = []): KnowledgeRepository {
+      return {
+        put: jest.fn(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+        list: jest.fn(async () => knowledge),
+        getLatest: jest.fn(async () => knowledge[0] ?? null),
+      };
+    }
+
+    function makeStudyTopicRepo(): StudyTopicRepository {
+      return {
+        put: jest.fn(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+        listByStatus: jest.fn(async () => []),
+        updateStatus: jest.fn(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+        findPendingByTopic: jest.fn(async () => null),
+      } as unknown as StudyTopicRepository;
+    }
+
+    it('知識ベースにヒット → 通常 LLM 応答（knowledge_hit）', async () => {
+      const k = makeKnowledge('モンスターハンター', 'カプコンのゲーム');
+      const knowledgeRepo = makeKnowledgeRepo([k]);
+      const llm = makeLLMClient(['モンハン面白いよね！']);
+      // chatStructured は knowledge_hit なので呼ばれない
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: 'モンスターハンター',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+        })
+      );
+
+      const textEvents = events.filter((e) => e.type === 'text');
+      expect(textEvents.length).toBeGreaterThan(0);
+      // chatStructured（分類）は呼ばれない
+      expect(llm.chatStructured).not.toHaveBeenCalled();
+    });
+
+    it('ヒットなし + needsStudy=true → 「勉強しておくね」テンプレ応答でLLMバイパス', async () => {
+      const knowledgeRepo = makeKnowledgeRepo([]);
+      const studyTopicRepo = makeStudyTopicRepo();
+      const llm = makeLLMClient(['応答']);
+      // chatStructured は needsStudy=true を返す
+      (llm.chatStructured as jest.Mock).mockResolvedValue({
+        needsStudy: true,
+        normalizedTopic: '最新アニメ',
+      });
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: '最新アニメ教えて',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+          studyTopicRepository: studyTopicRepo,
+        })
+      );
+
+      // chatStream（通常 LLM）は呼ばれない
+      expect(llm.chatStream).not.toHaveBeenCalled();
+      // テンプレ text が流れる
+      const textEvents = events.filter((e) => e.type === 'text');
+      expect(textEvents.length).toBeGreaterThan(0);
+      // done で終わる
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+      // STUDY_TOPIC が登録される
+      expect(studyTopicRepo.put).toHaveBeenCalledWith(
+        expect.objectContaining({ Topic: '最新アニメ', Status: 'pending' })
+      );
+    });
+
+    it('ヒットなし + needsStudy=true + 既存 pending → 重複登録しない', async () => {
+      const knowledgeRepo = makeKnowledgeRepo([]);
+      const studyTopicRepo = makeStudyTopicRepo();
+      // 既存 pending を返す
+      (studyTopicRepo.findPendingByTopic as jest.Mock).mockResolvedValue({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        TopicID: 'tp-existing',
+        Topic: '最新アニメ',
+        Priority: 10,
+        Status: 'pending',
+        CreatedAt: Date.now(),
+        UpdatedAt: Date.now(),
+      });
+      const llm = makeLLMClient(['応答']);
+      (llm.chatStructured as jest.Mock).mockResolvedValue({
+        needsStudy: true,
+        normalizedTopic: '最新アニメ',
+      });
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: '最新アニメ教えて',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+          studyTopicRepository: studyTopicRepo,
+        })
+      );
+
+      expect(studyTopicRepo.put).not.toHaveBeenCalled();
+    });
+
+    it('ヒットなし + needsStudy=false → 通常 LLM 応答（normal）', async () => {
+      const knowledgeRepo = makeKnowledgeRepo([]);
+      const llm = makeLLMClient(['もちろん！']);
+      (llm.chatStructured as jest.Mock).mockResolvedValue({
+        needsStudy: false,
+        normalizedTopic: '挨拶',
+      });
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: 'おはよう！',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+        })
+      );
+
+      expect(llm.chatStream).toHaveBeenCalled();
+      const textEvents = events.filter((e) => e.type === 'text');
+      expect(textEvents.length).toBeGreaterThan(0);
+    });
+
+    it('knowledgeRepository 未指定 → ゲートをスキップして通常フロー', async () => {
+      const llm = makeLLMClient(['普通の応答']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: 'こんにちは',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          // knowledgeRepository は未指定
+        })
+      );
+
+      expect(llm.chatStream).toHaveBeenCalled();
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+    });
+
+    it('知識ゲートがエラーを投げても通常フローで継続する（fail-warn）', async () => {
+      const knowledgeRepo = makeKnowledgeRepo([]);
+      (knowledgeRepo.list as jest.Mock).mockRejectedValue(new Error('DB error'));
+      const llm = makeLLMClient(['エラーでも応答']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: 'テスト',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+        })
+      );
+
+      // エラーでも通常 LLM 応答が返る
+      expect(llm.chatStream).toHaveBeenCalled();
+      expect(events[events.length - 1]).toEqual({ type: 'done' });
+    });
+
+    it('study 分岐後はアシスタントメッセージが保存される', async () => {
+      const knowledgeRepo = makeKnowledgeRepo([]);
+      const llm = makeLLMClient(['通常応答']);
+      (llm.chatStructured as jest.Mock).mockResolvedValue({
+        needsStudy: true,
+        normalizedTopic: 'テスト',
+      });
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: 'テスト',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+        })
+      );
+
+      const createCalls = (repo.create as jest.Mock).mock.calls;
+      const assistantCall = createCalls.find(
+        (args: unknown[]) => (args[0] as { Role: string }).Role === 'assistant'
+      );
+      expect(assistantCall).toBeDefined();
+      // テンプレ応答文（「知らない」系メッセージ）が保存される
+      const savedText = (assistantCall![0] as { Text: string }).Text;
+      expect(
+        savedText.includes('勉強') || savedText.includes('調べ') || savedText.includes('わからない')
+      ).toBe(true);
+    });
+
+    it('knowledge_hit 時は通常 LLM が知識 context で呼ばれる', async () => {
+      const k = makeKnowledge('モンスターハンター', 'カプコンのゲームシリーズ');
+      const knowledgeRepo = makeKnowledgeRepo([k]);
+      const llm = makeLLMClient(['モンハンの話ね！']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: 'モンスターハンター',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+        })
+      );
+
+      // chatStream（通常 LLM）が呼ばれた
+      expect(llm.chatStream).toHaveBeenCalled();
+      // system prompt に「この前調べたこと」セクションが含まれる
+      const streamArgs = (llm.chatStream as jest.Mock).mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const systemMsg = streamArgs.find((m) => m.role === 'system');
+      expect(systemMsg?.content).toContain('この前調べたこと');
     });
   });
 });

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -1252,7 +1252,11 @@ describe('runChatUseCase', () => {
       return {
         put: jest.fn(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
         listByStatus: jest.fn(async () => []),
-        updateStatus: jest.fn(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+        updateStatus: jest.fn(async (input) => ({
+          ...input,
+          CreatedAt: Date.now(),
+          UpdatedAt: Date.now(),
+        })),
         findPendingByTopic: jest.fn(async () => null),
       } as unknown as StudyTopicRepository;
     }

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -13,9 +13,6 @@ import type { KnowledgeEntity } from '../../../src/entities/knowledge.entity.js'
 import type { SafetyEventEntity } from '../../../src/entities/safety-event.entity.js';
 import type { IModerationClient, ModerationResult } from '../../../src/safety/types.js';
 import type { IMemoryRetriever, RetrievedMemory } from '../../../src/memory/types.js';
-import { InMemorySingleTableStore } from '@nagiyu/aws';
-import { InMemoryKnowledgeRepository } from '../../../src/repositories/in-memory-knowledge.repository.js';
-import { InMemoryStudyTopicRepository } from '../../../src/repositories/in-memory-study-topic.repository.js';
 
 // ── ヘルパー ──────────────────────────────────────────────────────────────
 

--- a/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
@@ -195,21 +195,17 @@ describe('studyForUser', () => {
   const makeStudyTopicRepo = (
     topics: StudyTopicEntity[] = []
   ): jest.Mocked<StudyTopicRepository> => ({
-    put: jest
-      .fn()
-      .mockImplementation(async (input) => ({
-        ...input,
-        CreatedAt: Date.now(),
-        UpdatedAt: Date.now(),
-      })),
+    put: jest.fn().mockImplementation(async (input) => ({
+      ...input,
+      CreatedAt: Date.now(),
+      UpdatedAt: Date.now(),
+    })),
     listByStatus: jest.fn().mockResolvedValue(topics),
-    updateStatus: jest
-      .fn()
-      .mockImplementation(async (input) => ({
-        ...input,
-        CreatedAt: Date.now(),
-        UpdatedAt: Date.now(),
-      })),
+    updateStatus: jest.fn().mockImplementation(async (input) => ({
+      ...input,
+      CreatedAt: Date.now(),
+      UpdatedAt: Date.now(),
+    })),
     findPendingByTopic: jest.fn().mockResolvedValue(null),
   });
 
@@ -309,7 +305,7 @@ describe('studyForUser', () => {
       rawComment: '',
     });
 
-    const result = await studyForUser('u1', 'hiyori', {
+    await studyForUser('u1', 'hiyori', {
       knowledgeRepo,
       interestRepo,
       researchClient,

--- a/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
@@ -192,10 +192,24 @@ describe('studyForUser', () => {
 
   // ── STUDY_TOPIC 優先処理（Phase 5b）──
 
-  const makeStudyTopicRepo = (topics: StudyTopicEntity[] = []): jest.Mocked<StudyTopicRepository> => ({
-    put: jest.fn().mockImplementation(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+  const makeStudyTopicRepo = (
+    topics: StudyTopicEntity[] = []
+  ): jest.Mocked<StudyTopicRepository> => ({
+    put: jest
+      .fn()
+      .mockImplementation(async (input) => ({
+        ...input,
+        CreatedAt: Date.now(),
+        UpdatedAt: Date.now(),
+      })),
     listByStatus: jest.fn().mockResolvedValue(topics),
-    updateStatus: jest.fn().mockImplementation(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+    updateStatus: jest
+      .fn()
+      .mockImplementation(async (input) => ({
+        ...input,
+        CreatedAt: Date.now(),
+        UpdatedAt: Date.now(),
+      })),
     findPendingByTopic: jest.fn().mockResolvedValue(null),
   });
 

--- a/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
@@ -2,6 +2,8 @@ import type { LifecycleEntity } from '../../../src/entities/lifecycle.entity.js'
 import { shouldStudyNow, studyForUser } from '../../../src/usecases/study.usecase.js';
 import type { KnowledgeRepository } from '../../../src/repositories/knowledge.repository.interface.js';
 import type { InterestRepository } from '../../../src/repositories/interest.repository.interface.js';
+import type { StudyTopicRepository } from '../../../src/repositories/study-topic.repository.interface.js';
+import type { StudyTopicEntity } from '../../../src/entities/study-topic.entity.js';
 import type { IResearchClient } from '../../../src/research/types.js';
 import type { CharacterDefinition } from '../../../src/characters/types.js';
 import { STUDY_MIN_INTERVAL_HOURS, STUDY_MIN_SUMMARY_LENGTH } from '../../../src/constants.js';
@@ -186,6 +188,146 @@ describe('studyForUser', () => {
     });
 
     expect(knowledgeRepo.put).not.toHaveBeenCalled();
+  });
+
+  // ── STUDY_TOPIC 優先処理（Phase 5b）──
+
+  const makeStudyTopicRepo = (topics: StudyTopicEntity[] = []): jest.Mocked<StudyTopicRepository> => ({
+    put: jest.fn().mockImplementation(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+    listByStatus: jest.fn().mockResolvedValue(topics),
+    updateStatus: jest.fn().mockImplementation(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+    findPendingByTopic: jest.fn().mockResolvedValue(null),
+  });
+
+  const makePendingStudyTopic = (overrides: Partial<StudyTopicEntity> = {}): StudyTopicEntity => ({
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    TopicID: 'tp1',
+    Topic: '最新アニメ',
+    Priority: 10,
+    Status: 'pending',
+    CreatedAt: 1_700_000_000_000,
+    UpdatedAt: 1_700_000_000_000,
+    ...overrides,
+  });
+
+  it('STUDY_TOPIC が pending なら優先的に研究される', async () => {
+    const topic = makePendingStudyTopic({ Topic: '最新アニメ情報' });
+    const studyTopicRepo = makeStudyTopicRepo([topic]);
+    const knowledgeRepo = makeKnowledgeRepo();
+    const interestRepo = makeInterestRepo();
+    interestRepo.list.mockResolvedValue([]); // 興味カテゴリは空
+    const researchClient = makeResearchClient();
+    researchClient.research.mockResolvedValue({
+      topic: '最新アニメ情報',
+      summary: '最新アニメに関する詳細情報です。'.repeat(5),
+      sourceUrls: ['https://example.com'],
+      rawComment: '面白そう！',
+    });
+
+    const result = await studyForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      interestRepo,
+      researchClient,
+      character,
+      lifecycle: makeLifecycle(),
+      now: () => awakeNonPeak,
+      studyTopicRepo,
+    });
+
+    expect(result.outcome).toBe('studied');
+    expect(result.savedCount).toBe(1);
+    expect(knowledgeRepo.put).toHaveBeenCalledWith(
+      expect.objectContaining({ Topic: '最新アニメ情報' })
+    );
+    // Status が done になる
+    expect(studyTopicRepo.updateStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ TopicID: 'tp1', Status: 'done' })
+    );
+  });
+
+  it('STUDY_TOPIC を優先して残り枠で通常カテゴリを処理する', async () => {
+    const topic = makePendingStudyTopic({ Topic: '優先トピック' });
+    const studyTopicRepo = makeStudyTopicRepo([topic]);
+    const knowledgeRepo = makeKnowledgeRepo();
+    const interestRepo = makeInterestRepo(); // コーヒーカテゴリあり
+    const researchClient = makeResearchClient();
+    researchClient.research
+      .mockResolvedValueOnce({
+        topic: '優先トピック',
+        summary: '優先トピックの詳細情報。'.repeat(5),
+        sourceUrls: [],
+        rawComment: '',
+      })
+      .mockResolvedValueOnce({
+        topic: 'コーヒーの効能',
+        summary: 'コーヒーに関する情報。'.repeat(5),
+        sourceUrls: [],
+        rawComment: '',
+      });
+
+    const result = await studyForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      interestRepo,
+      researchClient,
+      character,
+      lifecycle: makeLifecycle(),
+      now: () => awakeNonPeak,
+      studyTopicRepo,
+      maxQueriesPerRun: 3,
+    });
+
+    expect(result.outcome).toBe('studied');
+    expect(result.savedCount).toBe(2);
+  });
+
+  it('STUDY_TOPIC 研究が品質不足の場合は done にするが savedCount は増えない', async () => {
+    const topic = makePendingStudyTopic();
+    const studyTopicRepo = makeStudyTopicRepo([topic]);
+    const knowledgeRepo = makeKnowledgeRepo();
+    const interestRepo = makeInterestRepo();
+    interestRepo.list.mockResolvedValue([]);
+    const researchClient = makeResearchClient();
+    researchClient.research.mockResolvedValue({
+      topic: '最新アニメ',
+      summary: '短い',
+      sourceUrls: [],
+      rawComment: '',
+    });
+
+    const result = await studyForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      interestRepo,
+      researchClient,
+      character,
+      lifecycle: makeLifecycle(),
+      now: () => awakeNonPeak,
+      studyTopicRepo,
+    });
+
+    expect(knowledgeRepo.put).not.toHaveBeenCalled();
+    expect(studyTopicRepo.updateStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ Status: 'done' })
+    );
+  });
+
+  it('studyTopicRepo 未指定でも通常フローが動く（後方互換）', async () => {
+    const knowledgeRepo = makeKnowledgeRepo();
+    const interestRepo = makeInterestRepo();
+    const researchClient = makeResearchClient();
+
+    const result = await studyForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      interestRepo,
+      researchClient,
+      character,
+      lifecycle: makeLifecycle(),
+      now: () => awakeNonPeak,
+      // studyTopicRepo は未指定
+    });
+
+    expect(result.outcome).toBe('studied');
+    expect(knowledgeRepo.put).toHaveBeenCalled();
   });
 
   it('リサーチ失敗でも他カテゴリを継続する（fail-warn）', async () => {


### PR DESCRIPTION
## 変更の概要

Issue #3344「勉強しておくね」強制ゲートの実装。

会話中に知識ベース（KNOWLEDGE）にヒットしないトピックを聞かれた場合、LLMをバイパスしてキャラ口調のテンプレ応答を返し、STUDYTOPICキューに登録する。次回の勉強バッチ（Phase 5a）がこのキューを優先処理し、次の会話で学んだ知識を持ち出す。

### 実装した判定フロー

```
ユーザー発話
  ↓ セーフティ検出（既存）
  ↓ 知識ゲート（本PR）
    ├─ 知識ベースにキーワード一致 → 知識をpromptに注入して通常LLM応答（knowledge_hit）
    ├─ ヒットなし + LLM分類 needsStudy=true → STUDY_TOPIC登録 + テンプレ応答でLLMバイパス（study）
    └─ ヒットなし + needsStudy=false → 通常LLM応答（normal）
```

**LLM の自信過剰問題対策**：chatStructured による分類結果を受けて**コード側が最終 gating**。LLMに「勉強するかどうか」の決定権を与えない。

## 関連 Issue

#3344（Phase 5b）/ Parent: #3188（Phase 5）/ Grandparent: #3182

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] ライブラリ配置は `services/livetalk/core/` 配下（`libs/` には出さない）
- [x] TypeScript strict mode 準拠
- [x] 後方互換：`knowledgeRepository` / `studyTopicRepo` は任意注入、未指定時は従来フロー

## 新規ファイル一覧

| ファイル | 役割 |
|---------|------|
| `src/entities/study-topic.entity.ts` | StudyTopicEntity（SK: `CHAR#<charId>#STUDY#<ulid>`、TTL 30日） |
| `src/repositories/study-topic.repository.interface.ts` | put / listByStatus / updateStatus / findPendingByTopic |
| `src/repositories/in-memory-study-topic.repository.ts` | インメモリ実装（テスト用） |
| `src/repositories/dynamodb-study-topic.repository.ts` | DynamoDB 実装 |
| `src/mappers/study-topic.mapper.ts` | DynamoDB ↔ Entity 変換 |
| `src/llm-client/schemas/knowledge-gate.schema.ts` | KnowledgeGateSchema（Zod / ADR-008 準拠） |
| `src/study/knowledge-gate.ts` | searchKnowledge（キーワード照合）+ classifyTopic（chatStructured）+ evaluateKnowledgeGate |
| `src/study/templates.ts` | buildStudyDeferralMessage（「勉強しておくね」テンプレ） |

## 変更ファイル一覧

| ファイル | 変更内容 |
|---------|---------|
| `src/mappers/keys.ts` | buildStudyTopicSK / buildStudyTopicSKPrefix を追加 |
| `src/constants.ts` | STUDY_TOPIC_TTL_SECONDS / STUDY_TOPIC_GATE_PRIORITY を追加 |
| `src/characters/prompt-builder.ts` | knowledgeContext パラメータ追加、「この前調べたこと」セクション注入 |
| `src/usecases/chat-usecase.ts` | セーフティ直後に知識ゲートを挿入、knowledgeRepository / studyTopicRepository を任意注入 |
| `src/usecases/study.usecase.ts` | studyTopicRepo 任意注入、通常カテゴリ処理前に pending STUDY_TOPIC を優先処理 |
| `src/llm-client/schemas/index.ts` | KnowledgeGateSchema を re-export |
| `src/index.ts` | 新規モジュールをエクスポート |

## テスト内容

- `tests/unit/study/knowledge-gate.test.ts`：境界条件を網羅（ヒット有り/無し、一般常識、ニッチ、空配列、大文字小文字、LLMバイパス確認）
- `tests/unit/repositories/in-memory-study-topic.repository.test.ts`：CRUD・ソート・フィルタ・重複防止を網羅
- `tests/unit/repositories/dynamodb-study-topic.repository.test.ts`：DynamoDBモックで各メソッドを網羅
- `tests/unit/usecases/chat-usecase.test.ts`：知識ゲートの全分岐（knowledge_hit / study / normal / エラー時フォールバック）を追加
- `tests/unit/usecases/study.usecase.test.ts`：STUDY_TOPIC優先処理・残り枠での通常処理・品質不足・後方互換を追加

**結果：761 テスト全通過、カバレッジ 80% 閾値クリア**

## レビューポイント

- **`study/knowledge-gate.ts` の `evaluateKnowledgeGate`**：ここがコード側 gating の核心。「知識ベースにヒット → LLM を呼ばずに即返却」の流れが意図通りか確認をお願いします。
- **`chat-usecase.ts` の 3.6 節**：セーフティと同じ「pre-LLM ゲート + LLM バイパス + `return`」パターン。study 分岐後は Moderation・記憶昇格・親密度更新が走らない（意図通り）。
- **`study.usecase.ts`**：STUDY_TOPIC pending を先に消費し、残り枠（maxQueriesPerRun - 処理済み数）で通常カテゴリを処理する設計。枠が余らない場合は通常カテゴリをスキップ。
- **web 側（`services/livetalk/web`）の `route.ts` の更新は本 PR に含まない**：`knowledgeRepository` / `studyTopicRepository` の注入が未実装のため、実際の会話で知識ゲートは動作しない（knowledgeRepository 未指定 = 従来フローで継続）。web 側の接続は後続 PR で対応予定。

## 補足事項

- `services/livetalk/batch` の study handler への `studyTopicRepo` 注入も未実装（web 側と合わせて後続 PR で対応）
- 「次の会話で学んだ知識を自然に持ち出す」は knowledge_hit 分岐の prompt 注入（「この前調べたこと」セクション）で対応

---
_Generated by [Claude Code](https://claude.ai/code/session_01X39ehW7by39XJgL5ubmtzb)_