### PR TITLE
feat(livetalk): 知識ゲートを web/batch に配線（Phase 5b / #3344）

### DIFF
--- a/services/livetalk/batch/src/handlers/study.ts
+++ b/services/livetalk/batch/src/handlers/study.ts
@@ -4,6 +4,7 @@ import {
   DynamoDBInterestRepository,
   DynamoDBKnowledgeRepository,
   DynamoDBLifecycleRepository,
+  DynamoDBStudyTopicRepository,
   OpenAIResearchClient,
   defaultUlidFactory,
 } from '@nagiyu/livetalk-core';
@@ -42,6 +43,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const lifecycleRepo = new DynamoDBLifecycleRepository(docClient, tableName);
     const interestRepo = new DynamoDBInterestRepository(docClient, tableName);
     const knowledgeRepo = new DynamoDBKnowledgeRepository(docClient, tableName);
+    const studyTopicRepo = new DynamoDBStudyTopicRepository(docClient, tableName);
     const researchClient = new OpenAIResearchClient({ apiKey });
 
     const result = await studyAllUsers({
@@ -50,6 +52,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       lifecycleRepo,
       interestRepo,
       knowledgeRepo,
+      studyTopicRepo,
       researchClient,
       ulidFactory: defaultUlidFactory,
     });

--- a/services/livetalk/batch/src/usecases/study.usecase.ts
+++ b/services/livetalk/batch/src/usecases/study.usecase.ts
@@ -7,6 +7,7 @@ import {
   type InterestRepository,
   type KnowledgeRepository,
   type LifecycleRepository,
+  type StudyTopicRepository,
   type UlidFactory,
 } from '@nagiyu/livetalk-core';
 import type { IResearchClient } from '@nagiyu/livetalk-core';
@@ -17,6 +18,7 @@ export interface StudyAllUsersParams {
   lifecycleRepo: LifecycleRepository;
   interestRepo: InterestRepository;
   knowledgeRepo: KnowledgeRepository;
+  studyTopicRepo?: StudyTopicRepository;
   researchClient: IResearchClient;
   ulidFactory?: UlidFactory;
   now?: () => Date;
@@ -42,6 +44,7 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
     lifecycleRepo,
     interestRepo,
     knowledgeRepo,
+    studyTopicRepo,
     researchClient,
     ulidFactory,
     now,
@@ -73,6 +76,7 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
       const outcome = await studyForUser(userId, DEFAULT_CHARACTER_ID, {
         knowledgeRepo,
         interestRepo,
+        studyTopicRepo,
         researchClient,
         character: hiyori,
         lifecycle,

--- a/services/livetalk/batch/tests/unit/handlers/study.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/study.test.ts
@@ -10,6 +10,7 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBLifecycleRepository: jest.fn(),
   DynamoDBInterestRepository: jest.fn(),
   DynamoDBKnowledgeRepository: jest.fn(),
+  DynamoDBStudyTopicRepository: jest.fn(),
   OpenAIResearchClient: jest.fn(),
   defaultUlidFactory: jest.fn(),
 }));

--- a/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
@@ -92,4 +92,18 @@ describe('studyAllUsers', () => {
     expect(result.failedUsers).toBe(2);
     expect(result.failedUserIds).toEqual(['u1', 'u2']);
   });
+
+  it('studyTopicRepo を studyForUser に受け渡す（Phase 5b 配線）', async () => {
+    mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
+    const studyTopicRepo = { listByStatus: jest.fn() };
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    await studyAllUsers(makeParams({ studyTopicRepo: studyTopicRepo as never }));
+
+    expect(mockStudyForUser).toHaveBeenCalledWith(
+      'u1',
+      'hiyori',
+      expect.objectContaining({ studyTopicRepo })
+    );
+  });
 });

--- a/services/livetalk/web/src/app/api/chat/route.ts
+++ b/services/livetalk/web/src/app/api/chat/route.ts
@@ -6,9 +6,11 @@ import { getLLMClient } from '@/lib/server/llm';
 import { getVoicevoxClient } from '@/lib/server/voicevox';
 import {
   getCharacterStateRepository,
+  getKnowledgeRepository,
   getLifecycleRepository,
   getMemoryRepository,
   getMessageRepository,
+  getStudyTopicRepository,
 } from '@/lib/server/repositories';
 import { getModerationClient, getSafetyEventRepository } from '@/lib/server/safety';
 import { getMemoryRetriever } from '@/lib/server/memory-retriever';
@@ -101,6 +103,8 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
           embeddingClient: getEmbeddingClient(),
           characterStateRepository: getCharacterStateRepository(),
           lifecycleRepository: getLifecycleRepository(),
+          knowledgeRepository: getKnowledgeRepository(),
+          studyTopicRepository: getStudyTopicRepository(),
         });
 
         for await (const event of eventGenerator) {

--- a/services/livetalk/web/src/lib/server/repositories.ts
+++ b/services/livetalk/web/src/lib/server/repositories.ts
@@ -11,24 +11,30 @@ import { InMemorySingleTableStore, registerDynamoRepositories } from '@nagiyu/aw
 import type {
   CharacterStateRepository,
   InterestRepository,
+  KnowledgeRepository,
   LifecycleRepository,
   MemoryRepository,
   MessageRepository,
   ProfileRepository,
+  StudyTopicRepository,
 } from '@nagiyu/livetalk-core';
 import {
   DynamoDBCharacterStateRepository,
   DynamoDBInterestRepository,
+  DynamoDBKnowledgeRepository,
   DynamoDBLifecycleRepository,
   DynamoDBMemoryRepository,
   DynamoDBMessageRepository,
   DynamoDBProfileRepository,
+  DynamoDBStudyTopicRepository,
   InMemoryCharacterStateRepository,
   InMemoryInterestRepository,
+  InMemoryKnowledgeRepository,
   InMemoryLifecycleRepository,
   InMemoryMemoryRepository,
   InMemoryMessageRepository,
   InMemoryProfileRepository,
+  InMemoryStudyTopicRepository,
 } from '@nagiyu/livetalk-core';
 
 const registry = registerDynamoRepositories<
@@ -39,6 +45,8 @@ const registry = registerDynamoRepositories<
     characterState: CharacterStateRepository;
     interest: InterestRepository;
     lifecycle: LifecycleRepository;
+    knowledge: KnowledgeRepository;
+    studyTopic: StudyTopicRepository;
   },
   InMemorySingleTableStore
 >(
@@ -73,6 +81,16 @@ const registry = registerDynamoRepositories<
       createDynamoDBRepository: ({ docClient, tableName }) =>
         new DynamoDBLifecycleRepository(docClient, tableName),
     },
+    knowledge: {
+      createInMemoryRepository: (store) => new InMemoryKnowledgeRepository(store),
+      createDynamoDBRepository: ({ docClient, tableName }) =>
+        new DynamoDBKnowledgeRepository(docClient, tableName),
+    },
+    studyTopic: {
+      createInMemoryRepository: (store) => new InMemoryStudyTopicRepository(store),
+      createDynamoDBRepository: ({ docClient, tableName }) =>
+        new DynamoDBStudyTopicRepository(docClient, tableName),
+    },
   },
   {
     keyPrefix: 'livetalk',
@@ -102,6 +120,14 @@ export function getInterestRepository(): InterestRepository {
 
 export function getLifecycleRepository(): LifecycleRepository {
   return registry.lifecycle.createRepository();
+}
+
+export function getKnowledgeRepository(): KnowledgeRepository {
+  return registry.knowledge.createRepository();
+}
+
+export function getStudyTopicRepository(): StudyTopicRepository {
+  return registry.studyTopic.createRepository();
 }
 
 /**

--- a/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
@@ -16,6 +16,8 @@ jest.mock('@/lib/server/repositories', () => ({
   getMemoryRepository: jest.fn().mockReturnValue({}),
   getCharacterStateRepository: jest.fn().mockReturnValue({}),
   getLifecycleRepository: jest.fn().mockReturnValue({}),
+  getKnowledgeRepository: jest.fn().mockReturnValue({}),
+  getStudyTopicRepository: jest.fn().mockReturnValue({}),
 }));
 jest.mock('@/lib/server/safety', () => ({
   getSafetyEventRepository: jest.fn().mockReturnValue({}),

--- a/services/livetalk/web/tests/unit/lib/server/repositories.test.ts
+++ b/services/livetalk/web/tests/unit/lib/server/repositories.test.ts
@@ -30,6 +30,33 @@ describe('lib/server/repositories', () => {
     expect(p1).toBeDefined();
     expect(c1).toBeDefined();
     expect(l1).toBeDefined();
+
+    // Phase 5b 配線: 知識ゲートで使う Knowledge / StudyTopic も取得できる
+    const k1 = mod.getKnowledgeRepository();
+    const k2 = mod.getKnowledgeRepository();
+    expect(k1).toBe(k2);
+    const s1 = mod.getStudyTopicRepository();
+    const s2 = mod.getStudyTopicRepository();
+    expect(s1).toBe(s2);
+  });
+
+  it('InMemory 実装では StudyTopic を保存して status 別に取得できる（共有 store 検証）', async () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const mod = await import('@/lib/server/repositories');
+    mod.resetRepositoriesForTesting();
+    const repo = mod.getStudyTopicRepository();
+    await repo.put({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      TopicID: 'tp1',
+      Topic: 'モンスターハンター',
+      Priority: 10,
+      Status: 'pending',
+    });
+    const pending = await repo.listByStatus('u1', 'hiyori', 'pending');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].Topic).toBe('モンスターハンター');
+    mod.resetRepositoriesForTesting();
   });
 
   it('InMemory 実装では Message を保存して取得できる（共有 store 検証）', async () => {
@@ -70,6 +97,8 @@ describe('lib/server/repositories', () => {
     expect(() => mod.getProfileRepository()).not.toThrow();
     expect(() => mod.getCharacterStateRepository()).not.toThrow();
     expect(() => mod.getLifecycleRepository()).not.toThrow();
+    expect(() => mod.getKnowledgeRepository()).not.toThrow();
+    expect(() => mod.getStudyTopicRepository()).not.toThrow();
     mod.resetRepositoriesForTesting();
   });
 });


### PR DESCRIPTION
## 変更の概要

「勉強しておくね」強制ゲート（Phase 5b / #3344）の **呼び出し側への配線** を実装する。

core 側のゲートロジック（knowledge-gate / chat-usecase 統合 / STUDY_TOPIC 優先処理）は PR #3350 で実装済みだが、web の chat route と batch の study handler でリポジトリが未注入だったため、optional 設計によりゲートがスキップされていた。本 PR で注入し、dev で E2E 挙動を検証可能にする。

### 変更点

- **`web/src/lib/server/repositories.ts`**: `getKnowledgeRepository()` / `getStudyTopicRepository()` をファクトリ登録に追加（既存の memory 等と同じパターン）
- **`web/src/app/api/chat/route.ts`**: `runChatUseCase` に `knowledgeRepository` / `studyTopicRepository` を注入（`ulidFactory` は usecase 側で `defaultUlidFactory` がデフォルト適用されるため明示注入は不要）
- **`batch/src/handlers/study.ts` / `usecases/study.usecase.ts`**: `DynamoDBStudyTopicRepository` を生成し `studyTopicRepo` を注入、STUDY_TOPIC 優先処理を有効化
- 各配線箇所の単体テストを追加・更新

## 関連 Issue

#3344（Phase 5b・スコープ拡張で配線を本 Issue 射程に含めた）

※ integration ブランチ向けのため `Closes #` は付けない（develop マージ時にクローズ）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（配線箇所の単体テスト）
- [ ] 関連ドキュメントを更新した（永続ドキュメント変更なし）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `web/tests/.../repositories.test.ts`: 新 getter のシングルトン取得 / InMemory での StudyTopic put→listByStatus / DynamoDB モードでの生成を検証
- `web/tests/.../chat/route.test.ts`: 新リポジトリ getter をモックに追加し、既存ルートテストが緑であることを確認
- `batch/tests/.../study.usecase.test.ts`: `studyTopicRepo` が `studyForUser` に受け渡されることを検証
- `batch/tests/.../handlers/study.test.ts`: `DynamoDBStudyTopicRepository` のモックを追加
- ローカル結果: batch 25 / web 132 テスト緑、変更パッケージの lint・format 緑、core/batch/web の型チェック（変更ファイル）緑

## レビューポイント

- **配線方針**: web は getter ファクトリ経由、batch は handler で直接 `new` という既存パターンを踏襲。違和感がないか
- **`ulidFactory` 非注入**: chat-usecase 側で `defaultUlidFactory` がデフォルト適用されるため、route では明示注入していない（本番では実 ULID 生成）。この判断でよいか
- **後方互換**: 既存の注入引数はそのまま、追加注入のみ。挙動変化は「ゲートが発火するようになる」点のみ

## 補足事項

- dev 反映後の検証手段は確認済み（read-only）:
  - DynamoDB `nagiyu-livetalk-dynamodb-dev`（us-east-1）の `SK=CHAR#hiyori#STUDY#*` / `CHAR#hiyori#KNOWLEDGE#*`
  - 会話ログ `/ecs/nagiyu-livetalk-task-dev`、勉強バッチログ `/aws/lambda/nagiyu-livetalk-batch-study-dev`
- 本 PR マージ後、dev で「会話 → 勉強しておくね → STUDY_TOPIC 登録 → バッチ優先処理 → 次回会話で持ち出し」の E2E を確認する

---
_Generated by [Claude Code](https://claude.ai/code/session_01X39ehW7by39XJgL5ubmtzb)_