### PR TITLE
リブトーク Phase 5c: ノート（生成 + 閲覧 UI + 感想連携）

### DIFF
--- a/services/livetalk/batch/src/handlers/study.ts
+++ b/services/livetalk/batch/src/handlers/study.ts
@@ -4,6 +4,7 @@ import {
   DynamoDBInterestRepository,
   DynamoDBKnowledgeRepository,
   DynamoDBLifecycleRepository,
+  DynamoDBNoteRepository,
   DynamoDBStudyTopicRepository,
   OpenAIResearchClient,
   defaultUlidFactory,
@@ -44,6 +45,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const interestRepo = new DynamoDBInterestRepository(docClient, tableName);
     const knowledgeRepo = new DynamoDBKnowledgeRepository(docClient, tableName);
     const studyTopicRepo = new DynamoDBStudyTopicRepository(docClient, tableName);
+    const noteRepo = new DynamoDBNoteRepository(docClient, tableName);
     const researchClient = new OpenAIResearchClient({ apiKey });
 
     const result = await studyAllUsers({
@@ -53,6 +55,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       interestRepo,
       knowledgeRepo,
       studyTopicRepo,
+      noteRepo,
       researchClient,
       ulidFactory: defaultUlidFactory,
     });

--- a/services/livetalk/batch/src/usecases/study.usecase.ts
+++ b/services/livetalk/batch/src/usecases/study.usecase.ts
@@ -2,11 +2,13 @@ import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb'
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
   DEFAULT_CHARACTER_ID,
+  generateNotesForUser,
   hiyori,
   studyForUser,
   type InterestRepository,
   type KnowledgeRepository,
   type LifecycleRepository,
+  type NoteRepository,
   type StudyTopicRepository,
   type UlidFactory,
 } from '@nagiyu/livetalk-core';
@@ -19,6 +21,11 @@ export interface StudyAllUsersParams {
   interestRepo: InterestRepository;
   knowledgeRepo: KnowledgeRepository;
   studyTopicRepo?: StudyTopicRepository;
+  /**
+   * Note リポジトリ（Phase 5c / #3345）。
+   * 指定された場合、勉強が実行されたユーザーについて KNOWLEDGE → NOTE 昇格を行う。
+   */
+  noteRepo?: NoteRepository;
   researchClient: IResearchClient;
   ulidFactory?: UlidFactory;
   now?: () => Date;
@@ -29,6 +36,8 @@ export interface StudyAllUsersResult {
   skippedUsers: number;
   failedUsers: number;
   failedUserIds: string[];
+  /** 生成されたノートの総数（Phase 5c） */
+  generatedNotes: number;
 }
 
 /**
@@ -45,6 +54,7 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
     interestRepo,
     knowledgeRepo,
     studyTopicRepo,
+    noteRepo,
     researchClient,
     ulidFactory,
     now,
@@ -59,6 +69,7 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
     skippedUsers: 0,
     failedUsers: 0,
     failedUserIds: [],
+    generatedNotes: 0,
   };
 
   for (const userId of userIds) {
@@ -88,6 +99,24 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
         result.skippedUsers++;
       } else {
         result.studiedUsers++;
+
+        // KNOWLEDGE → NOTE 昇格（Phase 5c）。
+        // fail-warn: ノート生成の失敗は勉強バッチ全体を止めない。
+        if (noteRepo) {
+          try {
+            const noteResult = await generateNotesForUser(userId, DEFAULT_CHARACTER_ID, {
+              knowledgeRepo,
+              noteRepo,
+              ulidFactory,
+            });
+            result.generatedNotes += noteResult.generatedCount;
+          } catch (error) {
+            logger.warn('[studyAllUsers] ノート生成失敗（スキップして継続）', {
+              userId,
+              error: toErrorMessage(error),
+            });
+          }
+        }
       }
     } catch (error) {
       logger.error('[studyAllUsers] ユーザー処理失敗', {

--- a/services/livetalk/batch/tests/unit/handlers/study.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/study.test.ts
@@ -11,6 +11,7 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBInterestRepository: jest.fn(),
   DynamoDBKnowledgeRepository: jest.fn(),
   DynamoDBStudyTopicRepository: jest.fn(),
+  DynamoDBNoteRepository: jest.fn(),
   OpenAIResearchClient: jest.fn(),
   defaultUlidFactory: jest.fn(),
 }));

--- a/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
@@ -12,9 +12,12 @@ jest.mock('@nagiyu/livetalk-core', () => ({
     license: { displayText: '', creditName: '' },
   },
   studyForUser: jest.fn(),
+  generateNotesForUser: jest.fn(),
 }));
 
 const mockStudyForUser = jest.requireMock('@nagiyu/livetalk-core').studyForUser as jest.Mock;
+const mockGenerateNotesForUser = jest.requireMock('@nagiyu/livetalk-core')
+  .generateNotesForUser as jest.Mock;
 
 describe('studyAllUsers', () => {
   const mockDocClient = {
@@ -45,6 +48,7 @@ describe('studyAllUsers', () => {
     mockDocClient.send.mockResolvedValue({
       Items: [{ UserID: 'u1' }, { UserID: 'u2' }],
     });
+    mockGenerateNotesForUser.mockResolvedValue({ generatedCount: 0 });
   });
 
   it('全ユーザーをループして studyForUser を呼ぶ', async () => {
@@ -105,5 +109,47 @@ describe('studyAllUsers', () => {
       'hiyori',
       expect.objectContaining({ studyTopicRepo })
     );
+  });
+
+  it('noteRepo 指定時、勉強したユーザーに対しノート生成を行い件数を集計する（Phase 5c）', async () => {
+    mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
+    mockGenerateNotesForUser.mockResolvedValue({ generatedCount: 2 });
+    const noteRepo = { put: jest.fn(), list: jest.fn(), get: jest.fn(), listRecent: jest.fn() };
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams({ noteRepo: noteRepo as never }));
+
+    // u1 / u2 各 2 件 = 4 件
+    expect(result.generatedNotes).toBe(4);
+    expect(mockGenerateNotesForUser).toHaveBeenCalledTimes(2);
+    expect(mockGenerateNotesForUser).toHaveBeenCalledWith(
+      'u1',
+      'hiyori',
+      expect.objectContaining({ noteRepo })
+    );
+  });
+
+  it('スキップしたユーザーにはノート生成を行わない（Phase 5c）', async () => {
+    mockStudyForUser.mockResolvedValue({ outcome: 'skipped', skipReason: 'テスト' });
+    const noteRepo = { put: jest.fn(), list: jest.fn(), get: jest.fn(), listRecent: jest.fn() };
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams({ noteRepo: noteRepo as never }));
+
+    expect(result.generatedNotes).toBe(0);
+    expect(mockGenerateNotesForUser).not.toHaveBeenCalled();
+  });
+
+  it('ノート生成が失敗してもバッチは継続する（Phase 5c / fail-warn）', async () => {
+    mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
+    mockGenerateNotesForUser.mockRejectedValue(new Error('note エラー'));
+    const noteRepo = { put: jest.fn(), list: jest.fn(), get: jest.fn(), listRecent: jest.fn() };
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams({ noteRepo: noteRepo as never }));
+
+    expect(result.studiedUsers).toBe(2);
+    expect(result.generatedNotes).toBe(0);
+    expect(result.failedUsers).toBe(0);
   });
 });

--- a/services/livetalk/core/src/characters/prompt-builder.ts
+++ b/services/livetalk/core/src/characters/prompt-builder.ts
@@ -2,6 +2,7 @@ import type { CharacterDefinition } from './types.js';
 import type { MessageEntity } from '../entities/message.entity.js';
 import type { MemoryEntity } from '../entities/memory.entity.js';
 import type { KnowledgeEntity } from '../entities/knowledge.entity.js';
+import type { NoteEntity } from '../entities/note.entity.js';
 import type { ChatMessage } from '../llm-client/types.js';
 import type { RetrievedMemory } from '../memory/types.js';
 import type { LifecycleState } from '../entities/lifecycle.entity.js';
@@ -34,7 +35,8 @@ export function buildSystemPrompt(
   summaryText?: string,
   newLearnings?: MemoryEntity[],
   lifecycleState?: LifecycleState,
-  knowledgeContext?: KnowledgeEntity[]
+  knowledgeContext?: KnowledgeEntity[],
+  recentNotes?: NoteEntity[]
 ): string {
   const { personality, displayName } = character;
   const timeOfDay = getTimeOfDay(now);
@@ -59,8 +61,17 @@ export function buildSystemPrompt(
   const hasNewLearnings = newLearnings !== undefined && newLearnings.length > 0;
   const isSleeping = lifecycleState === 'sleeping';
   const hasKnowledge = knowledgeContext !== undefined && knowledgeContext.length > 0;
+  const hasRecentNotes = recentNotes !== undefined && recentNotes.length > 0;
 
-  if (!hasSummary && !hasMemories && !hasNewLearnings && !isSleeping && !hasKnowledge) return base;
+  if (
+    !hasSummary &&
+    !hasMemories &&
+    !hasNewLearnings &&
+    !isSleeping &&
+    !hasKnowledge &&
+    !hasRecentNotes
+  )
+    return base;
 
   const sections: string[] = [base];
 
@@ -93,6 +104,13 @@ export function buildSystemPrompt(
     );
   }
 
+  if (hasRecentNotes) {
+    const notesSection = recentNotes!.map((n) => `- ${n.Title}`).join('\n');
+    sections.push(
+      `あなたが最近ユーザーに渡したノート：\n${notesSection}\n\nこれらはあなたがユーザーのために調べてまとめてプレゼントしたノートです。ユーザーがノートの感想（「あのノート良かった」「読んだよ」など）を言ったら、どのノートのことか理解して嬉しそうに反応してください。ユーザーが触れていないのに無理に話題にする必要はありません。`
+    );
+  }
+
   return sections.join('\n\n');
 }
 
@@ -113,7 +131,8 @@ export function buildChatMessages(
   summaryText?: string,
   newLearnings?: MemoryEntity[],
   lifecycleState?: LifecycleState,
-  knowledgeContext?: KnowledgeEntity[]
+  knowledgeContext?: KnowledgeEntity[],
+  recentNotes?: NoteEntity[]
 ): ChatMessage[] {
   const systemPrompt = buildSystemPrompt(
     character,
@@ -122,7 +141,8 @@ export function buildChatMessages(
     summaryText,
     newLearnings,
     lifecycleState,
-    knowledgeContext
+    knowledgeContext,
+    recentNotes
   );
   const messages: ChatMessage[] = [{ role: 'system', content: systemPrompt }];
 

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -175,3 +175,31 @@ export const STUDY_TOPIC_GATE_PRIORITY = 10;
  * 0.5 は dev 実データでの実測に基づく値（既知トピックを拾いつつ無関係語を弾く境界）。
  */
 export const KNOWLEDGE_MATCH_MIN_RATIO = 0.5;
+
+/**
+ * ノート生成（Phase 5c / #3345）: KNOWLEDGE をノート化する際の品質ゲート。
+ * Summary がこの文字数未満の KNOWLEDGE はノート化しない（薄い知識の乱発防止）。
+ * 勉強バッチ保存時の STUDY_MIN_SUMMARY_LENGTH（50）より厳しくして「高品質なものだけ」を昇格する。
+ */
+export const NOTE_MIN_SUMMARY_LENGTH = 80;
+
+/**
+ * ノート生成: 1 実行・1 ユーザーあたりに生成するノートの最大数（乱発防止）。
+ */
+export const NOTE_MAX_PER_RUN = 2;
+
+/**
+ * ノート生成: ノート化候補としてスキャンする直近 KNOWLEDGE の最大件数。
+ */
+export const NOTE_KNOWLEDGE_LOOKBACK = 20;
+
+/**
+ * 感想連携: チャットの context に注入する「直近に提示したノート」の対象日数。
+ * この日数内に作成されたノートを LLM に渡し、ユーザーの感想にキャラが反応できるようにする。
+ */
+export const NOTE_RECENT_DAYS = 7;
+
+/**
+ * 感想連携: チャットの context に注入するノートの最大件数（プロンプト肥大の抑制）。
+ */
+export const NOTE_RECENT_LIMIT = 3;

--- a/services/livetalk/core/src/entities/note.entity.ts
+++ b/services/livetalk/core/src/entities/note.entity.ts
@@ -1,0 +1,36 @@
+/**
+ * キャラがユーザーへ「プレゼント」として渡すノート。
+ *
+ * Phase 5c（#3345）勉強バッチのノート生成ステップが、KNOWLEDGE のうち
+ * 高品質なものを昇格して書き込む。一覧 + 詳細閲覧のみ（編集なし）。
+ * DynamoDB SK: `CHAR#<charId>#NOTE#<ulid>`
+ */
+export interface NoteEntity {
+  UserID: string;
+  CharacterID: string;
+  /** ULID（時系列ソート可能） */
+  NoteID: string;
+  /** ノートのタイトル */
+  Title: string;
+  /** ノート本文 */
+  Body: string;
+  /** 昇格元の Knowledge ID 一覧 */
+  RelatedKnowledgeIds: string[];
+  /** 紐付く興味カテゴリ名 */
+  RelatedCategory: string;
+  CreatedAt: number;
+  UpdatedAt: number;
+  /**
+   * 既読日時（Unix ms）。未読なら undefined。
+   * Phase 5c では定義のみ（既読化 API は作らない）。Push 連携（#5d）で利用予定。
+   */
+  ReadAt?: number;
+}
+
+export interface NoteKey {
+  userId: string;
+  characterId: string;
+  noteId: string;
+}
+
+export type CreateNoteInput = Omit<NoteEntity, 'CreatedAt' | 'UpdatedAt'>;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -228,6 +228,19 @@ export { DynamoDBStudyTopicRepository } from './repositories/dynamodb-study-topi
 export { StudyTopicMapper } from './mappers/study-topic.mapper.js';
 export { buildStudyTopicSK, buildStudyTopicSKPrefix } from './mappers/keys.js';
 
+// Note（Phase 5c / #3345）
+export type { NoteEntity, NoteKey, CreateNoteInput } from './entities/note.entity.js';
+export type { NoteRepository } from './repositories/note.repository.interface.js';
+export { InMemoryNoteRepository } from './repositories/in-memory-note.repository.js';
+export { DynamoDBNoteRepository } from './repositories/dynamodb-note.repository.js';
+export { NoteMapper } from './mappers/note.mapper.js';
+export { buildNoteSK, buildNoteSKPrefix } from './mappers/keys.js';
+export {
+  generateNotesForUser,
+  type GenerateNotesParams,
+  type GenerateNotesResult,
+} from './usecases/generate-note.usecase.js';
+
 // 知識ゲート（Phase 5b / #3344）
 export {
   searchKnowledge,
@@ -274,6 +287,11 @@ export {
   STUDY_MIN_SUMMARY_LENGTH,
   STUDY_TOPIC_TTL_SECONDS,
   STUDY_TOPIC_GATE_PRIORITY,
+  NOTE_MIN_SUMMARY_LENGTH,
+  NOTE_MAX_PER_RUN,
+  NOTE_KNOWLEDGE_LOOKBACK,
+  NOTE_RECENT_DAYS,
+  NOTE_RECENT_LIMIT,
 } from './constants.js';
 
 // Study usecase（Phase 5a）

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -107,3 +107,11 @@ export function buildStudyTopicSKPrefix(characterId: string): string {
 export function buildStudyTopicSK(characterId: string, topicId: string): string {
   return `${buildStudyTopicSKPrefix(characterId)}${topicId}`;
 }
+
+export function buildNoteSKPrefix(characterId: string): string {
+  return `CHAR#${characterId}#NOTE#`;
+}
+
+export function buildNoteSK(characterId: string, noteId: string): string {
+  return `${buildNoteSKPrefix(characterId)}${noteId}`;
+}

--- a/services/livetalk/core/src/mappers/note.mapper.ts
+++ b/services/livetalk/core/src/mappers/note.mapper.ts
@@ -1,0 +1,66 @@
+import {
+  validateNumberField,
+  validateStringField,
+  validateTimestampField,
+  type DynamoDBItem,
+  type EntityMapper,
+} from '@nagiyu/aws';
+import type { NoteEntity, NoteKey } from '../entities/note.entity.js';
+import { buildNoteSK, buildUserPK } from './keys.js';
+
+export class NoteMapper implements EntityMapper<NoteEntity, NoteKey> {
+  public readonly entityType = 'Note';
+
+  public toItem(entity: NoteEntity): DynamoDBItem {
+    const { pk, sk } = this.buildKeys({
+      userId: entity.UserID,
+      characterId: entity.CharacterID,
+      noteId: entity.NoteID,
+    });
+    const item: DynamoDBItem = {
+      PK: pk,
+      SK: sk,
+      Type: this.entityType,
+      UserID: entity.UserID,
+      CharacterID: entity.CharacterID,
+      NoteID: entity.NoteID,
+      Title: entity.Title,
+      Body: entity.Body,
+      RelatedKnowledgeIds: entity.RelatedKnowledgeIds,
+      RelatedCategory: entity.RelatedCategory,
+      CreatedAt: entity.CreatedAt,
+      UpdatedAt: entity.UpdatedAt,
+    };
+    if (entity.ReadAt !== undefined) {
+      item.ReadAt = entity.ReadAt;
+    }
+    return item;
+  }
+
+  public toEntity(item: DynamoDBItem): NoteEntity {
+    const entity: NoteEntity = {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      CharacterID: validateStringField(item.CharacterID, 'CharacterID'),
+      NoteID: validateStringField(item.NoteID, 'NoteID'),
+      Title: validateStringField(item.Title, 'Title'),
+      Body: validateStringField(item.Body, 'Body'),
+      RelatedKnowledgeIds: Array.isArray(item.RelatedKnowledgeIds)
+        ? (item.RelatedKnowledgeIds as string[])
+        : [],
+      RelatedCategory: validateStringField(item.RelatedCategory, 'RelatedCategory'),
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+      UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
+    };
+    if (item.ReadAt !== undefined) {
+      entity.ReadAt = validateNumberField(item.ReadAt, 'ReadAt');
+    }
+    return entity;
+  }
+
+  public buildKeys(key: NoteKey): { pk: string; sk: string } {
+    return {
+      pk: buildUserPK(key.userId),
+      sk: buildNoteSK(key.characterId, key.noteId),
+    };
+  }
+}

--- a/services/livetalk/core/src/repositories/dynamodb-note.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-note.repository.ts
@@ -1,4 +1,9 @@
-import { GetCommand, PutCommand, QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
 import type { CreateNoteInput, NoteEntity, NoteKey } from '../entities/note.entity.js';
 import { NoteMapper } from '../mappers/note.mapper.js';

--- a/services/livetalk/core/src/repositories/dynamodb-note.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-note.repository.ts
@@ -1,0 +1,100 @@
+import { GetCommand, PutCommand, QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
+import type { CreateNoteInput, NoteEntity, NoteKey } from '../entities/note.entity.js';
+import { NoteMapper } from '../mappers/note.mapper.js';
+import { buildNoteSK, buildNoteSKPrefix, buildUserPK } from '../mappers/keys.js';
+import type { NoteRepository } from './note.repository.interface.js';
+
+export class DynamoDBNoteRepository implements NoteRepository {
+  private readonly mapper: NoteMapper;
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly nowMs: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.nowMs = nowMs;
+    this.mapper = new NoteMapper();
+  }
+
+  public async put(input: CreateNoteInput): Promise<NoteEntity> {
+    const now = this.nowMs();
+    const entity: NoteEntity = { ...input, CreatedAt: now, UpdatedAt: now };
+    try {
+      await this.docClient.send(
+        new PutCommand({ TableName: this.tableName, Item: this.mapper.toItem(entity) })
+      );
+      return entity;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async list(userId: string, characterId: string, limit = 100): Promise<NoteEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildNoteSKPrefix(characterId);
+    const results: NoteEntity[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: { ':pk': pk, ':prefix': prefix },
+            ScanIndexForward: false,
+            Limit: limit,
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        results.push(this.mapper.toEntity(raw as unknown as DynamoDBItem));
+      }
+
+      if (!result.LastEvaluatedKey || results.length >= limit) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return results;
+  }
+
+  public async get(key: NoteKey): Promise<NoteEntity | null> {
+    const pk = buildUserPK(key.userId);
+    const sk = buildNoteSK(key.characterId, key.noteId);
+    try {
+      const result = await this.docClient.send(
+        new GetCommand({ TableName: this.tableName, Key: { PK: pk, SK: sk } })
+      );
+      if (!result.Item) return null;
+      return this.mapper.toEntity(result.Item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async listRecent(
+    userId: string,
+    characterId: string,
+    options: { days: number; limit?: number }
+  ): Promise<NoteEntity[]> {
+    const { days, limit = 100 } = options;
+    const threshold = this.nowMs() - days * 24 * 60 * 60 * 1000;
+    const all = await this.list(userId, characterId, limit);
+    return all.filter((note) => note.CreatedAt >= threshold);
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-note.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-note.repository.ts
@@ -1,0 +1,54 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import type { CreateNoteInput, NoteEntity, NoteKey } from '../entities/note.entity.js';
+import { NoteMapper } from '../mappers/note.mapper.js';
+import { buildNoteSK, buildNoteSKPrefix, buildUserPK } from '../mappers/keys.js';
+import type { NoteRepository } from './note.repository.interface.js';
+
+export class InMemoryNoteRepository implements NoteRepository {
+  private readonly mapper: NoteMapper;
+  private readonly store: InMemorySingleTableStore;
+  private readonly nowMs: () => number;
+
+  constructor(store: InMemorySingleTableStore, nowMs: () => number = () => Date.now()) {
+    this.store = store;
+    this.nowMs = nowMs;
+    this.mapper = new NoteMapper();
+  }
+
+  public async put(input: CreateNoteInput): Promise<NoteEntity> {
+    const now = this.nowMs();
+    const entity: NoteEntity = { ...input, CreatedAt: now, UpdatedAt: now };
+    this.store.put(this.mapper.toItem(entity));
+    return entity;
+  }
+
+  public async list(userId: string, characterId: string, limit = 100): Promise<NoteEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildNoteSKPrefix(characterId);
+    // InMemorySingleTableStore は挿入順で返すため、全件取得して CreatedAt 降順に並べてから limit を適用する。
+    const result = this.store.query({ pk, sk: { operator: 'begins_with', value: prefix } });
+    return result.items
+      .map((item) => this.mapper.toEntity(item))
+      .sort((a, b) => b.CreatedAt - a.CreatedAt)
+      .slice(0, limit);
+  }
+
+  public async get(key: NoteKey): Promise<NoteEntity | null> {
+    const pk = buildUserPK(key.userId);
+    const sk = buildNoteSK(key.characterId, key.noteId);
+    const item = this.store.get(pk, sk);
+    if (!item) return null;
+    return this.mapper.toEntity(item);
+  }
+
+  public async listRecent(
+    userId: string,
+    characterId: string,
+    options: { days: number; limit?: number }
+  ): Promise<NoteEntity[]> {
+    const { days, limit = 100 } = options;
+    const threshold = this.nowMs() - days * 24 * 60 * 60 * 1000;
+    const all = await this.list(userId, characterId, limit);
+    return all.filter((note) => note.CreatedAt >= threshold);
+  }
+}

--- a/services/livetalk/core/src/repositories/note.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/note.repository.interface.ts
@@ -1,0 +1,18 @@
+import type { CreateNoteInput, NoteEntity, NoteKey } from '../entities/note.entity.js';
+
+export interface NoteRepository {
+  put(input: CreateNoteInput): Promise<NoteEntity>;
+  /** キャラ単位のノートを CreatedAt 降順で返す。 */
+  list(userId: string, characterId: string, limit?: number): Promise<NoteEntity[]>;
+  /** 単一ノートを返す。なければ null。 */
+  get(key: NoteKey): Promise<NoteEntity | null>;
+  /**
+   * 直近 days 日に作成されたノートを CreatedAt 降順で返す（チャットの感想連携用）。
+   * 「あのノート良かった」にキャラが反応できるよう、直近提示分を context に注入する。
+   */
+  listRecent(
+    userId: string,
+    characterId: string,
+    options: { days: number; limit?: number }
+  ): Promise<NoteEntity[]>;
+}

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -11,6 +11,8 @@ import type { MessageRepository } from '../repositories/message.repository.inter
 import type { SafetyEventRepository } from '../repositories/safety-event.repository.interface.js';
 import type { KnowledgeRepository } from '../repositories/knowledge.repository.interface.js';
 import type { StudyTopicRepository } from '../repositories/study-topic.repository.interface.js';
+import type { NoteRepository } from '../repositories/note.repository.interface.js';
+import type { NoteEntity } from '../entities/note.entity.js';
 import type { CharacterDefinition } from '../characters/types.js';
 import type { MemoryEntity } from '../entities/memory.entity.js';
 import type { MessageEntity } from '../entities/message.entity.js';
@@ -28,6 +30,8 @@ import {
   MEMORY_MAX_TIER_B,
   STUDY_TOPIC_TTL_SECONDS,
   STUDY_TOPIC_GATE_PRIORITY,
+  NOTE_RECENT_DAYS,
+  NOTE_RECENT_LIMIT,
 } from '../constants.js';
 import { detectSafetyRisk } from '../safety/detector.js';
 import { buildModerationReplacementMessage, buildSafetyMessage } from '../safety/templates.js';
@@ -101,6 +105,11 @@ export interface ChatUseCaseParams {
   knowledgeRepository?: KnowledgeRepository;
   /** StudyTopic リポジトリ。knowledgeRepository 指定時に study 分岐で使用する */
   studyTopicRepository?: StudyTopicRepository;
+  /**
+   * Note リポジトリ（Phase 5c / #3345）。未指定時はノートの感想連携をスキップする。
+   * 指定時は直近 NOTE_RECENT_DAYS 日に提示したノートを取得し、prompt context に注入する。
+   */
+  noteRepository?: NoteRepository;
   /**
    * 知識ベース照合のストラテジ。未指定時は文字 N-gram 照合（既定）。
    * 将来 embedding / LLM ベースの照合へ差し替えるための注入ポイント。
@@ -226,6 +235,7 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     lifecycleRepository,
     knowledgeRepository,
     studyTopicRepository,
+    noteRepository,
     knowledgeMatcher,
     ulidFactory = defaultUlidFactory,
   } = params;
@@ -476,6 +486,19 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
   }
   const newLearnings = identifyNewLearnings(promotionCandidates);
 
+  // 4c. 直近に提示したノートを取得（感想連携、Phase 5c / fail-warn: エラー時は空配列で継続）
+  let recentNotes: NoteEntity[] = [];
+  if (noteRepository) {
+    try {
+      recentNotes = await noteRepository.listRecent(userId, characterId, {
+        days: NOTE_RECENT_DAYS,
+        limit: NOTE_RECENT_LIMIT,
+      });
+    } catch (err) {
+      logger.warn('[chat-usecase] 直近ノートの取得に失敗しました（ノートなしで継続）', { err });
+    }
+  }
+
   // 5. LLM ストリーミング（通常フロー）
   const chatMessages = buildChatMessages(
     character,
@@ -486,7 +509,8 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     undefined,
     newLearnings.length > 0 ? newLearnings : undefined,
     lifecycleState,
-    knowledgeContextForPrompt
+    knowledgeContextForPrompt,
+    recentNotes.length > 0 ? recentNotes : undefined
   );
 
   // プロンプトトークン内訳を計算（best-effort）

--- a/services/livetalk/core/src/usecases/generate-note.usecase.ts
+++ b/services/livetalk/core/src/usecases/generate-note.usecase.ts
@@ -67,7 +67,9 @@ export async function generateNotesForUser(
     }
   }
 
-  const candidates = knowledgeList.filter((k) => isNoteWorthy(k, notedKnowledgeIds, minSummaryLength));
+  const candidates = knowledgeList.filter((k) =>
+    isNoteWorthy(k, notedKnowledgeIds, minSummaryLength)
+  );
 
   let generatedCount = 0;
   for (const knowledge of candidates) {

--- a/services/livetalk/core/src/usecases/generate-note.usecase.ts
+++ b/services/livetalk/core/src/usecases/generate-note.usecase.ts
@@ -1,0 +1,122 @@
+import { logger } from '@nagiyu/common';
+import {
+  NOTE_KNOWLEDGE_LOOKBACK,
+  NOTE_MAX_PER_RUN,
+  NOTE_MIN_SUMMARY_LENGTH,
+} from '../constants.js';
+import type { KnowledgeEntity } from '../entities/knowledge.entity.js';
+import type { CreateNoteInput } from '../entities/note.entity.js';
+import type { KnowledgeRepository } from '../repositories/knowledge.repository.interface.js';
+import type { NoteRepository } from '../repositories/note.repository.interface.js';
+import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+
+export interface GenerateNotesParams {
+  knowledgeRepo: KnowledgeRepository;
+  noteRepo: NoteRepository;
+  ulidFactory?: UlidFactory;
+  /** 品質ゲート（Summary 最小文字数）。未指定時は NOTE_MIN_SUMMARY_LENGTH */
+  minSummaryLength?: number;
+  /** 1 実行で生成するノートの最大数。未指定時は NOTE_MAX_PER_RUN */
+  maxPerRun?: number;
+  /** ノート化候補としてスキャンする直近 KNOWLEDGE の件数。未指定時は NOTE_KNOWLEDGE_LOOKBACK */
+  lookback?: number;
+}
+
+export interface GenerateNotesResult {
+  generatedCount: number;
+}
+
+/**
+ * 1 ユーザー × 1 キャラの KNOWLEDGE をノート化する（決定論的変換、LLM 不使用）。
+ *
+ * 勉強バッチ（Phase 5a）が貯めた KNOWLEDGE のうち「ノート化に値する高品質なもの」を
+ * NOTE に昇格する。Phase 5c では LLM での文体整形は行わず、Topic / Summary / RawComment を
+ * そのままプレゼント体験のノートに整形する（親密度に応じた文体変化は Phase 6+）。
+ *
+ * 昇格基準：
+ * 1. まだノート化されていない（既存ノートの RelatedKnowledgeIds に含まれない）
+ * 2. Summary が minSummaryLength 以上（薄い知識の乱発防止）
+ *
+ * なお「キャラのコメント（RawComment）が付いている」ことは KnowledgeMapper が
+ * 非空を保証するため、KNOWLEDGE である時点で常に満たされる（本文に必ず添えられる）。
+ */
+export async function generateNotesForUser(
+  userId: string,
+  characterId: string,
+  params: GenerateNotesParams
+): Promise<GenerateNotesResult> {
+  const {
+    knowledgeRepo,
+    noteRepo,
+    ulidFactory = defaultUlidFactory,
+    minSummaryLength = NOTE_MIN_SUMMARY_LENGTH,
+    maxPerRun = NOTE_MAX_PER_RUN,
+    lookback = NOTE_KNOWLEDGE_LOOKBACK,
+  } = params;
+
+  const [knowledgeList, existingNotes] = await Promise.all([
+    knowledgeRepo.list(userId, characterId, lookback),
+    noteRepo.list(userId, characterId),
+  ]);
+
+  // 既にノート化済みの Knowledge ID 集合
+  const notedKnowledgeIds = new Set<string>();
+  for (const note of existingNotes) {
+    for (const kid of note.RelatedKnowledgeIds) {
+      notedKnowledgeIds.add(kid);
+    }
+  }
+
+  const candidates = knowledgeList.filter((k) => isNoteWorthy(k, notedKnowledgeIds, minSummaryLength));
+
+  let generatedCount = 0;
+  for (const knowledge of candidates) {
+    if (generatedCount >= maxPerRun) break;
+    try {
+      const input: CreateNoteInput = {
+        UserID: userId,
+        CharacterID: characterId,
+        NoteID: ulidFactory(),
+        Title: buildNoteTitle(knowledge),
+        Body: buildNoteBody(knowledge),
+        RelatedKnowledgeIds: [knowledge.KnowledgeID],
+        RelatedCategory: knowledge.RelatedCategory,
+      };
+      await noteRepo.put(input);
+      generatedCount++;
+    } catch (err) {
+      logger.warn('[generate-note] ノート保存に失敗しました（スキップして継続）', {
+        userId,
+        characterId,
+        knowledgeId: knowledge.KnowledgeID,
+        err,
+      });
+    }
+  }
+
+  return { generatedCount };
+}
+
+function isNoteWorthy(
+  knowledge: KnowledgeEntity,
+  notedKnowledgeIds: Set<string>,
+  minSummaryLength: number
+): boolean {
+  if (notedKnowledgeIds.has(knowledge.KnowledgeID)) return false;
+  if (knowledge.Summary.trim().length < minSummaryLength) return false;
+  return true;
+}
+
+function buildNoteTitle(knowledge: KnowledgeEntity): string {
+  return knowledge.Topic.trim();
+}
+
+/**
+ * 「これ、あなたのために調べたの」というプレゼント体験になるよう、
+ * 要約本文にキャラのコメントを添える。
+ */
+function buildNoteBody(knowledge: KnowledgeEntity): string {
+  const summary = knowledge.Summary.trim();
+  const comment = knowledge.RawComment.trim();
+  return `${summary}\n\n${comment}`;
+}

--- a/services/livetalk/core/tests/unit/characters/prompt-builder.test.ts
+++ b/services/livetalk/core/tests/unit/characters/prompt-builder.test.ts
@@ -262,16 +262,9 @@ describe('buildSystemPrompt（recentNotes / 感想連携）', () => {
 
   it('recentNotes がある場合はノートのタイトルと感想連携の指示が含まれる', () => {
     const now = new Date(2026, 0, 1, 10, 0, 0);
-    const prompt = buildSystemPrompt(
-      hiyori,
-      now,
-      [],
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      [makeNote('コーヒーの効能')]
-    );
+    const prompt = buildSystemPrompt(hiyori, now, [], undefined, undefined, undefined, undefined, [
+      makeNote('コーヒーの効能'),
+    ]);
     expect(prompt).toContain('最近ユーザーに渡したノート');
     expect(prompt).toContain('- コーヒーの効能');
     expect(prompt).toContain('感想');

--- a/services/livetalk/core/tests/unit/characters/prompt-builder.test.ts
+++ b/services/livetalk/core/tests/unit/characters/prompt-builder.test.ts
@@ -246,3 +246,66 @@ describe('buildChatMessages（lifecycleState）', () => {
     expect(messages[0].content).not.toContain('眠っていて');
   });
 });
+
+describe('buildSystemPrompt（recentNotes / 感想連携）', () => {
+  const makeNote = (title: string, id = 'note-1') => ({
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    NoteID: id,
+    Title: title,
+    Body: '本文',
+    RelatedKnowledgeIds: ['know-1'],
+    RelatedCategory: 'コーヒー',
+    CreatedAt: 1_700_000_000_000,
+    UpdatedAt: 1_700_000_000_000,
+  });
+
+  it('recentNotes がある場合はノートのタイトルと感想連携の指示が含まれる', () => {
+    const now = new Date(2026, 0, 1, 10, 0, 0);
+    const prompt = buildSystemPrompt(
+      hiyori,
+      now,
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [makeNote('コーヒーの効能')]
+    );
+    expect(prompt).toContain('最近ユーザーに渡したノート');
+    expect(prompt).toContain('- コーヒーの効能');
+    expect(prompt).toContain('感想');
+  });
+
+  it('recentNotes が空の場合はノートセクションを含まない', () => {
+    const now = new Date(2026, 0, 1, 10, 0, 0);
+    const prompt = buildSystemPrompt(
+      hiyori,
+      now,
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      []
+    );
+    expect(prompt).not.toContain('最近ユーザーに渡したノート');
+  });
+
+  it('buildChatMessages 経由でも recentNotes が system prompt に反映される', () => {
+    const messages = buildChatMessages(
+      hiyori,
+      new Date(),
+      [],
+      'あのノート良かったよ',
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [makeNote('コーヒーの効能')]
+    );
+    expect(messages[0].content).toContain('最近ユーザーに渡したノート');
+    expect(messages[0].content).toContain('- コーヒーの効能');
+  });
+});

--- a/services/livetalk/core/tests/unit/mappers/note.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/note.mapper.test.ts
@@ -1,0 +1,87 @@
+import { InvalidEntityDataError } from '@nagiyu/aws';
+import { NoteMapper } from '../../../src/mappers/note.mapper.js';
+import type { NoteEntity } from '../../../src/entities/note.entity.js';
+
+const baseEntity: NoteEntity = {
+  UserID: 'user1',
+  CharacterID: 'hiyori',
+  NoteID: 'NOTE-001',
+  Title: 'コーヒーの効能',
+  Body: 'コーヒーには覚醒効果があります。\n\n面白いよね！',
+  RelatedKnowledgeIds: ['KNOW-001', 'KNOW-002'],
+  RelatedCategory: 'コーヒー',
+  CreatedAt: 1_750_000_000_000,
+  UpdatedAt: 1_750_086_400_000,
+};
+
+describe('NoteMapper', () => {
+  let mapper: NoteMapper;
+
+  beforeEach(() => {
+    mapper = new NoteMapper();
+  });
+
+  describe('toItem', () => {
+    it('エンティティを DynamoDB Item に変換する', () => {
+      const item = mapper.toItem(baseEntity);
+      expect(item.PK).toBe('USER#user1');
+      expect(item.SK).toBe('CHAR#hiyori#NOTE#NOTE-001');
+      expect(item.Type).toBe('Note');
+      expect(item.NoteID).toBe('NOTE-001');
+      expect(item.Title).toBe('コーヒーの効能');
+      expect(item.RelatedKnowledgeIds).toEqual(['KNOW-001', 'KNOW-002']);
+      expect(item.RelatedCategory).toBe('コーヒー');
+      expect(item.CreatedAt).toBe(1_750_000_000_000);
+    });
+
+    it('ReadAt 未設定時は Item に含めない', () => {
+      const item = mapper.toItem(baseEntity);
+      expect(item.ReadAt).toBeUndefined();
+      expect('ReadAt' in item).toBe(false);
+    });
+
+    it('ReadAt 設定時は Item に含める', () => {
+      const item = mapper.toItem({ ...baseEntity, ReadAt: 1_750_100_000_000 });
+      expect(item.ReadAt).toBe(1_750_100_000_000);
+    });
+  });
+
+  describe('toEntity', () => {
+    it('DynamoDB Item をエンティティに復元する', () => {
+      const item = mapper.toItem(baseEntity);
+      const entity = mapper.toEntity(item);
+      expect(entity).toEqual(baseEntity);
+    });
+
+    it('ReadAt を復元する', () => {
+      const item = mapper.toItem({ ...baseEntity, ReadAt: 1_750_100_000_000 });
+      const entity = mapper.toEntity(item);
+      expect(entity.ReadAt).toBe(1_750_100_000_000);
+    });
+
+    it('RelatedKnowledgeIds が配列でない場合は空配列にする', () => {
+      const item = mapper.toItem(baseEntity);
+      delete (item as Record<string, unknown>).RelatedKnowledgeIds;
+      const entity = mapper.toEntity(item);
+      expect(entity.RelatedKnowledgeIds).toEqual([]);
+    });
+
+    it('必須フィールド欠落で InvalidEntityDataError を投げる', () => {
+      const item = mapper.toItem(baseEntity);
+      delete (item as Record<string, unknown>).Title;
+      expect(() => mapper.toEntity(item)).toThrow(InvalidEntityDataError);
+    });
+  });
+
+  describe('buildKeys', () => {
+    it('PK / SK を組み立てる', () => {
+      const { pk, sk } = mapper.buildKeys({
+        userId: 'user1',
+        characterId: 'hiyori',
+        noteId: 'NOTE-001',
+      });
+      expect(pk).toBe('USER#user1');
+      expect(sk).toBe('CHAR#hiyori#NOTE#NOTE-001');
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-note.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-note.repository.test.ts
@@ -1,0 +1,138 @@
+import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError } from '@nagiyu/aws';
+import { DynamoDBNoteRepository } from '../../../src/repositories/dynamodb-note.repository.js';
+import type { CreateNoteInput } from '../../../src/entities/note.entity.js';
+
+type SendHandler = (command: unknown) => Promise<unknown>;
+const makeClient = (handler: SendHandler) => ({ send: handler });
+
+const fixedNow = 1_750_000_000_000;
+const tableName = 'nagiyu-livetalk-dev';
+
+const baseInput: CreateNoteInput = {
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  NoteID: 'note-001',
+  Title: 'コーヒーの効能',
+  Body: '本文。\n\nコメント。',
+  RelatedKnowledgeIds: ['know-001'],
+  RelatedCategory: 'コーヒー',
+};
+
+const baseItem = {
+  PK: 'USER#u1',
+  SK: 'CHAR#hiyori#NOTE#note-001',
+  Type: 'Note',
+  UserID: 'u1',
+  CharacterID: 'hiyori',
+  NoteID: 'note-001',
+  Title: 'コーヒーの効能',
+  Body: '本文。\n\nコメント。',
+  RelatedKnowledgeIds: ['know-001'],
+  RelatedCategory: 'コーヒー',
+  CreatedAt: fixedNow,
+  UpdatedAt: fixedNow,
+};
+
+describe('DynamoDBNoteRepository', () => {
+  describe('put', () => {
+    it('PutCommand を送り CreatedAt / UpdatedAt を付与する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return {};
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const entity = await repo.put(baseInput);
+      expect(entity.CreatedAt).toBe(fixedNow);
+      expect(entity.UpdatedAt).toBe(fixedNow);
+      expect(sent[0]).toBeInstanceOf(PutCommand);
+      const input = (sent[0] as PutCommand).input;
+      expect(input.Item?.SK).toBe('CHAR#hiyori#NOTE#note-001');
+    });
+
+    it('put 失敗時は DatabaseError を投げる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('boom');
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+      await expect(repo.put(baseInput)).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
+  describe('list', () => {
+    it('QueryCommand で降順取得する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Items: [baseItem] };
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const list = await repo.list('u1', 'hiyori');
+      expect(list).toHaveLength(1);
+      expect(list[0].NoteID).toBe('note-001');
+      expect(sent[0]).toBeInstanceOf(QueryCommand);
+      expect((sent[0] as QueryCommand).input.ScanIndexForward).toBe(false);
+    });
+
+    it('list 失敗時は DatabaseError を投げる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('boom');
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+      await expect(repo.list('u1', 'hiyori')).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
+  describe('get', () => {
+    it('GetCommand で単一ノートを返す', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Item: baseItem };
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const note = await repo.get({ userId: 'u1', characterId: 'hiyori', noteId: 'note-001' });
+      expect(note?.Title).toBe('コーヒーの効能');
+      expect(sent[0]).toBeInstanceOf(GetCommand);
+    });
+
+    it('Item が無ければ null を返す', async () => {
+      const client = makeClient(async () => ({}));
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+      expect(
+        await repo.get({ userId: 'u1', characterId: 'hiyori', noteId: 'missing' })
+      ).toBeNull();
+    });
+
+    it('get 失敗時は DatabaseError を投げる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('boom');
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+      await expect(
+        repo.get({ userId: 'u1', characterId: 'hiyori', noteId: 'note-001' })
+      ).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
+  describe('listRecent', () => {
+    it('threshold より新しいノートのみ返す', async () => {
+      const oldItem = {
+        ...baseItem,
+        SK: 'CHAR#hiyori#NOTE#old',
+        NoteID: 'old',
+        CreatedAt: fixedNow - 10 * 24 * 60 * 60 * 1000,
+      };
+      const client = makeClient(async () => ({ Items: [baseItem, oldItem] }));
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const recent = await repo.listRecent('u1', 'hiyori', { days: 7 });
+      expect(recent).toHaveLength(1);
+      expect(recent[0].NoteID).toBe('note-001');
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-note.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-note.repository.test.ts
@@ -103,9 +103,7 @@ describe('DynamoDBNoteRepository', () => {
     it('Item が無ければ null を返す', async () => {
       const client = makeClient(async () => ({}));
       const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
-      expect(
-        await repo.get({ userId: 'u1', characterId: 'hiyori', noteId: 'missing' })
-      ).toBeNull();
+      expect(await repo.get({ userId: 'u1', characterId: 'hiyori', noteId: 'missing' })).toBeNull();
     });
 
     it('get 失敗時は DatabaseError を投げる', async () => {

--- a/services/livetalk/core/tests/unit/repositories/in-memory-note.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-note.repository.test.ts
@@ -1,0 +1,100 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryNoteRepository } from '../../../src/repositories/in-memory-note.repository.js';
+
+describe('InMemoryNoteRepository', () => {
+  const baseNow = 1_700_000_000_000;
+  let now = baseNow;
+  let store: InMemorySingleTableStore;
+  let repo: InMemoryNoteRepository;
+
+  beforeEach(() => {
+    store = new InMemorySingleTableStore();
+    now = baseNow;
+    repo = new InMemoryNoteRepository(store, () => now);
+  });
+
+  const makeInput = (
+    overrides: Partial<{
+      UserID: string;
+      CharacterID: string;
+      NoteID: string;
+      Title: string;
+      Body: string;
+      RelatedKnowledgeIds: string[];
+      RelatedCategory: string;
+    }> = {}
+  ) => ({
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    NoteID: 'note-001',
+    Title: 'コーヒーの効能',
+    Body: 'コーヒーには覚醒効果があります。\n\n面白いよね！',
+    RelatedKnowledgeIds: ['know-001'],
+    RelatedCategory: 'コーヒー',
+    ...overrides,
+  });
+
+  it('put で新規作成できる', async () => {
+    const item = await repo.put(makeInput());
+    expect(item.NoteID).toBe('note-001');
+    expect(item.CreatedAt).toBe(baseNow);
+    expect(item.UpdatedAt).toBe(baseNow);
+  });
+
+  it('list でキャラ単位の全件を返す（CreatedAt 降順）', async () => {
+    await repo.put(makeInput({ NoteID: 'note-001' }));
+    now += 1000;
+    await repo.put(makeInput({ NoteID: 'note-002' }));
+    await repo.put(makeInput({ UserID: 'u2', NoteID: 'note-003' }));
+
+    const list = await repo.list('u1', 'hiyori');
+    expect(list).toHaveLength(2);
+    expect(list[0].NoteID).toBe('note-002');
+    expect(list[1].NoteID).toBe('note-001');
+  });
+
+  it('list は limit を超えない', async () => {
+    for (let i = 0; i < 5; i++) {
+      await repo.put(makeInput({ NoteID: `note-00${i}` }));
+      now += 100;
+    }
+    const list = await repo.list('u1', 'hiyori', 3);
+    expect(list).toHaveLength(3);
+  });
+
+  it('get は単一ノートを返す', async () => {
+    await repo.put(makeInput({ NoteID: 'note-001' }));
+    const note = await repo.get({ userId: 'u1', characterId: 'hiyori', noteId: 'note-001' });
+    expect(note?.Title).toBe('コーヒーの効能');
+  });
+
+  it('get は存在しないノートに対して null を返す', async () => {
+    expect(await repo.get({ userId: 'u1', characterId: 'hiyori', noteId: 'missing' })).toBeNull();
+  });
+
+  it('listRecent は指定日数内のノートのみ返す', async () => {
+    // 10 日前のノート
+    now = baseNow - 10 * 24 * 60 * 60 * 1000;
+    await repo.put(makeInput({ NoteID: 'old-note' }));
+    // 直近のノート
+    now = baseNow;
+    await repo.put(makeInput({ NoteID: 'recent-note' }));
+
+    const recent = await repo.listRecent('u1', 'hiyori', { days: 7 });
+    expect(recent).toHaveLength(1);
+    expect(recent[0].NoteID).toBe('recent-note');
+  });
+
+  it('listRecent は limit を尊重する', async () => {
+    for (let i = 0; i < 5; i++) {
+      await repo.put(makeInput({ NoteID: `note-00${i}` }));
+      now += 100;
+    }
+    const recent = await repo.listRecent('u1', 'hiyori', { days: 7, limit: 2 });
+    expect(recent).toHaveLength(2);
+  });
+
+  it('list は未登録ユーザーに対して空配列を返す', async () => {
+    expect(await repo.list('unknown', 'hiyori')).toHaveLength(0);
+  });
+});

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -7,6 +7,8 @@ import type { MessageRepository } from '../../../src/repositories/message.reposi
 import type { SafetyEventRepository } from '../../../src/repositories/safety-event.repository.interface.js';
 import type { KnowledgeRepository } from '../../../src/repositories/knowledge.repository.interface.js';
 import type { StudyTopicRepository } from '../../../src/repositories/study-topic.repository.interface.js';
+import type { NoteRepository } from '../../../src/repositories/note.repository.interface.js';
+import type { NoteEntity } from '../../../src/entities/note.entity.js';
 import type { MessageEntity } from '../../../src/entities/message.entity.js';
 import type { MemoryEntity } from '../../../src/entities/memory.entity.js';
 import type { KnowledgeEntity } from '../../../src/entities/knowledge.entity.js';
@@ -1486,6 +1488,104 @@ describe('runChatUseCase', () => {
       }>;
       const systemMsg = streamArgs.find((m) => m.role === 'system');
       expect(systemMsg?.content).toContain('この前調べたこと');
+    });
+  });
+
+  describe('ノートの感想連携（Phase 5c）', () => {
+    function makeNoteRepo(notes: NoteEntity[]): NoteRepository {
+      return {
+        put: jest.fn(),
+        list: jest.fn(async () => notes),
+        get: jest.fn(async () => null),
+        listRecent: jest.fn(async () => notes),
+      };
+    }
+
+    const sampleNote: NoteEntity = {
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      NoteID: 'note-1',
+      Title: 'コーヒーの淹れ方',
+      Body: '本文。\n\nコメント。',
+      RelatedKnowledgeIds: ['know-1'],
+      RelatedCategory: 'コーヒー',
+      CreatedAt: 1_700_000_000_000,
+      UpdatedAt: 1_700_000_000_000,
+    };
+
+    it('noteRepository 指定時は直近ノートを system prompt に注入する', async () => {
+      const llm = makeLLMClient(['うん']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const noteRepo = makeNoteRepo([sampleNote]);
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: 'あのノート良かったよ',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          noteRepository: noteRepo,
+        })
+      );
+
+      expect(noteRepo.listRecent).toHaveBeenCalledWith('u1', 'hiyori', {
+        days: 7,
+        limit: 3,
+      });
+      const streamArgs = (llm.chatStream as jest.Mock).mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const systemMsg = streamArgs.find((m) => m.role === 'system');
+      expect(systemMsg?.content).toContain('最近ユーザーに渡したノート');
+      expect(systemMsg?.content).toContain('コーヒーの淹れ方');
+    });
+
+    it('直近ノートが空なら system prompt にノートセクションを含めない', async () => {
+      const llm = makeLLMClient(['うん']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const noteRepo = makeNoteRepo([]);
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          noteRepository: noteRepo,
+        })
+      );
+
+      const streamArgs = (llm.chatStream as jest.Mock).mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const systemMsg = streamArgs.find((m) => m.role === 'system');
+      expect(systemMsg?.content).not.toContain('最近ユーザーに渡したノート');
+    });
+
+    it('listRecent が失敗してもノートなしで応答を継続する', async () => {
+      const llm = makeLLMClient(['うん']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const noteRepo = makeNoteRepo([]);
+      (noteRepo.listRecent as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          noteRepository: noteRepo,
+        })
+      );
+
+      expect(events.some((e) => e.type === 'done')).toBe(true);
+      expect(llm.chatStream).toHaveBeenCalled();
     });
   });
 });

--- a/services/livetalk/core/tests/unit/usecases/generate-note.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/generate-note.usecase.test.ts
@@ -1,0 +1,114 @@
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryKnowledgeRepository } from '../../../src/repositories/in-memory-knowledge.repository.js';
+import { InMemoryNoteRepository } from '../../../src/repositories/in-memory-note.repository.js';
+import { generateNotesForUser } from '../../../src/usecases/generate-note.usecase.js';
+
+const longSummary = 'コーヒーには覚醒効果があり、適量なら健康にも良いとされています。'.repeat(3);
+
+describe('generateNotesForUser', () => {
+  let store: InMemorySingleTableStore;
+  let knowledgeRepo: InMemoryKnowledgeRepository;
+  let noteRepo: InMemoryNoteRepository;
+  let ulidSeq: number;
+  const ulidFactory = () => `note-${(ulidSeq++).toString().padStart(3, '0')}`;
+
+  beforeEach(() => {
+    store = new InMemorySingleTableStore();
+    knowledgeRepo = new InMemoryKnowledgeRepository(store, () => 1000);
+    noteRepo = new InMemoryNoteRepository(store, () => 2000);
+    ulidSeq = 1;
+  });
+
+  const putKnowledge = (overrides: Record<string, unknown> = {}) =>
+    knowledgeRepo.put({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      KnowledgeID: 'know-001',
+      Topic: 'コーヒーの効能',
+      Summary: longSummary,
+      SourceUrls: ['https://example.com'],
+      RawComment: '面白いよね！',
+      RelatedCategory: 'コーヒー',
+      ...overrides,
+    });
+
+  it('高品質な KNOWLEDGE をノート化する', async () => {
+    await putKnowledge();
+    const result = await generateNotesForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      noteRepo,
+      ulidFactory,
+    });
+    expect(result.generatedCount).toBe(1);
+
+    const notes = await noteRepo.list('u1', 'hiyori');
+    expect(notes).toHaveLength(1);
+    expect(notes[0].Title).toBe('コーヒーの効能');
+    expect(notes[0].Body).toContain('面白いよね！');
+    expect(notes[0].RelatedKnowledgeIds).toEqual(['know-001']);
+    expect(notes[0].RelatedCategory).toBe('コーヒー');
+  });
+
+  it('Summary が短い KNOWLEDGE はノート化しない', async () => {
+    await putKnowledge({ KnowledgeID: 'know-001', Summary: '短い要約。' });
+    const result = await generateNotesForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      noteRepo,
+      ulidFactory,
+    });
+    expect(result.generatedCount).toBe(0);
+  });
+
+  it('既にノート化済みの KNOWLEDGE は重複生成しない', async () => {
+    await putKnowledge({ KnowledgeID: 'know-001' });
+    await noteRepo.put({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      NoteID: 'existing',
+      Title: '既存',
+      Body: '既存本文',
+      RelatedKnowledgeIds: ['know-001'],
+      RelatedCategory: 'コーヒー',
+    });
+
+    const result = await generateNotesForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      noteRepo,
+      ulidFactory,
+    });
+    expect(result.generatedCount).toBe(0);
+  });
+
+  it('maxPerRun を超えてノートを生成しない', async () => {
+    for (let i = 0; i < 5; i++) {
+      await putKnowledge({ KnowledgeID: `know-00${i}` });
+    }
+    const result = await generateNotesForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      noteRepo,
+      ulidFactory,
+      maxPerRun: 2,
+    });
+    expect(result.generatedCount).toBe(2);
+  });
+
+  it('KNOWLEDGE が無い場合は 0 件', async () => {
+    const result = await generateNotesForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      noteRepo,
+      ulidFactory,
+    });
+    expect(result.generatedCount).toBe(0);
+  });
+
+  it('保存失敗時はスキップして件数に数えない', async () => {
+    await putKnowledge({ KnowledgeID: 'know-001' });
+    jest.spyOn(noteRepo, 'put').mockRejectedValueOnce(new Error('boom'));
+    const result = await generateNotesForUser('u1', 'hiyori', {
+      knowledgeRepo,
+      noteRepo,
+      ulidFactory,
+    });
+    expect(result.generatedCount).toBe(0);
+  });
+});

--- a/services/livetalk/web/jest.config.ts
+++ b/services/livetalk/web/jest.config.ts
@@ -29,6 +29,7 @@ const config: Config = {
     '!src/lib/legal/**',
     // 型定義のみのモジュール（ランタイムコードなし）はカバレッジ対象外
     '!src/lib/memory/types.ts',
+    '!src/lib/notes/types.ts',
   ],
   coverageThreshold: {
     global: {

--- a/services/livetalk/web/src/app/api/chat/route.ts
+++ b/services/livetalk/web/src/app/api/chat/route.ts
@@ -10,6 +10,7 @@ import {
   getLifecycleRepository,
   getMemoryRepository,
   getMessageRepository,
+  getNoteRepository,
   getStudyTopicRepository,
 } from '@/lib/server/repositories';
 import { getModerationClient, getSafetyEventRepository } from '@/lib/server/safety';
@@ -105,6 +106,7 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
           lifecycleRepository: getLifecycleRepository(),
           knowledgeRepository: getKnowledgeRepository(),
           studyTopicRepository: getStudyTopicRepository(),
+          noteRepository: getNoteRepository(),
         });
 
         for await (const event of eventGenerator) {

--- a/services/livetalk/web/src/app/api/notes/[id]/route.ts
+++ b/services/livetalk/web/src/app/api/notes/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import { getSession } from '@/lib/server/session';
+import { getNoteRepository } from '@/lib/server/repositories';
+import { decodeNoteId } from '@/lib/notes/note-id';
+import { toNoteDetail } from '@/lib/notes/serializer';
+import { NOTE_ERROR_MESSAGES } from '../constants';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * GET /api/notes/:id
+ *
+ * 単一ノートを本文付きで返す。`:id` は base64url エンコードした完全 SK。
+ */
+export const GET = withAuth(
+  getSession,
+  'livetalk:chat',
+  async (session, _request: Request, context: RouteContext) => {
+    const { id } = await context.params;
+    const key = decodeNoteId(id, session.user.googleId);
+    if (!key) {
+      return NextResponse.json(
+        { error: 'INVALID_ID', message: NOTE_ERROR_MESSAGES.INVALID_ID },
+        { status: 400 }
+      );
+    }
+
+    try {
+      const note = await getNoteRepository().get(key);
+      if (!note) {
+        return NextResponse.json(
+          { error: 'NOT_FOUND', message: NOTE_ERROR_MESSAGES.NOT_FOUND },
+          { status: 404 }
+        );
+      }
+      return NextResponse.json({ note: toNoteDetail(note) });
+    } catch (error) {
+      console.error('[GET /api/notes/:id] ノートの取得に失敗しました', error);
+      return NextResponse.json(
+        { error: 'FETCH_FAILED', message: NOTE_ERROR_MESSAGES.FETCH_FAILED },
+        { status: 500 }
+      );
+    }
+  }
+);

--- a/services/livetalk/web/src/app/api/notes/constants.ts
+++ b/services/livetalk/web/src/app/api/notes/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * ノート API（`/api/notes`）のエラーメッセージ定数（日本語）。
+ */
+export const NOTE_ERROR_MESSAGES = {
+  INVALID_ID: 'ノート ID が不正です',
+  NOT_FOUND: '指定されたノートが見つかりません',
+  FETCH_FAILED: 'ノートの取得に失敗しました',
+} as const;

--- a/services/livetalk/web/src/app/api/notes/route.ts
+++ b/services/livetalk/web/src/app/api/notes/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import { DEFAULT_CHARACTER_ID } from '@nagiyu/livetalk-core';
+import { getSession } from '@/lib/server/session';
+import { getNoteRepository } from '@/lib/server/repositories';
+import { sortNotes, toNoteListItem } from '@/lib/notes/serializer';
+import { NOTE_ERROR_MESSAGES } from './constants';
+
+/**
+ * GET /api/notes
+ *
+ * 認証ユーザーのノートを一覧で返す（本文なし、作成日時の新しい順）。
+ * ノートは閲覧専用のため POST/PATCH/DELETE は提供しない。
+ */
+export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
+  const userId = session.user.googleId;
+  const characterId = DEFAULT_CHARACTER_ID;
+  const repo = getNoteRepository();
+
+  try {
+    const items = await repo.list(userId, characterId);
+    const notes = sortNotes(items.map(toNoteListItem));
+    return NextResponse.json({ notes });
+  } catch (error) {
+    console.error('[GET /api/notes] ノート一覧の取得に失敗しました', error);
+    return NextResponse.json(
+      { error: 'FETCH_FAILED', message: NOTE_ERROR_MESSAGES.FETCH_FAILED },
+      { status: 500 }
+    );
+  }
+});

--- a/services/livetalk/web/src/app/notes/[id]/page.tsx
+++ b/services/livetalk/web/src/app/notes/[id]/page.tsx
@@ -48,7 +48,10 @@ export default function NoteDetailPage({ params }: NoteDetailPageProps) {
       </Box>
 
       {loading && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }} data-testid="note-detail-loading">
+        <Box
+          sx={{ display: 'flex', justifyContent: 'center', py: 4 }}
+          data-testid="note-detail-loading"
+        >
           <CircularProgress />
         </Box>
       )}

--- a/services/livetalk/web/src/app/notes/[id]/page.tsx
+++ b/services/livetalk/web/src/app/notes/[id]/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { use, useCallback, useEffect, useState } from 'react';
+import { Box, CircularProgress, Container, Stack, Typography } from '@mui/material';
+import { Chip, Link } from '@nagiyu/ui';
+import type { NoteListItem } from '@/lib/notes/types';
+import { fetchNote } from '@/lib/notes/api-client';
+import { formatNoteDate } from '@/lib/notes/messages';
+
+interface NoteDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * ノート詳細画面（`/notes/[id]`）。
+ *
+ * タイトル・カテゴリ・作成日・本文を表示する閲覧専用画面。
+ * 本文はキャラがまとめた要約 + コメントで構成される（generate-note usecase 参照）。
+ */
+export default function NoteDetailPage({ params }: NoteDetailPageProps) {
+  const { id } = use(params);
+  const [note, setNote] = useState<NoteListItem | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const item = await fetchNote(id);
+      setNote(item);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'ノートの取得に失敗しました');
+      setNote(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 2 }}>
+      <Box sx={{ mb: 2 }}>
+        <Link href="/notes">← ノート一覧へ</Link>
+      </Box>
+
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }} data-testid="note-detail-loading">
+          <CircularProgress />
+        </Box>
+      )}
+
+      {!loading && error && (
+        <Typography color="error" variant="body2" role="alert">
+          {error}
+        </Typography>
+      )}
+
+      {!loading && !error && note && (
+        <Box component="article">
+          <Typography variant="h6" component="h1" sx={{ mb: 1 }}>
+            {note.title}
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 2 }}>
+            <Chip variant="outline" size="sm">
+              {note.relatedCategory}
+            </Chip>
+            <Typography variant="caption" color="text.secondary">
+              {formatNoteDate(note.createdAt)}
+            </Typography>
+          </Stack>
+          <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}>
+            {note.body}
+          </Typography>
+        </Box>
+      )}
+    </Container>
+  );
+}

--- a/services/livetalk/web/src/app/notes/page.tsx
+++ b/services/livetalk/web/src/app/notes/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Alert, Box, Container, Typography } from '@mui/material';
+import { Link } from '@nagiyu/ui';
+import NoteList from '@/components/NoteList';
+import type { NoteListItem } from '@/lib/notes/types';
+import { fetchNotes } from '@/lib/notes/api-client';
+import { NOTE_PAGE_GUIDANCE } from '@/lib/notes/messages';
+
+/**
+ * ノート一覧画面（`/notes`）。
+ *
+ * 勉強バッチが生成したノートを「プレゼント」として一覧表示する。
+ * 一覧 + 詳細閲覧のみ（編集機能なし、記憶 UI と同じ割り切り）。
+ */
+export default function NotesPage() {
+  const [notes, setNotes] = useState<NoteListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const items = await fetchNotes();
+      setNotes(items);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'ノートの取得に失敗しました');
+      setNotes([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 2 }}>
+      <Typography variant="h6" component="h1" sx={{ mb: 0.5 }}>
+        ノート
+      </Typography>
+      <Alert severity="info" icon={false} sx={{ mb: 2, fontSize: '0.875rem', py: 0.5 }}>
+        {NOTE_PAGE_GUIDANCE}
+      </Alert>
+
+      <Box>
+        {error && (
+          <Typography color="error" variant="body2" role="alert" sx={{ mb: 1 }}>
+            {error}
+          </Typography>
+        )}
+        <NoteList notes={notes} loading={loading} />
+      </Box>
+
+      <Box sx={{ textAlign: 'center', mt: 3 }}>
+        <Link href="/">チャットに戻る</Link>
+      </Box>
+    </Container>
+  );
+}

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -325,8 +325,9 @@ export default function HomePage() {
             onSubmit={handleSubmit}
             disabled={phase !== 'idle' || consentPhase !== 'done'}
           />
-          <Box sx={{ textAlign: 'center' }}>
+          <Box sx={{ textAlign: 'center', display: 'flex', justifyContent: 'center', gap: 2 }}>
             <Link href="/memory">私が覚えていること</Link>
+            <Link href="/notes">ノート</Link>
           </Box>
         </Stack>
         <LicenseFooter />

--- a/services/livetalk/web/src/components/NoteCard.tsx
+++ b/services/livetalk/web/src/components/NoteCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import NextLink from 'next/link';
+import { Card, CardActionArea, CardContent, Stack, Typography } from '@mui/material';
+import { Chip } from '@nagiyu/ui';
+import type { NoteListItem } from '@/lib/notes/types';
+import { formatNoteDate } from '@/lib/notes/messages';
+
+export interface NoteCardProps {
+  note: NoteListItem;
+}
+
+/**
+ * ノート一覧の 1 枚分のカード。タップで詳細（`/notes/[id]`）に遷移する。
+ * プレゼント体験を意識し、タイトル・カテゴリ・作成日をコンパクトに見せる。
+ */
+export default function NoteCard({ note }: NoteCardProps) {
+  const isUnread = note.readAt === undefined;
+  return (
+    <Card variant="outlined" data-testid="note-card">
+      <CardActionArea component={NextLink} href={`/notes/${note.id}`}>
+        <CardContent sx={{ py: 1.5 }}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 0.5 }}>
+            {isUnread && (
+              <Chip color="secondary" size="sm" data-testid="note-unread-badge">
+                NEW
+              </Chip>
+            )}
+            <Typography variant="subtitle1" component="h2" sx={{ fontWeight: 600 }} noWrap>
+              {note.title}
+            </Typography>
+          </Stack>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+            <Chip variant="outline" size="sm">
+              {note.relatedCategory}
+            </Chip>
+            <Typography variant="caption" color="text.secondary">
+              {formatNoteDate(note.createdAt)}
+            </Typography>
+          </Stack>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/services/livetalk/web/src/components/NoteList.tsx
+++ b/services/livetalk/web/src/components/NoteList.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Box, CircularProgress, Stack, Typography } from '@mui/material';
+import type { NoteListItem } from '@/lib/notes/types';
+import { NOTE_EMPTY_MESSAGE } from '@/lib/notes/messages';
+import NoteCard from './NoteCard';
+
+export interface NoteListProps {
+  notes: NoteListItem[];
+  loading: boolean;
+}
+
+/**
+ * ノートカードの一覧表示。ローディング・空状態を内包する。
+ */
+export default function NoteList({ notes, loading }: NoteListProps) {
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }} data-testid="note-loading">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (notes.length === 0) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 4, color: 'text.secondary' }} data-testid="note-empty">
+        <Typography variant="body2">{NOTE_EMPTY_MESSAGE}</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={1.5} data-testid="note-list">
+      {notes.map((note) => (
+        <NoteCard key={note.id} note={note} />
+      ))}
+    </Stack>
+  );
+}

--- a/services/livetalk/web/src/lib/notes/api-client.ts
+++ b/services/livetalk/web/src/lib/notes/api-client.ts
@@ -1,0 +1,41 @@
+import type { NoteListItem } from './types';
+
+/**
+ * ノート UI から `/api/notes` を呼ぶための fetch ラッパ。
+ *
+ * コンポーネントから fetch を直接呼ばず、ここに集約してテスト可能にする
+ * （カバレッジ計測対象は `src/lib/**` のみ）。
+ */
+
+export const NOTE_API_ERROR_MESSAGES = {
+  LIST_FAILED: 'ノートの取得に失敗しました',
+  DETAIL_FAILED: 'ノートの取得に失敗しました',
+} as const;
+
+/**
+ * ノート一覧を取得する（本文なし）。
+ */
+export async function fetchNotes(): Promise<NoteListItem[]> {
+  const res = await fetch('/api/notes', {
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(NOTE_API_ERROR_MESSAGES.LIST_FAILED);
+  }
+  const data = (await res.json()) as { notes?: NoteListItem[] };
+  return data.notes ?? [];
+}
+
+/**
+ * 単一ノートの詳細を取得する（本文あり）。
+ */
+export async function fetchNote(id: string): Promise<NoteListItem> {
+  const res = await fetch(`/api/notes/${encodeURIComponent(id)}`, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(NOTE_API_ERROR_MESSAGES.DETAIL_FAILED);
+  }
+  const data = (await res.json()) as { note: NoteListItem };
+  return data.note;
+}

--- a/services/livetalk/web/src/lib/notes/messages.ts
+++ b/services/livetalk/web/src/lib/notes/messages.ts
@@ -1,0 +1,22 @@
+/**
+ * ノートページで使用するユーザー向け文言定数。
+ *
+ * lib/ に集約することでカバレッジ計測対象に含めつつ、コンポーネント間で文言を統一する。
+ */
+
+/** ノート一覧冒頭に表示するガイダンス。「これ、あなたのために調べたの」というプレゼント体験の文脈。 */
+export const NOTE_PAGE_GUIDANCE = 'ひよりちゃんがあなたのために調べてまとめたノートだよ。';
+
+/** ノートが 1 件も無いときの空状態メッセージ。 */
+export const NOTE_EMPTY_MESSAGE = 'まだノートはないよ。ひよりちゃんがいろいろ調べてくれるのを待っててね。';
+
+/**
+ * createdAt（Unix ms）を日本語の日付文字列に整形する。
+ */
+export function formatNoteDate(createdAt: number): string {
+  const date = new Date(createdAt);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}年${month}月${day}日`;
+}

--- a/services/livetalk/web/src/lib/notes/messages.ts
+++ b/services/livetalk/web/src/lib/notes/messages.ts
@@ -8,7 +8,8 @@
 export const NOTE_PAGE_GUIDANCE = 'ひよりちゃんがあなたのために調べてまとめたノートだよ。';
 
 /** ノートが 1 件も無いときの空状態メッセージ。 */
-export const NOTE_EMPTY_MESSAGE = 'まだノートはないよ。ひよりちゃんがいろいろ調べてくれるのを待っててね。';
+export const NOTE_EMPTY_MESSAGE =
+  'まだノートはないよ。ひよりちゃんがいろいろ調べてくれるのを待っててね。';
 
 /**
  * createdAt（Unix ms）を日本語の日付文字列に整形する。

--- a/services/livetalk/web/src/lib/notes/note-id.ts
+++ b/services/livetalk/web/src/lib/notes/note-id.ts
@@ -1,0 +1,64 @@
+import { buildNoteSK, type NoteKey } from '@nagiyu/livetalk-core';
+
+/**
+ * Note の完全 SK を URL 安全な ID（base64url）にエンコード／デコードするユーティリティ。
+ *
+ * DynamoDB の SK は `CHAR#<characterId>#NOTE#<noteId>` で `#` を含むため API パスに
+ * そのまま乗せられない。記憶 UI（`lib/memory/memory-id.ts`）と同じ方針で完全 SK を
+ * base64url エンコードして `:id` として扱い、サーバ側で `NoteKey` に復元する。
+ */
+
+const SK_PREFIX = 'CHAR#';
+
+function toBase64Url(input: string): string {
+  const base64 =
+    typeof Buffer !== 'undefined'
+      ? Buffer.from(input, 'utf-8').toString('base64')
+      : btoa(unescape(encodeURIComponent(input)));
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(input: string): string {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(normalized, 'base64').toString('utf-8');
+  }
+  return decodeURIComponent(escape(atob(normalized)));
+}
+
+/**
+ * NoteKey から API パス用の ID（base64url）を生成する。
+ */
+export function encodeNoteId(key: NoteKey): string {
+  const sk = buildNoteSK(key.characterId, key.noteId);
+  return toBase64Url(sk);
+}
+
+/**
+ * API パス用の ID を NoteKey に復元する。
+ *
+ * @param id base64url エンコードされた完全 SK
+ * @param userId 認可済みセッションの userId（PK 側はクライアント入力を信用しない）
+ * @returns 復元した NoteKey。不正な形式なら null
+ */
+export function decodeNoteId(id: string, userId: string): NoteKey | null {
+  let sk: string;
+  try {
+    sk = fromBase64Url(id);
+  } catch {
+    return null;
+  }
+
+  if (!sk.startsWith(SK_PREFIX)) return null;
+
+  // `CHAR#<characterId>#NOTE#<noteId>`
+  // characterId / noteId に `#` は含まれない前提で分割する。
+  const parts = sk.split('#');
+  if (parts.length !== 4) return null;
+
+  const [, characterId, note, noteId] = parts;
+  if (note !== 'NOTE') return null;
+  if (!characterId || !noteId) return null;
+
+  return { userId, characterId, noteId };
+}

--- a/services/livetalk/web/src/lib/notes/serializer.ts
+++ b/services/livetalk/web/src/lib/notes/serializer.ts
@@ -1,0 +1,37 @@
+import type { NoteEntity } from '@nagiyu/livetalk-core';
+import { encodeNoteId } from './note-id';
+import type { NoteListItem } from './types';
+
+/**
+ * NoteEntity を一覧用 DTO（本文なし）に変換する。
+ */
+export function toNoteListItem(entity: NoteEntity): NoteListItem {
+  return {
+    id: encodeNoteId({
+      userId: entity.UserID,
+      characterId: entity.CharacterID,
+      noteId: entity.NoteID,
+    }),
+    title: entity.Title,
+    relatedCategory: entity.RelatedCategory,
+    createdAt: entity.CreatedAt,
+    readAt: entity.ReadAt,
+  };
+}
+
+/**
+ * NoteEntity を詳細用 DTO（本文あり）に変換する。
+ */
+export function toNoteDetail(entity: NoteEntity): NoteListItem {
+  return {
+    ...toNoteListItem(entity),
+    body: entity.Body,
+  };
+}
+
+/**
+ * 一覧を作成日時の新しい順で安定ソートする。
+ */
+export function sortNotes(items: NoteListItem[]): NoteListItem[] {
+  return [...items].sort((a, b) => b.createdAt - a.createdAt);
+}

--- a/services/livetalk/web/src/lib/notes/types.ts
+++ b/services/livetalk/web/src/lib/notes/types.ts
@@ -1,0 +1,17 @@
+/**
+ * ノート UI / API で受け渡しする Note の DTO。
+ *
+ * DynamoDB の SK（`CHAR#<char>#NOTE#<ulid>`）は URL に乗せにくいため、
+ * `id` には base64url エンコードした完全 SK を入れる（`lib/notes/note-id.ts` 参照）。
+ */
+export interface NoteListItem {
+  /** base64url エンコードした完全 SK。API パスの `:id` に使う */
+  id: string;
+  title: string;
+  /** 一覧では undefined、詳細でのみ本文を含む */
+  body?: string;
+  relatedCategory: string;
+  createdAt: number;
+  /** 既読日時（Unix ms、未読なら undefined） */
+  readAt?: number;
+}

--- a/services/livetalk/web/src/lib/server/repositories.ts
+++ b/services/livetalk/web/src/lib/server/repositories.ts
@@ -15,6 +15,7 @@ import type {
   LifecycleRepository,
   MemoryRepository,
   MessageRepository,
+  NoteRepository,
   ProfileRepository,
   StudyTopicRepository,
 } from '@nagiyu/livetalk-core';
@@ -25,6 +26,7 @@ import {
   DynamoDBLifecycleRepository,
   DynamoDBMemoryRepository,
   DynamoDBMessageRepository,
+  DynamoDBNoteRepository,
   DynamoDBProfileRepository,
   DynamoDBStudyTopicRepository,
   InMemoryCharacterStateRepository,
@@ -33,6 +35,7 @@ import {
   InMemoryLifecycleRepository,
   InMemoryMemoryRepository,
   InMemoryMessageRepository,
+  InMemoryNoteRepository,
   InMemoryProfileRepository,
   InMemoryStudyTopicRepository,
 } from '@nagiyu/livetalk-core';
@@ -47,6 +50,7 @@ const registry = registerDynamoRepositories<
     lifecycle: LifecycleRepository;
     knowledge: KnowledgeRepository;
     studyTopic: StudyTopicRepository;
+    note: NoteRepository;
   },
   InMemorySingleTableStore
 >(
@@ -91,6 +95,11 @@ const registry = registerDynamoRepositories<
       createDynamoDBRepository: ({ docClient, tableName }) =>
         new DynamoDBStudyTopicRepository(docClient, tableName),
     },
+    note: {
+      createInMemoryRepository: (store) => new InMemoryNoteRepository(store),
+      createDynamoDBRepository: ({ docClient, tableName }) =>
+        new DynamoDBNoteRepository(docClient, tableName),
+    },
   },
   {
     keyPrefix: 'livetalk',
@@ -128,6 +137,10 @@ export function getKnowledgeRepository(): KnowledgeRepository {
 
 export function getStudyTopicRepository(): StudyTopicRepository {
   return registry.studyTopic.createRepository();
+}
+
+export function getNoteRepository(): NoteRepository {
+  return registry.note.createRepository();
 }
 
 /**

--- a/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
@@ -18,6 +18,7 @@ jest.mock('@/lib/server/repositories', () => ({
   getLifecycleRepository: jest.fn().mockReturnValue({}),
   getKnowledgeRepository: jest.fn().mockReturnValue({}),
   getStudyTopicRepository: jest.fn().mockReturnValue({}),
+  getNoteRepository: jest.fn().mockReturnValue({}),
 }));
 jest.mock('@/lib/server/safety', () => ({
   getSafetyEventRepository: jest.fn().mockReturnValue({}),

--- a/services/livetalk/web/tests/unit/app/api/notes/id-route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/notes/id-route.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/notes/[id]/route';
+import { getSession } from '@/lib/server/session';
+import { getNoteRepository } from '@/lib/server/repositories';
+import type { NoteEntity, NoteRepository } from '@nagiyu/livetalk-core';
+import { encodeNoteId } from '@/lib/notes/note-id';
+
+jest.mock('@/lib/server/session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/server/repositories', () => ({ getNoteRepository: jest.fn() }));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetRepo = getNoteRepository as jest.MockedFunction<typeof getNoteRepository>;
+
+const session = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'u@example.com',
+    name: 'U',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60_000).toISOString(),
+};
+
+const entity: NoteEntity = {
+  UserID: 'g1',
+  CharacterID: 'hiyori',
+  NoteID: 'note-1',
+  Title: 'コーヒーの効能',
+  Body: '本文。\n\nコメント。',
+  RelatedKnowledgeIds: ['know-1'],
+  RelatedCategory: 'コーヒー',
+  CreatedAt: 100,
+  UpdatedAt: 100,
+};
+
+const makeRepo = (over: Partial<NoteRepository> = {}): NoteRepository =>
+  ({
+    list: jest.fn(),
+    get: jest.fn(async () => null),
+    put: jest.fn(),
+    listRecent: jest.fn(),
+    ...over,
+  }) as unknown as NoteRepository;
+
+const validId = encodeNoteId({ userId: 'g1', characterId: 'hiyori', noteId: 'note-1' });
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+const req = () => new Request('http://localhost/api/notes/x', { method: 'GET' });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/notes/:id', () => {
+  it('未認証は 401', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(req(), ctx(validId));
+    expect(res.status).toBe(401);
+  });
+
+  it('不正な ID は 400', async () => {
+    mockGetSession.mockResolvedValue(session);
+    mockGetRepo.mockReturnValue(makeRepo());
+    const res = await GET(req(), ctx('!!!not-base64!!!###'));
+    expect(res.status).toBe(400);
+  });
+
+  it('存在しないノートは 404', async () => {
+    mockGetSession.mockResolvedValue(session);
+    mockGetRepo.mockReturnValue(makeRepo({ get: jest.fn(async () => null) }));
+    const res = await GET(req(), ctx(validId));
+    expect(res.status).toBe(404);
+  });
+
+  it('本文付きで詳細を返す', async () => {
+    mockGetSession.mockResolvedValue(session);
+    const get = jest.fn(async () => entity);
+    mockGetRepo.mockReturnValue(makeRepo({ get }));
+
+    const res = await GET(req(), ctx(validId));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.note.title).toBe('コーヒーの効能');
+    expect(json.note.body).toBe('本文。\n\nコメント。');
+    // userId は SK ではなくセッションから（PK はクライアント入力を信用しない）
+    expect(get).toHaveBeenCalledWith({ userId: 'g1', characterId: 'hiyori', noteId: 'note-1' });
+  });
+
+  it('DB エラーは 500', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetSession.mockResolvedValue(session);
+    mockGetRepo.mockReturnValue(
+      makeRepo({
+        get: jest.fn(async () => {
+          throw new Error('boom');
+        }),
+      })
+    );
+    const res = await GET(req(), ctx(validId));
+    expect(res.status).toBe(500);
+    spy.mockRestore();
+  });
+});

--- a/services/livetalk/web/tests/unit/app/api/notes/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/notes/route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/notes/route';
+import { getSession } from '@/lib/server/session';
+import { getNoteRepository } from '@/lib/server/repositories';
+import type { NoteEntity, NoteRepository } from '@nagiyu/livetalk-core';
+import { decodeNoteId } from '@/lib/notes/note-id';
+
+jest.mock('@/lib/server/session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/server/repositories', () => ({ getNoteRepository: jest.fn() }));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetRepo = getNoteRepository as jest.MockedFunction<typeof getNoteRepository>;
+
+const session = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'u@example.com',
+    name: 'U',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60_000).toISOString(),
+};
+
+const makeEntity = (over: Partial<NoteEntity> = {}): NoteEntity => ({
+  UserID: 'g1',
+  CharacterID: 'hiyori',
+  NoteID: 'note-1',
+  Title: 'コーヒーの効能',
+  Body: '本文',
+  RelatedKnowledgeIds: ['know-1'],
+  RelatedCategory: 'コーヒー',
+  CreatedAt: 100,
+  UpdatedAt: 100,
+  ...over,
+});
+
+const makeRepo = (over: Partial<NoteRepository> = {}): NoteRepository =>
+  ({
+    list: jest.fn(async () => []),
+    get: jest.fn(),
+    put: jest.fn(),
+    listRecent: jest.fn(),
+    ...over,
+  }) as unknown as NoteRepository;
+
+const req = () => new Request('http://localhost/api/notes', { method: 'GET' });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/notes', () => {
+  it('未認証は 401', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it('一覧を作成日時降順で返す（本文は含めない）', async () => {
+    mockGetSession.mockResolvedValue(session);
+    const list = jest.fn(async () => [
+      makeEntity({ NoteID: 'old', CreatedAt: 100 }),
+      makeEntity({ NoteID: 'new', CreatedAt: 300 }),
+    ]);
+    mockGetRepo.mockReturnValue(makeRepo({ list }));
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.notes).toHaveLength(2);
+    expect(json.notes[0].body).toBeUndefined();
+    expect(decodeNoteId(json.notes[0].id, 'g1')?.noteId).toBe('new');
+  });
+
+  it('DB エラーは 500', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetSession.mockResolvedValue(session);
+    mockGetRepo.mockReturnValue(
+      makeRepo({
+        list: jest.fn(async () => {
+          throw new Error('boom');
+        }),
+      })
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(500);
+    spy.mockRestore();
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/notes/api-client.test.ts
+++ b/services/livetalk/web/tests/unit/lib/notes/api-client.test.ts
@@ -1,0 +1,42 @@
+import { NOTE_API_ERROR_MESSAGES, fetchNote, fetchNotes } from '@/lib/notes/api-client';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const okJson = (data: unknown) => ({ ok: true, json: async () => data });
+const fail = () => ({ ok: false, json: async () => ({}) });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('fetchNotes', () => {
+  it('一覧を取得する', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ notes: [{ id: 'x', title: 't' }] }));
+    const result = await fetchNotes();
+    expect(mockFetch).toHaveBeenCalledWith('/api/notes', expect.any(Object));
+    expect(result).toEqual([{ id: 'x', title: 't' }]);
+  });
+
+  it('notes 欠落時は空配列', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({}));
+    expect(await fetchNotes()).toEqual([]);
+  });
+
+  it('失敗時は LIST_FAILED を投げる', async () => {
+    mockFetch.mockResolvedValueOnce(fail());
+    await expect(fetchNotes()).rejects.toThrow(NOTE_API_ERROR_MESSAGES.LIST_FAILED);
+  });
+});
+
+describe('fetchNote', () => {
+  it('id をエンコードして詳細を取得する', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ note: { id: 'abc', title: 't', body: 'b' } }));
+    const result = await fetchNote('a/b');
+    expect(mockFetch).toHaveBeenCalledWith('/api/notes/a%2Fb', expect.any(Object));
+    expect(result).toEqual({ id: 'abc', title: 't', body: 'b' });
+  });
+
+  it('失敗時は DETAIL_FAILED を投げる', async () => {
+    mockFetch.mockResolvedValueOnce(fail());
+    await expect(fetchNote('abc')).rejects.toThrow(NOTE_API_ERROR_MESSAGES.DETAIL_FAILED);
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/notes/messages.test.ts
+++ b/services/livetalk/web/tests/unit/lib/notes/messages.test.ts
@@ -1,0 +1,20 @@
+import {
+  NOTE_EMPTY_MESSAGE,
+  NOTE_PAGE_GUIDANCE,
+  formatNoteDate,
+} from '@/lib/notes/messages';
+
+describe('notes messages', () => {
+  it('ガイダンス文言が定義されている', () => {
+    expect(NOTE_PAGE_GUIDANCE).toContain('ノート');
+    expect(NOTE_EMPTY_MESSAGE).toContain('ノート');
+  });
+});
+
+describe('formatNoteDate', () => {
+  it('Unix ms を YYYY年M月D日 形式に整形する', () => {
+    // 2025-06-15 をローカルタイムで生成して比較（タイムゾーン非依存）
+    const date = new Date(2025, 5, 15, 12, 0, 0);
+    expect(formatNoteDate(date.getTime())).toBe('2025年6月15日');
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/notes/messages.test.ts
+++ b/services/livetalk/web/tests/unit/lib/notes/messages.test.ts
@@ -1,8 +1,4 @@
-import {
-  NOTE_EMPTY_MESSAGE,
-  NOTE_PAGE_GUIDANCE,
-  formatNoteDate,
-} from '@/lib/notes/messages';
+import { NOTE_EMPTY_MESSAGE, NOTE_PAGE_GUIDANCE, formatNoteDate } from '@/lib/notes/messages';
 
 describe('notes messages', () => {
   it('ガイダンス文言が定義されている', () => {

--- a/services/livetalk/web/tests/unit/lib/notes/note-id.test.ts
+++ b/services/livetalk/web/tests/unit/lib/notes/note-id.test.ts
@@ -1,0 +1,50 @@
+import type { NoteKey } from '@nagiyu/livetalk-core';
+import { decodeNoteId, encodeNoteId } from '@/lib/notes/note-id';
+
+const baseKey: NoteKey = {
+  userId: 'user-1',
+  characterId: 'hiyori',
+  noteId: '01HZZ0000000000000000000AB',
+};
+
+describe('encodeNoteId / decodeNoteId', () => {
+  it('encode した ID は decode で元のキー（userId は引数優先）に戻る', () => {
+    const id = encodeNoteId(baseKey);
+    const decoded = decodeNoteId(id, baseKey.userId);
+    expect(decoded).toEqual(baseKey);
+  });
+
+  it('decode は引数の userId を使い、SK には userId を含めない', () => {
+    const id = encodeNoteId(baseKey);
+    const decoded = decodeNoteId(id, 'another-user');
+    expect(decoded?.userId).toBe('another-user');
+    expect(decoded?.characterId).toBe('hiyori');
+    expect(decoded?.noteId).toBe(baseKey.noteId);
+  });
+
+  it('encode は base64url（+ / = を含まない）', () => {
+    const id = encodeNoteId(baseKey);
+    expect(id).not.toMatch(/[+/=]/);
+  });
+
+  it('不正な base64url は null を返す', () => {
+    // CHAR# で始まらない SK
+    const notChar = Buffer.from('USER#x#NOTE#1', 'utf-8').toString('base64url');
+    expect(decodeNoteId(notChar, 'user-1')).toBeNull();
+  });
+
+  it('NOTE 以外の SK は null を返す', () => {
+    const memSk = Buffer.from('CHAR#hiyori#MEM#B#food#1', 'utf-8').toString('base64url');
+    expect(decodeNoteId(memSk, 'user-1')).toBeNull();
+  });
+
+  it('パーツ数が不正な SK は null を返す', () => {
+    const broken = Buffer.from('CHAR#hiyori#NOTE', 'utf-8').toString('base64url');
+    expect(decodeNoteId(broken, 'user-1')).toBeNull();
+  });
+
+  it('characterId / noteId が空の SK は null を返す', () => {
+    const empty = Buffer.from('CHAR##NOTE#', 'utf-8').toString('base64url');
+    expect(decodeNoteId(empty, 'user-1')).toBeNull();
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/notes/serializer.test.ts
+++ b/services/livetalk/web/tests/unit/lib/notes/serializer.test.ts
@@ -1,0 +1,50 @@
+import type { NoteEntity } from '@nagiyu/livetalk-core';
+import { sortNotes, toNoteDetail, toNoteListItem } from '@/lib/notes/serializer';
+import { decodeNoteId } from '@/lib/notes/note-id';
+
+const baseEntity: NoteEntity = {
+  UserID: 'user-1',
+  CharacterID: 'hiyori',
+  NoteID: 'note-001',
+  Title: 'コーヒーの効能',
+  Body: '本文。\n\nコメント。',
+  RelatedKnowledgeIds: ['know-001'],
+  RelatedCategory: 'コーヒー',
+  CreatedAt: 1_750_000_000_000,
+  UpdatedAt: 1_750_000_000_000,
+};
+
+describe('toNoteListItem', () => {
+  it('一覧 DTO に変換し本文を含めない', () => {
+    const item = toNoteListItem(baseEntity);
+    expect(item.title).toBe('コーヒーの効能');
+    expect(item.relatedCategory).toBe('コーヒー');
+    expect(item.createdAt).toBe(1_750_000_000_000);
+    expect(item.body).toBeUndefined();
+    // id は decode で復元できる
+    expect(decodeNoteId(item.id, 'user-1')?.noteId).toBe('note-001');
+  });
+
+  it('ReadAt を readAt に写す', () => {
+    const item = toNoteListItem({ ...baseEntity, ReadAt: 1_750_100_000_000 });
+    expect(item.readAt).toBe(1_750_100_000_000);
+  });
+});
+
+describe('toNoteDetail', () => {
+  it('詳細 DTO は本文を含む', () => {
+    const item = toNoteDetail(baseEntity);
+    expect(item.body).toBe('本文。\n\nコメント。');
+    expect(item.title).toBe('コーヒーの効能');
+  });
+});
+
+describe('sortNotes', () => {
+  it('createdAt 降順に並べ替える', () => {
+    const a = { ...toNoteListItem(baseEntity), createdAt: 100 };
+    const b = { ...toNoteListItem(baseEntity), createdAt: 300 };
+    const c = { ...toNoteListItem(baseEntity), createdAt: 200 };
+    const sorted = sortNotes([a, b, c]);
+    expect(sorted.map((n) => n.createdAt)).toEqual([300, 200, 100]);
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/server/repositories.test.ts
+++ b/services/livetalk/web/tests/unit/lib/server/repositories.test.ts
@@ -38,6 +38,31 @@ describe('lib/server/repositories', () => {
     const s1 = mod.getStudyTopicRepository();
     const s2 = mod.getStudyTopicRepository();
     expect(s1).toBe(s2);
+
+    // Phase 5c 配線: Note も取得できる
+    const n1 = mod.getNoteRepository();
+    const n2 = mod.getNoteRepository();
+    expect(n1).toBe(n2);
+  });
+
+  it('InMemory 実装では Note を保存して取得できる（共有 store 検証）', async () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const mod = await import('@/lib/server/repositories');
+    mod.resetRepositoriesForTesting();
+    const repo = mod.getNoteRepository();
+    await repo.put({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      NoteID: 'note-1',
+      Title: 'コーヒーの効能',
+      Body: '本文',
+      RelatedKnowledgeIds: ['know-1'],
+      RelatedCategory: 'コーヒー',
+    });
+    const list = await repo.list('u1', 'hiyori');
+    expect(list).toHaveLength(1);
+    expect(list[0].Title).toBe('コーヒーの効能');
+    mod.resetRepositoriesForTesting();
   });
 
   it('InMemory 実装では StudyTopic を保存して status 別に取得できる（共有 store 検証）', async () => {
@@ -99,6 +124,7 @@ describe('lib/server/repositories', () => {
     expect(() => mod.getLifecycleRepository()).not.toThrow();
     expect(() => mod.getKnowledgeRepository()).not.toThrow();
     expect(() => mod.getStudyTopicRepository()).not.toThrow();
+    expect(() => mod.getNoteRepository()).not.toThrow();
     mod.resetRepositoriesForTesting();
   });
 });


### PR DESCRIPTION
## 変更の概要

リブトーク Phase 5c（#3345）。勉強バッチの成果（KNOWLEDGE）を「ノート」というプレゼント体験としてユーザーに提示する機能を実装。スコープは **一覧 + 詳細閲覧のみ（編集なし）**。最重要要件である **感想連携**（ユーザーがチャットでノートの感想を言うとキャラが反応できる）も実装。

### Core
- `NoteEntity` / `NoteMapper` / `NoteRepository`（in-memory・dynamodb）を新規追加（SK: `CHAR#<char>#NOTE#<ulid>`、TTL なし、`ReadAt?` はフィールド定義のみ）
- `generate-note.usecase`: KNOWLEDGE → NOTE の**決定論的昇格**（LLM 不使用）。品質ゲート（Summary 文字数）と既存ノートとの重複防止つき
- `prompt-builder` / `chat-usecase`: 直近 N 日に提示したノートを prompt context に注入（fail-warn）。「あのノート良かった」にキャラが反応できる

### Batch
- 勉強バッチ（`studyAllUsers`）に KNOWLEDGE → NOTE 昇格ステップを**相乗り**で追加
- **専用 Lambda は新設せず**、既存の study Lambda（毎時 EventBridge）を再利用。`generate-note` は独立 usecase として切り出しており、将来の専用 Lambda 化も容易

### Web
- `GET /api/notes`（一覧、本文なし）・`GET /api/notes/:id`（詳細、本文あり）を追加。閲覧専用のため POST/PATCH/DELETE は提供しない。認可は `livetalk:chat`
- `/notes` 一覧・`/notes/[id]` 詳細画面、`NoteCard` / `NoteList` コンポーネント（MUI モバイルファースト、Chip は `@nagiyu/ui`）
- ホーム画面にノートへの導線を追加

## 関連 Issue

Parent: #3188（Phase 5） / Grandparent: #3182
対象: #3345

（Issue は integration → develop マージ後にクローズするため、本 PR では `Closes #` を付けません）

## 変更種別

- [x] 新規機能

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（core / batch / web すべてカバレッジ 80% 以上を維持）
- [x] ローカルでテストが全て通ることを確認した（core 813 / batch 28 / web 159）
- [x] ビルド・型チェック・ESLint がノート関連ファイルで通ることを確認した

## テスト内容

- Core: `note.mapper` / in-memory・dynamodb `note.repository` / `generate-note.usecase`（品質ゲート・重複防止・上限・失敗継続）/ `prompt-builder` の recentNotes 分岐 / `chat-usecase` のノート注入・fail-warn
- Batch: `studyAllUsers` のノート生成集計・スキップ時の非実行・失敗継続
- Web: `note-id`（base64url 往復・不正入力）/ `serializer` / `api-client` / `messages` / `/api/notes`・`/api/notes/:id` ルート（401/400/404/500）/ repositories 配線

## レビューポイント

- **設計判断（バッチ形態）**: ノート生成を「専用 Lambda 新設（B）」ではなく「既存 study Lambda 相乗り（A）」とした。概念的に学習の後工程であること・KNOWLEDGE 生成直後にその場でノート化できること・生成が決定論的で軽いこと・将来 B へ分離しやすいことを理由に A を採用。これにより **デプロイワークフロー（`livetalk-deploy.yml`）の修正は不要**（study Lambda は既に `update-function-code` 反映ループ済み）
- **ノート生成は決定論的**（LLM 不使用）。`title=Topic` / `body=Summary + RawComment`。品質ゲートは `NOTE_MIN_SUMMARY_LENGTH=80` で初期は緩め・定数化（dev で調整可能）
- **dev での確認手順**: マージ → デプロイ後、study Lambda（毎時）or 手動 `aws lambda invoke` でノート生成 → `/notes` で確認。テストユーザーに KNOWLEDGE が存在することが前提

## 補足事項

- `ReadAt`（未読/既読）はエンティティに定義のみ（更新 API は作らない）。Push 連携（#5d）で利用予定
- 親密度に応じた文体変化は Phase 6+ の将来拡張


---
_Generated by [Claude Code](https://claude.ai/code/session_01CGeAbtNjfNe3V8yoaEu8iG)_