### PR TITLE
feat(livetalk): 通知体験の品質改善（Topic 崩壊修正 + 通知→会話文脈受け渡し）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -818,7 +818,6 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -838,7 +837,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
       "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
@@ -852,7 +850,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@asamuzakjp/dom-selector": {
@@ -2134,7 +2131,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
       "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2154,7 +2150,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2178,7 +2173,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
       "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2206,7 +2200,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2253,7 +2246,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3902,7 +3894,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
       "integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.4.1",
@@ -7451,7 +7442,6 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -7471,7 +7461,6 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
@@ -7491,14 +7480,12 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
       "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -7526,7 +7513,6 @@
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12",
@@ -7578,7 +7564,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -7788,7 +7773,6 @@
       "version": "21.1.7",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
       "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -7866,7 +7850,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -7922,7 +7906,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -8678,7 +8661,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -9707,14 +9689,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
       "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
@@ -9741,7 +9721,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
@@ -10066,7 +10045,6 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -10217,7 +10195,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11930,7 +11907,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
       "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
@@ -11978,7 +11954,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -12029,7 +12004,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12115,7 +12089,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13666,7 +13639,6 @@
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
       "integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.4.1",
@@ -14323,7 +14295,6 @@
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",
@@ -14907,7 +14878,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -15899,7 +15869,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16165,7 +16134,6 @@
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/oauth4webapi": {
@@ -16590,7 +16558,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -16981,7 +16948,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -16996,7 +16962,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -17009,7 +16974,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/process-nextick-args": {
@@ -17285,7 +17249,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -17299,7 +17262,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -17588,7 +17550,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/run-applescript": {
@@ -18692,7 +18653,6 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
@@ -18705,7 +18665,6 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -18731,7 +18690,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -18744,7 +18702,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -19609,7 +19566,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -19627,7 +19583,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -19640,7 +19595,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -19650,7 +19604,6 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -19850,7 +19803,6 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -20360,6 +20312,10 @@
         "@nagiyu/livetalk-core": "*",
         "@nagiyu/nextjs": "*",
         "@nagiyu/ui": "*",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "jest-environment-jsdom": "^30.4.1",
         "pixi-live2d-display-lipsyncpatch": "0.5.0-ls-8",
         "pixi.js": "^7.4.3"
       }

--- a/services/livetalk/batch/src/usecases/notify.usecase.ts
+++ b/services/livetalk/batch/src/usecases/notify.usecase.ts
@@ -187,6 +187,7 @@ async function processUser(params: ProcessUserParams): Promise<boolean> {
     );
     title = msg.title;
     body = msg.body;
+    knowledgeId = latestKnowledge?.KnowledgeID;
   }
 
   const ttl = Math.floor(currentNow.getTime() / 1000) + NOTIFICATION_EVENT_TTL_SECONDS;

--- a/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
@@ -261,9 +261,7 @@ describe('notifyAllUsers', () => {
     const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
     await notifyAllUsers(makeParams({ notifEventRepo: notifEventRepo as never }));
 
-    expect(notifEventRepo.put).toHaveBeenCalledWith(
-      expect.objectContaining({ KnowledgeID: 'k1' })
-    );
+    expect(notifEventRepo.put).toHaveBeenCalledWith(expect.objectContaining({ KnowledgeID: 'k1' }));
   });
 
   it('DynamoDB scan がページネーション → 全ユーザーを収集する', async () => {

--- a/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
@@ -247,6 +247,25 @@ describe('notifyAllUsers', () => {
     expect(result.failedUserIds).toContain('u2');
   });
 
+  it('normal 通知で latestKnowledge の KnowledgeID が notifEvent に保存される', async () => {
+    mockDetectCritical.mockResolvedValue({ isCritical: false });
+    mockShouldNotifyNow.mockReturnValue({
+      notify: true,
+      kind: 'normal',
+      toneBucket: 'normal',
+      elapsedMs: DAY,
+    });
+    mockSendWebPush.mockResolvedValue(true);
+
+    const notifEventRepo = makeNotifEventRepo();
+    const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
+    await notifyAllUsers(makeParams({ notifEventRepo: notifEventRepo as never }));
+
+    expect(notifEventRepo.put).toHaveBeenCalledWith(
+      expect.objectContaining({ KnowledgeID: 'k1' })
+    );
+  });
+
   it('DynamoDB scan がページネーション → 全ユーザーを収集する', async () => {
     const docClient = {
       send: jest

--- a/services/livetalk/core/src/characters/prompt-builder.ts
+++ b/services/livetalk/core/src/characters/prompt-builder.ts
@@ -36,7 +36,8 @@ export function buildSystemPrompt(
   newLearnings?: MemoryEntity[],
   lifecycleState?: LifecycleState,
   knowledgeContext?: KnowledgeEntity[],
-  recentNotes?: NoteEntity[]
+  recentNotes?: NoteEntity[],
+  notificationKnowledge?: KnowledgeEntity
 ): string {
   const { personality, displayName } = character;
   const timeOfDay = getTimeOfDay(now);
@@ -62,6 +63,7 @@ export function buildSystemPrompt(
   const isSleeping = lifecycleState === 'sleeping';
   const hasKnowledge = knowledgeContext !== undefined && knowledgeContext.length > 0;
   const hasRecentNotes = recentNotes !== undefined && recentNotes.length > 0;
+  const hasNotificationKnowledge = notificationKnowledge !== undefined;
 
   if (
     !hasSummary &&
@@ -69,7 +71,8 @@ export function buildSystemPrompt(
     !hasNewLearnings &&
     !isSleeping &&
     !hasKnowledge &&
-    !hasRecentNotes
+    !hasRecentNotes &&
+    !hasNotificationKnowledge
   )
     return base;
 
@@ -111,6 +114,14 @@ export function buildSystemPrompt(
     );
   }
 
+  if (hasNotificationKnowledge) {
+    const k = notificationKnowledge!;
+    const detail = `- ${k.Topic}：${k.Summary}${k.RawComment ? `（${k.RawComment}）` : ''}`;
+    sections.push(
+      `あなたが通知でユーザーに話しかけた話題：\n${detail}\n\nユーザーはこの通知を受けて会話を始めました。この話題をあなた自身が始めた会話として自然に展開してください。「うん、${k.Topic}だけどね〜」や「そうそう、調べたらすごく面白くて！」のように、自分が振った話題として続けてください。`
+    );
+  }
+
   return sections.join('\n\n');
 }
 
@@ -132,7 +143,8 @@ export function buildChatMessages(
   newLearnings?: MemoryEntity[],
   lifecycleState?: LifecycleState,
   knowledgeContext?: KnowledgeEntity[],
-  recentNotes?: NoteEntity[]
+  recentNotes?: NoteEntity[],
+  notificationKnowledge?: KnowledgeEntity
 ): ChatMessage[] {
   const systemPrompt = buildSystemPrompt(
     character,
@@ -142,7 +154,8 @@ export function buildChatMessages(
     newLearnings,
     lifecycleState,
     knowledgeContext,
-    recentNotes
+    recentNotes,
+    notificationKnowledge
   );
   const messages: ChatMessage[] = [{ role: 'system', content: systemPrompt }];
 

--- a/services/livetalk/core/src/notification/message-builder.ts
+++ b/services/livetalk/core/src/notification/message-builder.ts
@@ -51,6 +51,11 @@ function pick<T>(arr: T[], seed: number): T {
   return arr[Math.abs(seed) % arr.length];
 }
 
+/** Topic 末尾の句読点・改行を除去して通知テンプレートに安全に埋め込める形に正規化する */
+function normalizeKnowledgeTopic(topic: string): string {
+  return topic.trim().replace(/[。、．,\n\r]+$/, '');
+}
+
 export function buildNotificationMessage(
   input: BuildNotificationMessageInput,
   seed = Date.now()
@@ -63,26 +68,29 @@ export function buildNotificationMessage(
 
   if (toneBucket === 'long') {
     if (knowledgeTopic) {
+      const normalizedTopic = normalizeKnowledgeTopic(knowledgeTopic);
       const template = pick(LONG_WITH_TOPIC, seed);
-      return { title: template.title, body: template.body(knowledgeTopic) };
+      return { title: template.title, body: template.body(normalizedTopic) };
     }
     return pick(LONG_MESSAGES, seed);
   }
 
   // normal
   if (knowledgeTopic) {
+    const normalizedTopic = normalizeKnowledgeTopic(knowledgeTopic);
     const templateDef = pick(NORMAL_MESSAGES_WITH_TOPIC, seed) as unknown as {
       title: string;
       body: (t: string) => string;
     };
-    return { title: templateDef.title, body: templateDef.body(knowledgeTopic) };
+    return { title: templateDef.title, body: templateDef.body(normalizedTopic) };
   }
   return pick(NORMAL_MESSAGES_WITHOUT_TOPIC, seed);
 }
 
 export function buildCriticalNotificationMessage(knowledgeTopic: string): NotificationMessage {
+  const normalizedTopic = normalizeKnowledgeTopic(knowledgeTopic);
   return {
     title: `${CHAR_NAME}より（重要）`,
-    body: `${knowledgeTopic}について大事なことを見つけたよ！確認してみて`,
+    body: `${normalizedTopic}について大事なことを見つけたよ！確認してみて`,
   };
 }

--- a/services/livetalk/core/src/repositories/dynamodb-knowledge.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-knowledge.repository.ts
@@ -1,8 +1,13 @@
-import { PutCommand, QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
 import type { CreateKnowledgeInput, KnowledgeEntity } from '../entities/knowledge.entity.js';
 import { KnowledgeMapper } from '../mappers/knowledge.mapper.js';
-import { buildKnowledgeSKPrefix, buildUserPK } from '../mappers/keys.js';
+import { buildKnowledgeSK, buildKnowledgeSKPrefix, buildUserPK } from '../mappers/keys.js';
 import type { KnowledgeRepository } from './knowledge.repository.interface.js';
 
 export class DynamoDBKnowledgeRepository implements KnowledgeRepository {
@@ -70,6 +75,27 @@ export class DynamoDBKnowledgeRepository implements KnowledgeRepository {
     }
 
     return results;
+  }
+
+  public async getById(
+    userId: string,
+    characterId: string,
+    knowledgeId: string
+  ): Promise<KnowledgeEntity | null> {
+    const pk = buildUserPK(userId);
+    const sk = buildKnowledgeSK(characterId, knowledgeId);
+
+    try {
+      const result = await this.docClient.send(
+        new GetCommand({ TableName: this.tableName, Key: { PK: pk, SK: sk } })
+      );
+
+      if (!result.Item) return null;
+      return this.mapper.toEntity(result.Item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
   }
 
   public async getLatest(userId: string, characterId: string): Promise<KnowledgeEntity | null> {

--- a/services/livetalk/core/src/repositories/in-memory-knowledge.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-knowledge.repository.ts
@@ -1,7 +1,7 @@
 import { InMemorySingleTableStore } from '@nagiyu/aws';
 import type { CreateKnowledgeInput, KnowledgeEntity } from '../entities/knowledge.entity.js';
 import { KnowledgeMapper } from '../mappers/knowledge.mapper.js';
-import { buildKnowledgeSKPrefix, buildUserPK } from '../mappers/keys.js';
+import { buildKnowledgeSK, buildKnowledgeSKPrefix, buildUserPK } from '../mappers/keys.js';
 import type { KnowledgeRepository } from './knowledge.repository.interface.js';
 
 export class InMemoryKnowledgeRepository implements KnowledgeRepository {
@@ -33,6 +33,18 @@ export class InMemoryKnowledgeRepository implements KnowledgeRepository {
       .map((item) => this.mapper.toEntity(item))
       .sort((a, b) => b.CreatedAt - a.CreatedAt)
       .slice(0, limit);
+  }
+
+  public async getById(
+    userId: string,
+    characterId: string,
+    knowledgeId: string
+  ): Promise<KnowledgeEntity | null> {
+    const pk = buildUserPK(userId);
+    const sk = buildKnowledgeSK(characterId, knowledgeId);
+    const item = this.store.get(pk, sk);
+    if (!item) return null;
+    return this.mapper.toEntity(item);
   }
 
   public async getLatest(userId: string, characterId: string): Promise<KnowledgeEntity | null> {

--- a/services/livetalk/core/src/repositories/knowledge.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/knowledge.repository.interface.ts
@@ -5,4 +5,10 @@ export interface KnowledgeRepository {
   list(userId: string, characterId: string, limit?: number): Promise<KnowledgeEntity[]>;
   /** 最新の Knowledge を 1 件返す。なければ null。 */
   getLatest(userId: string, characterId: string): Promise<KnowledgeEntity | null>;
+  /** KnowledgeID を指定して 1 件返す。なければ null。 */
+  getById(
+    userId: string,
+    characterId: string,
+    knowledgeId: string
+  ): Promise<KnowledgeEntity | null>;
 }

--- a/services/livetalk/core/src/research/openai-research-client.ts
+++ b/services/livetalk/core/src/research/openai-research-client.ts
@@ -89,8 +89,8 @@ function buildPrompt(query: string, character: CharacterDefinition): string {
     `「${query}」について必ず Web 検索し、${character.displayName} らしい視点で内容を要約してください。`,
     '',
     '返す項目（JSON）:',
-    '- topic: 検索したトピックを 1〜2 文で説明',
-    '- summary: キャラクター目線の要約（200 文字以上）',
+    '- topic: 検索したトピックの短い名詞句（5〜15 文字程度、例: 飲み物の新作、超かぐや姫）。説明文ではなく固有名詞や短い語句にすること',
+    '- summary: キャラクター目線の要約（200 文字以上）。topic の詳細説明はここに書く',
     '- sourceUrls: 参照した URL のリスト（空の場合は空配列）',
     `- rawComment: ${character.displayName} として一言コメント（50〜100 文字、上記の口調で）`,
   ].join('\n');

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -117,6 +117,12 @@ export interface ChatUseCaseParams {
   knowledgeMatcher?: KnowledgeMatcher;
   /** ULID ファクトリ。テスト時に差し替え可能。未指定時はデフォルト実装 */
   ulidFactory?: UlidFactory;
+  /**
+   * 通知起点の会話に対応する KnowledgeID（案B: 保存せず受け渡しのみ）。
+   * 指定時は該当 KNOWLEDGE を context に注入し、キャラが自分で振った話題として展開する。
+   * knowledgeRepository が未指定の場合はスキップする。
+   */
+  notificationKnowledgeId?: string;
 }
 
 type SynthesisResult = { index: number; text: string; audio: string | null; elapsedMs: number };
@@ -238,6 +244,7 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     noteRepository,
     knowledgeMatcher,
     ulidFactory = defaultUlidFactory,
+    notificationKnowledgeId,
   } = params;
 
   const chatStart = performance.now();
@@ -416,6 +423,31 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     }
   }
 
+  // 3.7. 通知起点 KNOWLEDGE の取得（案B: 保存せず受け渡しのみ）
+  // notificationKnowledgeId が指定されている場合、該当 KNOWLEDGE を取得して別セクションとして注入する。
+  // knowledgeContextForPrompt（知識ゲートのヒット分）と重複する場合はそちらから除外する。
+  let notificationKnowledge: import('../entities/knowledge.entity.js').KnowledgeEntity | null =
+    null;
+  if (notificationKnowledgeId && knowledgeRepository) {
+    try {
+      notificationKnowledge = await knowledgeRepository.getById(
+        userId,
+        characterId,
+        notificationKnowledgeId
+      );
+      // 知識ゲートのヒット分と重複していれば除外（prompt の冗長化を防ぐ）
+      if (notificationKnowledge && knowledgeContextForPrompt) {
+        knowledgeContextForPrompt = knowledgeContextForPrompt.filter(
+          (k) => k.KnowledgeID !== notificationKnowledge!.KnowledgeID
+        );
+      }
+    } catch (err) {
+      logger.warn('[chat-usecase] 通知起点 KNOWLEDGE の取得に失敗しました（スキップして継続）', {
+        err,
+      });
+    }
+  }
+
   // 4. Memory retrieve（fail-warn: エラー時は空配列で継続）
   let retrievedMemories: RetrievedMemory[] = [];
   if (memoryRetriever) {
@@ -509,7 +541,8 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     newLearnings.length > 0 ? newLearnings : undefined,
     lifecycleState,
     knowledgeContextForPrompt,
-    recentNotes.length > 0 ? recentNotes : undefined
+    recentNotes.length > 0 ? recentNotes : undefined,
+    notificationKnowledge ?? undefined
   );
 
   // プロンプトトークン内訳を計算（best-effort）

--- a/services/livetalk/core/src/usecases/generate-note.usecase.ts
+++ b/services/livetalk/core/src/usecases/generate-note.usecase.ts
@@ -110,7 +110,7 @@ function isNoteWorthy(
 }
 
 function buildNoteTitle(knowledge: KnowledgeEntity): string {
-  return knowledge.Topic.trim();
+  return knowledge.Topic.trim().replace(/[。、．,\n\r]+$/, '');
 }
 
 /**

--- a/services/livetalk/core/tests/unit/notification/message-builder.test.ts
+++ b/services/livetalk/core/tests/unit/notification/message-builder.test.ts
@@ -101,7 +101,10 @@ describe('buildCriticalNotificationMessage', () => {
 
 describe('normalizeKnowledgeTopic（通知テンプレート堅牢化）', () => {
   it('normal・topic 末尾句点が除去される', () => {
-    const msg = buildNotificationMessage({ toneBucket: 'normal', knowledgeTopic: 'コーヒーの新作。' }, 0);
+    const msg = buildNotificationMessage(
+      { toneBucket: 'normal', knowledgeTopic: 'コーヒーの新作。' },
+      0
+    );
     expect(msg.body).not.toMatch(/。について|。のこと/);
     expect(msg.body).toContain('コーヒーの新作');
   });

--- a/services/livetalk/core/tests/unit/notification/message-builder.test.ts
+++ b/services/livetalk/core/tests/unit/notification/message-builder.test.ts
@@ -83,4 +83,32 @@ describe('buildCriticalNotificationMessage', () => {
     const msg = buildCriticalNotificationMessage('健康診断');
     expect(msg.body).toContain('健康診断');
   });
+
+  it('末尾に句点がある Topic は正規化される', () => {
+    const msg = buildCriticalNotificationMessage('飲み物の新作。');
+    expect(msg.body).toContain('飲み物の新作');
+    expect(msg.body).not.toMatch(/。について/);
+  });
+
+  it('長い説明文 Topic でも文が崩壊しない', () => {
+    const longTopic =
+      '日本の食べ物（特にスイーツ・コンビニ新商品）の最新トレンドを検索しました。メーカーの新作、コラボ商品、新食感菓子など、春〜初夏にかけての動きを中心に調べたよ。';
+    const msg = buildCriticalNotificationMessage(longTopic);
+    // 末尾句点が除去されて「〜調べたよ」で終わる文字列が Topic として埋め込まれる
+    expect(msg.body).not.toMatch(/。について/);
+  });
+});
+
+describe('normalizeKnowledgeTopic（通知テンプレート堅牢化）', () => {
+  it('normal・topic 末尾句点が除去される', () => {
+    const msg = buildNotificationMessage({ toneBucket: 'normal', knowledgeTopic: 'コーヒーの新作。' }, 0);
+    expect(msg.body).not.toMatch(/。について|。のこと/);
+    expect(msg.body).toContain('コーヒーの新作');
+  });
+
+  it('long・topic 末尾句点が除去される', () => {
+    const msg = buildNotificationMessage({ toneBucket: 'long', knowledgeTopic: 'カフェラテ。' }, 0);
+    expect(msg.body).toContain('カフェラテ');
+    expect(msg.body).not.toMatch(/。のこと/);
+  });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-knowledge.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-knowledge.repository.test.ts
@@ -80,4 +80,23 @@ describe('InMemoryKnowledgeRepository', () => {
   it('list は未登録ユーザーに対して空配列を返す', async () => {
     expect(await repo.list('unknown', 'hiyori')).toHaveLength(0);
   });
+
+  describe('getById', () => {
+    it('存在する KnowledgeID で該当エンティティを返す', async () => {
+      await repo.put(makeInput({ KnowledgeID: 'ulid-001' }));
+      const result = await repo.getById('u1', 'hiyori', 'ulid-001');
+      expect(result).not.toBeNull();
+      expect(result!.KnowledgeID).toBe('ulid-001');
+    });
+
+    it('存在しない KnowledgeID で null を返す', async () => {
+      await repo.put(makeInput({ KnowledgeID: 'ulid-001' }));
+      expect(await repo.getById('u1', 'hiyori', 'not-exist')).toBeNull();
+    });
+
+    it('別ユーザーの KnowledgeID には null を返す', async () => {
+      await repo.put(makeInput({ UserID: 'u2', KnowledgeID: 'ulid-001' }));
+      expect(await repo.getById('u1', 'hiyori', 'ulid-001')).toBeNull();
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -1259,6 +1259,7 @@ describe('runChatUseCase', () => {
         put: jest.fn(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
         list: jest.fn(async () => knowledge),
         getLatest: jest.fn(async () => knowledge[0] ?? null),
+        getById: jest.fn(async (_userId, _charId, id) => knowledge.find((k) => k.KnowledgeID === id) ?? null),
       };
     }
 
@@ -1743,6 +1744,154 @@ describe('runChatUseCase', () => {
 
       expect(events[events.length - 1]).toEqual({ type: 'done' });
       expect(llm.chatStream).toHaveBeenCalled();
+    });
+  });
+
+  describe('通知起点の KNOWLEDGE context 注入（Issue #3359 課題Y）', () => {
+    function makeKnowledgeRepo(knowledge: KnowledgeEntity[] = []): KnowledgeRepository {
+      return {
+        put: jest.fn(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
+        list: jest.fn(async () => knowledge),
+        getLatest: jest.fn(async () => knowledge[0] ?? null),
+        getById: jest.fn(async (_u, _c, id) => knowledge.find((k) => k.KnowledgeID === id) ?? null),
+      };
+    }
+
+    function makeKnowledgeForNotif(id: string, topic: string): KnowledgeEntity {
+      return {
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        KnowledgeID: id,
+        Topic: topic,
+        Summary: `${topic}の詳細要約。`.repeat(5),
+        SourceUrls: [],
+        RawComment: 'おもしろい！',
+        RelatedCategory: 'test',
+        CreatedAt: 1_700_000_000_000,
+        UpdatedAt: 1_700_000_000_000,
+      };
+    }
+
+    it('notificationKnowledgeId 指定時、該当 KNOWLEDGE が system prompt に注入される', async () => {
+      const k = makeKnowledgeForNotif('notif-k1', 'カフェラテの新作');
+      const knowledgeRepo = makeKnowledgeRepo([k]);
+      const llm = makeLLMClient(['そうそう！']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+          notificationKnowledgeId: 'notif-k1',
+        })
+      );
+
+      expect(knowledgeRepo.getById).toHaveBeenCalledWith('u1', 'hiyori', 'notif-k1');
+      const streamArgs = (llm.chatStream as jest.Mock).mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const systemMsg = streamArgs.find((m) => m.role === 'system');
+      expect(systemMsg?.content).toContain('通知でユーザーに話しかけた話題');
+      expect(systemMsg?.content).toContain('カフェラテの新作');
+    });
+
+    it('notificationKnowledgeId が存在しない ID のとき通常フローで継続', async () => {
+      const knowledgeRepo = makeKnowledgeRepo([]);
+      const llm = makeLLMClient(['うん']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+          notificationKnowledgeId: 'no-such-id',
+        })
+      );
+
+      expect(events.some((e) => e.type === 'done')).toBe(true);
+      expect(llm.chatStream).toHaveBeenCalled();
+    });
+
+    it('notificationKnowledgeId 未指定のとき通知セクションを含めない', async () => {
+      const llm = makeLLMClient(['うん']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+        })
+      );
+
+      const streamArgs = (llm.chatStream as jest.Mock).mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const systemMsg = streamArgs.find((m) => m.role === 'system');
+      expect(systemMsg?.content).not.toContain('通知でユーザーに話しかけた話題');
+    });
+
+    it('getById が失敗してもスキップして通常応答を継続する', async () => {
+      const knowledgeRepo = makeKnowledgeRepo([]);
+      (knowledgeRepo.getById as jest.Mock).mockRejectedValueOnce(new Error('DB error'));
+      const llm = makeLLMClient(['うん']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+          notificationKnowledgeId: 'notif-k1',
+        })
+      );
+
+      expect(events.some((e) => e.type === 'done')).toBe(true);
+    });
+
+    it('knowledge_hit と notificationKnowledgeId が同じ ID のとき重複注入しない', async () => {
+      const k = makeKnowledgeForNotif('k1', 'モンハン');
+      const knowledgeRepo = makeKnowledgeRepo([k]);
+      const llm = makeLLMClient(['モンハン！']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          userText: 'モンハン',
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          knowledgeRepository: knowledgeRepo,
+          notificationKnowledgeId: 'k1',
+        })
+      );
+
+      const streamArgs = (llm.chatStream as jest.Mock).mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const systemMsg = streamArgs.find((m) => m.role === 'system');
+      // 通知セクションが含まれ、知識ゲートセクションでは重複しない
+      expect(systemMsg?.content).toContain('通知でユーザーに話しかけた話題');
+      const knowledgeCount = (systemMsg?.content.match(/この前調べたこと/g) ?? []).length;
+      expect(knowledgeCount).toBeLessThanOrEqual(1);
     });
   });
 });

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -1259,7 +1259,9 @@ describe('runChatUseCase', () => {
         put: jest.fn(async (input) => ({ ...input, CreatedAt: Date.now(), UpdatedAt: Date.now() })),
         list: jest.fn(async () => knowledge),
         getLatest: jest.fn(async () => knowledge[0] ?? null),
-        getById: jest.fn(async (_userId, _charId, id) => knowledge.find((k) => k.KnowledgeID === id) ?? null),
+        getById: jest.fn(
+          async (_userId, _charId, id) => knowledge.find((k) => k.KnowledgeID === id) ?? null
+        ),
       };
     }
 

--- a/services/livetalk/core/tests/unit/usecases/generate-note.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/generate-note.usecase.test.ts
@@ -111,4 +111,20 @@ describe('generateNotesForUser', () => {
     });
     expect(result.generatedCount).toBe(0);
   });
+
+  it('Topic 末尾の句点はノートタイトルから除去される', async () => {
+    await putKnowledge({ KnowledgeID: 'know-001', Topic: '飲み物の新作。' });
+    await generateNotesForUser('u1', 'hiyori', { knowledgeRepo, noteRepo, ulidFactory });
+    const notes = await noteRepo.list('u1', 'hiyori');
+    expect(notes[0].Title).toBe('飲み物の新作');
+  });
+
+  it('長い説明文 Topic でも末尾句点が除去される', async () => {
+    const longTopic =
+      '日本の食べ物（特にスイーツ・コンビニ新商品）の最新トレンドを検索しました。メーカーの新作、コラボ商品、新食感菓子など、春〜初夏にかけての動きを中心に調べたよ。';
+    await putKnowledge({ KnowledgeID: 'know-001', Topic: longTopic });
+    await generateNotesForUser('u1', 'hiyori', { knowledgeRepo, noteRepo, ulidFactory });
+    const notes = await noteRepo.list('u1', 'hiyori');
+    expect(notes[0].Title).not.toMatch(/。$/);
+  });
 });

--- a/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/study.usecase.test.ts
@@ -91,6 +91,7 @@ describe('studyForUser', () => {
     put: jest.fn().mockImplementation(async (input) => ({ ...input, CreatedAt: Date.now() })),
     list: jest.fn().mockResolvedValue([]),
     getLatest: jest.fn().mockResolvedValue(null),
+    getById: jest.fn().mockResolvedValue(null),
   });
 
   const makeInterestRepo = (): jest.Mocked<InterestRepository> => ({

--- a/services/livetalk/web/package.json
+++ b/services/livetalk/web/package.json
@@ -24,6 +24,10 @@
     "@nagiyu/livetalk-core": "*",
     "@nagiyu/nextjs": "*",
     "@nagiyu/ui": "*",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "jest-environment-jsdom": "^30.4.1",
     "pixi-live2d-display-lipsyncpatch": "0.5.0-ls-8",
     "pixi.js": "^7.4.3"
   }

--- a/services/livetalk/web/src/app/api/chat/route.ts
+++ b/services/livetalk/web/src/app/api/chat/route.ts
@@ -21,13 +21,17 @@ import { CHAT_ERROR_MESSAGES, CHAT_MAX_TEXT_LENGTH } from './constants';
 
 interface ChatRequest {
   text: string;
+  /** 通知起点の会話の場合、元となった KnowledgeID（任意） */
+  knowledgeId?: string;
 }
 
 function isChatRequest(body: unknown): body is ChatRequest {
   return (
     typeof body === 'object' &&
     body !== null &&
-    typeof (body as Partial<ChatRequest>).text === 'string'
+    typeof (body as Partial<ChatRequest>).text === 'string' &&
+    ((body as Partial<ChatRequest>).knowledgeId === undefined ||
+      typeof (body as Partial<ChatRequest>).knowledgeId === 'string')
   );
 }
 
@@ -67,6 +71,7 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
   }
 
   const text = body.text.trim();
+  const notificationKnowledgeId = body.knowledgeId?.trim() || undefined;
   if (!text) {
     return NextResponse.json(
       { error: 'EMPTY_TEXT', message: CHAT_ERROR_MESSAGES.EMPTY_TEXT },
@@ -109,6 +114,7 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
           knowledgeRepository: getKnowledgeRepository(),
           studyTopicRepository: getStudyTopicRepository(),
           noteRepository: getNoteRepository(),
+          notificationKnowledgeId,
         });
 
         for await (const event of eventGenerator) {

--- a/services/livetalk/web/src/app/api/push/first-word/route.ts
+++ b/services/livetalk/web/src/app/api/push/first-word/route.ts
@@ -20,5 +20,12 @@ export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
     return new NextResponse(null, { status: 204 });
   }
 
-  return NextResponse.json({ notifId: unconsumed.NotifID, body: unconsumed.Body }, { status: 200 });
+  return NextResponse.json(
+    {
+      notifId: unconsumed.NotifID,
+      body: unconsumed.Body,
+      knowledgeId: unconsumed.KnowledgeID ?? null,
+    },
+    { status: 200 }
+  );
 });

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -78,6 +78,8 @@ export default function HomePage() {
 
   // キャラ第一声（未消化の通知から表示）
   const [firstWordText, setFirstWordText] = useState<string | null>(null);
+  // 第一声の元となった KnowledgeID（次の chat 送信時に文脈として渡す）
+  const firstWordKnowledgeIdRef = useRef<string | null>(null);
 
   const audioQueueRef = useRef<AudioBuffer[]>([]);
   const isPlayingRef = useRef(false);
@@ -104,9 +106,10 @@ export default function HomePage() {
   useEffect(() => {
     fetch('/api/push/first-word')
       .then((res) => (res.ok ? res.json() : null))
-      .then((data: { notifId: string; body: string } | null) => {
+      .then((data: { notifId: string; body: string; knowledgeId?: string | null } | null) => {
         if (!data) return;
         setFirstWordText(data.body);
+        firstWordKnowledgeIdRef.current = data.knowledgeId ?? null;
         // 消化済みマーク
         fetch('/api/push/consumed', {
           method: 'PATCH',
@@ -222,6 +225,10 @@ export default function HomePage() {
       const controller = new AbortController();
       abortControllerRef.current = controller;
 
+      // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）
+      const notifKnowledgeId = firstWordKnowledgeIdRef.current;
+      firstWordKnowledgeIdRef.current = null;
+
       setUserText(text);
       setResponseText('');
       setFirstWordText(null);
@@ -232,10 +239,13 @@ export default function HomePage() {
       clearAudioQueue();
 
       try {
+        const chatBody: { text: string; knowledgeId?: string } = { text };
+        if (notifKnowledgeId) chatBody.knowledgeId = notifKnowledgeId;
+
         const response = await fetch('/api/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ text }),
+          body: JSON.stringify(chatBody),
           signal: controller.signal,
         });
 

--- a/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
@@ -197,5 +197,36 @@ describe('POST /api/chat', () => {
         expect.objectContaining({ userId: 'g1', userText: 'テスト' })
       );
     });
+
+    it('knowledgeId を含むリクエストは notificationKnowledgeId として usecase に渡される', async () => {
+      mockRunChatUseCase.mockImplementation(async function* () {
+        yield { type: 'done' };
+      });
+
+      await POST(buildRequest({ text: 'こんにちは', knowledgeId: 'k-abc' }));
+
+      expect(mockRunChatUseCase).toHaveBeenCalledWith(
+        expect.objectContaining({ notificationKnowledgeId: 'k-abc' })
+      );
+    });
+
+    it('knowledgeId が空文字列のときは notificationKnowledgeId が undefined になる', async () => {
+      mockRunChatUseCase.mockImplementation(async function* () {
+        yield { type: 'done' };
+      });
+
+      await POST(buildRequest({ text: 'こんにちは', knowledgeId: '' }));
+
+      expect(mockRunChatUseCase).toHaveBeenCalledWith(
+        expect.objectContaining({ notificationKnowledgeId: undefined })
+      );
+    });
+
+    it('knowledgeId が数値型のリクエストは 400 INVALID_REQUEST', async () => {
+      const res = await POST(buildRequest({ text: 'hello', knowledgeId: 123 }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.message).toBe(CHAT_ERROR_MESSAGES.INVALID_REQUEST);
+    });
   });
 });

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -358,9 +358,7 @@ describe('通知起点の knowledgeId 受け渡し（Issue #3359 課題Y）', ()
     const input = await waitForInputEnabled();
 
     // first-word 取得を待つ
-    await waitFor(() =>
-      expect(global.fetch).toHaveBeenCalledWith('/api/push/first-word')
-    );
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/push/first-word'));
 
     await user.type(input, 'ありがとう');
     await user.click(screen.getByRole('button', { name: '送信' }));

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -320,3 +320,115 @@ describe('handlePlaybackError のデバッグログ', () => {
     consoleSpy.mockRestore();
   });
 });
+
+describe('通知起点の knowledgeId 受け渡し（Issue #3359 課題Y）', () => {
+  it('first-word に knowledgeId がある場合、次の chat リクエストに含まれる', async () => {
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url === '/api/lifecycle') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url === '/api/push/first-word') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ notifId: 'n1', body: 'テスト第一声', knowledgeId: 'k-xyz' }),
+        });
+      }
+      if (url === '/api/push/consumed') {
+        return Promise.resolve({ ok: true });
+      }
+      // /api/chat
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    setupMockAudioContext('running');
+    const user = userEvent.setup();
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    // first-word 取得を待つ
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith('/api/push/first-word')
+    );
+
+    await user.type(input, 'ありがとう');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    const chatCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]: [string]) => url === '/api/chat'
+    );
+    expect(chatCall).toBeDefined();
+    const chatBody = JSON.parse(chatCall[1].body as string);
+    expect(chatBody.knowledgeId).toBe('k-xyz');
+  });
+
+  it('2 回目の送信では knowledgeId を含まない（1 ターン限り）', async () => {
+    const encoder = new TextEncoder();
+    const makeChatStream = () =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+          controller.close();
+        },
+      });
+
+    let chatCallCount = 0;
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url === '/api/lifecycle') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url === '/api/push/first-word') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ notifId: 'n1', body: 'テスト第一声', knowledgeId: 'k-xyz' }),
+        });
+      }
+      if (url === '/api/push/consumed') {
+        return Promise.resolve({ ok: true });
+      }
+      chatCallCount++;
+      return Promise.resolve({ ok: true, body: makeChatStream() });
+    });
+
+    setupMockAudioContext('running');
+    const user = userEvent.setup();
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/push/first-word'));
+
+    // 1 回目送信
+    await user.type(input, '1回目');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+    await waitFor(() => expect(chatCallCount).toBe(1));
+
+    // 2 回目送信
+    await user.type(input, '2回目');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+    await waitFor(() => expect(chatCallCount).toBe(2));
+
+    const chatCalls = (global.fetch as jest.Mock).mock.calls.filter(
+      ([url]: [string]) => url === '/api/chat'
+    );
+    expect(chatCalls).toHaveLength(2);
+    const firstBody = JSON.parse(chatCalls[0][1].body as string);
+    const secondBody = JSON.parse(chatCalls[1][1].body as string);
+    expect(firstBody.knowledgeId).toBe('k-xyz');
+    expect(secondBody.knowledgeId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 変更の概要

Issue #3359 の 2 つの品質課題を修正する。

**課題 X：通知文面・ノート Title の崩壊（Topic に説明文が入る問題）**
- Phase 5a 勉強バッチの `topic` 生成プロンプトを「短い名詞句（5〜15 文字程度、例: 飲み物の新作）」に修正（根本治療）
- `message-builder.ts` に末尾句点除去の正規化ヘルパーを追加し全テンプレートに適用（堅牢化）
- `generate-note.usecase.ts` の `buildNoteTitle` にも同様の防御整形を追加

**課題 Y：第一声後の会話断絶修正（案B: knowledgeId 受け渡し方式）**
- `NotificationEvent` の `KnowledgeID` を平常通知でも記録するよう batch 修正
- `first-word` API が `knowledgeId` も返すように拡張
- `page.tsx` が受け取った `knowledgeId` を ref で保持し、次の chat 送信時に 1 ターン限り添付
- `chat` API → `chat-usecase` → `prompt-builder` の順に `notificationKnowledgeId` を通し、KNOWLEDGE を「通知で話しかけた話題」セクションとして prompt 注入
- `KnowledgeRepository.getById()` を追加（DynamoDB / InMemory 両実装）

## 関連 Issue

<!-- integration → develop の PR でのみ Closes を使う -->
関連: #3359（Phase 5 品質修正）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ 80% 以上を確保）
- [ ] 関連ドキュメントを更新した（dev KNOWLEDGE の Topic 再生成は人力対応）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

### core（935 件通過）
- `message-builder.test.ts`: 末尾句点除去の正規化テスト追加
- `generate-note.usecase.test.ts`: Topic 末尾句点除去のタイトル正規化テスト追加
- `in-memory-knowledge.repository.test.ts`: `getById` の正常/異常/別ユーザーテスト追加
- `chat-usecase.test.ts`: `notificationKnowledgeId` 各シナリオ（注入・ID不在・未指定・エラー・重複排除）テスト追加

### batch（41 件通過）
- `notify.usecase.test.ts`: 平常通知で `KnowledgeID` が notifEvent に保存されることを確認

### web（14 件通過）
- `chat/route.test.ts`: `knowledgeId` → `notificationKnowledgeId` 受け渡し、空文字 undefined 化、型不正 400 テスト追加
- `page.test.tsx`: `knowledgeId` が初回送信に含まれ 2 回目以降は除外されることを確認

## レビューポイント

- **設計判断（案B）**: 第一声を Message に保存せず `knowledgeId` 受け渡しのみとした。圧縮要約（#3354）・履歴汚染を避けた最小実装
- **平常通知でも `KnowledgeID` 記録**: `notify.usecase.ts:189` で `latestKnowledge?.KnowledgeID` をセット。`undefined` の場合は従来通り
- **重複排除**: `chat-usecase.ts` 内で knowledge_hit と notificationKnowledge が同一 ID の場合は knowledge_hit 側から除外してプロンプト冗長化を防止
- **dev KNOWLEDGE 再生成**: 既存 6 件の Topic が長い説明文のまま残っている。対応はコード外（NOTIF アイテム削除 → `nagiyu-livetalk-batch-notify-dev` invoke で再生成可能）

## 補足事項

Issue #3359 に記載の「通知文面を LLM 生成にする案」は本 Issue スコープ外とし、「Topic 正常化 + テンプレート堅牢化」で対応。

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQo1Gm7HyXvTaEE3ZwEP4d)_