### PR TITLE
[Feature] [リブトーク] livetalk:admin 権限 + ステータスページ（/status）追加

### DIFF
--- a/libs/common/src/auth/roles.ts
+++ b/libs/common/src/auth/roles.ts
@@ -79,7 +79,8 @@ export const ROLES = {
   'livetalk-admin': {
     id: 'livetalk-admin',
     name: 'LiveTalk 管理者',
-    description: 'LiveTalk の管理者機能（ステータス閲覧等）にアクセス可能。livetalk:chat も含む（middleware 要件）',
+    description:
+      'LiveTalk の管理者機能（ステータス閲覧等）にアクセス可能。livetalk:chat も含む（middleware 要件）',
     permissions: ['livetalk:chat', 'livetalk:admin'],
   },
 } as const satisfies Record<string, RoleDefinition>;

--- a/libs/common/src/auth/roles.ts
+++ b/libs/common/src/auth/roles.ts
@@ -76,6 +76,12 @@ export const ROLES = {
     description: 'LiveTalk のチャット UI および API にアクセス可能',
     permissions: ['livetalk:chat'],
   },
+  'livetalk-admin': {
+    id: 'livetalk-admin',
+    name: 'LiveTalk 管理者',
+    description: 'LiveTalk の管理者機能（ステータス閲覧等）にアクセス可能。livetalk:chat も含む（middleware 要件）',
+    permissions: ['livetalk:chat', 'livetalk:admin'],
+  },
 } as const satisfies Record<string, RoleDefinition>;
 
 /**

--- a/libs/common/src/auth/types.ts
+++ b/libs/common/src/auth/types.ts
@@ -57,6 +57,7 @@ export interface Session {
  *
  * LiveTalk permissions:
  * - livetalk:chat - Access LiveTalk chat UI and API
+ * - livetalk:admin - Access LiveTalk admin features (status page, debug panel)
  */
 export type Permission =
   | 'users:read'
@@ -70,7 +71,8 @@ export type Permission =
   | 'stocks:read-evaluation'
   | 'auth:read'
   | 'auth:write'
-  | 'livetalk:chat';
+  | 'livetalk:chat'
+  | 'livetalk:admin';
 
 /**
  * Valid role IDs defined in ROLES constant

--- a/libs/common/tests/unit/auth/permissions.test.ts
+++ b/libs/common/tests/unit/auth/permissions.test.ts
@@ -310,12 +310,52 @@ describe('Permission Functions', () => {
         expect(hasPermission(['livetalk-user'], 'livetalk:chat')).toBe(true);
       });
 
+      it('livetalk-admin should have livetalk:chat', () => {
+        expect(hasPermission(['livetalk-admin'], 'livetalk:chat')).toBe(true);
+      });
+
       it('admin should not have livetalk:chat', () => {
         expect(hasPermission(['admin'], 'livetalk:chat')).toBe(false);
       });
 
       it('stock-admin should not have livetalk:chat', () => {
         expect(hasPermission(['stock-admin'], 'livetalk:chat')).toBe(false);
+      });
+    });
+
+    describe('livetalk-admin role', () => {
+      it('should have livetalk:chat permission', () => {
+        expect(hasPermission(['livetalk-admin'], 'livetalk:chat')).toBe(true);
+      });
+
+      it('should have livetalk:admin permission', () => {
+        expect(hasPermission(['livetalk-admin'], 'livetalk:admin')).toBe(true);
+      });
+
+      it('should not have users:read permission', () => {
+        expect(hasPermission(['livetalk-admin'], 'users:read')).toBe(false);
+      });
+
+      it('should not have stocks:read permission', () => {
+        expect(hasPermission(['livetalk-admin'], 'stocks:read')).toBe(false);
+      });
+    });
+
+    describe('livetalk:admin permission', () => {
+      it('livetalk-admin should have livetalk:admin', () => {
+        expect(hasPermission(['livetalk-admin'], 'livetalk:admin')).toBe(true);
+      });
+
+      it('livetalk-user should not have livetalk:admin', () => {
+        expect(hasPermission(['livetalk-user'], 'livetalk:admin')).toBe(false);
+      });
+
+      it('admin should not have livetalk:admin', () => {
+        expect(hasPermission(['admin'], 'livetalk:admin')).toBe(false);
+      });
+
+      it('stock-admin should not have livetalk:admin', () => {
+        expect(hasPermission(['stock-admin'], 'livetalk:admin')).toBe(false);
       });
     });
 

--- a/libs/common/tests/unit/auth/roles.test.ts
+++ b/libs/common/tests/unit/auth/roles.test.ts
@@ -13,6 +13,7 @@ describe('VALID_ROLES', () => {
     expect(VALID_ROLES).toContain('stock-user');
     expect(VALID_ROLES).toContain('stock-admin');
     expect(VALID_ROLES).toContain('livetalk-user');
+    expect(VALID_ROLES).toContain('livetalk-admin');
   });
 
   it('配列として提供されるべき', () => {
@@ -152,13 +153,45 @@ describe('ROLES', () => {
   });
 
   describe('livetalk:chat 権限の付与範囲', () => {
-    it('livetalk-user のみが livetalk:chat を持つべき', () => {
+    it('livetalk-user と livetalk-admin が livetalk:chat を持つべき', () => {
       expect(ROLES['livetalk-user'].permissions).toContain('livetalk:chat');
+      expect(ROLES['livetalk-admin'].permissions).toContain('livetalk:chat');
       expect(ROLES.admin.permissions).not.toContain('livetalk:chat');
       expect(ROLES['user-manager'].permissions).not.toContain('livetalk:chat');
       expect(ROLES['stock-viewer'].permissions).not.toContain('livetalk:chat');
       expect(ROLES['stock-user'].permissions).not.toContain('livetalk:chat');
       expect(ROLES['stock-admin'].permissions).not.toContain('livetalk:chat');
+    });
+  });
+
+  describe('livetalk-admin role', () => {
+    it('正しい構造を持つべき', () => {
+      expect(ROLES['livetalk-admin']).toBeDefined();
+      expect(ROLES['livetalk-admin'].id).toBe('livetalk-admin');
+      expect(ROLES['livetalk-admin'].name).toBe('LiveTalk 管理者');
+      expect(ROLES['livetalk-admin'].description).toBeDefined();
+      expect(Array.isArray(ROLES['livetalk-admin'].permissions)).toBe(true);
+    });
+
+    it('livetalk:chat と livetalk:admin 権限を持つべき', () => {
+      expect(ROLES['livetalk-admin'].permissions).toContain('livetalk:chat');
+      expect(ROLES['livetalk-admin'].permissions).toContain('livetalk:admin');
+      expect(ROLES['livetalk-admin'].permissions).toHaveLength(2);
+    });
+
+    it('livetalk:admin 権限のみを持つべき（それ以外の権限は不要）', () => {
+      expect(ROLES['livetalk-admin'].permissions).not.toContain('users:read');
+      expect(ROLES['livetalk-admin'].permissions).not.toContain('stocks:read');
+    });
+  });
+
+  describe('livetalk:admin 権限の付与範囲', () => {
+    it('livetalk-admin のみが livetalk:admin を持つべき', () => {
+      expect(ROLES['livetalk-admin'].permissions).toContain('livetalk:admin');
+      expect(ROLES['livetalk-user'].permissions).not.toContain('livetalk:admin');
+      expect(ROLES.admin.permissions).not.toContain('livetalk:admin');
+      expect(ROLES['user-manager'].permissions).not.toContain('livetalk:admin');
+      expect(ROLES['stock-admin'].permissions).not.toContain('livetalk:admin');
     });
   });
 });

--- a/services/livetalk/web/src/app/(protected)/layout.tsx
+++ b/services/livetalk/web/src/app/(protected)/layout.tsx
@@ -1,0 +1,3 @@
+export default function ProtectedLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/services/livetalk/web/src/app/(protected)/status/page.tsx
+++ b/services/livetalk/web/src/app/(protected)/status/page.tsx
@@ -1,0 +1,230 @@
+/**
+ * /status — livetalk:admin 権限保持者向けデバッグパネル（L3 生データ表示）
+ *
+ * 通知が来ない理由（正常 / 異常）を外部から一目で判別するための運用支援ページ。
+ * Issue #3363
+ */
+
+import { redirect } from 'next/navigation';
+import { Box, Container, Divider, Typography } from '@mui/material';
+import { Chip } from '@nagiyu/ui';
+import { hasPermission } from '@nagiyu/common';
+import {
+  DEFAULT_CHARACTER_ID,
+  LIFECYCLE_DEFAULT_BEDTIME,
+  LIFECYCLE_DEFAULT_WAKE_UP_TIME,
+  NOTIFY_BACKOFF_BASE,
+  NOTIFY_RECENT_SESSION_SAMPLE_N,
+  NOTIFY_SESSION_GAP_MINUTES,
+  resolveLifecycleState,
+  shouldNotifyNow,
+  extractSessionStartTimes,
+  computeSessionIntervals,
+  computeBaseIntervalMs,
+  type MessageEntity,
+  type NotificationEventEntity,
+} from '@nagiyu/livetalk-core';
+import { getSession } from '@/lib/server/session';
+import {
+  getLifecycleRepository,
+  getNotificationEventRepository,
+  getKnowledgeRepository,
+  getStudyTopicRepository,
+  getMessageRepository,
+} from '@/lib/server/repositories';
+
+const JST = 'Asia/Tokyo';
+
+function formatJst(ms: number): string {
+  return new Date(ms).toLocaleString('ja-JP', { timeZone: JST });
+}
+
+function computeNextEarliestAt(
+  userMessages: Pick<MessageEntity, 'CreatedAt'>[],
+  notificationEvents: NotificationEventEntity[]
+): number {
+  const sessionGapMs = NOTIFY_SESSION_GAP_MINUTES * 60 * 1000;
+  const sessionStarts = extractSessionStartTimes(userMessages, sessionGapMs);
+  const intervals = computeSessionIntervals(sessionStarts, NOTIFY_RECENT_SESSION_SAMPLE_N);
+  const baseIntervalMs = computeBaseIntervalMs(intervals);
+
+  const lastNormalAt = notificationEvents.find((e) => e.Kind === 'normal')?.CreatedAt ?? 0;
+  const lastInteractionAt =
+    userMessages.length > 0 ? Math.max(...userMessages.map((m) => m.CreatedAt)) : 0;
+  const referenceTime = Math.max(lastInteractionAt, lastNormalAt);
+
+  const missedCount = notificationEvents.filter(
+    (e) => e.Kind === 'normal' && e.CreatedAt > lastInteractionAt
+  ).length;
+
+  return referenceTime + baseIntervalMs * Math.pow(NOTIFY_BACKOFF_BASE, missedCount);
+}
+
+const REASON_LABELS: Record<string, string> = {
+  not_due: 'インターバル未経過',
+  outside_window: '活動時間帯外',
+  sleeping: '睡眠帯',
+  daily_cap: '本日の上限到達',
+  inactive_stopped: '長期不在（通知停止）',
+  no_content: 'コンテンツなし',
+};
+
+export default async function StatusPage() {
+  const session = await getSession();
+
+  if (!session || !hasPermission(session.user.roles, 'livetalk:admin')) {
+    redirect('/');
+  }
+
+  const userId = session.user.googleId;
+  const characterId = DEFAULT_CHARACTER_ID;
+  const now = new Date();
+
+  const [lifecycle, notificationEvents, allMessages, knowledge, studyPending] = await Promise.all([
+    getLifecycleRepository().get({ userId, characterId }),
+    getNotificationEventRepository().listByUser(userId, 10),
+    getMessageRepository().listSince(userId, characterId, 0),
+    getKnowledgeRepository().list(userId, characterId),
+    getStudyTopicRepository().listByStatus(userId, characterId, 'pending'),
+  ]);
+
+  const bedtime = lifecycle?.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME;
+  const wakeUpTime = lifecycle?.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME;
+  const state = resolveLifecycleState(now, bedtime, wakeUpTime);
+  const userMessages = allMessages.filter((m) => m.Role === 'user');
+
+  const lifecycleForDecision = lifecycle ?? {
+    UserID: userId,
+    CharacterID: characterId,
+    Bedtime: LIFECYCLE_DEFAULT_BEDTIME,
+    WakeUpTime: LIFECYCLE_DEFAULT_WAKE_UP_TIME,
+    CreatedAt: 0,
+    UpdatedAt: 0,
+  };
+
+  const notifyDecision = shouldNotifyNow({
+    userMessages,
+    lifecycle: lifecycleForDecision,
+    notificationEvents,
+    now,
+  });
+
+  let nextEarliestAt: number | undefined;
+  if (!notifyDecision.notify && notifyDecision.reason === 'not_due') {
+    nextEarliestAt = computeNextEarliestAt(userMessages, notificationEvents);
+  }
+
+  const recentNotifications = notificationEvents.slice(0, 5);
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 2 }}>
+      <Typography variant="h6" component="h1" sx={{ mb: 2 }}>
+        ステータス（デバッグ）
+      </Typography>
+
+      {/* ライフサイクル */}
+      <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+        ライフサイクル
+      </Typography>
+      <Box sx={{ mb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography variant="body2">状態:</Typography>
+        <Chip size="sm" color={state === 'awake' ? 'success' : 'neutral'}>
+          {state}
+        </Chip>
+      </Box>
+      <Typography variant="body2" sx={{ mb: 0.5 }}>
+        就寝: {bedtime} / 起床: {wakeUpTime}
+      </Typography>
+      {lifecycle?.UserActivityProfile ? (
+        <Box sx={{ mb: 1 }}>
+          <Typography variant="body2">
+            活動プロファイル: 朝 {lifecycle.UserActivityProfile.morningPeak} / 夕{' '}
+            {lifecycle.UserActivityProfile.eveningPeak}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            サンプル {lifecycle.UserActivityProfile.sampleSize} 件 / 最終学習:{' '}
+            {lifecycle.UserActivityProfile.lastLearnedAt}
+          </Typography>
+        </Box>
+      ) : (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          活動プロファイル: 未学習（時間帯ゲートをスキップ中）
+        </Typography>
+      )}
+
+      <Divider sx={{ my: 1.5 }} />
+
+      {/* 通知判定 */}
+      <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+        通知判定（現時刻）
+      </Typography>
+      {notifyDecision.notify ? (
+        <Box sx={{ mb: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="body2">結果:</Typography>
+            <Chip size="sm" color="success">
+              通知可能 — {notifyDecision.kind}
+            </Chip>
+          </Box>
+          {'toneBucket' in notifyDecision && (
+            <Typography variant="body2" color="text.secondary">
+              toneBucket: {notifyDecision.toneBucket}
+            </Typography>
+          )}
+        </Box>
+      ) : (
+        <Box sx={{ mb: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="body2">結果:</Typography>
+            <Chip size="sm" color="neutral">
+              NG — {REASON_LABELS[notifyDecision.reason] ?? notifyDecision.reason}
+            </Chip>
+          </Box>
+          {nextEarliestAt !== undefined && (
+            <Typography variant="body2" color="text.secondary">
+              インターバル解除予測: {formatJst(nextEarliestAt)}（活動窓・睡眠帯は別途）
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      <Divider sx={{ my: 1.5 }} />
+
+      {/* 直近通知履歴 */}
+      <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+        直近通知履歴（最新 5 件）
+      </Typography>
+      {recentNotifications.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          履歴なし
+        </Typography>
+      ) : (
+        <Box sx={{ mb: 1 }}>
+          {recentNotifications.map((e) => (
+            <Box
+              key={e.NotifID}
+              sx={{ mb: 1, pl: 1, borderLeft: '2px solid', borderColor: 'divider' }}
+            >
+              <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                {formatJst(e.CreatedAt)} | {e.Kind} |{' '}
+                {e.ConsumedAt ? `消化済み ${formatJst(e.ConsumedAt)}` : '未消化'}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.75rem' }}>
+                {e.Body.slice(0, 100)}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <Divider sx={{ my: 1.5 }} />
+
+      {/* コンテンツ */}
+      <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+        コンテンツ
+      </Typography>
+      <Typography variant="body2">KNOWLEDGE: {knowledge.length} 件</Typography>
+      <Typography variant="body2">STUDY_TOPIC (pending): {studyPending.length} 件</Typography>
+    </Container>
+  );
+}

--- a/services/livetalk/web/src/app/api/status/constants.ts
+++ b/services/livetalk/web/src/app/api/status/constants.ts
@@ -1,0 +1,3 @@
+export const STATUS_ERROR_MESSAGES = {
+  FETCH_FAILED: 'ステータス情報の取得に失敗しました',
+} as const;

--- a/services/livetalk/web/src/app/api/status/route.ts
+++ b/services/livetalk/web/src/app/api/status/route.ts
@@ -1,0 +1,141 @@
+/**
+ * GET /api/status
+ *
+ * livetalk:admin 権限保持者向けのデバッグ用ステータス集約 API（Issue #3363）。
+ *
+ * 返却内容:
+ *   - ライフサイクル状態（state / bedtime / wakeUpTime / userActivityProfile）
+ *   - 直近通知履歴（最新 5 件）
+ *   - 現時点の通知判定結果（shouldNotifyNow の reason / toneBucket 等）
+ *   - インターバル解除予測時刻（reason が not_due の場合のみ）
+ *   - KNOWLEDGE 件数 / STUDY_TOPIC pending 件数
+ *
+ * chat metrics（promptTokens / latencyMs）は DynamoDB 未永続のため本 Issue のスコープ外。
+ * CloudWatch Logs Insights で確認する。
+ */
+
+import { NextResponse } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import {
+  DEFAULT_CHARACTER_ID,
+  LIFECYCLE_DEFAULT_BEDTIME,
+  LIFECYCLE_DEFAULT_WAKE_UP_TIME,
+  NOTIFY_BACKOFF_BASE,
+  NOTIFY_RECENT_SESSION_SAMPLE_N,
+  NOTIFY_SESSION_GAP_MINUTES,
+  resolveLifecycleState,
+  shouldNotifyNow,
+  extractSessionStartTimes,
+  computeSessionIntervals,
+  computeBaseIntervalMs,
+  type MessageEntity,
+  type NotificationEventEntity,
+} from '@nagiyu/livetalk-core';
+import { getSession } from '@/lib/server/session';
+import {
+  getLifecycleRepository,
+  getNotificationEventRepository,
+  getKnowledgeRepository,
+  getStudyTopicRepository,
+  getMessageRepository,
+} from '@/lib/server/repositories';
+import { STATUS_ERROR_MESSAGES } from './constants';
+
+/**
+ * reason が 'not_due' のときに「インターバル条件が解除される最早時刻」を算出する。
+ * shouldNotifyNow の内部ロジックを再現した純粋計算。
+ * 活動時間帯ゲート・睡眠帯は考慮しないため、あくまで「インターバル解除の目安」。
+ */
+function computeNextEarliestAt(
+  userMessages: Pick<MessageEntity, 'CreatedAt'>[],
+  notificationEvents: NotificationEventEntity[]
+): number {
+  const sessionGapMs = NOTIFY_SESSION_GAP_MINUTES * 60 * 1000;
+  const sessionStarts = extractSessionStartTimes(userMessages, sessionGapMs);
+  const intervals = computeSessionIntervals(sessionStarts, NOTIFY_RECENT_SESSION_SAMPLE_N);
+  const baseIntervalMs = computeBaseIntervalMs(intervals);
+
+  const lastNormalAt = notificationEvents.find((e) => e.Kind === 'normal')?.CreatedAt ?? 0;
+  const lastInteractionAt =
+    userMessages.length > 0 ? Math.max(...userMessages.map((m) => m.CreatedAt)) : 0;
+  const referenceTime = Math.max(lastInteractionAt, lastNormalAt);
+
+  const missedCount = notificationEvents.filter(
+    (e) => e.Kind === 'normal' && e.CreatedAt > lastInteractionAt
+  ).length;
+
+  return referenceTime + baseIntervalMs * Math.pow(NOTIFY_BACKOFF_BASE, missedCount);
+}
+
+export const GET = withAuth(getSession, 'livetalk:admin', async (session) => {
+  const userId = session.user.googleId;
+  const characterId = DEFAULT_CHARACTER_ID;
+  const now = new Date();
+
+  try {
+    const [lifecycle, notificationEvents, allMessages, knowledge, studyPending] =
+      await Promise.all([
+        getLifecycleRepository().get({ userId, characterId }),
+        getNotificationEventRepository().listByUser(userId, 10),
+        getMessageRepository().listSince(userId, characterId, 0),
+        getKnowledgeRepository().list(userId, characterId),
+        getStudyTopicRepository().listByStatus(userId, characterId, 'pending'),
+      ]);
+
+    const bedtime = lifecycle?.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME;
+    const wakeUpTime = lifecycle?.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME;
+    const state = resolveLifecycleState(now, bedtime, wakeUpTime);
+
+    const userMessages = allMessages.filter((m) => m.Role === 'user');
+
+    const lifecycleForDecision = lifecycle ?? {
+      UserID: userId,
+      CharacterID: characterId,
+      Bedtime: LIFECYCLE_DEFAULT_BEDTIME,
+      WakeUpTime: LIFECYCLE_DEFAULT_WAKE_UP_TIME,
+      CreatedAt: 0,
+      UpdatedAt: 0,
+    };
+
+    const notifyDecision = shouldNotifyNow({
+      userMessages,
+      lifecycle: lifecycleForDecision,
+      notificationEvents,
+      now,
+    });
+
+    let nextEarliestAt: number | undefined;
+    if (!notifyDecision.notify && notifyDecision.reason === 'not_due') {
+      nextEarliestAt = computeNextEarliestAt(userMessages, notificationEvents);
+    }
+
+    return NextResponse.json({
+      lifecycle: {
+        state,
+        bedtime,
+        wakeUpTime,
+        userActivityProfile: lifecycle?.UserActivityProfile ?? null,
+      },
+      recentNotifications: notificationEvents.slice(0, 5).map((e) => ({
+        notifId: e.NotifID,
+        kind: e.Kind,
+        title: e.Title,
+        body: e.Body.slice(0, 100),
+        createdAt: e.CreatedAt,
+        consumedAt: e.ConsumedAt ?? null,
+      })),
+      notifyDecision: {
+        ...notifyDecision,
+        ...(nextEarliestAt !== undefined ? { nextEarliestAt } : {}),
+      },
+      knowledgeCount: knowledge.length,
+      studyTopicPendingCount: studyPending.length,
+    });
+  } catch (error) {
+    console.error('[GET /api/status] ステータス情報の取得に失敗しました', error);
+    return NextResponse.json(
+      { error: 'FETCH_FAILED', message: STATUS_ERROR_MESSAGES.FETCH_FAILED },
+      { status: 500 }
+    );
+  }
+});

--- a/services/livetalk/web/src/app/api/status/route.ts
+++ b/services/livetalk/web/src/app/api/status/route.ts
@@ -73,14 +73,15 @@ export const GET = withAuth(getSession, 'livetalk:admin', async (session) => {
   const now = new Date();
 
   try {
-    const [lifecycle, notificationEvents, allMessages, knowledge, studyPending] =
-      await Promise.all([
+    const [lifecycle, notificationEvents, allMessages, knowledge, studyPending] = await Promise.all(
+      [
         getLifecycleRepository().get({ userId, characterId }),
         getNotificationEventRepository().listByUser(userId, 10),
         getMessageRepository().listSince(userId, characterId, 0),
         getKnowledgeRepository().list(userId, characterId),
         getStudyTopicRepository().listByStatus(userId, characterId, 'pending'),
-      ]);
+      ]
+    );
 
     const bedtime = lifecycle?.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME;
     const wakeUpTime = lifecycle?.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME;

--- a/services/livetalk/web/src/app/layout.tsx
+++ b/services/livetalk/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import { ServiceLayout, ServiceWorkerRegistration } from '@nagiyu/ui';
+import SessionProviderWrapper from '@/components/SessionProviderWrapper';
 import '@nagiyu/ui/tokens.css';
 
 export const metadata: Metadata = {
@@ -45,7 +46,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           }}
           footerProps={{ version }}
         >
-          {children}
+          <SessionProviderWrapper>{children}</SessionProviderWrapper>
         </ServiceLayout>
       </body>
     </html>

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { useSession } from 'next-auth/react';
 import { Box, Container, Stack } from '@mui/material';
 import { Link } from '@nagiyu/ui';
+import { hasPermission } from '@nagiyu/common';
 import ChatInput from '@/components/ChatInput';
 import LicenseFooter from '@/components/LicenseFooter';
 import ResponseDisplay from '@/components/ResponseDisplay';
@@ -63,6 +65,13 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
  *   （HTMLAudioElement の autoplay 制約を回避）
  */
 export default function HomePage() {
+  const { data: session } = useSession();
+  const isAdmin =
+    !!session?.user &&
+    'roles' in session.user &&
+    Array.isArray(session.user.roles) &&
+    hasPermission(session.user.roles, 'livetalk:admin');
+
   const [consentPhase, setConsentPhase] = useState<ConsentPhase>('checking');
   const [onboardingPhase, setOnboardingPhase] = useState<OnboardingPhase>(null);
   const [onboardingText, setOnboardingText] = useState<string | null>(null);
@@ -411,6 +420,7 @@ export default function HomePage() {
           <Box sx={{ textAlign: 'center', display: 'flex', justifyContent: 'center', gap: 2 }}>
             <Link href="/memory">私が覚えていること</Link>
             <Link href="/notes">ノート</Link>
+            {isAdmin && <Link href="/status">ステータス</Link>}
           </Box>
           <NotificationToggle />
         </Stack>

--- a/services/livetalk/web/src/components/SessionProviderWrapper.tsx
+++ b/services/livetalk/web/src/components/SessionProviderWrapper.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+
+export default function SessionProviderWrapper({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/services/livetalk/web/tests/unit/app/api/status/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/status/route.test.ts
@@ -81,32 +81,32 @@ const makeLifecycleRepo = () =>
       CreatedAt: 0,
       UpdatedAt: 0,
     })),
-  } as unknown as LifecycleRepository);
+  }) as unknown as LifecycleRepository;
 
 const makeEmptyLifecycleRepo = () =>
   ({
     get: jest.fn(async () => null),
-  } as unknown as LifecycleRepository);
+  }) as unknown as LifecycleRepository;
 
 const makeNotifEventRepo = () =>
   ({
     listByUser: jest.fn(async () => []),
-  } as unknown as NotificationEventRepository);
+  }) as unknown as NotificationEventRepository;
 
 const makeKnowledgeRepo = (count = 0) =>
   ({
     list: jest.fn(async () => Array(count).fill({ KnowledgeID: 'k1' })),
-  } as unknown as KnowledgeRepository);
+  }) as unknown as KnowledgeRepository;
 
 const makeStudyTopicRepo = (pendingCount = 0) =>
   ({
     listByStatus: jest.fn(async () => Array(pendingCount).fill({ TopicID: 't1' })),
-  } as unknown as StudyTopicRepository);
+  }) as unknown as StudyTopicRepository;
 
 const makeMessageRepo = () =>
   ({
     listSince: jest.fn(async () => []),
-  } as unknown as MessageRepository);
+  }) as unknown as MessageRepository;
 
 const buildGetRequest = () => new Request('http://localhost/api/status', { method: 'GET' });
 

--- a/services/livetalk/web/tests/unit/app/api/status/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/status/route.test.ts
@@ -71,7 +71,7 @@ const adminSession = {
   expires: new Date(Date.now() + 60 * 1000).toISOString(),
 };
 
-const makeLifecycleRepo = (entity: Parameters<LifecycleRepository['get']>[0] extends infer K ? K : never) =>
+const makeLifecycleRepo = () =>
   ({
     get: jest.fn(async () => ({
       UserID: 'g1',
@@ -111,7 +111,7 @@ const makeMessageRepo = () =>
 const buildGetRequest = () => new Request('http://localhost/api/status', { method: 'GET' });
 
 function setupDefaultMocks() {
-  mockGetLifecycleRepo.mockReturnValue(makeLifecycleRepo({}));
+  mockGetLifecycleRepo.mockReturnValue(makeLifecycleRepo());
   mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
   mockGetKnowledgeRepo.mockReturnValue(makeKnowledgeRepo(3));
   mockGetStudyTopicRepo.mockReturnValue(makeStudyTopicRepo(1));
@@ -202,7 +202,7 @@ describe('GET /api/status', () => {
 
   it('通知履歴は最大 5 件・body は 100 文字で切り詰める', async () => {
     mockGetSession.mockResolvedValueOnce(adminSession);
-    mockGetLifecycleRepo.mockReturnValue(makeLifecycleRepo({}));
+    mockGetLifecycleRepo.mockReturnValue(makeLifecycleRepo());
 
     const longBody = 'a'.repeat(200);
     const events = Array.from({ length: 7 }, (_, i) => ({

--- a/services/livetalk/web/tests/unit/app/api/status/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/status/route.test.ts
@@ -1,0 +1,268 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/status/route';
+import { getSession } from '@/lib/server/session';
+import {
+  getLifecycleRepository,
+  getNotificationEventRepository,
+  getKnowledgeRepository,
+  getStudyTopicRepository,
+  getMessageRepository,
+} from '@/lib/server/repositories';
+import type {
+  LifecycleRepository,
+  NotificationEventRepository,
+  KnowledgeRepository,
+  StudyTopicRepository,
+  MessageRepository,
+} from '@nagiyu/livetalk-core';
+
+jest.mock('@/lib/server/session', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@/lib/server/repositories', () => ({
+  getLifecycleRepository: jest.fn(),
+  getNotificationEventRepository: jest.fn(),
+  getKnowledgeRepository: jest.fn(),
+  getStudyTopicRepository: jest.fn(),
+  getMessageRepository: jest.fn(),
+}));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetLifecycleRepo = getLifecycleRepository as jest.MockedFunction<
+  typeof getLifecycleRepository
+>;
+const mockGetNotifEventRepo = getNotificationEventRepository as jest.MockedFunction<
+  typeof getNotificationEventRepository
+>;
+const mockGetKnowledgeRepo = getKnowledgeRepository as jest.MockedFunction<
+  typeof getKnowledgeRepository
+>;
+const mockGetStudyTopicRepo = getStudyTopicRepository as jest.MockedFunction<
+  typeof getStudyTopicRepository
+>;
+const mockGetMessageRepo = getMessageRepository as jest.MockedFunction<typeof getMessageRepository>;
+
+const livetalkUserSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'user@example.com',
+    name: 'User',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+const adminSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'admin@example.com',
+    name: 'Admin',
+    roles: ['livetalk-admin'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+const makeLifecycleRepo = (entity: Parameters<LifecycleRepository['get']>[0] extends infer K ? K : never) =>
+  ({
+    get: jest.fn(async () => ({
+      UserID: 'g1',
+      CharacterID: 'hiyori',
+      Bedtime: '01:30',
+      WakeUpTime: '09:30',
+      CreatedAt: 0,
+      UpdatedAt: 0,
+    })),
+  } as unknown as LifecycleRepository);
+
+const makeEmptyLifecycleRepo = () =>
+  ({
+    get: jest.fn(async () => null),
+  } as unknown as LifecycleRepository);
+
+const makeNotifEventRepo = () =>
+  ({
+    listByUser: jest.fn(async () => []),
+  } as unknown as NotificationEventRepository);
+
+const makeKnowledgeRepo = (count = 0) =>
+  ({
+    list: jest.fn(async () => Array(count).fill({ KnowledgeID: 'k1' })),
+  } as unknown as KnowledgeRepository);
+
+const makeStudyTopicRepo = (pendingCount = 0) =>
+  ({
+    listByStatus: jest.fn(async () => Array(pendingCount).fill({ TopicID: 't1' })),
+  } as unknown as StudyTopicRepository);
+
+const makeMessageRepo = () =>
+  ({
+    listSince: jest.fn(async () => []),
+  } as unknown as MessageRepository);
+
+const buildGetRequest = () => new Request('http://localhost/api/status', { method: 'GET' });
+
+function setupDefaultMocks() {
+  mockGetLifecycleRepo.mockReturnValue(makeLifecycleRepo({}));
+  mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
+  mockGetKnowledgeRepo.mockReturnValue(makeKnowledgeRepo(3));
+  mockGetStudyTopicRepo.mockReturnValue(makeStudyTopicRepo(1));
+  mockGetMessageRepo.mockReturnValue(makeMessageRepo());
+}
+
+describe('GET /api/status', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('未認証は 401', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('livetalk:admin 権限なし（livetalk-user のみ）は 403', async () => {
+    mockGetSession.mockResolvedValueOnce(livetalkUserSession);
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it('livetalk-admin 権限ありは 200 でステータスデータを返す', async () => {
+    mockGetSession.mockResolvedValueOnce(adminSession);
+    setupDefaultMocks();
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json).toHaveProperty('lifecycle');
+    expect(json).toHaveProperty('recentNotifications');
+    expect(json).toHaveProperty('notifyDecision');
+    expect(json).toHaveProperty('knowledgeCount');
+    expect(json).toHaveProperty('studyTopicPendingCount');
+  });
+
+  it('lifecycle が null の場合はデフォルト値でフォールバックする', async () => {
+    mockGetSession.mockResolvedValueOnce(adminSession);
+    mockGetLifecycleRepo.mockReturnValue(makeEmptyLifecycleRepo());
+    mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
+    mockGetKnowledgeRepo.mockReturnValue(makeKnowledgeRepo());
+    mockGetStudyTopicRepo.mockReturnValue(makeStudyTopicRepo());
+    mockGetMessageRepo.mockReturnValue(makeMessageRepo());
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.lifecycle.bedtime).toBe('01:30');
+    expect(json.lifecycle.wakeUpTime).toBe('09:30');
+    expect(json.lifecycle.userActivityProfile).toBeNull();
+  });
+
+  it('lifecycle.userActivityProfile が存在する場合は返却する', async () => {
+    const profile = {
+      morningPeak: '09:00',
+      eveningPeak: '21:00',
+      sampleSize: 10,
+      lastLearnedAt: '2026-06-01T00:00:00.000Z',
+    };
+    mockGetSession.mockResolvedValueOnce(adminSession);
+    mockGetLifecycleRepo.mockReturnValue({
+      get: jest.fn(async () => ({
+        UserID: 'g1',
+        CharacterID: 'hiyori',
+        Bedtime: '01:30',
+        WakeUpTime: '09:30',
+        UserActivityProfile: profile,
+        CreatedAt: 0,
+        UpdatedAt: 0,
+      })),
+    } as unknown as LifecycleRepository);
+    mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
+    mockGetKnowledgeRepo.mockReturnValue(makeKnowledgeRepo(5));
+    mockGetStudyTopicRepo.mockReturnValue(makeStudyTopicRepo(2));
+    mockGetMessageRepo.mockReturnValue(makeMessageRepo());
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.lifecycle.userActivityProfile).toEqual(profile);
+    expect(json.knowledgeCount).toBe(5);
+    expect(json.studyTopicPendingCount).toBe(2);
+  });
+
+  it('通知履歴は最大 5 件・body は 100 文字で切り詰める', async () => {
+    mockGetSession.mockResolvedValueOnce(adminSession);
+    mockGetLifecycleRepo.mockReturnValue(makeLifecycleRepo({}));
+
+    const longBody = 'a'.repeat(200);
+    const events = Array.from({ length: 7 }, (_, i) => ({
+      UserID: 'g1',
+      NotifID: `notif-${i}`,
+      Kind: 'normal' as const,
+      Title: 'タイトル',
+      Body: longBody,
+      CreatedAt: 1000 * (i + 1),
+      Ttl: 9999999,
+    }));
+    mockGetNotifEventRepo.mockReturnValue({
+      listByUser: jest.fn(async () => events),
+    } as unknown as NotificationEventRepository);
+    mockGetKnowledgeRepo.mockReturnValue(makeKnowledgeRepo());
+    mockGetStudyTopicRepo.mockReturnValue(makeStudyTopicRepo());
+    mockGetMessageRepo.mockReturnValue(makeMessageRepo());
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.recentNotifications).toHaveLength(5);
+    expect(json.recentNotifications[0].body).toHaveLength(100);
+  });
+
+  it('notifyDecision に notify と reason/toneBucket が含まれる', async () => {
+    mockGetSession.mockResolvedValueOnce(adminSession);
+    setupDefaultMocks();
+
+    const res = await GET(buildGetRequest());
+    const json = await res.json();
+
+    expect(json.notifyDecision).toHaveProperty('notify');
+    // notify=true (normal) or notify=false (reason) どちらかの構造
+    if (json.notifyDecision.notify) {
+      expect(json.notifyDecision).toHaveProperty('kind');
+    } else {
+      expect(json.notifyDecision).toHaveProperty('reason');
+    }
+  });
+
+  it('リポジトリエラーは 500 を返す', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetSession.mockResolvedValueOnce(adminSession);
+    mockGetLifecycleRepo.mockReturnValue({
+      get: jest.fn(async () => {
+        throw new Error('DynamoDB エラー');
+      }),
+    } as unknown as LifecycleRepository);
+    mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
+    mockGetKnowledgeRepo.mockReturnValue(makeKnowledgeRepo());
+    mockGetStudyTopicRepo.mockReturnValue(makeStudyTopicRepo());
+    mockGetMessageRepo.mockReturnValue(makeMessageRepo());
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(500);
+
+    const json = await res.json();
+    expect(json.error).toBe('FETCH_FAILED');
+    consoleSpy.mockRestore();
+  });
+});

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -69,6 +69,13 @@ jest.mock('@/components/NotificationPermission', () => ({
   default: jest.fn(() => null),
 }));
 
+// next-auth/react は ESM のため jest が transform できない。
+// HomePage は useSession で livetalk:admin 判定のみに使うため、未認証扱いでスタブ化する。
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(() => ({ data: null, status: 'unauthenticated' })),
+  SessionProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 // オンボーディング判定がチャットテストに干渉しないようにスタブ化する
 jest.mock('@/lib/pwa/standalone', () => ({
   isStandalone: jest.fn().mockReturnValue(false),


### PR DESCRIPTION
## 変更の概要

Issue #3363 の実装。リブトーク運用・検証時に「通知が来ない理由（正常 / 異常）」を外部から一目で判別できるよう、`livetalk:admin` 権限と `/status` デバッグパネルを追加する。

**主な変更:**
- `libs/common` — `Permission` union に `livetalk:admin` 追加、`livetalk-admin` role 新設
- `GET /api/status` — livetalk:admin 限定の集約 API（lifecycle / 通知判定 / 履歴 / コンテンツ件数）
- `/status` ページ — Server Component、L3 生データ表示
- チャット画面ナビ — `useSession` + `hasPermission` で管理者限定の「ステータス」リンクを表示（stock-tracker パターン踏襲）
- `SessionProviderWrapper` — layout に追加し `useSession` を使用可能に

**スコープ外（明示）:**
- chat metrics（promptTokens / latencyMs）は DynamoDB 未永続のため本 Issue では省略。必要なら別 Issue で CloudWatch Logs Insights 連携を追加する。
- 運用者（自分）への `livetalk-admin` role 付与は auth サービス DB への ops 作業（このPRの外）。

## 関連 Issue

<!-- integration → develop の PR でないため Closes # は使用しない -->
関連: #3363（親: #3182）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（libs/common auth テスト更新、`/api/status` ユニットテスト追加）
- [ ] ローカルでテストが全て通ることを確認した（環境に node_modules 未インストールのため CI で確認）
- [ ] ビルドエラーがないことを確認した（CI で確認）

## テスト内容

- `libs/common/tests/unit/auth/roles.test.ts` — `livetalk-admin` role の構造・権限テスト追加。`livetalk:chat` 付与範囲の修正（livetalk-admin も保持）
- `libs/common/tests/unit/auth/permissions.test.ts` — `livetalk-admin` role / `livetalk:admin` permission のテスト追加
- `services/livetalk/web/tests/unit/app/api/status/route.test.ts` — 新規。401 / 403 / 200 / lifecycle null フォールバック / 通知履歴切り詰め / リポジトリエラー 500 のテストケース

## レビューポイント

- **`livetalk-admin` role の権限構成**（`['livetalk:chat', 'livetalk:admin']`）: middleware が全パスに `livetalk:chat` を要求するため両方持たせた。`livetalk:chat` 単体の一般ユーザーが `/status` に直接アクセスしても `withAuth(... 'livetalk:admin' ...)` で 403 を返す。
- **`SessionProviderWrapper` の挿入位置**: `<ServiceLayout>` の children を包む形で挿入。stock-tracker が `ThemeRegistry` で同様のパターンを採用している（`components/ThemeRegistry.tsx` 参照）。
- **`nextEarliestAt` の算出**: `shouldNotifyNow()` 内部ロジックを再現。活動時間帯・睡眠帯は考慮しないため「インターバル条件のみの最早時刻」として表示（UI にも注記あり）。
- **chat metrics のスコープ外化**: Issue 本文の「best-effort」方針に基づき、セッション中のユーザーとの合意のもとで省略。PR 説明に明記。

## ops 手順（PR マージ後）

運用者（自分）の auth サービス DynamoDB 上のロール設定に `livetalk-admin` を追加すること。既存の `livetalk-user` ロールとの組み合わせか、`livetalk-admin` 単体のどちらでも可（両ロールとも `livetalk:chat` を持つ）。

## 補足事項

- ナビ導線の権限判定: 「クライアント side の API プローブ」案を採用せず、`useSession()` + `hasPermission()` の既存パターン（stock-tracker 実績あり）を採用した

https://claude.ai/code/session_01NKr1dou6eq7YHmN9F4FQRH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKr1dou6eq7YHmN9F4FQRH)_