### PR TITLE
[リブトーク] フッターのライセンス表記をコンパクト化（モバイル見切れ対策）

### DIFF
--- a/libs/ui/src/components/layout/Footer.tsx
+++ b/libs/ui/src/components/layout/Footer.tsx
@@ -50,7 +50,10 @@ export default function Footer({
       <Box
         component="footer"
         sx={{
-          py: 3,
+          // licenseText がある場合（リブトーク等）はクレジット行ぶん縦に伸びるため、
+          // 上下 padding を詰めてモバイルでの見切れを抑える。
+          // licenseText 未指定の既存サービスは従来どおり py: 3 を維持する。
+          py: licenseText ? 1.5 : 3,
           px: 2,
           mt: 'auto',
           backgroundColor: (theme) => theme.palette.grey[200],
@@ -101,7 +104,14 @@ export default function Footer({
               variant="caption"
               color="text.secondary"
               align="center"
-              sx={{ display: 'block', mt: 0.5 }}
+              sx={{
+                display: 'block',
+                mt: 0.5,
+                // 長いクレジット表記がモバイル幅で折り返しても収まるよう、
+                // フォントと行間を詰めてコンパクトに表示する。
+                fontSize: '0.7rem',
+                lineHeight: 1.4,
+              }}
             >
               {licenseText}
             </Typography>

--- a/libs/ui/tests/unit/components/layout/Footer.test.tsx
+++ b/libs/ui/tests/unit/components/layout/Footer.test.tsx
@@ -214,6 +214,22 @@ describe('Footer', () => {
 
       expect(screen.getByTestId('license-node')).toBeInTheDocument();
     });
+
+    it('licenseTextがある場合はフッターのpaddingが詰められる', () => {
+      const { container } = render(<Footer licenseText="ライセンス" />);
+
+      const footer = container.querySelector('footer');
+      // py: 1.5 → 12px（theme spacing 8px * 1.5）
+      expect(footer).toHaveStyle({ paddingTop: '12px', paddingBottom: '12px' });
+    });
+
+    it('licenseTextが省略された場合はフッターのpaddingが従来どおり', () => {
+      const { container } = render(<Footer />);
+
+      const footer = container.querySelector('footer');
+      // py: 3 → 24px（theme spacing 8px * 3）
+      expect(footer).toHaveStyle({ paddingTop: '24px', paddingBottom: '24px' });
+    });
   });
 
   describe('termsContent / privacyContent props', () => {


### PR DESCRIPTION
## 変更の概要

#3362（フッター統合 / PR #3364）の追従。モバイル幅でライセンスクレジット（`VOICEVOX:冥鳴ひまり / Live2D キャラクター: 桃瀬ひより ©2010 Live2D Inc.`）が折り返し、画面下端で `©2010 Live2D Inc.` が見切れてスクロールしないと全文が見えない問題を緩和する。

実機スクリーンショットで、ライセンス行がフッターの大きな上下 padding（`py: 3`）とフォントサイズにより縦に伸び、ビューポート下端で見切れていることを確認した。

## 関連 Issue

関連: #3362（フッター統合の UX 追従）

## 変更種別

- [ ] 新規機能
- [x] バグ修正（UX 改善）
- [ ] リファクタリング
- [ ] その他

## 変更内容

`libs/ui/src/components/layout/Footer.tsx`:

- `licenseText` がある場合のみフッターの上下 padding を `py: 3`（24px）→ `py: 1.5`（12px）に縮小
- ライセンス行のフォントを `0.7rem`・行間 `1.4` に詰めてコンパクト化
- **`licenseText` 未指定の既存サービス（Portal 等）は従来どおり `py: 3` を維持** → 非破壊互換

## テスト内容

- `licenseText` がある場合に padding が 12px に縮小されること
- `licenseText` 省略時は padding が 24px（従来どおり）であること
- libs/ui: 332 テスト全パス、カバレッジ閾値通過

## レビューポイント

1. **スコープ**: padding 縮小・フォント縮小は `licenseText` が渡された場合のみ適用。他サービスのフッター表示は一切変わらない。
2. **法的要件**: ライセンスはフッター本体に常時 DOM 描画される点は維持（統合前と同じ常時表示要件を充足）。本変更は見切れの緩和のみ。
3. 補足: ページ全体の高さは Live2D アバター + 入力欄が支配的なため、モバイルでフッターがファーストビュー外になること自体は残るが、見切れ（クレジットの途中切れ）は解消される想定。

## 補足事項

dev 環境デプロイ後の実機確認をお願いします。

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4AwLtPfLNdVyvW6mmzWCW)_