### PR TITLE
[Bug] [リブトーク] /status 導線ボタンが表示されない不具合の修正（NextAuth ルートハンドラ追加）

### DIFF
--- a/services/livetalk/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/services/livetalk/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,36 @@
+import { handlers } from '@/auth';
+import { NextRequest } from 'next/server';
+
+/**
+ * NextAuth のルートハンドラ（`/api/auth/*`）。
+ *
+ * クライアント側の `useSession()`（next-auth/react）は `/api/auth/session` を
+ * fetch してセッションを取得する。このハンドラが無いと session が取得できず、
+ * 権限ベースの UI 出し分け（例: ステータスページへの導線）が機能しない。
+ *
+ * OAuth プロバイダーは Auth サービス側で管理するため、ここでは JWT 検証のみを
+ * 担う（`auth.ts` の `providers: []`）。
+ *
+ * `SKIP_AUTH_CHECK=true`（dev / E2E）では `/api/auth/session` に対して
+ * テスト用セッションを返し、サーバー側の `getSession()`（session.ts）と
+ * ロールの見え方を一致させる。
+ */
+async function GET(req: NextRequest) {
+  if (process.env.SKIP_AUTH_CHECK === 'true' && req.nextUrl.pathname === '/api/auth/session') {
+    return Response.json({
+      user: {
+        name: 'Test User',
+        email: process.env.TEST_USER_EMAIL || 'test@example.com',
+        image: null,
+        roles: process.env.TEST_USER_ROLES?.split(',').map((role) => role.trim()) || [
+          'livetalk-user',
+        ],
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+  }
+  return handlers.GET(req);
+}
+
+export { GET };
+export const POST = handlers.POST;


### PR DESCRIPTION
## 変更の概要

#3363 で追加した「ステータス」導線ボタンが `livetalk:admin` 保持者にも表示されない不具合（#3367）を修正する。

`/status` ページには遷移できる（サーバー側 `getSession()` は JWT cookie を直接検証）のに、ナビボタンが出ない（クライアント `useSession()` がセッションを取得できない）という不一致が起きていた。

**原因:** livetalk web に NextAuth のルートハンドラ `src/app/api/auth/[...nextauth]/route.ts` が無く、`useSession()` が叩く `/api/auth/session` が応答しないため、クライアントのセッションが常に `null` → `isAdmin` が false → ボタン非表示。

**修正:** stock-tracker と同形のルートハンドラを追加。これで `/api/auth/session` が応答し、`useSession()` が roles を含むセッションを取得できるようになる。

## 関連 Issue

関連: #3367（親: #3182 / 元実装: #3363）

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] 既存パターン（stock-tracker）を踏襲した
- [ ] ローカルでテストが全て通ることを確認した（環境に node_modules 未インストールのため CI で確認）

## テスト内容

- ルートハンドラは薄いラッパーで、既存サービス（stock-tracker / auth）でも同様にユニットテスト対象外（カバレッジ対象は `src/lib/**` のみ）。慣習に従いテストは追加していない。
- 動作確認は dev 環境で実施想定：`livetalk:admin` 保持者のチャット画面に「ステータス」ボタンが表示されること、権限なしでは非表示であること。

## レビューポイント

- **middleware の matcher** は `/api` を除外済みのため、追加した `/api/auth/[...nextauth]` は権限ガードを受けず到達可能。
- **SKIP_AUTH_CHECK 時の既定ロール**は `session.ts` の `getSession()` と一致させるため `['livetalk-user']` とした（stock-tracker は `['stock-user']`）。
- これは #3363 移植時の漏れ（stock-tracker には存在するルートが livetalk に無かった）を補う修正。

## 補足事項

#3363 の PR はマージ済みのため、本修正は別ブランチ・別 PR として `integration/3182-livetalk` 宛に作成。

https://claude.ai/code/session_01NKr1dou6eq7YHmN9F4FQRH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKr1dou6eq7YHmN9F4FQRH)_