### PR TITLE
feat(livetalk): クライアントエラーのサーバ集約基盤（#3369）

### DIFF
--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -13,6 +13,7 @@ import {
   getDynamoDBTableArn,
   getDynamoDBTableName,
   getEcrRepositoryName,
+  grantErrorEventsWrite,
 } from '@nagiyu/infra-common';
 
 export interface LiveTalkEcsServiceStackProps extends cdk.StackProps {
@@ -273,6 +274,8 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
         // VAPID キー（Phase 5d / #3346）。Web Push subscribe / vapid-public-key route が参照する。
         VAPID_PUBLIC_KEY: vapidPublicKey,
         VAPID_PRIVATE_KEY: vapidPrivateKey,
+        // エラーイベント登録テーブル（Phase 5f / Issue #3369）
+        ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
       },
       portMappings: [
         {
@@ -307,6 +310,9 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     // ECS Task が DynamoDB Single Table を読み書きできるよう IAM 権限を付与する。
     // PITR や Backup 系の操作は不要、Read/Write のみで十分。
     dynamoTable.grantReadWriteData(taskRole);
+
+    // エラーイベント書き込み権限（Phase 5f / Issue #3369）。batch と同じ設定。
+    grantErrorEventsWrite(this, taskRole, environment);
 
     // ALB ターゲットには明示的に livetalk-web:3000 を指定する。
     // attachToApplicationTargetGroup() の暗黙的なデフォルトは「最初に addContainer された

--- a/services/livetalk/web/src/app/api/client-log/constants.ts
+++ b/services/livetalk/web/src/app/api/client-log/constants.ts
@@ -1,0 +1,8 @@
+export const CLIENT_LOG_ERROR_MESSAGES = {
+  INVALID_REQUEST: 'リクエスト形式が不正です',
+  INTERNAL_ERROR: '内部エラーが発生しました',
+} as const;
+
+export const CLIENT_LOG_ALLOWED_SEVERITIES = ['warning', 'error', 'critical'] as const;
+export const CLIENT_LOG_MAX_TITLE_LENGTH = 200;
+export const CLIENT_LOG_MAX_MESSAGE_LENGTH = 1000;

--- a/services/livetalk/web/src/app/api/client-log/route.ts
+++ b/services/livetalk/web/src/app/api/client-log/route.ts
@@ -44,7 +44,8 @@ function isValidBody(body: unknown): body is ClientLogRequest {
     typeof b.message === 'string' &&
     b.message.length > 0 &&
     b.message.length <= CLIENT_LOG_MAX_MESSAGE_LENGTH &&
-    (b.context === undefined || (typeof b.context === 'object' && b.context !== null && !Array.isArray(b.context))) &&
+    (b.context === undefined ||
+      (typeof b.context === 'object' && b.context !== null && !Array.isArray(b.context))) &&
     (b.occurredAt === undefined || typeof b.occurredAt === 'string')
   );
 }

--- a/services/livetalk/web/src/app/api/client-log/route.ts
+++ b/services/livetalk/web/src/app/api/client-log/route.ts
@@ -1,0 +1,83 @@
+/**
+ * POST /api/client-log
+ *
+ * クライアントで捕捉したエラーを受け取り、reportErrorEvent 経由で DynamoDB に登録する。
+ * 認証済みユーザーのみ受け付ける（全ユーザー対象、未認証は弾く）。
+ */
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import { reportErrorEvent } from '@nagiyu/aws';
+import { getSession } from '@/lib/server/session';
+import {
+  CLIENT_LOG_ALLOWED_SEVERITIES,
+  CLIENT_LOG_ERROR_MESSAGES,
+  CLIENT_LOG_MAX_MESSAGE_LENGTH,
+  CLIENT_LOG_MAX_TITLE_LENGTH,
+} from './constants';
+
+type AllowedSeverity = (typeof CLIENT_LOG_ALLOWED_SEVERITIES)[number];
+
+interface ClientLogRequest {
+  severity: AllowedSeverity;
+  title: string;
+  message: string;
+  context?: Record<string, unknown>;
+  occurredAt?: string;
+}
+
+function isAllowedSeverity(value: unknown): value is AllowedSeverity {
+  return (
+    typeof value === 'string' &&
+    (CLIENT_LOG_ALLOWED_SEVERITIES as readonly string[]).includes(value)
+  );
+}
+
+function isValidBody(body: unknown): body is ClientLogRequest {
+  if (!body || typeof body !== 'object') return false;
+  const b = body as Record<string, unknown>;
+  return (
+    isAllowedSeverity(b.severity) &&
+    typeof b.title === 'string' &&
+    b.title.length > 0 &&
+    b.title.length <= CLIENT_LOG_MAX_TITLE_LENGTH &&
+    typeof b.message === 'string' &&
+    b.message.length > 0 &&
+    b.message.length <= CLIENT_LOG_MAX_MESSAGE_LENGTH &&
+    (b.context === undefined || (typeof b.context === 'object' && b.context !== null && !Array.isArray(b.context))) &&
+    (b.occurredAt === undefined || typeof b.occurredAt === 'string')
+  );
+}
+
+export const POST = withAuth(getSession, 'livetalk:chat', async (session, request: NextRequest) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'INVALID_REQUEST', message: CLIENT_LOG_ERROR_MESSAGES.INVALID_REQUEST },
+      { status: 400 }
+    );
+  }
+
+  if (!isValidBody(body)) {
+    return NextResponse.json(
+      { error: 'INVALID_REQUEST', message: CLIENT_LOG_ERROR_MESSAGES.INVALID_REQUEST },
+      { status: 400 }
+    );
+  }
+
+  await reportErrorEvent({
+    serviceId: 'livetalk',
+    severity: body.severity,
+    title: body.title,
+    message: body.message,
+    context: {
+      userId: session.user.googleId,
+      ...(body.context ?? {}),
+    },
+    occurredAt: body.occurredAt,
+  });
+
+  return new NextResponse(null, { status: 204 });
+});

--- a/services/livetalk/web/src/app/layout.tsx
+++ b/services/livetalk/web/src/app/layout.tsx
@@ -55,7 +55,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           }}
         >
           <ClientErrorReporter />
-        <SessionProviderWrapper>{children}</SessionProviderWrapper>
+          <SessionProviderWrapper>{children}</SessionProviderWrapper>
         </ServiceLayout>
       </body>
     </html>

--- a/services/livetalk/web/src/app/layout.tsx
+++ b/services/livetalk/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import { ServiceLayout, ServiceWorkerRegistration } from '@nagiyu/ui';
 import SessionProviderWrapper from '@/components/SessionProviderWrapper';
+import ClientErrorReporter from '@/components/ClientErrorReporter';
 import '@nagiyu/ui/tokens.css';
 import { liveTalkTermsSections, LIVETALK_LICENSE_TEXT } from '@/lib/legal/terms-data';
 import { liveTalkPrivacySections } from '@/lib/legal/privacy-data';
@@ -53,7 +54,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             licenseText: LIVETALK_LICENSE_TEXT,
           }}
         >
-          <SessionProviderWrapper>{children}</SessionProviderWrapper>
+          <ClientErrorReporter />
+        <SessionProviderWrapper>{children}</SessionProviderWrapper>
         </ServiceLayout>
       </body>
     </html>

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -22,6 +22,7 @@ import {
   shouldShowNotificationPermission,
 } from '@/lib/pwa/standalone';
 import { PWA_MESSAGES } from '@/lib/pwa/messages';
+import { reportClientError } from '@/lib/client-logger';
 
 const Live2DCanvas = dynamic(() => import('@/components/Live2DCanvas'), {
   ssr: false,
@@ -93,6 +94,7 @@ export default function HomePage() {
   const isPlayingRef = useRef(false);
   const streamDoneRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const sentenceReceivedRef = useRef(0);
   // AudioContext は子コンポーネント（Live2DCanvas）に prop で渡すため state で持つ。
   // 同期アクセス用に ref も併用する（callback 内で最新値を読むため）。
   const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
@@ -245,6 +247,7 @@ export default function HomePage() {
       setPhase('loading');
       setAudioBuffer(null);
       clearAudioQueue();
+      sentenceReceivedRef.current = 0;
 
       try {
         const chatBody: { text: string; knowledgeId?: string } = { text };
@@ -260,6 +263,10 @@ export default function HomePage() {
         if (!response.ok || !response.body) {
           setErrorMessage('応答の取得に失敗しました。時間を置いて再度お試しください。');
           setPhase('idle');
+          reportClientError('error', 'チャット fetch 失敗', `HTTP ${response.status}`, {
+            screen: 'chat',
+            audioContextState: audioCtxRef.current?.state,
+          });
           return;
         }
 
@@ -273,6 +280,7 @@ export default function HomePage() {
           if (event.type === 'text') {
             setResponseText((prev) => (prev ?? '') + event.delta);
           } else if (event.type === 'sentence' && event.audio) {
+            sentenceReceivedRef.current++;
             if (!audioCtx) {
               // AudioContext が無いブラウザ（極めて稀）: 音声をスキップしてテキストだけ表示
               return;
@@ -284,6 +292,16 @@ export default function HomePage() {
               advanceAudioQueue();
             } catch (err) {
               console.error('[LiveTalk] 音声 decode に失敗しました', err);
+              reportClientError(
+                'warning',
+                '音声 decode 失敗',
+                err instanceof Error ? err.message : '不明なエラー',
+                {
+                  screen: 'chat',
+                  audioContextState: audioCtxRef.current?.state,
+                  sentenceReceived: sentenceReceivedRef.current,
+                }
+              );
             }
           } else if (event.type === 'lifecycle') {
             setLifecycleState(event.state);
@@ -300,6 +318,17 @@ export default function HomePage() {
             setErrorMessage(event.message ?? '内部エラーが発生しました。');
             streamDoneRef.current = true;
             advanceAudioQueue();
+            reportClientError(
+              'error',
+              'チャット stream エラー',
+              event.message ?? '内部エラーが発生しました',
+              {
+                screen: 'chat',
+                audioContextState: audioCtxRef.current?.state,
+                sentenceReceived: sentenceReceivedRef.current,
+                streamDone: streamDoneRef.current,
+              }
+            );
           }
         };
 
@@ -335,6 +364,17 @@ export default function HomePage() {
         console.error('[LiveTalk] チャット応答の取得に失敗しました', error);
         setErrorMessage('エラーが発生しました。時間を置いて再度お試しください。');
         setPhase('idle');
+        reportClientError(
+          'error',
+          'チャット通信エラー',
+          error instanceof Error ? error.message : '不明なエラー',
+          {
+            screen: 'chat',
+            audioContextState: audioCtxRef.current?.state,
+            sentenceReceived: sentenceReceivedRef.current,
+            stack: error instanceof Error ? error.stack : undefined,
+          }
+        );
       }
     },
     [ensureAudioContextUnlocked, clearAudioQueue, advanceAudioQueue]
@@ -353,6 +393,11 @@ export default function HomePage() {
       setAudioBuffer(null);
       isPlayingRef.current = false;
       advanceAudioQueue();
+      reportClientError('warning', '音声再生エラー', error.message, {
+        screen: 'chat',
+        audioContextState: audioCtxRef.current?.state,
+        sentenceReceived: sentenceReceivedRef.current,
+      });
     },
     [advanceAudioQueue]
   );

--- a/services/livetalk/web/src/components/ClientErrorReporter.tsx
+++ b/services/livetalk/web/src/components/ClientErrorReporter.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { reportClientError } from '@/lib/client-logger';
+
+export default function ClientErrorReporter() {
+  useEffect(() => {
+    function handleError(event: ErrorEvent) {
+      reportClientError('error', '未捕捉例外', event.message || '不明なエラー', {
+        screen: 'global',
+        stack: event.error instanceof Error ? event.error.stack : undefined,
+        filename: event.filename,
+        lineno: event.lineno,
+      });
+    }
+
+    function handleUnhandledRejection(event: PromiseRejectionEvent) {
+      const message =
+        event.reason instanceof Error
+          ? event.reason.message
+          : String(event.reason ?? '不明な Promise rejection');
+
+      reportClientError('error', '未処理の Promise rejection', message, {
+        screen: 'global',
+        stack: event.reason instanceof Error ? event.reason.stack : undefined,
+      });
+    }
+
+    window.addEventListener('error', handleError);
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+
+    return () => {
+      window.removeEventListener('error', handleError);
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/services/livetalk/web/src/lib/client-logger.ts
+++ b/services/livetalk/web/src/lib/client-logger.ts
@@ -1,0 +1,56 @@
+import type { ErrorSeverity } from '@nagiyu/common';
+
+export type ClientSeverity = Extract<ErrorSeverity, 'warning' | 'error' | 'critical'>;
+
+export interface ClientErrorContext {
+  screen?: string;
+  audioContextState?: string;
+  sentenceReceived?: number;
+  streamDone?: boolean;
+  stack?: string;
+  filename?: string;
+  lineno?: number;
+  [key: string]: unknown;
+}
+
+function collectBaseContext(): Record<string, unknown> {
+  /* istanbul ignore next */
+  if (typeof window === 'undefined') return {};
+
+  const standalone =
+    (typeof window.matchMedia === 'function' &&
+      window.matchMedia('(display-mode: standalone)').matches) ||
+    (window.navigator as { standalone?: boolean }).standalone === true;
+
+  return {
+    userAgent: window.navigator.userAgent,
+    standalone,
+  };
+}
+
+export function reportClientError(
+  severity: ClientSeverity,
+  title: string,
+  message: string,
+  context?: ClientErrorContext
+): void {
+  /* istanbul ignore next */
+  if (typeof window === 'undefined') return;
+
+  const payload = {
+    severity,
+    title,
+    message,
+    context: {
+      ...collectBaseContext(),
+      ...context,
+    },
+    occurredAt: new Date().toISOString(),
+  };
+
+  fetch('/api/client-log', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).catch(() => {});
+}

--- a/services/livetalk/web/tests/unit/app/api/client-log/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/client-log/route.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from '@/app/api/client-log/route';
+import { CLIENT_LOG_ERROR_MESSAGES } from '@/app/api/client-log/constants';
+import { getSession } from '@/lib/server/session';
+import { reportErrorEvent } from '@nagiyu/aws';
+
+jest.mock('@/lib/server/session', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockReportErrorEvent = reportErrorEvent as jest.MockedFunction<typeof reportErrorEvent>;
+
+const validSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'u@example.com',
+    name: 'U',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+function buildRequest(body: unknown): Request {
+  return new Request('http://localhost/api/client-log', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/client-log', () => {
+  it('未認証は 401', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await POST(buildRequest({ severity: 'error', title: 'T', message: 'M' }));
+    expect(res.status).toBe(401);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('JSON でない body は 400', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(buildRequest('invalid-json'));
+    expect(res.status).toBe(400);
+    const json = await res.json() as Record<string, string>;
+    expect(json.message).toBe(CLIENT_LOG_ERROR_MESSAGES.INVALID_REQUEST);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('severity が info のとき 400（クライアントから info は受け付けない）', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(buildRequest({ severity: 'info', title: 'T', message: 'M' }));
+    expect(res.status).toBe(400);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('severity が不正な文字列のとき 400', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(buildRequest({ severity: 'debug', title: 'T', message: 'M' }));
+    expect(res.status).toBe(400);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('title が空文字のとき 400', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(buildRequest({ severity: 'error', title: '', message: 'M' }));
+    expect(res.status).toBe(400);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('title が長すぎるとき 400', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(
+      buildRequest({ severity: 'error', title: 'a'.repeat(201), message: 'M' })
+    );
+    expect(res.status).toBe(400);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('message が空文字のとき 400', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(buildRequest({ severity: 'error', title: 'T', message: '' }));
+    expect(res.status).toBe(400);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('message が長すぎるとき 400', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(
+      buildRequest({ severity: 'error', title: 'T', message: 'a'.repeat(1001) })
+    );
+    expect(res.status).toBe(400);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('context が配列のとき 400', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(
+      buildRequest({ severity: 'error', title: 'T', message: 'M', context: [1, 2] })
+    );
+    expect(res.status).toBe(400);
+    expect(mockReportErrorEvent).not.toHaveBeenCalled();
+  });
+
+  it('severity: warning で正常に 204 を返し reportErrorEvent を呼ぶ', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(buildRequest({ severity: 'warning', title: 'T', message: 'M' }));
+    expect(res.status).toBe(204);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'livetalk',
+        severity: 'warning',
+        title: 'T',
+        message: 'M',
+        context: expect.objectContaining({ userId: 'g1' }),
+      })
+    );
+  });
+
+  it('severity: error で 204', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(buildRequest({ severity: 'error', title: 'T', message: 'M' }));
+    expect(res.status).toBe(204);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error' })
+    );
+  });
+
+  it('severity: critical で 204', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(buildRequest({ severity: 'critical', title: 'T', message: 'M' }));
+    expect(res.status).toBe(204);
+  });
+
+  it('context が渡されたとき userId と一緒に reportErrorEvent に渡される', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const res = await POST(
+      buildRequest({
+        severity: 'error',
+        title: 'T',
+        message: 'M',
+        context: { screen: 'chat', audioContextState: 'suspended' },
+      })
+    );
+    expect(res.status).toBe(204);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: {
+          userId: 'g1',
+          screen: 'chat',
+          audioContextState: 'suspended',
+        },
+      })
+    );
+  });
+
+  it('occurredAt が渡されたとき reportErrorEvent に渡される', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const occurredAt = '2026-06-03T00:00:00.000Z';
+    const res = await POST(
+      buildRequest({ severity: 'error', title: 'T', message: 'M', occurredAt })
+    );
+    expect(res.status).toBe(204);
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ occurredAt })
+    );
+  });
+
+  it('reportErrorEvent が失敗（null 返却）しても 204 を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    mockReportErrorEvent.mockResolvedValueOnce(null);
+    const res = await POST(buildRequest({ severity: 'error', title: 'T', message: 'M' }));
+    expect(res.status).toBe(204);
+  });
+});

--- a/services/livetalk/web/tests/unit/app/api/client-log/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/client-log/route.test.ts
@@ -54,7 +54,7 @@ describe('POST /api/client-log', () => {
     mockGetSession.mockResolvedValue(validSession);
     const res = await POST(buildRequest('invalid-json'));
     expect(res.status).toBe(400);
-    const json = await res.json() as Record<string, string>;
+    const json = (await res.json()) as Record<string, string>;
     expect(json.message).toBe(CLIENT_LOG_ERROR_MESSAGES.INVALID_REQUEST);
     expect(mockReportErrorEvent).not.toHaveBeenCalled();
   });
@@ -173,9 +173,7 @@ describe('POST /api/client-log', () => {
       buildRequest({ severity: 'error', title: 'T', message: 'M', occurredAt })
     );
     expect(res.status).toBe(204);
-    expect(mockReportErrorEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ occurredAt })
-    );
+    expect(mockReportErrorEvent).toHaveBeenCalledWith(expect.objectContaining({ occurredAt }));
   });
 
   it('reportErrorEvent が失敗（null 返却）しても 204 を返す', async () => {

--- a/services/livetalk/web/tests/unit/lib/client-logger.test.ts
+++ b/services/livetalk/web/tests/unit/lib/client-logger.test.ts
@@ -1,0 +1,156 @@
+import { reportClientError } from '@/lib/client-logger';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue({ ok: true, status: 204 });
+
+  // matchMedia のデフォルト（standalone でない）
+  window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+
+  // navigator.standalone をリセット
+  Object.defineProperty(window.navigator, 'standalone', {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('reportClientError', () => {
+  it('fetch を POST /api/client-log に対して呼ぶ', () => {
+    reportClientError('error', 'テストエラー', 'エラー詳細');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/client-log');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+
+  it('正しいペイロードで fetch を呼ぶ', () => {
+    reportClientError('warning', '音声エラー', 'decode failed', {
+      screen: 'chat',
+      audioContextState: 'suspended',
+      sentenceReceived: 3,
+    });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+    expect(body.severity).toBe('warning');
+    expect(body.title).toBe('音声エラー');
+    expect(body.message).toBe('decode failed');
+    expect(typeof body.occurredAt).toBe('string');
+
+    const ctx = body.context as Record<string, unknown>;
+    expect(ctx.screen).toBe('chat');
+    expect(ctx.audioContextState).toBe('suspended');
+    expect(ctx.sentenceReceived).toBe(3);
+  });
+
+  it('context を省略しても fetch を呼ぶ', () => {
+    reportClientError('critical', 'タイトル', 'メッセージ');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.severity).toBe('critical');
+  });
+
+  it('fetch 失敗は握りつぶされてアプリを止めない', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network error'));
+
+    expect(() => reportClientError('error', 'タイトル', 'メッセージ')).not.toThrow();
+    // Promise 内のエラーが uncaught rejection にならないことを確認するため少し待つ
+    await Promise.resolve();
+  });
+
+  it('baseContext に userAgent と standalone が含まれる', () => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'TestAgent/1.0',
+      configurable: true,
+    });
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+
+    reportClientError('error', 'タイトル', 'メッセージ');
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const ctx = body.context as Record<string, unknown>;
+    expect(ctx.userAgent).toBe('TestAgent/1.0');
+    expect(ctx.standalone).toBe(false);
+  });
+
+  it('standalone: matchMedia が true のとき standalone: true になる', () => {
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+
+    reportClientError('error', 'タイトル', 'メッセージ');
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const ctx = body.context as Record<string, unknown>;
+    expect(ctx.standalone).toBe(true);
+  });
+
+  it('standalone: navigator.standalone が true のとき standalone: true になる', () => {
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    Object.defineProperty(window.navigator, 'standalone', {
+      value: true,
+      configurable: true,
+    });
+
+    reportClientError('error', 'タイトル', 'メッセージ');
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const ctx = body.context as Record<string, unknown>;
+    expect(ctx.standalone).toBe(true);
+  });
+
+  it('matchMedia が undefined でも例外を投げず standalone: false になる', () => {
+    // @ts-expect-error テスト用
+    window.matchMedia = undefined;
+
+    expect(() => reportClientError('error', 'タイトル', 'メッセージ')).not.toThrow();
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const ctx = body.context as Record<string, unknown>;
+    expect(ctx.standalone).toBe(false);
+
+    // restore
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+  });
+
+  it('渡した context が baseContext にマージされる', () => {
+    reportClientError('warning', 'タイトル', 'メッセージ', {
+      screen: 'chat',
+      streamDone: true,
+    });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const ctx = body.context as Record<string, unknown>;
+    expect(ctx.screen).toBe('chat');
+    expect(ctx.streamDone).toBe(true);
+    // baseContext のキーも入っている
+    expect('userAgent' in ctx).toBe(true);
+  });
+
+  it('occurredAt が ISO 8601 形式でペイロードに含まれる', () => {
+    const before = Date.now();
+    reportClientError('error', 'タイトル', 'メッセージ');
+    const after = Date.now();
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const ts = new Date(body.occurredAt as string).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/server/memory-retriever.test.ts
+++ b/services/livetalk/web/tests/unit/lib/server/memory-retriever.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment node
+ */
+import type { IMemoryRetriever } from '@nagiyu/livetalk-core';
+
+jest.mock('@/lib/server/embedding', () => ({
+  getEmbeddingClient: jest.fn().mockReturnValue({ embed: jest.fn() }),
+}));
+
+jest.mock('@/lib/server/repositories', () => ({
+  getMemoryRepository: jest.fn().mockReturnValue({}),
+}));
+
+describe('lib/server/memory-retriever', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('getMemoryRetriever はインスタンスを返す', async () => {
+    const mod = await import('@/lib/server/memory-retriever');
+    const r = mod.getMemoryRetriever();
+    expect(r).toBeDefined();
+  });
+
+  it('getMemoryRetriever はシングルトンを返す', async () => {
+    const mod = await import('@/lib/server/memory-retriever');
+    const r1 = mod.getMemoryRetriever();
+    const r2 = mod.getMemoryRetriever();
+    expect(r1).toBe(r2);
+  });
+
+  it('setMemoryRetrieverForTesting でキャッシュを差し替えられる', async () => {
+    const mod = await import('@/lib/server/memory-retriever');
+    const mock = {} as IMemoryRetriever;
+    mod.setMemoryRetrieverForTesting(mock);
+    expect(mod.getMemoryRetriever()).toBe(mock);
+  });
+
+  it('setMemoryRetrieverForTesting(null) にすると次回呼び出しで新インスタンスを生成する', async () => {
+    const mod = await import('@/lib/server/memory-retriever');
+    const mock = {} as IMemoryRetriever;
+    mod.setMemoryRetrieverForTesting(mock);
+    mod.setMemoryRetrieverForTesting(null);
+    const r = mod.getMemoryRetriever();
+    expect(r).toBeDefined();
+    expect(r).not.toBe(mock);
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/server/safety.test.ts
+++ b/services/livetalk/web/tests/unit/lib/server/safety.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment node
+ */
+
+describe('lib/server/safety', () => {
+  const originalFlag = process.env.USE_IN_MEMORY_DB;
+  const originalKey = process.env.OPENAI_API_KEY;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) delete process.env.USE_IN_MEMORY_DB;
+    else process.env.USE_IN_MEMORY_DB = originalFlag;
+    if (originalKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = originalKey;
+  });
+
+  it('getSafetyEventRepository は InMemory 実装を返す', async () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const mod = await import('@/lib/server/safety');
+    const repo = mod.getSafetyEventRepository();
+    expect(repo).toBeDefined();
+  });
+
+  it('getModerationClient: USE_IN_MEMORY_DB=true なら NoOpModerationClient を返す', async () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    delete process.env.OPENAI_API_KEY;
+    const mod = await import('@/lib/server/safety');
+    const client = mod.getModerationClient();
+    expect(client).toBeDefined();
+    // シングルトン確認
+    expect(mod.getModerationClient()).toBe(client);
+  });
+
+  it('getModerationClient: OPENAI_API_KEY 未設定なら NoOpModerationClient にフォールバック', async () => {
+    process.env.USE_IN_MEMORY_DB = 'false';
+    delete process.env.OPENAI_API_KEY;
+    const mod = await import('@/lib/server/safety');
+    const client = mod.getModerationClient();
+    expect(client).toBeDefined();
+  });
+
+  it('getModerationClient: OPENAI_API_KEY 設定済みなら OpenAI クライアントを返す', async () => {
+    process.env.USE_IN_MEMORY_DB = 'false';
+    process.env.OPENAI_API_KEY = 'sk-test-key';
+    const mod = await import('@/lib/server/safety');
+    const client = mod.getModerationClient();
+    expect(client).toBeDefined();
+  });
+
+  it('resetSafetyForTesting でキャッシュをリセットできる', async () => {
+    process.env.USE_IN_MEMORY_DB = 'true';
+    const mod = await import('@/lib/server/safety');
+    const client1 = mod.getModerationClient();
+    mod.resetSafetyForTesting();
+    const client2 = mod.getModerationClient();
+    expect(client1).not.toBe(client2);
+  });
+});


### PR DESCRIPTION
## 変更の概要

iOS PWA（standalone）ではブラウザコンソールが使えないため、クライアントで発生したエラーをサーバに集約して Admin / CloudWatch で検知できる基盤を実装した。

クライアントでエラーを捕捉 → `POST /api/client-log` → 既存の `reportErrorEvent`（@nagiyu/aws）呼び出し → DynamoDB error-events テーブル → DynamoDB Stream → Admin サービスで閲覧 / Web Push 通知、という経路を繋ぐ薄い配線のみ。DynamoDB 登録以降は既存フローに完全に乗る。

**スパム対策（dedup / レート制限）は Admin 側責務**として本 Issue のスコープ外とした（`stream-handler.ts` が全サービスのエラーを通知に変換する合流点であるため、各サービスが個別実装するより Admin 側で一元対応が適切）。詳細は [Issue コメント](https://github.com/nagiyu/nagiyu-platform/issues/3369#issuecomment-4608159038) 参照。

## 関連 Issue

関連: #3369（integration → develop PR 時に Closes を付与）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（本 Issue は基盤整備のため追加ドキュメント不要と判断）
- [ ] CI/CD 設定を追加・更新した（既存 CI で対応可能）
- [x] ローカルでテストが全て通ることを確認した（252 tests passed）
- [x] ビルドエラーがないことを確認した

## テスト内容

- **`tests/unit/lib/client-logger.test.ts`**（新規）
  - `reportClientError` が正しいペイロードで `POST /api/client-log` を呼ぶ
  - fetch 失敗を握りつぶすこと（fire-and-forget）
  - UA / standalone フラグが baseContext に含まれること
  - matchMedia / navigator.standalone による standalone 判定の分岐
  - 渡した context が baseContext にマージされること

- **`tests/unit/app/api/client-log/route.test.ts`**（新規）
  - 未認証は 401
  - severity `info` / 不正値 は 400
  - title / message の空文字・長さ超過は 400
  - `warning` / `error` / `critical` はそれぞれ 204 を返す
  - context + userId が `reportErrorEvent` に渡されること
  - `occurredAt` が渡されること
  - `reportErrorEvent` 失敗（null 返却）でも 204 を返すこと

- **`tests/unit/lib/server/memory-retriever.test.ts`**（新規・pre-existing coverage 修正）
- **`tests/unit/lib/server/safety.test.ts`**（新規・pre-existing coverage 修正）

カバレッジ結果: statements 97.1% / branches 90.05% / functions 80.68% / lines 97.1%

## レビューポイント

- **severity 方針**：未捕捉例外・unhandledrejection・fetch 失敗・stream error → `error`、音声 decode/再生失敗 → `warning`。Issue コメントに確定済み。
- **スパム対策なし**：意図的。Admin の `stream-handler.ts` 側で severity フィルタ等を実装する際に一緒に検討。
- **インフラ差分**：`ecs-service-stack.ts` の `taskRole` に `grantErrorEventsWrite` + `ERROR_EVENTS_TABLE_NAME` を追加。batch と同じ1行ずつ。
- **グローバルハンドラ**：`ClientErrorReporter.tsx` を `layout.tsx` に mount。`SessionProviderWrapper` の前に置くことで全ページをカバー。

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

- `client-logger.ts` の SSR ガード（`typeof window === 'undefined'`）は jsdom テスト環境では到達不能なため `/* istanbul ignore next */` でカバレッジ対象外としている（ブラウザ専用コードとして正常）。
- `lib/server/memory-retriever.ts` / `safety.ts` のテストは pre-existing なカバレッジ不足（78%）を修正するために追加。本 Issue の変更とは直接関係ない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQrAkjG6ND8amN9RcNHtS5)_