### PR TITLE
[Bug] [リブトーク] EMF メトリクスの Environment を LIVETALK_ENV で dev/prod 分離（#3320）

### DIFF
--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -93,6 +93,7 @@ export class LiveTalkBatchStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(15),
       environment: {
         NODE_ENV: environment,
+        LIVETALK_ENV: environment,
         DYNAMODB_TABLE_NAME: dynamoTableName,
         OPENAI_API_KEY: openAiApiKey,
         ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
@@ -156,6 +157,7 @@ export class LiveTalkBatchStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(15),
       environment: {
         NODE_ENV: environment,
+        LIVETALK_ENV: environment,
         DYNAMODB_TABLE_NAME: dynamoTableName,
         ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
         TZ: 'Asia/Tokyo',
@@ -217,6 +219,7 @@ export class LiveTalkBatchStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(15),
       environment: {
         NODE_ENV: environment,
+        LIVETALK_ENV: environment,
         DYNAMODB_TABLE_NAME: dynamoTableName,
         OPENAI_API_KEY: openAiApiKey,
         ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
@@ -281,6 +284,7 @@ export class LiveTalkBatchStack extends cdk.Stack {
       timeout: cdk.Duration.minutes(15),
       environment: {
         NODE_ENV: environment,
+        LIVETALK_ENV: environment,
         DYNAMODB_TABLE_NAME: dynamoTableName,
         OPENAI_API_KEY: openAiApiKey,
         VAPID_PUBLIC_KEY: vapidPublicKey,

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -252,6 +252,10 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
         // 'development' にすると @nagiyu/nextjs の cookie 名サフィックスと domain スコープが
         // Auth サービスの発行 cookie とずれるため、'dev' / 'prod' を使う。
         NODE_ENV: environment,
+        // LIVETALK_ENV: EMF メトリクスの Environment ディメンション専用（Issue #3320）。
+        // Next.js は next start で NODE_ENV を 'production' に強制上書きするため、
+        // メトリクス用の環境識別子として別変数を用意する。
+        LIVETALK_ENV: environment,
         PORT: '3000',
         APP_VERSION: appVersion,
         // NextAuth v5 が JWT 署名・検証に使用する secret。Auth サービスと同じ値が必要。

--- a/services/livetalk/core/src/observability/metrics.ts
+++ b/services/livetalk/core/src/observability/metrics.ts
@@ -82,7 +82,7 @@ export function emitChatMetricsLog(metrics: ChatMetrics): void {
 
 /** L2: CloudWatch EMF メトリクスを emit する（Namespace: LiveTalk/Chat）。 */
 export function emitChatMetricsEMF(metrics: ChatMetrics): void {
-  const environment = process.env.NODE_ENV ?? 'unknown';
+  const environment = process.env.LIVETALK_ENV ?? process.env.NODE_ENV ?? 'unknown';
 
   const emfMetrics: EmfMetricDefinition[] = [
     { name: 'PromptTotalTokens', value: metrics.promptTokens.total, unit: 'Count' },
@@ -146,7 +146,7 @@ export function emitBatchMetricsLog(metrics: BatchMetrics): void {
 
 /** L2: バッチ EMF メトリクスを emit する（Namespace: LiveTalk/Batch）。 */
 export function emitBatchMetricsEMF(metrics: BatchMetrics): void {
-  const environment = process.env.NODE_ENV ?? 'unknown';
+  const environment = process.env.LIVETALK_ENV ?? process.env.NODE_ENV ?? 'unknown';
 
   const emfMetrics: EmfMetricDefinition[] = [
     { name: 'MemorySummaryTokens', value: metrics.summaryTokenCount, unit: 'Count' },

--- a/services/livetalk/core/tests/unit/observability/metrics.test.ts
+++ b/services/livetalk/core/tests/unit/observability/metrics.test.ts
@@ -105,6 +105,41 @@ describe('emitChatMetricsEMF', () => {
     expect(parsed._aws.CloudWatchMetrics[0].Namespace).toBe('LiveTalk/Chat');
     logSpy.mockRestore();
   });
+
+  it('LIVETALK_ENV が設定されている場合は Environment ディメンションにその値が使われる', () => {
+    const originalEnv = process.env.LIVETALK_ENV;
+    process.env.LIVETALK_ENV = 'dev';
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const metrics = createChatMetrics('u1', 'hiyori');
+    emitChatMetricsEMF(metrics);
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain('"dev"');
+    logSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.LIVETALK_ENV;
+    } else {
+      process.env.LIVETALK_ENV = originalEnv;
+    }
+  });
+
+  it('LIVETALK_ENV が未設定の場合は NODE_ENV にフォールバックする', () => {
+    const originalLivetalkEnv = process.env.LIVETALK_ENV;
+    delete process.env.LIVETALK_ENV;
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const metrics = createChatMetrics('u1', 'hiyori');
+    emitChatMetricsEMF(metrics);
+    const output = logSpy.mock.calls[0][0] as string;
+    // NODE_ENV または 'unknown' のいずれかが Environment ディメンションに入る
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    const dimensions = (
+      parsed['_aws'] as { CloudWatchMetrics: Array<{ Dimensions: string[][] }> }
+    ).CloudWatchMetrics[0].Dimensions;
+    expect(dimensions.flat()).toContain('Environment');
+    logSpy.mockRestore();
+    if (originalLivetalkEnv !== undefined) {
+      process.env.LIVETALK_ENV = originalLivetalkEnv;
+    }
+  });
 });
 
 describe('emitBatchMetricsLog', () => {
@@ -165,5 +200,28 @@ describe('emitBatchMetricsEMF', () => {
     expect(parsed['CompressedMessageCount']).toBe(7);
     expect(parsed['BatchLatency']).toBe(3000);
     logSpy.mockRestore();
+  });
+
+  it('LIVETALK_ENV が設定されている場合は Environment ディメンションにその値が使われる（Batch）', () => {
+    const originalEnv = process.env.LIVETALK_ENV;
+    process.env.LIVETALK_ENV = 'dev';
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const batchMetrics = {
+      userId: 'u1',
+      characterId: 'hiyori',
+      timestamp: new Date().toISOString(),
+      messageCount: 5,
+      summaryTokenCount: 300,
+      summaryCharCount: 600,
+    };
+    emitBatchMetricsEMF(batchMetrics);
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain('"dev"');
+    logSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.LIVETALK_ENV;
+    } else {
+      process.env.LIVETALK_ENV = originalEnv;
+    }
   });
 });

--- a/services/livetalk/core/tests/unit/observability/metrics.test.ts
+++ b/services/livetalk/core/tests/unit/observability/metrics.test.ts
@@ -131,9 +131,8 @@ describe('emitChatMetricsEMF', () => {
     const output = logSpy.mock.calls[0][0] as string;
     // NODE_ENV または 'unknown' のいずれかが Environment ディメンションに入る
     const parsed = JSON.parse(output) as Record<string, unknown>;
-    const dimensions = (
-      parsed['_aws'] as { CloudWatchMetrics: Array<{ Dimensions: string[][] }> }
-    ).CloudWatchMetrics[0].Dimensions;
+    const dimensions = (parsed['_aws'] as { CloudWatchMetrics: Array<{ Dimensions: string[][] }> })
+      .CloudWatchMetrics[0].Dimensions;
     expect(dimensions.flat()).toContain('Environment');
     logSpy.mockRestore();
     if (originalLivetalkEnv !== undefined) {


### PR DESCRIPTION
## 変更の概要

EMF メトリクス（`LiveTalk/Chat` / `LiveTalk/Batch`）の `Environment` ディメンションが、chat 側（ECS/Next.js）で常に `production` になり dev/prod が混ざる問題を修正する。

原因は `next start` が `NODE_ENV` をランタイムで `production` に強制上書きするため。観測用の専用環境変数 `LIVETALK_ENV` を新設し、Next.js に上書きされない経路で環境を識別する。

## 関連 Issue

関連: #3320
親 Issue: #3182

## 変更種別

- [x] バグ修正
- [ ] 新規機能 / リファクタリング / その他

## 変更内容

| ファイル | 操作 |
|---|---|
| `services/livetalk/core/src/observability/metrics.ts` | `Environment` 算出を `LIVETALK_ENV ?? NODE_ENV ?? 'unknown'` に変更（chat/batch 2箇所）|
| `infra/livetalk/lib/ecs-service-stack.ts` | web コンテナに `LIVETALK_ENV: environment` を追加（NODE_ENV は cookie 名等で使うため残す）|
| `infra/livetalk/lib/batch-stack.ts` | 全 4 Lambda（compress / learn-activity / study / notify）に `LIVETALK_ENV: environment` を追加 |
| `services/livetalk/core/tests/unit/observability/metrics.test.ts` | `LIVETALK_ENV` 考慮のテストを追加 |

## 修正方針（Issue #3320 準拠）

- `NODE_ENV` は Next.js / cookie スコープで使われるため**変更・削除しない**。観測用識別子を別変数 `LIVETALK_ENV` として追加
- `metrics.ts` は `LIVETALK_ENV ?? NODE_ENV ?? 'unknown'` のフォールバックで、env 未設定でも従来挙動を維持
- batch は Issue で compress / learn-activity の 2 つが明示されていたが、**study / notify も同一の `environment` 変数を持つため、分離の一貫性のため全 4 Lambda に追加**（拡張判断）

## 完了条件の検証

- [x] `metrics.ts` の `Environment` 算出が `LIVETALK_ENV` 優先になっている（chat/batch 両箇所）
- [x] web コンテナ・全 Lambda に `LIVETALK_ENV` が渡る
- [x] 既存 `NODE_ENV` 依存（cookie 名等）に影響を与えない（NODE_ENV は残置）
- [x] **metrics.test.ts 14 件がローカルで全 pass**（マスターが `npx jest` で確認、新規 3 件含む）
- [ ] dev 実機で chat の EMF `Environment` が `dev` になる → **デプロイ後に確認**（運用）
- [ ] `LiveTalk/Chat` を `Environment=dev` でフィルタして chat メトリクスが取れる → デプロイ後に確認

## 検証内容（マスターセッションによる検証）

- 実装はサブセッション（Sonnet）が担当、検証・PR 作成はマスターが実施
- ローカルで `npx jest --testPathPatterns="observability/metrics"` → **14 件全 pass** を確認
- 変更内容が Issue #3320 の方針（LIVETALK_ENV 新設 + フォールバック維持 + NODE_ENV 残置）に厳密準拠していることを確認
- ブランチは最新 integration から単一コミットで分岐（履歴クリーン）

## 実装上の注意点

- リージョン: us-east-1
- 既に誤って `production` に入った過去の dev メトリクスは遡及修正できないが、本対応以降は正しく分離される
- infra/livetalk/tests/ が存在しないため CDK スナップショットテストの更新は不要

## デプロイ後の確認事項（運用）

dev へデプロイ後、CloudWatch メトリクスで：
- `LiveTalk/Chat` namespace を `Environment=dev` でフィルタして chat メトリクスが出ること
- chat と batch の `Environment` 値が揃うこと（dev では両方 dev）

## UI 変更

なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ByvuBZymxbkgvp5uQ4ygzm)_