### PR TITLE
infra(livetalk): VOICEVOX 並列性改善・Fargate Spot 化（Issue #3356）

### DIFF
--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -201,13 +201,13 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     const imageTag = process.env.IMAGE_TAG || 'latest';
 
     // Phase 1f で VOICEVOX コンテナを同一 Task に追加。
-    // メモリ内訳: VOICEVOX 2GB + Next.js 0.5GB + オーバーヘッド ≈ 3GB
-    // Fargate の CPU/Memory 組み合わせ制約に従い 1 vCPU / 3072 MiB を使用（dev 想定の最小値、
-    // prod でメモリ・CPU 不足が見えた段階で引き上げる）。
+    // メモリ内訳: VOICEVOX 2.5GB + Next.js 0.5GB + オーバーヘッド ≈ 4GB
+    // CPU は 2 vCPU を web と VOICEVOX で配分（Issue #3356: VOICEVOX 合成の直列化解消）。
+    // Fargate の CPU/Memory 組み合わせ制約: cpu=2048 には memory 4096〜16384 が必要。
     this.taskDefinition = new ecs.FargateTaskDefinition(this, 'TaskDefinition', {
       family: `nagiyu-livetalk-task-${environment}`,
-      cpu: 1024,
-      memoryLimitMiB: 3072,
+      cpu: 2048,
+      memoryLimitMiB: 4096,
       executionRole: taskExecutionRole,
       taskRole,
     });
@@ -220,6 +220,9 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     const voicevoxContainer = this.taskDefinition.addContainer('voicevox', {
       containerName: 'voicevox',
       image: ecs.ContainerImage.fromRegistry('voicevox/voicevox_engine:cpu-latest'),
+      // cpu_num_threads を 2 に設定し、並列合成リクエストを処理できるようにする（Issue #3356）。
+      // 公式イメージの ENTRYPOINT は run バイナリ。command は引数として追記される。
+      command: ['--cpu_num_threads', '2'],
       essential: true,
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'ecs',
@@ -298,6 +301,8 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
 
     // VOICEVOX 起動待ちを含む Service の healthCheckGracePeriod を確保する（VOICEVOX の
     // startPeriod 60s に余裕を持たせる）。
+    // dev は Fargate Spot でコスト削減（中断されても Service が自動復旧するため許容）。
+    // prod はユーザー利用中の中断を避けるためオンデマンドを維持（Issue #3356）。
     this.service = new ecs.FargateService(this, 'Service', {
       cluster,
       taskDefinition: this.taskDefinition,
@@ -309,6 +314,12 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
         subnets: vpc.publicSubnets,
       },
       healthCheckGracePeriod: cdk.Duration.seconds(120),
+      capacityProviderStrategies: [
+        {
+          capacityProvider: environment === 'dev' ? 'FARGATE_SPOT' : 'FARGATE',
+          weight: 1,
+        },
+      ],
     });
 
     // ECS Task が DynamoDB Single Table を読み書きできるよう IAM 権限を付与する。

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -17,14 +17,14 @@ const synth = (environment, props = {}) => {
 };
 
 describe('LiveTalkEcsServiceStack', () => {
-  it('Task Definition family を環境名込みで作成する（VOICEVOX 同居のため Memory 3072）', () => {
+  it('Task Definition family を環境名込みで作成する（VOICEVOX 同居のため 2vCPU/4096MiB）', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::ECS::TaskDefinition', {
       Family: 'nagiyu-livetalk-task-dev',
       RequiresCompatibilities: ['FARGATE'],
       NetworkMode: 'awsvpc',
-      Cpu: '1024',
-      Memory: '3072',
+      Cpu: '2048',
+      Memory: '4096',
     });
   });
 
@@ -82,8 +82,23 @@ describe('LiveTalkEcsServiceStack', () => {
     template.hasResourceProperties('AWS::ECS::Service', {
       ServiceName: 'nagiyu-livetalk-service-dev',
       DesiredCount: 1,
-      LaunchType: 'FARGATE',
       HealthCheckGracePeriodSeconds: 120,
+    });
+  });
+
+  it('dev は Fargate Spot を使用し、prod はオンデマンド FARGATE を使用する', () => {
+    const devTemplate = synth('dev');
+    devTemplate.hasResourceProperties('AWS::ECS::Service', {
+      CapacityProviderStrategy: Match.arrayWith([
+        Match.objectLike({ CapacityProvider: 'FARGATE_SPOT' }),
+      ]),
+    });
+
+    const prodTemplate = synth('prod');
+    prodTemplate.hasResourceProperties('AWS::ECS::Service', {
+      CapacityProviderStrategy: Match.arrayWith([
+        Match.objectLike({ CapacityProvider: 'FARGATE' }),
+      ]),
     });
   });
 


### PR DESCRIPTION
## 変更の概要

VOICEVOX 音声合成の直列化（chatTotal の約 75% を占める主ボトルネック）を解消するため、ECS Task リソースの増強・VOICEVOX スレッド設定・Fargate Spot 化を実施。

変更対象は `infra/livetalk/lib/ecs-service-stack.ts` のみ（コアロジックには一切触れない）。

### 変更内容

1. **Task CPU/Memory 増強**
   - `cpu: 1024 → 2048`、`memoryLimitMiB: 3072 → 4096`
   - Fargate 制約: `cpu=2048` には `memory 4096〜16384` が必要（3072 は組み合わせ不可）
   - CDK コメントのメモリ内訳も実態に合わせて更新

2. **VOICEVOX スレッド数の明示指定**
   - `command: ['--cpu_num_threads', '2']` を追加
   - 公式イメージ（`voicevox/voicevox_engine:cpu-latest`）は ENTRYPOINT が `run` バイナリ。`command` が引数として追記される形で `--cpu_num_threads 2` が渡される

3. **dev のみ Fargate Spot 化**
   - `capacityProviderStrategies` で `environment` を出し分け
     - `dev`: `FARGATE_SPOT`（コスト削減、中断時は Service が自動復旧）
     - `prod`: `FARGATE`（ユーザー利用中の中断を防ぐためオンデマンド維持）
   - 共有クラスタ（`nagiyu-shared-cluster-{env}`）は `FARGATE` / `FARGATE_SPOT` 両方を登録済み
   - 既存の `launchType` 指定なし（デフォルト）なので `capacityProviderStrategies` との競合なし

### コスト試算（dev）

| | 現状 | 変更後 |
|---|---|---|
| スペック | 1 vCPU / 3 GB オンデマンド | 2 vCPU / 4 GB Fargate Spot |
| 月額概算 | 約 $39 | 約 $21（Spot 約7割引）|

**性能2倍でコストは現状以下**になる見込み。

## 関連 Issue

#3356（VOICEVOX 並列性改善）/ 親 Issue: #3182（リブトーク）

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（インフラのみの変更のためアプリテストなし）
- [x] 関連ドキュメントを更新した（コメントのみ）
- [ ] CI/CD 設定を追加・更新した（変更なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（`cdk synth` 通過確認済み）

## テスト内容

- `cdk synth` 実行済み（全スタック正常生成、エラーなし）
- 生成テンプレート（`NagiyuLiveTalkServiceDev`）で以下を確認
  - `TaskDefinition.Cpu: 2048`、`Memory: 4096`
  - `voicevox` コンテナに `Command: ['--cpu_num_threads', '2']`
  - `ECS Service.CapacityProviderStrategy: [{CapacityProvider: 'FARGATE_SPOT', Weight: 1}]`
  - `LaunchType: not set`（capacityProviderStrategy との競合なし）

## レビューポイント

- `cpu_num_threads` の値を `2` にしているが、2 vCPU 構成で web と VOICEVOX が CPU を共有するため適切な値か確認
- prod の `FARGATE` 固定は意図通りか確認（将来 prod も Spot 化するなら別途 Issue）
- `capacityProviderStrategies` と `launchType` の排他制約はクリアしている（launchType は元々未指定）

## 補足事項

**デプロイ後の効果確認（マスター/運用で実施）**

デプロイ後、実機で以下の EMF メトリクスを再計測して効果確認をお願いします。

| 指標 | 現状（#3354 マージ後） | 目標 |
|---|---|---|
| `voicevoxTotal`（合計）| 21,048 ms | 大幅短縮（並列効果が出れば 1/2〜1/3 程度を期待）|
| `chatTotal` | 28,210 ms | 同上 |

`chatTotal - llmTotal ≈ voicevoxTotal`（並列効果ゼロ）の状態が改善されれば成功。


---
_Generated by [Claude Code](https://claude.ai/code/session_017WmxUCNAbcqohguMN8wcSX)_