### PR TITLE
[Bug Fix] [リブトーク] VOICEVOX の cpu_num_threads 指定を環境変数に変更（#3356 デプロイ失敗修正）

### DIFF
--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -220,9 +220,13 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     const voicevoxContainer = this.taskDefinition.addContainer('voicevox', {
       containerName: 'voicevox',
       image: ecs.ContainerImage.fromRegistry('voicevox/voicevox_engine:cpu-latest'),
-      // cpu_num_threads を 2 に設定し、並列合成リクエストを処理できるようにする（Issue #3356）。
-      // 公式イメージの ENTRYPOINT は run バイナリ。command は引数として追記される。
-      command: ['--cpu_num_threads', '2'],
+      // VV_CPU_NUM_THREADS で並列合成リクエストを処理できるようにする（Issue #3356）。
+      // 当初は command で --cpu_num_threads を渡したが Docker CMD 上書きの影響で
+      // コンテナが exit 2 で起動失敗したため、公式が明示的にサポートする
+      // 環境変数経由（VV_CPU_NUM_THREADS）に切り替えている。
+      environment: {
+        VV_CPU_NUM_THREADS: '2',
+      },
       essential: true,
       logging: ecs.LogDriver.awsLogs({
         streamPrefix: 'ecs',

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -57,8 +57,7 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     // OpenAI API キー（Phase 2b / Issue #3248）。
     // 既存の AUTH_SECRET と同じく、deploy ワークフローが Secrets Manager から取得して
     // `--context openAiApiKey=<value>` で渡す方式。Container では `OPENAI_API_KEY` env で参照する。
-    const openAiApiKey =
-      scope.node.tryGetContext('openAiApiKey') || 'PLACEHOLDER_OPENAI_API_KEY';
+    const openAiApiKey = scope.node.tryGetContext('openAiApiKey') || 'PLACEHOLDER_OPENAI_API_KEY';
 
     // VAPID キー（Phase 5d / #3346）。Web Push の subscribe / vapid-public-key route が参照する。
     const vapidPublicKey =
@@ -70,9 +69,7 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
       environment === 'prod' ? 'https://auth.nagiyu.com' : `https://dev-auth.nagiyu.com`;
 
     const appUrl =
-      environment === 'prod'
-        ? 'https://live-talk.nagiyu.com'
-        : 'https://dev-live-talk.nagiyu.com';
+      environment === 'prod' ? 'https://live-talk.nagiyu.com' : 'https://dev-live-talk.nagiyu.com';
 
     const vpcId = ssm.StringParameter.valueForStringParameter(
       this,
@@ -87,10 +84,7 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     const vpc = ec2.Vpc.fromVpcAttributes(this, 'ImportedVpc', {
       vpcId,
       availabilityZones: ['us-east-1a', 'us-east-1b'],
-      publicSubnetIds: [
-        cdk.Fn.select(0, publicSubnetIds),
-        cdk.Fn.select(1, publicSubnetIds),
-      ],
+      publicSubnetIds: [cdk.Fn.select(0, publicSubnetIds), cdk.Fn.select(1, publicSubnetIds)],
     });
 
     const clusterName = ssm.StringParameter.valueForStringParameter(
@@ -132,11 +126,7 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     // これにより ECS Service stack は DynamoDB stack の deploy 順序に縛られない。
     const dynamoTableName = getDynamoDBTableName('livetalk', environment);
     const dynamoTableArn = getDynamoDBTableArn(this.region, this.account, dynamoTableName);
-    const dynamoTable = dynamodb.Table.fromTableArn(
-      this,
-      'ImportedDynamoTable',
-      dynamoTableArn
-    );
+    const dynamoTable = dynamodb.Table.fromTableArn(this, 'ImportedDynamoTable', dynamoTableArn);
 
     this.ecsTaskSecurityGroup = new ec2.SecurityGroup(this, 'EcsTaskSecurityGroup', {
       vpc,
@@ -161,9 +151,7 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
       assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
       description: 'ECS Task Execution Role for LiveTalk',
       managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName(
-          'service-role/AmazonECSTaskExecutionRolePolicy'
-        ),
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy'),
       ],
     });
 


### PR DESCRIPTION
## 変更の概要

#3356（音声レイテンシ改善）で追加した VOICEVOX の `cpu_num_threads` 指定を、**Docker `command` 上書きから環境変数 `VV_CPU_NUM_THREADS` に変更**する緊急修正。

#3356 マージ後の **dev 自動デプロイで CloudFormation が NotStabilized で失敗**（3 時間タイムアウト → ロールバック）した事象の修正。

## 関連 Issue

関連: #3356（dev デプロイ失敗修正、Issue は既にクローズ済み）
親 Issue: #3182

## 変更種別

- [x] バグ修正
- [ ] 新規機能 / リファクタリング / その他

## 失敗の経緯

1. PR #3382（#3356 VOICEVOX 並列性 / 2vCPU / cpu_num_threads / Spot 化）マージ後、`integration/3182-livetalk` → dev 自動デプロイがトリガー
2. CloudFormation の `NagiyuLiveTalkServiceDev` 更新で `AWS::ECS::Service` が `NotStabilized`（タスク起動完了せずタイムアウト）
3. 3 時間経過後にロールバック、デプロイ workflow が exit 1

## 原因（AWS CLI 調査済み）

```
voicevox container: exitCode=2 で起動失敗
Task Definition :73 で command: ['--cpu_num_threads', '2']
```

ECS の Container Definition で `command` を指定すると、これは **Docker の CMD を完全上書き**する仕様。

公式 `voicevox/voicevox_engine:cpu-latest` イメージの構造：

```
ENTRYPOINT: /entrypoint.sh
CMD: （明示的な指定なし、ENTRYPOINT 内で run バイナリへ引数を流す）
```

→ `command: ['--cpu_num_threads', '2']` だけを渡すと、ENTRYPOINT 経由で `run --cpu_num_threads 2` として起動するはずだったが、何らかの理由で exit 2（おそらく引数パーサーの細部 or 環境差異）。

## 修正内容

公式が明示的にサポートする **環境変数 `VV_CPU_NUM_THREADS`**（参考: [VOICEVOX/voicevox_engine README](https://github.com/VOICEVOX/voicevox_engine/blob/master/README.md)、[Issue #1092](https://github.com/VOICEVOX/voicevox_engine/issues/1092)）に切り替える。

```typescript
// 変更前
command: ['--cpu_num_threads', '2'],

// 変更後
environment: {
  VV_CPU_NUM_THREADS: '2',
},
```

これにより：

- ✅ Docker CMD 上書きの罠を回避
- ✅ 引数パーサーの細部依存も回避
- ✅ 公式が明示的に推奨する方法
- ✅ `cpu_num_threads` の効果は変わらず維持

## 維持される変更（#3356 の他要素はそのまま）

- ✅ Task CPU 1024 → 2048（2 vCPU）
- ✅ Memory 3072 → 4096 MiB
- ✅ Fargate Spot 化（dev のみ、`capacityProviderStrategy`）

つまり **#3356 の意図した改善（CPU 増強・Spot 化・スレッド指定）は全て維持**、唯一壊れていたスレッド指定の渡し方だけを直す。

## 完了条件・検証

- [x] `prettier --check` 通過
- [x] `git mv` で履歴保持された rename ではなく、純粋な修正（4 ファイル変更ではなく 1 ファイル）
- [ ] CI の Infrastructure Format Check / Lint Code / Synth が green（再走で確認）
- [ ] 本 PR マージ後の dev 自動デプロイが成功（CloudFormation 完走）
- [ ] デプロイ後 ECS Task が起動し Service が安定化（`running: 1 / desired: 1`）
- [ ] `voicevox` コンテナのログから `VV_CPU_NUM_THREADS` が認識されていることを確認

## レビューポイント

1. 環境変数名 `VV_CPU_NUM_THREADS` が公式仕様で正しいこと（README に記載あり）
2. `command: ['--cpu_num_threads', '2']` 削除後、他に影響がないこと
3. 既存の cpu / memory / capacityProviderStrategy は変更していない

## UI 変更

なし（インフラ設定のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ByvuBZymxbkgvp5uQ4ygzm)_