### PR TITLE
リブトークのノート本文を Markdown 描画に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20317,7 +20317,9 @@
         "@testing-library/user-event": "^14.6.1",
         "jest-environment-jsdom": "^30.4.1",
         "pixi-live2d-display-lipsyncpatch": "0.5.0-ls-8",
-        "pixi.js": "^7.4.3"
+        "pixi.js": "^7.4.3",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       }
     },
     "services/niconico-mylist-assistant/batch": {

--- a/services/livetalk/web/package.json
+++ b/services/livetalk/web/package.json
@@ -29,6 +29,8 @@
     "@testing-library/user-event": "^14.6.1",
     "jest-environment-jsdom": "^30.4.1",
     "pixi-live2d-display-lipsyncpatch": "0.5.0-ls-8",
-    "pixi.js": "^7.4.3"
+    "pixi.js": "^7.4.3",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   }
 }

--- a/services/livetalk/web/src/app/notes/[id]/page.tsx
+++ b/services/livetalk/web/src/app/notes/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Chip, Link } from '@nagiyu/ui';
 import type { NoteListItem } from '@/lib/notes/types';
 import { fetchNote } from '@/lib/notes/api-client';
 import { formatNoteDate } from '@/lib/notes/messages';
+import NoteMarkdown from '@/components/NoteMarkdown';
 
 interface NoteDetailPageProps {
   params: Promise<{ id: string }>;
@@ -75,9 +76,7 @@ export default function NoteDetailPage({ params }: NoteDetailPageProps) {
               {formatNoteDate(note.createdAt)}
             </Typography>
           </Stack>
-          <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}>
-            {note.body}
-          </Typography>
+          <NoteMarkdown content={note.body ?? ''} />
         </Box>
       )}
     </Container>

--- a/services/livetalk/web/src/components/NoteMarkdown.tsx
+++ b/services/livetalk/web/src/components/NoteMarkdown.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Box, Typography, type SxProps, type Theme } from '@mui/material';
+import { Link } from '@nagiyu/ui';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+/**
+ * NoteMarkdown コンポーネントの props 型定義。
+ */
+interface NoteMarkdownProps {
+  /** 描画する Markdown テキスト */
+  content: string;
+  /** Box ラッパーへ渡す追加スタイル */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * react-markdown が使用する要素マッピング。
+ * 各 Markdown 要素を MUI / nagiyu-ui コンポーネントに変換する。
+ */
+export const MARKDOWN_COMPONENTS: Components = {
+  /** 段落：MUI Typography の p タグ */
+  p: ({ children }) => (
+    <Typography component="p" sx={{ mb: 1, '&:last-child': { mb: 0 } }}>
+      {children}
+    </Typography>
+  ),
+  /** リンク：nagiyu/ui の Link で新規タブ表示 */
+  a: ({ children, href }) => (
+    <Link href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </Link>
+  ),
+  /** 箇条書きリスト */
+  ul: ({ children }) => (
+    <Box component="ul" sx={{ pl: 3, mb: 1, '&:last-child': { mb: 0 } }}>
+      {children}
+    </Box>
+  ),
+  /** 番号付きリスト */
+  ol: ({ children }) => (
+    <Box component="ol" sx={{ pl: 3, mb: 1, '&:last-child': { mb: 0 } }}>
+      {children}
+    </Box>
+  ),
+  /** リスト項目 */
+  li: ({ children }) => (
+    <Typography component="li" sx={{ mb: 0.25 }}>
+      {children}
+    </Typography>
+  ),
+  /** 太字 */
+  strong: ({ children }) => (
+    <Box component="strong" sx={{ fontWeight: 'bold' }}>
+      {children}
+    </Box>
+  ),
+  /** イタリック */
+  em: ({ children }) => (
+    <Box component="em" sx={{ fontStyle: 'italic' }}>
+      {children}
+    </Box>
+  ),
+  /** インラインコード */
+  code: ({ children }) => (
+    <Box
+      component="code"
+      sx={{
+        bgcolor: 'grey.100',
+        px: 0.5,
+        borderRadius: 0.5,
+        fontFamily: 'monospace',
+        fontSize: '0.875em',
+      }}
+    >
+      {children}
+    </Box>
+  ),
+  /** 見出し H1（意味的階層のため h3 タグとして描画） */
+  h1: ({ children }) => (
+    <Typography variant="subtitle1" component="h3" sx={{ mt: 1, mb: 0.5, fontWeight: 'bold' }}>
+      {children}
+    </Typography>
+  ),
+  /** 見出し H2（意味的階層のため h4 タグとして描画） */
+  h2: ({ children }) => (
+    <Typography variant="subtitle1" component="h4" sx={{ mt: 1, mb: 0.5, fontWeight: 'bold' }}>
+      {children}
+    </Typography>
+  ),
+  /** 見出し H3（意味的階層のため h5 タグとして描画） */
+  h3: ({ children }) => (
+    <Typography variant="subtitle2" component="h5" sx={{ mt: 1, mb: 0.5, fontWeight: 'bold' }}>
+      {children}
+    </Typography>
+  ),
+};
+
+/**
+ * ノート本文の Markdown 描画コンポーネント。
+ * react-markdown + remark-gfm を用いて GFM 形式の Markdown を HTML に変換する。
+ * リンク記法（[text](url)）は `_blank` + `noopener noreferrer` で新規タブ表示される。
+ */
+export default function NoteMarkdown({ content, sx }: NoteMarkdownProps) {
+  return (
+    <Box
+      sx={[
+        { wordBreak: 'break-word', overflowWrap: 'anywhere' },
+        ...(sx == null ? [] : Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={MARKDOWN_COMPONENTS}>
+        {content}
+      </ReactMarkdown>
+    </Box>
+  );
+}

--- a/services/livetalk/web/tests/unit/components/NoteMarkdown.test.tsx
+++ b/services/livetalk/web/tests/unit/components/NoteMarkdown.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+// @mui/material はサーバーサイドレンダリングで sx を処理できないため、軽量なモックに置き換える。
+jest.mock('@mui/material', () => {
+  const createComponent = (tag: string) => {
+    const MockComponent = ({ children, component, ...props }: Record<string, unknown>) => {
+      const elementTag = (typeof component === 'string' ? component : tag) as string;
+      // sx はスタイルプロパティのため DOM に渡さない
+      const { sx, ...rest } = props as { sx?: unknown } & Record<string, unknown>;
+      void sx;
+      return React.createElement(elementTag, rest, children as React.ReactNode);
+    };
+    MockComponent.displayName = `Mock${tag}`;
+    return MockComponent;
+  };
+
+  return {
+    Box: createComponent('div'),
+    Typography: createComponent('span'),
+  };
+});
+
+// @nagiyu/ui の Link を a タグにマッピングするモック
+jest.mock('@nagiyu/ui', () => {
+  const Link = ({ children, href, target, rel, ...rest }: Record<string, unknown>) =>
+    React.createElement(
+      'a',
+      { href: href as string, target: target as string, rel: rel as string, ...rest },
+      children as React.ReactNode
+    );
+  Link.displayName = 'MockNagiyuLink';
+  return { Link };
+});
+
+// react-markdown は ESM 専用のため Jest から直接ロードしない。
+// MARKDOWN_COMPONENTS マップを named export から取り出してテストする。
+jest.mock('react-markdown', () => ({ __esModule: true, default: () => null }));
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => undefined }));
+
+import { MARKDOWN_COMPONENTS } from '../../../src/components/NoteMarkdown';
+
+/**
+ * MARKDOWN_COMPONENTS の各マッピングを renderToStaticMarkup で検証するヘルパー。
+ */
+const renderComponent = (
+  key: keyof typeof MARKDOWN_COMPONENTS,
+  props: Record<string, unknown>,
+  children?: React.ReactNode
+) => {
+  const Component = MARKDOWN_COMPONENTS[key] as React.ComponentType<Record<string, unknown>>;
+  return renderToStaticMarkup(React.createElement(Component, props, children));
+};
+
+describe('NoteMarkdown - MARKDOWN_COMPONENTS', () => {
+  it('リンクは nagiyu/ui Link 経由で a タグとなり、新規タブで開く属性を付与する', () => {
+    const html = renderComponent('a', { href: 'https://example.com' }, 'リンク先');
+
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain('リンク先');
+  });
+
+  it('段落は p タグとしてレンダリングされる', () => {
+    const html = renderComponent('p', {}, 'ノートの本文テキストです。');
+
+    expect(html).toContain('<p');
+    expect(html).toContain('ノートの本文テキストです。');
+  });
+
+  it('箇条書き（ul, li）は ul/li タグとしてレンダリングされる', () => {
+    const ulHtml = renderComponent('ul', {}, '項目一覧');
+    const liHtml = renderComponent('li', {}, '各項目の内容');
+
+    expect(ulHtml).toContain('<ul');
+    expect(ulHtml).toContain('項目一覧');
+    expect(liHtml).toContain('<li');
+    expect(liHtml).toContain('各項目の内容');
+  });
+
+  it('番号付きリスト（ol）は ol タグとしてレンダリングされる', () => {
+    const html = renderComponent('ol', {}, '一番目の手順');
+
+    expect(html).toContain('<ol');
+    expect(html).toContain('一番目の手順');
+  });
+
+  it('強調（strong, em）は strong/em タグとしてレンダリングされる', () => {
+    const strongHtml = renderComponent('strong', {}, '重要なポイント');
+    const emHtml = renderComponent('em', {}, '補足説明');
+
+    expect(strongHtml).toContain('<strong');
+    expect(strongHtml).toContain('重要なポイント');
+    expect(emHtml).toContain('<em');
+    expect(emHtml).toContain('補足説明');
+  });
+
+  it('インラインコードは code タグとしてレンダリングされる', () => {
+    const html = renderComponent('code', {}, 'someFunction()');
+
+    expect(html).toContain('<code');
+    expect(html).toContain('someFunction()');
+  });
+
+  it('見出し（h1, h2, h3）はそれぞれ h3, h4, h5 タグとしてレンダリングされる', () => {
+    const h1Html = renderComponent('h1', {}, '大見出し');
+    const h2Html = renderComponent('h2', {}, '中見出し');
+    const h3Html = renderComponent('h3', {}, '小見出し');
+
+    expect(h1Html).toContain('<h3');
+    expect(h1Html).toContain('大見出し');
+    expect(h2Html).toContain('<h4');
+    expect(h2Html).toContain('中見出し');
+    expect(h3Html).toContain('<h5');
+    expect(h3Html).toContain('小見出し');
+  });
+});


### PR DESCRIPTION
## 変更の概要

リブトーク（livetalk）のノート詳細画面（`/notes/[id]`）で、本文がプレーンテキスト（`whiteSpace: 'pre-wrap'`）で表示されており、Markdown 記法（リンク `[text](url)` など）が崩れて見えていた。これを Markdown として正しく描画するよう変更した。

Stock Tracker の AI 分析サマリー描画（`AiAnalysisMarkdown`）と同じ `react-markdown` + `remark-gfm` のクライアント描画パターンを livetalk に移植している。

- `NoteMarkdown` コンポーネントを新規作成（`MARKDOWN_COMPONENTS` マッピング + 本体）。リンクは `@nagiyu/ui` の `Link` で `target="_blank" rel="noopener noreferrer"` を付与し新規タブ表示。
- ノート詳細画面の本文を `NoteMarkdown` に置き換え（`note.body` は型上 `string | undefined` のため `?? ''` でフォールバック。空本文時に何も描画しない点は従来の `pre-wrap` 表示と同等）。
- `services/livetalk/web` に `react-markdown` / `remark-gfm` を追加（Stock Tracker と同一バージョン）。

## 関連 Issue

Closes #3389

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [ ] 関連ドキュメントを更新した（永続ドキュメントへの反映は不要と判断）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `NoteMarkdown.test.tsx` を新規追加。`react-markdown` / `remark-gfm`（ESM）をモックし、`MARKDOWN_COMPONENTS` の各マッピングを `renderToStaticMarkup` で検証（リンクが `a` タグ + 新規タブ属性になること、p / ul / ol / li / strong / em / code / h1〜h3 の描画）。7 件すべて green。
- livetalk web 全テスト: 41 suites / 259 tests すべて green（既存テストへの影響なし）。

## レビューポイント

- 単一改行の扱い: `remark-gfm` のみのため、本文中の単一改行は段落内で結合される（Stock Tracker の参考実装と同じ挙動）。段落区切り（空行）は正しく改段する。単一改行を `<br>` にしたい場合は `remark-breaks` の追加を別途検討可能。
- `NoteMarkdown` は livetalk ローカルに実装（Stock Tracker の `AiAnalysisMarkdown` と類似の重複あり）。共有ライブラリ（`libs/ui`）への切り出しは複数サービスへの波及があるため本 PR では行わず、必要なら別タスクとした。

## スクリーンショット（該当する場合）

（描画ロジックの変更のため省略。必要であれば dev 環境で確認可能）

## 補足事項

dev へデプロイされる軽量変更のため、integration ブランチは作成せず `develop` 向けの Draft PR としている。


---
_Generated by [Claude Code](https://claude.ai/code/session_019ik5AmtfzDGzasytdtwdMk)_