### PR TITLE
Phase 1: エンターキー確定用の共通 hook useEnterSubmit を追加

### DIFF
--- a/libs/react/src/hooks/index.ts
+++ b/libs/react/src/hooks/index.ts
@@ -8,3 +8,5 @@ export { useAPIRequest } from './useAPIRequest';
 export type { UseAPIRequestOptions, UseAPIRequestReturn } from './useAPIRequest';
 export { usePushSubscription } from './usePushSubscription';
 export type { UsePushSubscriptionOptions, UsePushSubscriptionReturn } from './usePushSubscription';
+export { useEnterSubmit } from './useEnterSubmit';
+export type { UseEnterSubmitOptions } from './useEnterSubmit';

--- a/libs/react/src/hooks/useEnterSubmit.ts
+++ b/libs/react/src/hooks/useEnterSubmit.ts
@@ -59,7 +59,7 @@ export interface UseEnterSubmitOptions {
  */
 export function useEnterSubmit<T extends HTMLElement = HTMLInputElement>(
   onSubmit: () => void,
-  options?: UseEnterSubmitOptions,
+  options?: UseEnterSubmitOptions
 ): (event: React.KeyboardEvent<T>) => void {
   const disabled = options?.disabled ?? false;
   const preventDefault = options?.preventDefault ?? true;
@@ -95,6 +95,6 @@ export function useEnterSubmit<T extends HTMLElement = HTMLInputElement>(
 
       onSubmit();
     },
-    [onSubmit, disabled, preventDefault],
+    [onSubmit, disabled, preventDefault]
   );
 }

--- a/libs/react/src/hooks/useEnterSubmit.ts
+++ b/libs/react/src/hooks/useEnterSubmit.ts
@@ -1,0 +1,100 @@
+/**
+ * useEnterSubmit Hook
+ *
+ * 単一行入力でエンターキー押下時に onSubmit を呼ぶ onKeyDown ハンドラを生成するカスタムフック。
+ * IME 変換確定中の Enter による誤発火を防ぐ。
+ *
+ * @example
+ * ```tsx
+ * import { useEnterSubmit } from '@nagiyu/react';
+ *
+ * function SearchInput() {
+ *   const [value, setValue] = React.useState('');
+ *
+ *   const handleKeyDown = useEnterSubmit(() => {
+ *     console.log('検索実行:', value);
+ *   });
+ *
+ *   return (
+ *     <input
+ *       value={value}
+ *       onChange={(e) => setValue(e.target.value)}
+ *       onKeyDown={handleKeyDown}
+ *     />
+ *   );
+ * }
+ * ```
+ */
+
+import { useCallback } from 'react';
+import type React from 'react';
+
+/**
+ * useEnterSubmit のオプション
+ */
+export interface UseEnterSubmitOptions {
+  /**
+   * true の間はエンター確定を無効化する。
+   * 既定: false
+   */
+  disabled?: boolean;
+
+  /**
+   * エンター確定時に event.preventDefault() を呼ぶか。
+   * 既定: true
+   */
+  preventDefault?: boolean;
+}
+
+/**
+ * useEnterSubmit Hook
+ *
+ * 単一行入力でエンターキー押下時に onSubmit を呼ぶ onKeyDown ハンドラを生成する。
+ * IME 変換確定中の Enter を無視し、修飾キー付きの Enter も無視する。
+ *
+ * @template T - イベントターゲットの HTML 要素型（既定: HTMLInputElement）
+ * @param onSubmit - エンターキー確定時に呼ばれるコールバック
+ * @param options - Hook のオプション
+ * @returns onKeyDown に渡すイベントハンドラ
+ */
+export function useEnterSubmit<T extends HTMLElement = HTMLInputElement>(
+  onSubmit: () => void,
+  options?: UseEnterSubmitOptions,
+): (event: React.KeyboardEvent<T>) => void {
+  const disabled = options?.disabled ?? false;
+  const preventDefault = options?.preventDefault ?? true;
+
+  return useCallback(
+    (event: React.KeyboardEvent<T>) => {
+      // Enter キー以外は無視
+      if (event.key !== 'Enter') {
+        return;
+      }
+
+      // IME 変換確定中の Enter は無視する（誤確定防止）
+      // isComposing: 標準的な IME 確定検出
+      // keyCode === 229: 一部ブラウザ・環境での IME 確定検出（後方互換）
+      if (event.nativeEvent.isComposing || event.keyCode === 229) {
+        return;
+      }
+
+      // 修飾キー付きの Enter は無視する（改行・ショートカット等を壊さないため）
+      if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) {
+        return;
+      }
+
+      // disabled の場合は何もしない
+      if (disabled) {
+        return;
+      }
+
+      // 確定条件を満たした場合の処理
+      if (preventDefault) {
+        event.preventDefault();
+      }
+
+      onSubmit();
+    },
+    [onSubmit, disabled, preventDefault],
+  );
+}

--- a/libs/react/src/index.ts
+++ b/libs/react/src/index.ts
@@ -7,12 +7,13 @@
  */
 
 // Export React hooks
-export { useAPIRequest, usePushSubscription } from './hooks';
+export { useAPIRequest, usePushSubscription, useEnterSubmit } from './hooks';
 export type {
   UseAPIRequestOptions,
   UseAPIRequestReturn,
   UsePushSubscriptionOptions,
   UsePushSubscriptionReturn,
+  UseEnterSubmitOptions,
 } from './hooks';
 
 // Export API Client

--- a/libs/react/tests/hooks/useEnterSubmit.test.tsx
+++ b/libs/react/tests/hooks/useEnterSubmit.test.tsx
@@ -340,11 +340,11 @@ describe('useEnterSubmit', () => {
   describe('ジェネリック型の動作', () => {
     it('HTMLTextAreaElement 型でもハンドラが正しく動作する', () => {
       const onSubmit = jest.fn();
-      const { result } = renderHook(() =>
-        useEnterSubmit<HTMLTextAreaElement>(onSubmit)
-      );
+      const { result } = renderHook(() => useEnterSubmit<HTMLTextAreaElement>(onSubmit));
 
-      const event = createKeyboardEvent({ key: 'Enter' }) as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
+      const event = createKeyboardEvent({
+        key: 'Enter',
+      }) as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
       result.current(event);
 
       expect(onSubmit).toHaveBeenCalledTimes(1);

--- a/libs/react/tests/hooks/useEnterSubmit.test.tsx
+++ b/libs/react/tests/hooks/useEnterSubmit.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * useEnterSubmit Hook テスト
+ *
+ * エンターキーによる確定処理と IME 誤発火防止の動作を検証する
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useEnterSubmit } from '../../src/hooks/useEnterSubmit';
+import type { UseEnterSubmitOptions } from '../../src/hooks/useEnterSubmit';
+
+/**
+ * KeyboardEvent モックオブジェクトを生成するヘルパー
+ */
+function createKeyboardEvent(
+  overrides: Partial<{
+    key: string;
+    keyCode: number;
+    isComposing: boolean;
+    shiftKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    altKey: boolean;
+  }> = {}
+): React.KeyboardEvent<HTMLInputElement> {
+  const {
+    key = 'Enter',
+    keyCode = 13,
+    isComposing = false,
+    shiftKey = false,
+    ctrlKey = false,
+    metaKey = false,
+    altKey = false,
+  } = overrides;
+
+  return {
+    key,
+    keyCode,
+    shiftKey,
+    ctrlKey,
+    metaKey,
+    altKey,
+    nativeEvent: {
+      isComposing,
+    } as KeyboardEvent,
+    preventDefault: jest.fn(),
+  } as unknown as React.KeyboardEvent<HTMLInputElement>;
+}
+
+describe('useEnterSubmit', () => {
+  describe('基本動作', () => {
+    it('素の Enter で onSubmit が呼ばれる', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('Enter 以外のキー（例: "a"）では onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'a', keyCode: 65 });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('Space キーでは onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: ' ', keyCode: 32 });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('preventDefault の動作', () => {
+    it('既定では event.preventDefault() が呼ばれる', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('preventDefault: true の場合 event.preventDefault() が呼ばれる', () => {
+      const onSubmit = jest.fn();
+      const options: UseEnterSubmitOptions = { preventDefault: true };
+      const { result } = renderHook(() => useEnterSubmit(onSubmit, options));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('preventDefault: false の場合 event.preventDefault() が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const options: UseEnterSubmitOptions = { preventDefault: false };
+      const { result } = renderHook(() => useEnterSubmit(onSubmit, options));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('IME 変換確定の誤発火防止', () => {
+    it('isComposing: true の Enter では onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', isComposing: true });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('isComposing: true の場合 event.preventDefault() も呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', isComposing: true });
+      result.current(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('keyCode === 229 の Enter では onSubmit が呼ばれない（後方互換 IME 検出）', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', keyCode: 229 });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('keyCode === 229 かつ isComposing: false でも onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', keyCode: 229, isComposing: false });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('修飾キー付きの Enter', () => {
+    it('Shift+Enter では onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', shiftKey: true });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('Ctrl+Enter では onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', ctrlKey: true });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('Meta+Enter では onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', metaKey: true });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('Alt+Enter では onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', altKey: true });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('修飾キー付きの場合 event.preventDefault() も呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const event = createKeyboardEvent({ key: 'Enter', shiftKey: true });
+      result.current(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled オプション', () => {
+    it('disabled: true のときは onSubmit が呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const options: UseEnterSubmitOptions = { disabled: true };
+      const { result } = renderHook(() => useEnterSubmit(onSubmit, options));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('disabled: true のときは event.preventDefault() も呼ばれない', () => {
+      const onSubmit = jest.fn();
+      const options: UseEnterSubmitOptions = { disabled: true };
+      const { result } = renderHook(() => useEnterSubmit(onSubmit, options));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('disabled: false のときは onSubmit が呼ばれる', () => {
+      const onSubmit = jest.fn();
+      const options: UseEnterSubmitOptions = { disabled: false };
+      const { result } = renderHook(() => useEnterSubmit(onSubmit, options));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('disabled が未指定（既定 false）のときは onSubmit が呼ばれる', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit, {}));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ハンドラの参照安定性', () => {
+    it('依存が変わらなければ再レンダー間でハンドラが同一参照を返す', () => {
+      const onSubmit = jest.fn();
+      const { result, rerender } = renderHook(() => useEnterSubmit(onSubmit));
+
+      const handlerBefore = result.current;
+      rerender();
+      const handlerAfter = result.current;
+
+      expect(handlerBefore).toBe(handlerAfter);
+    });
+
+    it('onSubmit が変わるとハンドラの参照が変わる', () => {
+      const onSubmit1 = jest.fn();
+      const onSubmit2 = jest.fn();
+
+      const { result, rerender } = renderHook(
+        ({ onSubmit }: { onSubmit: () => void }) => useEnterSubmit(onSubmit),
+        { initialProps: { onSubmit: onSubmit1 } }
+      );
+
+      const handlerBefore = result.current;
+      rerender({ onSubmit: onSubmit2 });
+      const handlerAfter = result.current;
+
+      expect(handlerBefore).not.toBe(handlerAfter);
+    });
+
+    it('disabled が変わるとハンドラの参照が変わる', () => {
+      const onSubmit = jest.fn();
+
+      const { result, rerender } = renderHook(
+        ({ disabled }: { disabled: boolean }) => useEnterSubmit(onSubmit, { disabled }),
+        { initialProps: { disabled: false } }
+      );
+
+      const handlerBefore = result.current;
+      rerender({ disabled: true });
+      const handlerAfter = result.current;
+
+      expect(handlerBefore).not.toBe(handlerAfter);
+    });
+
+    it('preventDefault が変わるとハンドラの参照が変わる', () => {
+      const onSubmit = jest.fn();
+
+      const { result, rerender } = renderHook(
+        ({ preventDefault }: { preventDefault: boolean }) =>
+          useEnterSubmit(onSubmit, { preventDefault }),
+        { initialProps: { preventDefault: true } }
+      );
+
+      const handlerBefore = result.current;
+      rerender({ preventDefault: false });
+      const handlerAfter = result.current;
+
+      expect(handlerBefore).not.toBe(handlerAfter);
+    });
+  });
+
+  describe('オプション未指定時の既定値', () => {
+    it('options が undefined でも動作する', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit, undefined));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('options が空オブジェクトでも既定値で動作する', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() => useEnterSubmit(onSubmit, {}));
+
+      const event = createKeyboardEvent({ key: 'Enter' });
+      result.current(event);
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ジェネリック型の動作', () => {
+    it('HTMLTextAreaElement 型でもハンドラが正しく動作する', () => {
+      const onSubmit = jest.fn();
+      const { result } = renderHook(() =>
+        useEnterSubmit<HTMLTextAreaElement>(onSubmit)
+      );
+
+      const event = createKeyboardEvent({ key: 'Enter' }) as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
+      result.current(event);
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

各サービスの単一行 input を「エンターキーで確定」できるよう統一するための共通基盤（Phase 1）。`@nagiyu/react` に hook `useEnterSubmit` を追加する。後続 Phase で各サービスがこの hook を利用する。

`useEnterSubmit(onSubmit, options?)` は input に渡す `onKeyDown` ハンドラを生成する。既存の素朴な `event.key === 'Enter'` 実装にあった **IME 変換確定の Enter による誤発火**を防ぐ設計とした。

- 素の Enter のときのみ `onSubmit` を呼ぶ
- IME 変換確定中（`nativeEvent.isComposing` / `keyCode === 229`）は無視
- 修飾キー付き（Shift / Ctrl / Meta / Alt）の Enter は無視
- `disabled` で無効化、`preventDefault`（既定 true）で `event.preventDefault()` 制御
- `@nagiyu/ui` の TextField・MUI TextField の双方に渡せるようジェネリック `T extends HTMLElement`
- `useCallback` で参照安定

## 関連 Issue

#3393 の Phase 1（共通基盤）

<!-- 作業ブランチ → integration の PR のため Closes は付けない（Issue は integration → develop マージ後にクローズ） -->

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（共通 UI/hook ドキュメントへの反映は Issue 完了後にまとめて実施）
- [x] CI/CD 設定を追加・更新した（新規ライブラリではないため変更なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

`libs/react/tests/hooks/useEnterSubmit.test.tsx` を新規追加。

- 素の Enter で `onSubmit` が呼ばれる
- `preventDefault` 既定で `event.preventDefault()` が呼ばれる / `false` で呼ばれない
- IME 変換中（`isComposing: true`）・`keyCode === 229` では呼ばれない
- Shift / Ctrl / Meta / Alt + Enter では呼ばれない
- Enter 以外のキーでは呼ばれない
- `disabled: true` のとき呼ばれない
- 返り値ハンドラの参照安定性

検証結果: `@nagiyu/react` のテスト 73 件 pass、`useEnterSubmit.ts` カバレッジ 100%、build / lint green。

## レビューポイント

- IME 確定検出の条件（`isComposing` || `keyCode === 229`）の妥当性
- 「修飾キー付き Enter は一律無視」という方針（単一行確定は素の Enter のみとする想定）

## 補足事項

複数行入力（`multiline` / `textarea`）はスコープ外（Enter=改行を維持）。本 hook は単一行確定向け。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DR96yo53TU25dqFYnksnJ1)_