### PR TITLE
Phase 2: 動画検索キーワード入力でエンターキー検索を可能にする

### DIFF
--- a/services/niconico-mylist-assistant/web/e2e/video-search.spec.ts
+++ b/services/niconico-mylist-assistant/web/e2e/video-search.spec.ts
@@ -105,3 +105,67 @@ test.describe('Video Search Modal - Existing Video Detection', () => {
     await expect(registeredButton).toBeDisabled();
   });
 });
+
+test.describe('Video Search Modal - Enter Key Search', () => {
+  test('should execute search when Enter key is pressed in keyword input', async ({ page }) => {
+    // /api/videos/search の fetch をモックしてダミーの動画を返す
+    await page.addInitScript(() => {
+      const originalFetch = window.fetch;
+
+      const resolveRequestUrl = (input: URL | RequestInfo): string => {
+        if (typeof input === 'string') return input;
+        if (input instanceof URL) return input.toString();
+        if (input instanceof Request) return input.url;
+        return String(input);
+      };
+
+      window.fetch = async (input, init) => {
+        const requestUrl = resolveRequestUrl(input);
+
+        if (requestUrl.includes('/api/videos/search')) {
+          return new Response(
+            JSON.stringify({
+              videos: [
+                {
+                  videoId: 'sm12345',
+                  title: 'エンターキー検索テスト動画',
+                  description: 'エンターキーで検索が実行されることを確認するテスト',
+                  thumbnailUrl: 'https://example.com/thumb-enter.jpg',
+                  duration: 60,
+                  viewCount: 100,
+                  commentCount: 10,
+                  mylistCount: 5,
+                  uploadedAt: '2024-01-01T00:00:00+09:00',
+                  tags: [],
+                  isRegistered: false,
+                },
+              ],
+              total: 1,
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          );
+        }
+
+        return originalFetch(input, init);
+      };
+    });
+
+    await page.goto('/import');
+    // 「動画を検索して追加」ボタンをクリックして検索モーダルを開く
+    await page.getByRole('button', { name: '動画を検索して追加' }).click();
+    const keywordInput = page.getByLabel('検索キーワード');
+    await keywordInput.waitFor({ state: 'visible' });
+
+    // キーワードを入力し、ボタンをクリックせずエンターキーで検索を実行する
+    await keywordInput.fill('エンターキー検索');
+    await keywordInput.press('Enter');
+
+    // モックで返した動画タイトルと videoId がダイアログ内に表示されることを確認する
+    const searchDialog = page.getByRole('dialog', { name: '動画検索' });
+    await expect(searchDialog.getByText('エンターキー検索テスト動画')).toBeVisible();
+    await expect(searchDialog.getByText('sm12345')).toBeVisible();
+  });
+});

--- a/services/niconico-mylist-assistant/web/src/components/VideoSearchModal.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/VideoSearchModal.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from '@mui/material';
 import { Button, ErrorAlert, TextField } from '@nagiyu/ui';
+import { useEnterSubmit } from '@nagiyu/react';
 import { ERROR_MESSAGES, VALIDATION_LIMITS } from '@/lib/constants/errors';
 
 interface VideoSearchModalProps {
@@ -72,6 +73,19 @@ export default function VideoSearchModal({ open, onClose }: VideoSearchModalProp
     }
   };
 
+  // 検索ボタン・エンターキー共通の disabled 判定
+  const isSearchDisabled =
+    loading ||
+    !keyword.trim() ||
+    keyword.trim().length > VALIDATION_LIMITS.SEARCH_KEYWORD_MAX_LENGTH;
+
+  // 検索キーワード入力でエンターキーを押したときに検索を実行するハンドラ
+  // TextField の onKeyDown は HTMLInputElement | HTMLTextAreaElement 型を受け取るため型引数を明示する
+  const handleKeywordEnterDown = useEnterSubmit<HTMLInputElement | HTMLTextAreaElement>(
+    handleSearch,
+    { disabled: isSearchDisabled }
+  );
+
   const handleAddVideo = async (videoId: string) => {
     setError(null);
     try {
@@ -102,6 +116,7 @@ export default function VideoSearchModal({ open, onClose }: VideoSearchModalProp
             label="検索キーワード"
             value={keyword}
             onChange={(event) => setKeyword(event.target.value)}
+            onKeyDown={handleKeywordEnterDown}
             disabled={loading}
             maxLength={VALIDATION_LIMITS.SEARCH_KEYWORD_MAX_LENGTH}
           />
@@ -109,9 +124,7 @@ export default function VideoSearchModal({ open, onClose }: VideoSearchModalProp
             variant="solid"
             onClick={handleSearch}
             loading={loading}
-            disabled={
-              !keyword.trim() || keyword.trim().length > VALIDATION_LIMITS.SEARCH_KEYWORD_MAX_LENGTH
-            }
+            disabled={isSearchDisabled}
           >
             検索
           </Button>


### PR DESCRIPTION
## 変更の概要

Issue #3393 Phase 2。niconico-mylist-assistant の動画検索モーダル（`VideoSearchModal`）で、検索キーワード入力時に**エンターキーで検索を実行**できるようにする。Phase 1 で追加した共通 hook `useEnterSubmit`（`@nagiyu/react`）を利用する。

- 検索ボタンとエンター確定で共通の `isSearchDisabled` 判定（`loading` / 空 / 上限超過）に集約し、無効時はエンターでも検索しない
- 検索キーワードの `TextField` に `onKeyDown` を追加
- 既存の検索ボタンの挙動・見た目は変更なし（エンター確定は追加機能）

単一行入力のため Enter=改行の懸念はない。

## 関連 Issue

#3393 の Phase 2

<!-- 作業ブランチ → integration の PR のため Closes は付けない -->

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（E2E に Enter 検索ケースを追加）
- [ ] 関連ドキュメントを更新した（Issue 完了後にまとめて実施）
- [x] CI/CD 設定を追加・更新した（変更不要）
- [x] ローカルでテストが全て通ることを確認した（lint / format:check / build）
- [x] ビルドエラーがないことを確認した

## テスト内容

`e2e/video-search.spec.ts` に「検索キーワード入力でエンターキーを押すと検索が実行される」E2E テストを追加。

- 既存テスト同様 `/api/videos/search` の fetch を `addInitScript` でモック
- `/import` で検索モーダルを開き、キーワードを `fill` 後に**ボタンをクリックせず `press('Enter')`**
- モックで返した動画タイトル・videoId がダイアログ内に表示されることを assert

ローカル検証: lint / format:check / Next.js build いずれも green。E2E はローカル実行（Playwright Chromium 未インストールのため）スキップし、CI の chromium-mobile E2E で検証。

## レビューポイント

- 検索ボタンの `disabled` を `isSearchDisabled`（`loading` を含む式）に一本化した点（従来挙動と等価: loading 中はボタンが loading 表示で操作不能のため）

## 補足事項

Phase 1（#3394）でマージ済みの `useEnterSubmit` に依存。IME 変換確定中・修飾キー付き Enter では発火しない（hook 側で考慮済み）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DR96yo53TU25dqFYnksnJ1)_