### PR TITLE
カテゴリ別ハブページ 3 本の新設（A2 / #3268）

### DIFF
--- a/services/portal/web/fixtures/content/tech-category/aws.md
+++ b/services/portal/web/fixtures/content/tech-category/aws.md
@@ -1,0 +1,9 @@
+---
+title: 'AWS インフラ運用ノート'
+description: 'Test description for aws hub'
+slug: 'aws'
+---
+
+# AWS hub
+
+Sample hub content for testing.

--- a/services/portal/web/fixtures/content/tech-category/nextjs.md
+++ b/services/portal/web/fixtures/content/tech-category/nextjs.md
@@ -1,0 +1,9 @@
+---
+title: 'Next.js × Portal 実装ノート'
+description: 'Test description for nextjs hub'
+slug: 'nextjs'
+---
+
+# Next.js hub
+
+Sample hub content for testing.

--- a/services/portal/web/fixtures/content/tech/test-article-1.md
+++ b/services/portal/web/fixtures/content/tech/test-article-1.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-10'
 updatedAt: '2026-04-15'
 author: 'なぎゆー'
 tags: ['AWS', 'Test']
+categories: ['aws']
 ---
 
 # Test Article 1

--- a/services/portal/web/fixtures/content/tech/test-article-2.md
+++ b/services/portal/web/fixtures/content/tech/test-article-2.md
@@ -4,6 +4,7 @@ description: 'Test description for fixture article 2'
 slug: 'test-article-2'
 publishedAt: '2026-04-05'
 tags: ['AWS', 'Next.js']
+categories: ['aws', 'nextjs']
 ---
 
 # Test Article 2

--- a/services/portal/web/src/app/sitemap.ts
+++ b/services/portal/web/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import {
   getAllArticles,
   getAllServiceSlugs,
   getAllTags,
+  getAllTechCategoryMetas,
   isLinkableTag,
   tagToSlug,
 } from '@/lib/content';
@@ -48,5 +49,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     }));
 
-  return [...staticEntries, ...serviceEntries, ...articleEntries, ...tagEntries];
+  const categoryEntries: MetadataRoute.Sitemap = getAllTechCategoryMetas().map((category) => ({
+    url: `${SITE_URL}/tech/category/${category.slug}`,
+    lastModified: now,
+    changeFrequency: 'weekly' as const,
+    priority: 0.7,
+  }));
+
+  return [
+    ...staticEntries,
+    ...serviceEntries,
+    ...articleEntries,
+    ...tagEntries,
+    ...categoryEntries,
+  ];
 }

--- a/services/portal/web/src/app/tech/[slug]/page.tsx
+++ b/services/portal/web/src/app/tech/[slug]/page.tsx
@@ -10,7 +10,12 @@ import {
   Divider,
 } from '@mui/material';
 import { Chip, Link } from '@nagiyu/ui';
-import { getAllArticles, getArticle, getRelatedArticles } from '@/lib/content';
+import {
+  getAllArticles,
+  getArticle,
+  getRelatedArticles,
+  getTechCategoriesForArticle,
+} from '@/lib/content';
 import MarkdownContent from '@/components/MarkdownContent';
 import { buildBlogPostingJsonLd, buildBreadcrumbJsonLd, jsonLdScript } from '@/lib/jsonLd';
 import { AUTHOR } from '@/lib/author';
@@ -88,6 +93,7 @@ export default async function TechArticlePage({ params }: Params) {
   const authorName = article.author ?? AUTHOR.name;
   const readingMinutes = estimateReadingMinutes(article.content);
   const relatedArticles = getRelatedArticles(article.slug, article.tags, 3);
+  const categories = getTechCategoriesForArticle(article.categories);
 
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
@@ -120,6 +126,19 @@ export default async function TechArticlePage({ params }: Params) {
           読了目安: 約 {readingMinutes} 分
         </Typography>
       </Box>
+      {/* 所属カテゴリ別ハブへの戻りリンク（Hub-and-Spoke の双方向クラスター） */}
+      {categories.length > 0 && (
+        <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 0.5, mb: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+            関連カテゴリ:
+          </Typography>
+          {categories.map((category) => (
+            <Chip key={category.slug} asChild size="sm" variant="solid" color="primary">
+              <Link href={`/tech/category/${category.slug}`}>{category.title} →</Link>
+            </Chip>
+          ))}
+        </Box>
+      )}
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 3 }}>
         {article.tags.map((tag) => (
           <Chip key={tag} size="sm" variant="outline">

--- a/services/portal/web/src/app/tech/category/[category]/page.tsx
+++ b/services/portal/web/src/app/tech/category/[category]/page.tsx
@@ -1,0 +1,122 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import {
+  Container,
+  Typography,
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  Divider,
+} from '@mui/material';
+import { Chip } from '@nagiyu/ui';
+import { TECH_CATEGORY_SLUGS, getArticlesByCategory, getTechCategory } from '@/lib/content';
+import MarkdownContent from '@/components/MarkdownContent';
+import { buildBreadcrumbJsonLd, jsonLdScript } from '@/lib/jsonLd';
+
+type Params = { params: Promise<{ category: string }> };
+
+export async function generateStaticParams() {
+  return TECH_CATEGORY_SLUGS.map((category) => ({ category }));
+}
+
+export const dynamicParams = false;
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { category: slug } = await params;
+  try {
+    const category = await getTechCategory(slug);
+    const url = `https://nagiyu.com/tech/category/${slug}`;
+    return {
+      title: category.title,
+      description: category.description,
+      alternates: { canonical: url },
+      openGraph: {
+        type: 'website',
+        url,
+        title: category.title,
+        description: category.description,
+        images: ['/og-default.png'],
+      },
+    };
+  } catch {
+    return { title: 'カテゴリ別ハブ' };
+  }
+}
+
+export default async function TechCategoryPage({ params }: Params) {
+  const { category: slug } = await params;
+
+  let category;
+  try {
+    category = await getTechCategory(slug);
+  } catch {
+    notFound();
+  }
+
+  const articles = getArticlesByCategory(slug);
+
+  const breadcrumb = buildBreadcrumbJsonLd([
+    { name: 'ホーム', url: 'https://nagiyu.com/' },
+    { name: '技術記事', url: 'https://nagiyu.com/tech' },
+    { name: category.title, url: `https://nagiyu.com/tech/category/${slug}` },
+  ]);
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdScript(breadcrumb) }}
+      />
+      <Typography variant="h4" component="h1" gutterBottom>
+        {category.title}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3, fontStyle: 'italic' }}>
+        {category.description}
+      </Typography>
+
+      {/* ハブ解説本文 */}
+      <MarkdownContent html={category.content} />
+
+      {/* 関連記事リスト */}
+      <Box sx={{ mt: 6 }}>
+        <Divider sx={{ mb: 3 }} />
+        <Typography variant="h5" component="h2" gutterBottom>
+          このカテゴリの記事（全 {articles.length} 件）
+        </Typography>
+        {articles.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            記事はまだありません。
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {articles.map((article) => (
+              <Card key={article.slug} variant="outlined">
+                <CardActionArea href={`/tech/${article.slug}`}>
+                  <CardContent>
+                    <Typography variant="h6" component="h3" gutterBottom>
+                      {article.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      {article.description}
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1 }}>
+                      {article.tags.map((tag) => (
+                        <Chip key={tag} size="sm" variant="outline">
+                          {tag}
+                        </Chip>
+                      ))}
+                    </Box>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                      公開日: {article.publishedAt}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Container>
+  );
+}

--- a/services/portal/web/src/app/tech/page.tsx
+++ b/services/portal/web/src/app/tech/page.tsx
@@ -1,8 +1,17 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { Container, Typography, Grid, Box, Card, CardContent, CardActions } from '@mui/material';
+import {
+  Container,
+  Typography,
+  Grid,
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  CardActions,
+} from '@mui/material';
 import { Button, Chip } from '@nagiyu/ui';
-import { getAllArticles } from '@/lib/content';
+import { getAllArticles, getAllTechCategoryMetas } from '@/lib/content';
 
 export const metadata: Metadata = {
   title: '技術記事',
@@ -15,6 +24,7 @@ export const metadata: Metadata = {
 
 export default function TechPage() {
   const articles = getAllArticles();
+  const categories = getAllTechCategoryMetas();
 
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
@@ -24,6 +34,40 @@ export default function TechPage() {
 
       <Typography variant="body1" align="center" sx={{ mb: 4 }}>
         nagiyu のサービス開発で得た技術知見・アーキテクチャ解説を公開しています。
+      </Typography>
+
+      {/* カテゴリ別ハブ（テーマ深堀りページ）への導線 */}
+      {categories.length > 0 && (
+        <Box sx={{ mb: 5 }}>
+          <Typography variant="h5" component="h2" gutterBottom>
+            カテゴリ別ハブ
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            テーマごとの全体像と関連記事をまとめたページです。
+          </Typography>
+          <Grid container spacing={2}>
+            {categories.map((category) => (
+              <Grid size={{ xs: 12, sm: 4 }} key={category.slug}>
+                <Card variant="outlined" sx={{ height: '100%' }}>
+                  <CardActionArea href={`/tech/category/${category.slug}`} sx={{ height: '100%' }}>
+                    <CardContent>
+                      <Typography variant="h6" component="h3" gutterBottom>
+                        {category.title}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {category.description}
+                      </Typography>
+                    </CardContent>
+                  </CardActionArea>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Box>
+      )}
+
+      <Typography variant="h5" component="h2" gutterBottom>
+        記事一覧
       </Typography>
 
       {articles.length === 0 ? (

--- a/services/portal/web/src/content/tech-category/aws.md
+++ b/services/portal/web/src/content/tech-category/aws.md
@@ -1,0 +1,26 @@
+---
+title: 'AWS インフラ運用ノート'
+description: 'nagiyu-platform を支える AWS インフラの全体像をまとめたハブページです。CDK による IaC、dev=Lambda / prod=ECS の使い分け、CloudFront・DynamoDB・EventBridge・S3・ECR・AWS Batch の採用判断を、実装ベースで横断的に紹介します。'
+slug: 'aws'
+---
+
+## このカテゴリで扱うこと
+
+nagiyu-platform の各サービスは、ほぼすべての本番インフラを AWS 上に構築しています。配信は CloudFront、永続化は DynamoDB、定期実行は EventBridge、重い処理は AWS Batch、コンテナは ECS / ECR、関数実行は Lambda——といった構成要素を、すべて AWS CDK（TypeScript）でコード化しています。
+
+このハブでは、それら個別技術の「なぜその選択をしたか」を運用視点でまとめます。各記事は特定テーマの深堀りですが、ここを起点に読むことで「Portal というツール群を実際に動かしている AWS 構成の全体像」が掴めるようにしています。
+
+## nagiyu-platform での採用状況
+
+私が AWS を使うときの基本方針は「環境ごとに過剰なコストを払わない」ことです。dev 環境はリクエストの少ない時間帯が多いため Lambda（`portal-lambda-stack.ts` / `cloudfront-lambda-stack.ts`）で従量課金に寄せ、常時トラフィックのある prod 環境は ECS Fargate（`ecs-cluster-stack.ts` / `ecs-service-stack.ts`）に切り替える、という二段構えを `infra/root` で組んでいます。同じアプリを環境変数とスタック分割だけで両系統に流せるようにしているのが工夫した点です。
+
+データ層は全サービスで DynamoDB のシングルテーブル設計に統一し、`libs/aws` の抽象リポジトリ層（`abstract-repository.ts` / `repository-factory.ts`）で共通化しています。Stock Tracker のように GSI を複数張って User / Alert / Ticker / Summary を 1 テーブルで捌くケースもあれば、Quick Clip のように S3 への署名付き URL でアップロード/ダウンロードを完結させるケースもあります。定期バッチは EventBridge Rules（Scheduler API ではなく `aws-events`）で組み、Stock Tracker では `rate()` と `cron()` を使い分けた 6 つのルールを運用しています。
+
+## 振り返って
+
+自分でゼロから CDK を書いて気づいたのは、「マネージドサービスの選定よりも、環境差分（dev/prod）をどう吸収するかの設計のほうが運用を左右する」ということでした。Lambda の 15 分制限に詰まって AWS Batch / ECS へ逃がす、ECR は `maxImageCount: 10` でイメージを溜め込まない、IAM は CDK で Role を機能単位に分けて最小権限に寄せる——こうした地味な判断の積み重ねが、いまの nagiyu-platform の安定運用を支えています。下の関連記事は、その一つひとつを実装コード付きで掘り下げたものです。
+
+## 参考リンク
+
+- [AWS CDK 公式ドキュメント](https://docs.aws.amazon.com/cdk/v2/guide/home.html)
+- [Amazon DynamoDB 開発者ガイド](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html)

--- a/services/portal/web/src/content/tech-category/dev-stack.md
+++ b/services/portal/web/src/content/tech-category/dev-stack.md
@@ -1,0 +1,26 @@
+---
+title: '開発基盤・モノレポ運用ノート'
+description: 'nagiyu-platform を支える開発基盤をまとめたハブページです。npm workspaces によるモノレポ構成、TypeScript strict、判別ユニオンによる型安全な API、GitHub Actions の差分デプロイ、Playwright の並列 CI を、実装ベースで横断的に紹介します。'
+slug: 'dev-stack'
+---
+
+## このカテゴリで扱うこと
+
+nagiyu-platform は、複数のサービス（Portal / Quick Clip / Stock Tracker など）と共通ライブラリ（`libs/common` / `browser` / `ui` / `react` / `nextjs` / `aws`）を 1 つのリポジトリにまとめたモノレポです。このハブでは、その「土台」——パッケージ管理・型安全・CI/CD・E2E テストといった、機能には直接現れないが開発速度と品質を左右する部分をまとめます。
+
+個別の記事はそれぞれ独立した技法の解説ですが、ここを起点に読むことで「1 人で複数サービスを保守し続けるために、どんな開発基盤を組んだか」という全体設計が見えるようにしています。
+
+## nagiyu-platform での採用状況
+
+依存管理は npm workspaces で統一し、共通ロジックは `libs/*` に切り出して `ui → browser → common` のような一方向の依存に保っています（循環依存は禁止）。TypeScript は全パッケージで strict モードを有効にし、API のレスポンスは判別ユニオン（discriminated union）で表現して、成功・失敗を型レベルで網羅できるようにしています。DynamoDB アクセスは `libs/aws` の抽象リポジトリに集約し、`USE_IN_MEMORY_DB` で InMemory 実装に差し替えられるようにしてテスト容易性を確保しています。
+
+CI/CD は GitHub Actions で組んでいます。私が特に手を入れたのは、`paths:` フィルタで「変更があったサービスだけをデプロイする」差分デプロイと、`.github/actions` の composite action による共通ロジックの抽出です。E2E は Playwright で、`chromium-mobile` を常時実行しつつ、`chromium-desktop` / `webkit-mobile` は develop 向け PR のときだけ走らせる、という段階的な構成にしてフィードバック速度とカバレッジのバランスを取っています。
+
+## 振り返って
+
+モノレポを 1 人で回してみて痛感したのは、「基盤の自動化に投資した分だけ、後の自分が楽になる」ということでした。差分デプロイがなければ毎回全サービスをビルドする羽目になり、strict や判別ユニオンがなければリファクタのたびに実行時エラーに怯えることになります。下の関連記事は、こうした基盤づくりの一つひとつを、実際の設定ファイルやコード付きで掘り下げたものです。
+
+## 参考リンク
+
+- [npm workspaces 公式ドキュメント](https://docs.npmjs.com/cli/v10/using-npm/workspaces)
+- [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)

--- a/services/portal/web/src/content/tech-category/nextjs.md
+++ b/services/portal/web/src/content/tech-category/nextjs.md
@@ -1,0 +1,26 @@
+---
+title: 'Next.js × Portal 実装ノート'
+description: 'この Portal サイトそのものを題材に、Next.js App Router・SSG・Metadata API・RSC 境界・MUI v7 統合・Docker マルチステージビルドの実装をまとめたハブページです。フレームワークの機能を実プロダクトでどう使い分けているかを横断的に紹介します。'
+slug: 'nextjs'
+---
+
+## このカテゴリで扱うこと
+
+いま読んでいるこの Portal サイト自体が、Next.js の実装サンプルです。技術記事もサービスドキュメントも Markdown ファイルとして持ち、App Router の SSG（静的生成）でビルド時に HTML 化しています。動的な API サーバーを持たずに、記事追加 = ファイル追加だけで完結する構成です。
+
+このハブでは、App Router・Server Components・Metadata API・SSG ルーティングといった Next.js の機能群を、「この Portal で実際にどう組んだか」という単一プロダクトの文脈でまとめます。断片的なチュートリアルではなく、一つのサイトを成立させている実装の集合として読めるようにしています。
+
+## nagiyu-platform での採用状況
+
+Portal の本文描画は、`src/lib/content.ts` を Repository 層に見立てて Markdown を読み込み、remark / rehype で HTML 化したうえで DOMPurify でサニタイズする流れにしています。記事ページ・タグページ・このカテゴリ別ハブはいずれも `generateStaticParams` で URL を列挙し、ビルド時に静的化しています。`dynamicParams = false` を設定して、想定外の URL は 404 に倒すようにしているのも意図的な選択です。
+
+UI は `libs/ui` に切り出した共通コンポーネント（Chip / Link / Button など）を軸に、MUI v7 を App Router のテーマレジストリ経由で統合しています。私が一番こだわったのは Server / Client コンポーネントの境界で、データ取得とメタデータ生成はサーバー側に寄せ、インタラクションが必要な最小範囲だけを Client Component に切り出しています。各ページの `<title>` / OGP / canonical は Metadata API（`generateMetadata`）で個別に出し分け、構造化データ（BlogPosting / BreadcrumbList）も `lib/jsonLd.ts` のヘルパーで一元的に組み立てています。
+
+## 振り返って
+
+App Router を本番で運用してみて実感したのは、「SSG とコンテンツの所在をシンプルに保つほど運用が軽くなる」ことでした。記事を増やすときに触るのは Markdown ファイルだけで、ルーティング・サイトマップ・構造化データは既存のロジックが自動で拾ってくれる——この自動化のおかげで、コンテンツ追加の心理的コストをかなり下げられています。下の関連記事では、その各レイヤーの実装を個別に掘り下げています。
+
+## 参考リンク
+
+- [Next.js App Router ドキュメント](https://nextjs.org/docs/app)
+- [MUI（Material UI）公式ドキュメント](https://mui.com/material-ui/getting-started/)

--- a/services/portal/web/src/content/tech/aws-batch-architecture.md
+++ b/services/portal/web/src/content/tech/aws-batch-architecture.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-10'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['AWS', 'AWS Batch', 'サーバーレス']
+categories: ['aws']
 relatedServices: ['quick-clip', 'codec-converter']
 ---
 

--- a/services/portal/web/src/content/tech/cdk-iam-least-privilege.md
+++ b/services/portal/web/src/content/tech/cdk-iam-least-privilege.md
@@ -6,6 +6,7 @@ publishedAt: '2026-05-21'
 updatedAt: '2026-05-31'
 author: 'なぎゆー'
 tags: ['AWS', 'CDK', 'IAM', 'セキュリティ']
+categories: ['aws']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/cloudfront-cache-strategy.md
+++ b/services/portal/web/src/content/tech/cloudfront-cache-strategy.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-22'
 updatedAt: '2026-05-31'
 author: 'なぎゆー'
 tags: ['AWS', 'CloudFront', 'キャッシュ', 'パフォーマンス']
+categories: ['aws']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/cloudfront-ecs-deployment.md
+++ b/services/portal/web/src/content/tech/cloudfront-ecs-deployment.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-10'
 updatedAt: '2026-05-31'
 author: 'なぎゆー'
 tags: ['AWS', 'CloudFront', 'ECS', 'Next.js']
+categories: ['aws']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/discriminated-union-api.md
+++ b/services/portal/web/src/content/tech/discriminated-union-api.md
@@ -6,6 +6,7 @@ publishedAt: '2026-03-30'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['TypeScript', '型設計', 'union types']
+categories: ['dev-stack']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/docker-multistage-nextjs.md
+++ b/services/portal/web/src/content/tech/docker-multistage-nextjs.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-05'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['Docker', 'Next.js', 'CI/CD']
+categories: ['nextjs', 'aws']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/dynamodb-single-table.md
+++ b/services/portal/web/src/content/tech/dynamodb-single-table.md
@@ -6,6 +6,7 @@ publishedAt: '2026-03-17'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['AWS', 'DynamoDB', 'NoSQL', '設計']
+categories: ['aws']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/ecr-lifecycle-policy.md
+++ b/services/portal/web/src/content/tech/ecr-lifecycle-policy.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-12'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['AWS', 'ECR', 'コスト最適化']
+categories: ['aws']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/ecs-fargate-vs-lambda.md
+++ b/services/portal/web/src/content/tech/ecs-fargate-vs-lambda.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-25'
 updatedAt: '2026-05-31'
 author: 'なぎゆー'
 tags: ['AWS', 'ECS', 'Lambda', 'アーキテクチャ']
+categories: ['aws']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/eventbridge-rule-scheduling.md
+++ b/services/portal/web/src/content/tech/eventbridge-rule-scheduling.md
@@ -6,6 +6,7 @@ publishedAt: '2026-05-27'
 updatedAt: '2026-05-27'
 author: 'なぎゆー'
 tags: ['AWS', 'EventBridge', 'Lambda', 'CDK']
+categories: ['aws']
 relatedServices: ['stock-tracker']
 ---
 

--- a/services/portal/web/src/content/tech/github-actions-monorepo-deploy.md
+++ b/services/portal/web/src/content/tech/github-actions-monorepo-deploy.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-02'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['GitHub Actions', 'CI/CD', 'monorepo']
+categories: ['dev-stack']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/lambda-cold-start.md
+++ b/services/portal/web/src/content/tech/lambda-cold-start.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-03'
 updatedAt: '2026-05-31'
 author: 'なぎゆー'
 tags: ['AWS', 'Lambda', 'パフォーマンス']
+categories: ['aws']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/monorepo-typescript-workspaces.md
+++ b/services/portal/web/src/content/tech/monorepo-typescript-workspaces.md
@@ -6,6 +6,7 @@ publishedAt: '2026-03-20'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['TypeScript', 'monorepo', 'npm workspaces']
+categories: ['dev-stack']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/mui-nextjs-theme-registry.md
+++ b/services/portal/web/src/content/tech/mui-nextjs-theme-registry.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-15'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['Next.js', 'MUI', 'App Router', 'Emotion']
+categories: ['nextjs']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/nextjs-generate-static-params.md
+++ b/services/portal/web/src/content/tech/nextjs-generate-static-params.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-28'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['Next.js', 'SSG', 'App Router']
+categories: ['nextjs']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/nextjs-ssg-markdown.md
+++ b/services/portal/web/src/content/tech/nextjs-ssg-markdown.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-10'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['Next.js', 'Markdown', 'SSG']
+categories: ['nextjs']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/nextjs16-metadata-api.md
+++ b/services/portal/web/src/content/tech/nextjs16-metadata-api.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-30'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['Next.js', 'SEO', 'メタデータ']
+categories: ['nextjs']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/playwright-parallel-ci.md
+++ b/services/portal/web/src/content/tech/playwright-parallel-ci.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-08'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['Playwright', 'GitHub Actions', 'テスト']
+categories: ['dev-stack']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/rsc-use-client-boundary.md
+++ b/services/portal/web/src/content/tech/rsc-use-client-boundary.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-20'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['Next.js', 'React', 'Server Components', 'App Router']
+categories: ['nextjs']
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/s3-presigned-url.md
+++ b/services/portal/web/src/content/tech/s3-presigned-url.md
@@ -6,6 +6,7 @@ publishedAt: '2026-04-18'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['AWS', 'S3', 'セキュリティ']
+categories: ['aws']
 relatedServices: ['quick-clip', 'codec-converter']
 ---
 

--- a/services/portal/web/src/content/tech/typescript-strict-repository.md
+++ b/services/portal/web/src/content/tech/typescript-strict-repository.md
@@ -6,6 +6,7 @@ publishedAt: '2026-03-15'
 updatedAt: '2026-05-01'
 author: 'なぎゆー'
 tags: ['TypeScript', 'Repository', '型設計']
+categories: ['dev-stack']
 ---
 
 ## はじめに

--- a/services/portal/web/src/lib/content.ts
+++ b/services/portal/web/src/lib/content.ts
@@ -6,17 +6,32 @@ import remarkGfm from 'remark-gfm';
 import remarkRehype from 'remark-rehype';
 import rehypeStringify from 'rehype-stringify';
 import DOMPurify from 'isomorphic-dompurify';
-import type { ServiceDocument, ServiceDocumentMeta, Article, ArticleMeta } from '@/types/content';
+import type {
+  ServiceDocument,
+  ServiceDocumentMeta,
+  Article,
+  ArticleMeta,
+  TechCategory,
+  TechCategoryMeta,
+} from '@/types/content';
 
 const ERROR_MESSAGES = {
   SERVICE_DOCUMENT_NOT_FOUND: 'サービスドキュメントが見つかりません',
   ARTICLE_NOT_FOUND: '技術記事が見つかりません',
+  TECH_CATEGORY_NOT_FOUND: 'カテゴリ別ハブが見つかりません',
   INVALID_FRONTMATTER: 'フロントマターの形式が正しくありません',
 } as const;
 
 const CONTENT_DIR = path.join(process.cwd(), 'src', 'content');
 const SERVICES_DIR = path.join(CONTENT_DIR, 'services');
 const TECH_DIR = path.join(CONTENT_DIR, 'tech');
+const TECH_CATEGORY_DIR = path.join(CONTENT_DIR, 'tech-category');
+
+/**
+ * カテゴリ別ハブの slug 一覧（表示順を兼ねる）。
+ * `/tech/category/{slug}` の静的生成・並び順の正とする。
+ */
+export const TECH_CATEGORY_SLUGS = ['aws', 'nextjs', 'dev-stack'] as const;
 
 const TYPE_TO_FILENAME: Record<'overview' | 'guide' | 'faq', string> = {
   overview: 'index.md',
@@ -208,4 +223,65 @@ export function getTagBySlug(slug: string): string | null {
  */
 export function getArticlesByTag(tag: string): ArticleMeta[] {
   return getAllArticles().filter((article) => article.tags.includes(tag));
+}
+
+/**
+ * 全カテゴリ別ハブのメタデータを TECH_CATEGORY_SLUGS の順で返す。
+ * Markdown ファイルが存在しない slug は黙って除外する。
+ */
+export function getAllTechCategoryMetas(): TechCategoryMeta[] {
+  return TECH_CATEGORY_SLUGS.map((slug): TechCategoryMeta | null => {
+    const filePath = path.join(TECH_CATEGORY_DIR, `${slug}.md`);
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    const { data } = matter(fileContents);
+    const meta = data as Omit<TechCategoryMeta, 'slug'>;
+    return { ...meta, slug };
+  }).filter((meta): meta is TechCategoryMeta => meta !== null);
+}
+
+/**
+ * カテゴリ別ハブの解説本文（HTML 変換済み）を取得する
+ * @param slug - ハブ slug（aws / nextjs / dev-stack）
+ */
+export async function getTechCategory(slug: string): Promise<TechCategory> {
+  const filePath = path.join(TECH_CATEGORY_DIR, `${slug}.md`);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(ERROR_MESSAGES.TECH_CATEGORY_NOT_FOUND);
+  }
+
+  const fileContents = fs.readFileSync(filePath, 'utf8');
+  const { data, content } = matter(fileContents);
+  const meta = data as Omit<TechCategoryMeta, 'slug'>;
+  const htmlContent = await markdownToHtml(content);
+
+  return {
+    ...meta,
+    slug,
+    content: htmlContent,
+  };
+}
+
+/**
+ * 指定カテゴリ別ハブに所属する記事を publishedAt 降順で返す。
+ * 記事側フロントマターの `categories` に slug を含むものを抽出する。
+ */
+export function getArticlesByCategory(slug: string): ArticleMeta[] {
+  return getAllArticles().filter((article) => article.categories?.includes(slug));
+}
+
+/**
+ * 記事が所属するカテゴリ別ハブのメタデータを返す（記事 → ハブの戻りリンク用）。
+ * 実在するハブのみを TECH_CATEGORY_SLUGS の順で返す。
+ * @param categories - 記事フロントマターの categories（未設定なら空配列）
+ */
+export function getTechCategoriesForArticle(categories: string[] | undefined): TechCategoryMeta[] {
+  if (!categories || categories.length === 0) {
+    return [];
+  }
+  const categorySet = new Set(categories);
+  return getAllTechCategoryMetas().filter((meta) => categorySet.has(meta.slug));
 }

--- a/services/portal/web/src/types/content.ts
+++ b/services/portal/web/src/types/content.ts
@@ -22,11 +22,24 @@ export type ArticleMeta = {
   updatedAt?: string; // ISO 8601 date（任意。記事の最終更新日）
   author?: string; // 任意。未指定時は AUTHOR.name を使用
   tags: string[];
+  categories?: string[]; // 任意。所属するカテゴリ別ハブの slug 配列（複数所属可）
   relatedServices?: string[]; // 任意。サービス slug の配列（相互リンク用）
 };
 
 /** 技術記事（フロントマター + 本文） */
 export type Article = ArticleMeta & {
+  content: string; // HTML（remark/rehype 変換済み）
+};
+
+/** カテゴリ別ハブ（テーマ深堀りページ）のフロントマター */
+export type TechCategoryMeta = {
+  title: string;
+  description: string;
+  slug: string; // ハブ slug（aws / nextjs / dev-stack）
+};
+
+/** カテゴリ別ハブ（フロントマター + 解説本文） */
+export type TechCategory = TechCategoryMeta & {
   content: string; // HTML（remark/rehype 変換済み）
 };
 

--- a/services/portal/web/tests/unit/lib/content.test.ts
+++ b/services/portal/web/tests/unit/lib/content.test.ts
@@ -10,6 +10,10 @@ import {
   getTagBySlug,
   tagToSlug,
   isLinkableTag,
+  getAllTechCategoryMetas,
+  getTechCategory,
+  getArticlesByCategory,
+  getTechCategoriesForArticle,
 } from '@/lib/content';
 
 // ESM-only パッケージ（remark/rehype/unified）は Jest の CommonJS 環境では読み込めないためモック化する
@@ -210,6 +214,64 @@ describe('content', () => {
 
     it('存在しないスラッグは null', () => {
       expect(getTagBySlug('nonexistent-slug')).toBeNull();
+    });
+  });
+
+  describe('getAllTechCategoryMetas', () => {
+    it('実在するハブのメタデータを TECH_CATEGORY_SLUGS の順で返す', () => {
+      const metas = getAllTechCategoryMetas();
+      // フィクスチャには aws / nextjs のみ存在し、dev-stack は存在しない
+      expect(metas.map((m) => m.slug)).toEqual(['aws', 'nextjs']);
+      expect(metas[0].title).toBe('AWS インフラ運用ノート');
+      expect(typeof metas[0].description).toBe('string');
+    });
+  });
+
+  describe('getTechCategory', () => {
+    it('ハブの解説本文（HTML 変換済み）を取得できる', async () => {
+      const category = await getTechCategory('aws');
+      expect(category.slug).toBe('aws');
+      expect(category.title).toBe('AWS インフラ運用ノート');
+      expect(typeof category.content).toBe('string');
+    });
+
+    it('存在しないハブ slug でエラーが発生する', async () => {
+      await expect(getTechCategory('nonexistent')).rejects.toThrow();
+    });
+  });
+
+  describe('getArticlesByCategory', () => {
+    it('指定カテゴリに所属する記事を publishedAt 降順で返す', () => {
+      const articles = getArticlesByCategory('aws');
+      // test-article-1 (aws), test-article-2 (aws, nextjs) が該当
+      expect(articles.map((a) => a.slug)).toEqual(['test-article-1', 'test-article-2']);
+    });
+
+    it('単一カテゴリにのみ所属する記事を抽出する', () => {
+      const articles = getArticlesByCategory('nextjs');
+      expect(articles.map((a) => a.slug)).toEqual(['test-article-2']);
+    });
+
+    it('該当記事がないカテゴリでは空配列', () => {
+      expect(getArticlesByCategory('dev-stack')).toEqual([]);
+    });
+  });
+
+  describe('getTechCategoriesForArticle', () => {
+    it('記事の categories から実在するハブのメタを返す', () => {
+      const metas = getTechCategoriesForArticle(['aws', 'nextjs']);
+      expect(metas.map((m) => m.slug)).toEqual(['aws', 'nextjs']);
+    });
+
+    it('実在しないハブ slug は除外する', () => {
+      const metas = getTechCategoriesForArticle(['aws', 'dev-stack']);
+      // dev-stack はフィクスチャに存在しないため除外される
+      expect(metas.map((m) => m.slug)).toEqual(['aws']);
+    });
+
+    it('categories が未指定なら空配列', () => {
+      expect(getTechCategoriesForArticle(undefined)).toEqual([]);
+      expect(getTechCategoriesForArticle([])).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## 変更の概要

Master #3262 の AdSense 審査再申請対応のうち、A2（カテゴリ別ハブページの新設）を実装した。Hub-and-Spoke モデルに沿って、技術記事のカテゴリ別ハブを 3 本新設し、解説 + 関連記事リスト + 記事側からの戻りリンクで双方向クラスターを構成する。

新設ハブ:

| slug | URL | タイトル |
|---|---|---|
| `aws` | `/tech/category/aws` | AWS インフラ運用ノート |
| `nextjs` | `/tech/category/nextjs` | Next.js × Portal 実装ノート |
| `dev-stack` | `/tech/category/dev-stack` | 開発基盤・モノレポ運用ノート |

主な実装:

- `ArticleMeta` に `categories?: string[]` を追加し、対象 21 記事のフロントマターに付与（複数所属可。`docker-multistage-nextjs` は `aws` / `nextjs` の両方に所属）
- 各ハブの解説本文を Markdown（`src/content/tech-category/*.md`）で作成。導入 + nagiyu-platform での採用状況 + 一人称セクション + 参考リンクで構成し、解説本文は各 1000〜1200 字
- `src/app/tech/category/[category]/page.tsx` を新設。`generateStaticParams` で 3 ハブを静的生成（`dynamicParams: false`）、関連記事リストは `publishedAt` 降順で表示、BreadcrumbList JSON-LD を設定
- `content.ts` にハブ取得・カテゴリ別記事抽出の関数を追加（`getAllTechCategoryMetas` / `getTechCategory` / `getArticlesByCategory` / `getTechCategoriesForArticle`）
- 個別記事ページのヘッダーに所属ハブへの戻りリンク Chip を設置（複数所属は複数 Chip）
- `/tech` 一覧の冒頭に「カテゴリ別ハブ」導線セクションを追加
- サイトマップに 3 ハブ URL を priority 0.7 で追加

設計方針は #3268 の設計合意コメントに準拠。

## 関連 Issue

#3268 / Master: #3262

（本 PR は integration ブランチ向けのため `Closes` は使用しない）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（ハブは本 PR の新規機能。永続ドキュメント更新は対象外）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `content.ts` の新規関数 4 つにユニットテストを追加（`getAllTechCategoryMetas` / `getTechCategory` / `getArticlesByCategory` / `getTechCategoriesForArticle`）。実在しないハブ slug の除外、複数所属記事の抽出、未指定時の空配列などを網羅
- フィクスチャに `tech-category/`（`aws` / `nextjs` のみ。`dev-stack` 不在で「実在ハブのみ返す」分岐を検証）と記事への `categories` を追加
- `npm run test -- --coverage`: 56 件全 pass、`src/lib` カバレッジ 98.77%（しきい値 80%）
- `npx tsc --noEmit`: エラーなし
- `npm run lint`: エラーなし
- `npm run build`: 成功。`/tech/category/{aws,nextjs,dev-stack}` が静的生成され、サイトマップに 3 ハブ URL、`docker-multistage-nextjs` 記事に AWS / Next.js 両ハブへの戻りリンクが出力されることを確認

## レビューポイント

- ハブ本文（`src/content/tech-category/*.md`）の「採用状況」記述に、実装と乖離した記述（捏造）がないか。CDK 構成・dev=Lambda / prod=ECS・DynamoDB シングルテーブル・EventBridge Rules・npm workspaces・差分デプロイ・Playwright 段階実行などは実装から抽出して記述
- 記事 → ハブの戻りリンク Chip の配置（ヘッダーのタグ Chip 群の直上、`関連カテゴリ:` ラベル付き）の見た目
- 既存タグページ（`/tech/tags/`）との URL・SEO 上の競合がないこと

## 補足事項

- `eventbridge-rule-scheduling`（A5 で新規執筆）にも `categories: ['aws']` を付与済み
- グローバルナビへのハブ組み込みは B4、トップページからの導線は B1 のスコープのため本 PR では対応しない（#3268 の合意どおり `/tech` 一覧内の導線追加に留める）


---
_Generated by [Claude Code](https://claude.ai/code/session_01XycD9G6g6Qx51N7KV9YDDQ)_