### PR TITLE
全件失敗時にジョブステータスを FAILED に更新するよう修正

### DIFF
--- a/services/niconico-mylist-assistant/batch/src/index.ts
+++ b/services/niconico-mylist-assistant/batch/src/index.ts
@@ -13,6 +13,7 @@ import {
   createBatchCompletionPayload,
   createTwoFactorAuthRequiredPayload,
 } from './lib/web-push-client.js';
+import { determineBatchJobStatus } from './lib/job-status.js';
 import { formatLocalDateTime, getTimestamp, sleep, toErrorMessage } from '@nagiyu/common';
 import {
   DEFAULT_MYLIST_NAME_PREFIX,
@@ -304,11 +305,17 @@ async function main() {
 
     console.log('================');
 
-    // ジョブステータスを SUCCEEDED に更新
+    // 登録結果からジョブの最終ステータスを確定する（DB 書き込み前に決定）
+    const finalStatus = determineBatchJobStatus(
+      result.successVideoIds.length,
+      result.failedVideoIds.length
+    );
+
+    // ジョブステータスを確定ステータスで更新
     if (params.jobId) {
       try {
         await updateBatchJob(params.jobId, params.userId, {
-          status: 'SUCCEEDED',
+          status: finalStatus,
           result: {
             registeredCount: result.successVideoIds.length,
             failedCount: result.failedVideoIds.length,
@@ -317,7 +324,7 @@ async function main() {
           },
           completedAt: Date.now(),
         });
-        console.log('ジョブステータスを SUCCEEDED に更新しました');
+        console.log(`ジョブステータスを ${finalStatus} に更新しました`);
 
         // Web Push 通知を送信
         if (pushSubscription) {
@@ -347,8 +354,8 @@ async function main() {
           console.log('Push サブスクリプション情報がないため、通知をスキップします');
         }
       } catch (error) {
-        console.error('ジョブステータス更新に失敗しました (SUCCEEDED):', error);
-        // 更新失敗してもジョブ自体は成功
+        console.error(`ジョブステータス更新に失敗しました (${finalStatus}):`, error);
+        // 更新失敗してもジョブ自体は続行
       }
     }
 
@@ -359,9 +366,8 @@ async function main() {
     console.log(`完了時刻: ${getTimestamp()}`);
     console.log('========================================');
 
-    // 一部失敗があってもバッチジョブ自体は成功とみなす
-    // （全失敗の場合のみエラー終了）
-    if (result.successVideoIds.length === 0 && result.failedVideoIds.length > 0) {
+    // DB に FAILED を書いた後、全件失敗の場合は異常終了する
+    if (finalStatus === 'FAILED') {
       console.error('全ての動画の登録に失敗しました');
       await reportErrorEvent({
         serviceId: 'niconico-mylist-assistant',

--- a/services/niconico-mylist-assistant/batch/src/lib/job-status.ts
+++ b/services/niconico-mylist-assistant/batch/src/lib/job-status.ts
@@ -1,0 +1,37 @@
+/**
+ * バッチジョブステータス判定ユーティリティ
+ *
+ * マイリスト登録結果に基づいてバッチジョブの最終ステータスを決定する。
+ * @nagiyu/niconico-mylist-assistant-core の BatchStatus 型のうち、
+ * 完了系ステータス（'SUCCEEDED' | 'FAILED'）のみを扱う純粋関数を提供する。
+ */
+
+/**
+ * バッチジョブの完了ステータス型
+ *
+ * BatchStatus（'SUBMITTED' | 'RUNNING' | 'WAITING_FOR_2FA' | 'SUCCEEDED' | 'FAILED'）の
+ * 完了系サブセット。
+ */
+export type BatchJobFinalStatus = 'SUCCEEDED' | 'FAILED';
+
+/**
+ * マイリスト登録結果からバッチジョブの最終ステータスを決定する
+ *
+ * 判定ルール:
+ * - 全件失敗（successCount === 0 かつ failedCount > 0）→ 'FAILED'
+ * - それ以外（全件成功・一部失敗・0件）→ 'SUCCEEDED'
+ *   ※一部失敗は UI が SUCCEEDED/FAILED の二値しか扱えないため SUCCEEDED 扱い
+ *
+ * @param successCount - 登録成功件数
+ * @param failedCount - 登録失敗件数
+ * @returns バッチジョブの最終ステータス
+ */
+export function determineBatchJobStatus(
+  successCount: number,
+  failedCount: number
+): BatchJobFinalStatus {
+  if (successCount === 0 && failedCount > 0) {
+    return 'FAILED';
+  }
+  return 'SUCCEEDED';
+}

--- a/services/niconico-mylist-assistant/batch/tests/unit/job-status.test.ts
+++ b/services/niconico-mylist-assistant/batch/tests/unit/job-status.test.ts
@@ -1,0 +1,50 @@
+/**
+ * job-status.ts のユニットテスト
+ *
+ * determineBatchJobStatus の判定ロジックを検証する。
+ */
+
+import { determineBatchJobStatus } from '../../src/lib/job-status.js';
+
+describe('determineBatchJobStatus', () => {
+  describe('全件失敗（FAILED）', () => {
+    it('success=0, failed=2 のとき FAILED を返す', () => {
+      expect(determineBatchJobStatus(0, 2)).toBe('FAILED');
+    });
+
+    it('success=0, failed=1 のとき FAILED を返す', () => {
+      expect(determineBatchJobStatus(0, 1)).toBe('FAILED');
+    });
+
+    it('success=0, failed=100 のとき FAILED を返す', () => {
+      expect(determineBatchJobStatus(0, 100)).toBe('FAILED');
+    });
+  });
+
+  describe('全件成功（SUCCEEDED）', () => {
+    it('success=3, failed=0 のとき SUCCEEDED を返す', () => {
+      expect(determineBatchJobStatus(3, 0)).toBe('SUCCEEDED');
+    });
+
+    it('success=1, failed=0 のとき SUCCEEDED を返す', () => {
+      expect(determineBatchJobStatus(1, 0)).toBe('SUCCEEDED');
+    });
+  });
+
+  describe('一部失敗（SUCCEEDED 扱い）', () => {
+    it('success=1, failed=1 のとき SUCCEEDED を返す', () => {
+      expect(determineBatchJobStatus(1, 1)).toBe('SUCCEEDED');
+    });
+
+    it('success=5, failed=3 のとき SUCCEEDED を返す', () => {
+      expect(determineBatchJobStatus(5, 3)).toBe('SUCCEEDED');
+    });
+  });
+
+  describe('境界値（success=0, failed=0）', () => {
+    it('success=0, failed=0 のとき SUCCEEDED を返す', () => {
+      // 実運用では発生しないが、関数仕様として success=0 AND failed=0 は全件失敗の条件を満たさないため SUCCEEDED
+      expect(determineBatchJobStatus(0, 0)).toBe('SUCCEEDED');
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

`niconico-mylist-assistant` のマイリスト自動登録バッチで、**全動画の登録に失敗した場合でも DynamoDB のジョブステータスが `SUCCEEDED` に誤更新される**バグを修正する。

従来は登録結果に関わらず無条件で `SUCCEEDED` を書き込み、全件失敗時のみ後段で `process.exit(1)` していたが、その時点では DB は既に `SUCCEEDED` 済みで手遅れだった。本 PR では **DB 書き込み前に登録結果から最終ステータスを確定**するよう修正する。

### 判定ロジック

| 状況 | ステータス |
|---|---|
| 全件失敗（`success === 0 && failed > 0`） | `FAILED` |
| 全件成功（`failed === 0`） | `SUCCEEDED` |
| 一部失敗（`success ≥ 1 && failed ≥ 1`） | `SUCCEEDED`（後述） |

**一部失敗の扱い**: UI（`JobStatusDisplay`）とステータス enum `BatchStatus` は `SUCCEEDED` / `FAILED` の二値しか扱えないため、新ステータス（`PARTIAL` 等）の追加は UI 改修を伴う。本 Issue のスコープを「全件失敗を `FAILED` にする」に限定し、一部失敗は `SUCCEEDED` 扱いとした（Issue 本文の判断基準に従い、事前に方針合意済み）。partial の扱いは必要なら別途検討とする。

### 主な変更

- 新規 `batch/src/lib/job-status.ts`: ステータス判定を純粋関数 `determineBatchJobStatus` として切り出し（`index.ts` は `main()` を即時実行するためテスト用に分離）
- `batch/src/index.ts`: `updateBatchJob` 呼び出し前に `finalStatus` を確定して渡す。ログ・`process.exit(1)` の条件を確定ステータスと整合（DB に `FAILED` を書いた後に異常終了）
- Web Push 完了通知の payload は既に全件失敗時の文言分岐を持つため変更なし

## 関連 Issue

Issue #3148

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（判定ロジックを純粋関数化し全ケース網羅）
- [ ] 関連ドキュメントを更新した（ドキュメント更新は不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（batch パッケージ）

## テスト内容

- `batch/tests/unit/job-status.test.ts` を新規追加し、`determineBatchJobStatus` を検証
  - 全件失敗（success=0, failed=1/2/100）→ `FAILED`
  - 全件成功（success=1/3, failed=0）→ `SUCCEEDED`
  - 一部失敗（success=1/5, failed=1/3）→ `SUCCEEDED`
  - 境界値（success=0, failed=0）→ `SUCCEEDED`
- `npm run test --workspace=@nagiyu/niconico-mylist-assistant-batch`: 4 suites / 56 tests all passed
- `npm run build`（tsc）/ `npm run lint`: いずれも正常終了

## レビューポイント

- 一部失敗を `SUCCEEDED` 扱いとした判断（UI 二値制約に基づくスコープ限定）が妥当か
- `process.exit(1)` を DB 更新後（`finalStatus === 'FAILED'` 判定）に配置した点の整合性

## 補足事項

- dev 環境での実地検証（誤認証情報でジョブ実行 → CloudWatch Logs で `ジョブステータスを FAILED に更新しました`、UI で失敗表示）は本ブランチを `integration/3148-batch-job-status` 経由で dev デプロイ後に実施予定。
- 本リポジトリのサンドボックス環境では `@nagiyu/niconico-mylist-assistant-core` の `dynamodb-video.repository.ts` で AWS SDK 型の既存ビルドエラーが出るが、本 PR が触れていない既存事象であり batch パッケージのビルドは独立して成功している。


---
_Generated by [Claude Code](https://claude.ai/code/session_01WernPmVZeEoFWSdBjjAFmv)_