### PR TITLE
Phase 4a: ティッカー作成・編集の入力でエンターキー確定を可能にする

### DIFF
--- a/services/stock-tracker/web/app/tickers/page.tsx
+++ b/services/stock-tracker/web/app/tickers/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '@mui/material';
 import { Button, ErrorAlert, Select, TextField } from '@nagiyu/ui';
 import { Add as AddIcon, Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import { useEnterSubmit } from '@nagiyu/react';
 
 // エラーメッセージ定数
 const ERROR_MESSAGES = {
@@ -273,6 +274,22 @@ export default function TickersPage() {
     }
   };
 
+  // エンターキーで作成を確定するハンドラ（新規作成モーダル用）
+  const handleCreateEnterDown = useEnterSubmit<HTMLInputElement | HTMLTextAreaElement>(
+    handleCreate,
+    {
+      disabled: !formData.symbol || !formData.name || !formData.exchangeId,
+    }
+  );
+
+  // エンターキーで更新を確定するハンドラ（編集モーダル用）
+  const handleUpdateEnterDown = useEnterSubmit<HTMLInputElement | HTMLTextAreaElement>(
+    handleUpdate,
+    {
+      disabled: !formData.name,
+    }
+  );
+
   // ティッカー削除
   const handleDelete = async () => {
     setError('');
@@ -409,6 +426,7 @@ export default function TickersPage() {
               label="シンボル"
               value={formData.symbol}
               onChange={(e) => handleInputChange('symbol', e.target.value.toUpperCase())}
+              onKeyDown={handleCreateEnterDown}
               fullWidth
               required
               helperText="例: AAPL, NVDA（英大文字と数字のみ）"
@@ -417,6 +435,7 @@ export default function TickersPage() {
               label="銘柄名"
               value={formData.name}
               onChange={(e) => handleInputChange('name', e.target.value)}
+              onKeyDown={handleCreateEnterDown}
               fullWidth
               required
               helperText="例: Apple Inc., NVIDIA Corporation"
@@ -473,6 +492,7 @@ export default function TickersPage() {
               label="銘柄名"
               value={formData.name}
               onChange={(e) => handleInputChange('name', e.target.value)}
+              onKeyDown={handleUpdateEnterDown}
               fullWidth
               required
             />

--- a/services/stock-tracker/web/tests/e2e/ticker-management.spec.ts
+++ b/services/stock-tracker/web/tests/e2e/ticker-management.spec.ts
@@ -66,6 +66,90 @@ test.describe('ティッカー管理', () => {
   });
 
   test.describe('ティッカー作成', () => {
+    test('シンボル入力欄でエンターキーを押すとティッカーを作成できる', async ({
+      page,
+      request,
+    }) => {
+      // テスト用の Exchange を API 経由で作成
+      const exchange = await factory.createExchange();
+
+      // データが反映されるまで待つ
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // ページをリロード
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+
+      // テスト用のユニークなシンボルと名前
+      const testSymbol = `E${Date.now() % 100000}`.substring(0, 10).toUpperCase();
+      const testName = 'Enter Key Test Corporation';
+
+      // 新規作成ボタンをクリック
+      await page.getByRole('button', { name: '新規作成' }).click();
+
+      // モーダルが表示される
+      await expect(page.getByRole('dialog')).toBeVisible();
+
+      const symbolField = page.getByRole('textbox', { name: /シンボル/ });
+      const nameField = page.getByRole('textbox', { name: /銘柄名/ });
+      const exchangeField = page.locator('#create-exchange');
+
+      // シンボルを入力
+      await symbolField.fill(testSymbol);
+
+      // 銘柄名を入力
+      await nameField.fill(testName);
+
+      // 取引所を選択
+      await exchangeField.click();
+
+      const exchangeOption = page.locator(
+        `[role="listbox"] [role="option"]:has-text("${exchange.name}")`
+      );
+      const isExchangeVisible = await exchangeOption.isVisible().catch(() => false);
+
+      if (isExchangeVisible) {
+        await exchangeOption.click();
+      } else {
+        // 作成した取引所が見つからない場合は最初のオプションを選択
+        const exchangeOptions = page.locator('[role="listbox"] [role="option"]');
+        const optionCount = await exchangeOptions.count();
+        if (optionCount > 0) {
+          await exchangeOptions.first().click();
+        } else {
+          console.log('取引所データがないためテストをスキップ');
+          test.skip();
+          return;
+        }
+      }
+
+      // 作成ボタンをクリックせず、シンボル入力欄でエンターキーを押す
+      await symbolField.press('Enter');
+
+      // 成功メッセージが表示される
+      await expect(page.getByText('ティッカーを作成しました')).toBeVisible({ timeout: 10000 });
+
+      // モーダルが閉じる
+      await expect(page.getByRole('dialog')).not.toBeVisible();
+
+      // テーブルに新しいティッカーが表示される
+      const tickerRow = page.getByRole('row').filter({ hasText: testSymbol });
+      await expect(tickerRow).toBeVisible();
+
+      // ティッカーIDを取得してクリーンアップ
+      const tickerIdCell = tickerRow.getByRole('cell').first();
+      const createdTickerId = (await tickerIdCell.textContent()) || '';
+
+      if (createdTickerId) {
+        try {
+          await request.delete(`/api/tickers/${encodeURIComponent(createdTickerId)}`);
+          console.log(`UI作成ティッカーをクリーンアップ（Enter確定テスト）: ${createdTickerId}`);
+        } catch (error) {
+          console.warn(`Warning: Failed to cleanup UI-created ticker ${createdTickerId}:`, error);
+        }
+      }
+    });
+
     test('ティッカーを作成できる', async ({ page, request }) => {
       // テスト用の Exchange を API 経由で作成
       const exchange = await factory.createExchange();


### PR DESCRIPTION
## 変更の概要

Issue #3393 Phase 4a（stock-tracker をファイル単位に分割した 1/4）。ティッカー管理ページ（`app/tickers/page.tsx`）の単一行入力をエンターキーで確定できるようにする。共通 hook `useEnterSubmit`（`@nagiyu/react`）を利用。

- **新規作成モーダル**: 「シンボル」「銘柄名」入力でエンター → 作成（`disabled: !symbol || !name || !exchangeId`）
- **編集モーダル**: 「銘柄名」入力でエンター → 更新（`disabled: !formData.name`）。「ティッカーID」「シンボル」は編集時 disabled のため対象外
- Select には付けない（ネイティブのキーボード挙動を尊重）
- 既存のボタン挙動・バリデーション・見た目は変更なし

stock-tracker web は `@nagiyu/react` の配線（依存・lock・jest・CI・Dockerfile・transpilePackages）が完備済みのため、infra 変更は不要（コードと E2E のみ）。

## 関連 Issue

#3393 の Phase 4a

<!-- 作業ブランチ → integration の PR のため Closes は付けない -->

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（E2E に Enter 作成ケースを追加）
- [ ] 関連ドキュメントを更新した（Issue 完了後にまとめて実施）
- [x] CI/CD 設定を追加・更新した（変更不要）
- [x] ローカルでテストが全て通ることを確認した（lint / format:check / build / test 220 件）
- [x] ビルドエラーがないことを確認した

## テスト内容

`tests/e2e/ticker-management.spec.ts` に「シンボル入力欄でエンターキーを押すとティッカーを作成できる」E2E を追加。既存スペックの流儀（`factory.createExchange`・成功メッセージ assert・`request.delete` でクリーンアップ）に準拠し、作成ボタンをクリックせず `symbolField.press('Enter')` で作成確定 → 成功メッセージ・モーダルクローズ・一覧追加を検証。

ローカル検証: lint / format:check / Next.js build / jest（220 件）すべて green。E2E はローカル実行スキップ（CI の chromium-mobile E2E で検証）。

## レビューポイント

- 編集モーダルで onKeyDown を「銘柄名」のみに付与（「ティッカーID」「シンボル」は編集時 disabled のため）

## 補足事項

stock-tracker Phase 4 はファイル単位で 4 分割（4a: tickers / 4b: holdings / 4c: exchanges / 4d: AlertSettingsModal 数値入力）。本 PR はその 1 つ目。`useEnterSubmit` は IME 変換確定中・修飾キー付き Enter では発火しない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DR96yo53TU25dqFYnksnJ1)_