### PR TITLE
Phase 4c: 取引所の登録・編集の入力でエンターキー確定を可能にする

### DIFF
--- a/services/stock-tracker/web/app/exchanges/page.tsx
+++ b/services/stock-tracker/web/app/exchanges/page.tsx
@@ -23,6 +23,7 @@ import {
 } from '@mui/material';
 import { Button, ErrorAlert, Select } from '@nagiyu/ui';
 import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
+import { useEnterSubmit } from '@nagiyu/react';
 import {
   Add as AddIcon,
   Edit as EditIcon,
@@ -381,6 +382,16 @@ export default function ExchangesPage() {
     }
   };
 
+  // エンターキー確定ハンドラ（登録モーダル用）
+  const handleCreateEnterDown = useEnterSubmit<HTMLDivElement>(handleCreate, {
+    disabled: submitting,
+  });
+
+  // エンターキー確定ハンドラ（編集モーダル用）
+  const handleUpdateEnterDown = useEnterSubmit<HTMLDivElement>(handleUpdate, {
+    disabled: submitting,
+  });
+
   return (
     <Container maxWidth="xl" sx={{ py: 3 }}>
       {/* エラーメッセージ表示 */}
@@ -505,6 +516,7 @@ export default function ExchangesPage() {
                 value={formData.exchangeId}
                 onChange={handleInputChange('exchangeId')}
                 disabled={submitting}
+                onKeyDown={handleCreateEnterDown}
               />
               <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>
                 ※ システム内部で使用する識別子（例: NASDAQ, NYSE, TSE）
@@ -521,6 +533,7 @@ export default function ExchangesPage() {
                 value={formData.name}
                 onChange={handleInputChange('name')}
                 disabled={submitting}
+                onKeyDown={handleCreateEnterDown}
               />
             </Box>
 
@@ -534,6 +547,7 @@ export default function ExchangesPage() {
                 value={formData.key}
                 onChange={handleInputChange('key')}
                 disabled={submitting}
+                onKeyDown={handleCreateEnterDown}
               />
               <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>
                 ※ TradingView API で使用する取引所コード（例: NSDQ, NYSE, TSE）
@@ -656,6 +670,7 @@ export default function ExchangesPage() {
                 value={formData.name}
                 onChange={handleInputChange('name')}
                 disabled={submitting}
+                onKeyDown={handleUpdateEnterDown}
               />
             </Box>
 

--- a/services/stock-tracker/web/tests/e2e/exchange-management.spec.ts
+++ b/services/stock-tracker/web/tests/e2e/exchange-management.spec.ts
@@ -142,6 +142,59 @@ test.describe('取引所管理画面 (E2E-006)', () => {
       await page.request.delete(`/api/exchanges/${encodeURIComponent(testId)}`);
       await page.waitForTimeout(1000);
     });
+
+    test('登録モーダルのテキスト入力でエンターキーを押すと取引所が登録される', async ({ page }) => {
+      // テスト用のユニークなデータを生成（TestDataFactoryのパターンに合わせる）
+      const timestamp = Date.now();
+      const random = Math.random().toString(36).substring(2, 6);
+      const testId = `E2E-${timestamp}-${random}-EX`;
+      const testKey = `E2E${random}`.substring(0, 10).toUpperCase();
+
+      // 新規登録ボタンをクリック
+      await page.locator('button:has-text("新規登録")').click();
+
+      const modal = page.getByRole('dialog', { name: '取引所登録' });
+      await expect(modal).toBeVisible();
+
+      // 基本情報を入力
+      await page.locator('input[placeholder="NASDAQ"]').fill(testId);
+      await page.locator('input[placeholder="NASDAQ Stock Market"]').fill('Test Exchange Enter');
+      await page.locator('input[placeholder="NSDQ"]').fill(testKey);
+
+      // タイムゾーン
+      await modal.locator('#exchange-timezone').selectOption('America/New_York');
+
+      // 取引開始時間 - 時
+      await modal.locator('#exchange-start-hour').selectOption('09');
+
+      // 取引開始時間 - 分
+      await modal.locator('#exchange-start-minute').selectOption('30');
+
+      // 取引終了時間 - 時
+      await modal.locator('#exchange-end-hour').selectOption('16');
+
+      // 取引終了時間 - 分
+      await modal.locator('#exchange-end-minute').selectOption('00');
+
+      // 保存ボタンをクリックせず、取引所ID入力欄でエンターキーを押して登録する
+      await page.locator('input[placeholder="NASDAQ"]').press('Enter');
+
+      // モーダルが閉じるまで待つ
+      await expect(modal).not.toBeVisible({ timeout: 10000 });
+
+      // 成功メッセージが表示される
+      await expect(page.locator('text=取引所を作成しました')).toBeVisible({ timeout: 3000 });
+
+      // テーブルに新しい取引所が表示される
+      await expect(page.locator(`td:has-text("${testId}")`)).toBeVisible();
+      // テスト用の取引所の行で「Test Exchange Enter」が表示されることを確認
+      const createdRow = page.locator(`tr:has-text("${testId}")`);
+      await expect(createdRow.locator('td:has-text("Test Exchange Enter")')).toBeVisible();
+
+      // API経由でクリーンアップ
+      await page.request.delete(`/api/exchanges/${encodeURIComponent(testId)}`);
+      await page.waitForTimeout(1000);
+    });
   });
 
   test.describe('取引所編集', () => {


### PR DESCRIPTION
## 変更の概要

Issue #3393 Phase 4c（stock-tracker 3/4）。取引所管理ページ（`app/exchanges/page.tsx`）の単一行入力をエンターキーで確定できるようにする。共通 hook `useEnterSubmit`（`@nagiyu/react`）を利用。

- **登録モーダル**: 「取引所ID」「取引所名」「APIキー」入力でエンター → 登録
- **編集モーダル**: 「取引所名」入力でエンター → 更新（取引所ID・APIキーは read-only のため対象外）
- 時/分・タイムゾーンは Select のため対象外
- disabled は二重送信防止の `submitting` のみ（登録/更新ボタンも disabled なしのため Enter 確定はボタンクリックと等価）
- 既存のボタン挙動・バリデーション・見た目は変更なし

MUI の TextField を直接使用しているため `useEnterSubmit<HTMLDivElement>` と型引数を明示。hook はハンドラ定義の後にトップレベルで直接呼び出し（ref 等の間接化なし）。stock-tracker は `@nagiyu/react` 配線が完備済みのため infra 変更は不要。

## 関連 Issue

#3393 の Phase 4c

<!-- 作業ブランチ → integration の PR のため Closes は付けない -->

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（E2E に Enter 登録ケースを追加）
- [ ] 関連ドキュメントを更新した（Issue 完了後にまとめて実施）
- [x] CI/CD 設定を追加・更新した（変更不要）
- [x] ローカルでテストが全て通ることを確認した（lint / format:check / build / test 220 件）
- [x] ビルドエラーがないことを確認した

## テスト内容

`tests/e2e/exchange-management.spec.ts` に「登録モーダルのテキスト入力でエンターキーを押すと取引所が登録される」E2E を追加。既存スペックの流儀（placeholder セレクタ・`page.request.delete` クリーンアップ・`press('Enter')`）に準拠。

ローカル検証: lint / format:check / Next.js build / jest（220 件）すべて green。E2E はローカル実行スキップ（CI で検証）。

## レビューポイント

- 編集モーダルで onKeyDown を「取引所名」のみに付与（取引所ID・APIキーは read-only）

## 補足事項

stock-tracker Phase 4 のファイル単位分割 3 つ目。残りは 4d（AlertSettingsModal の数値入力）。`useEnterSubmit` は IME 変換確定中・修飾キー付き Enter では発火しない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DR96yo53TU25dqFYnksnJ1)_