### PR TITLE
Phase 4d: アラート設定の価格入力でエンターキー確定を可能にする

### DIFF
--- a/services/stock-tracker/web/components/AlertSettingsModal.tsx
+++ b/services/stock-tracker/web/components/AlertSettingsModal.tsx
@@ -17,6 +17,7 @@ import {
 import { Button, ErrorAlert, Select } from '@nagiyu/ui';
 import { subscribePush } from '@nagiyu/browser';
 import { formatPrice } from '@nagiyu/common';
+import { useEnterSubmit } from '@nagiyu/react';
 import { calculateTargetPriceFromPercentage } from '../lib/percentage-helper';
 import type { Timeframe } from '../types/stock';
 import { TIMEFRAME_LABELS } from '../types/stock';
@@ -950,6 +951,12 @@ export default function AlertSettingsModal({
     }
   };
 
+  // 価格入力欄でエンターキーを押したときに保存処理を実行するハンドラ
+  // MUI の TextField は onKeyDown の型が React.KeyboardEvent<HTMLDivElement> のため HTMLDivElement を指定する
+  const handlePriceEnterDown = useEnterSubmit<HTMLDivElement>(handleSubmit, {
+    disabled: submitting,
+  });
+
   const handleTimeframeChange = (value: string) => {
     setTimeframe(value as Timeframe);
   };
@@ -1104,6 +1111,7 @@ export default function AlertSettingsModal({
                     setTargetPrice(e.target.value);
                     clearFieldError('targetPrice');
                   }}
+                  onKeyDown={handlePriceEnterDown}
                   error={!!formErrors.targetPrice}
                   helperText={formErrors.targetPrice}
                   slotProps={{ htmlInput: { step: '0.01', min: '0.01', max: '1000000' } }}
@@ -1240,6 +1248,7 @@ export default function AlertSettingsModal({
                       setMinPrice(e.target.value);
                       clearFieldError('minPrice');
                     }}
+                    onKeyDown={handlePriceEnterDown}
                     error={!!formErrors.minPrice}
                     helperText={
                       formErrors.minPrice ||
@@ -1258,6 +1267,7 @@ export default function AlertSettingsModal({
                       setMaxPrice(e.target.value);
                       clearFieldError('maxPrice');
                     }}
+                    onKeyDown={handlePriceEnterDown}
                     error={!!formErrors.maxPrice}
                     helperText={
                       formErrors.maxPrice ||

--- a/services/stock-tracker/web/tests/e2e/alert-management.spec.ts
+++ b/services/stock-tracker/web/tests/e2e/alert-management.spec.ts
@@ -537,6 +537,23 @@ test.describe('アラート設定フロー (E2E-002 一部)', () => {
         alertDialog.getByLabel('カスタムメッセージ（通知本文の末尾に追加されます）')
       ).toHaveValue('戦略メモ');
     });
+
+    test('目標価格入力欄でエンターキーを押すと保存処理が実行される', async ({ page }) => {
+      // PUT リクエストが呼ばれたことを確認するためのカウンタ
+      let updateCallCount = 0;
+      await setupAlertsEditPage(page, editableAlert, () => {
+        updateCallCount += 1;
+      });
+
+      const alertDialog = page.getByRole('dialog').first();
+      // 目標価格を入力してエンターキーで保存する（保存ボタンはクリックしない）
+      const targetPriceInput = alertDialog.getByLabel('目標価格');
+      await targetPriceInput.fill('190');
+      await targetPriceInput.press('Enter');
+
+      // PUT リクエストが 1 回呼ばれ、保存処理が実行されたことを確認する
+      expect(updateCallCount).toBe(1);
+    });
   });
 
   test.describe('Web Push通知許可', () => {


### PR DESCRIPTION
## 変更の概要

Issue #3393 Phase 4d（stock-tracker 4/4・最終）。アラート設定モーダル（`components/AlertSettingsModal.tsx`）の数値（価格）入力をエンターキーで確定できるようにする。共通 hook `useEnterSubmit`（`@nagiyu/react`）を利用。

対象は編集可能な単一行の数値入力（`type="number"` の MUI TextField）3 つのみ:

- **目標価格**（単一条件・value 入力モード）
- **最小価格（下限）/ 下限価格**（範囲・value 入力モード）
- **最大価格（上限）/ 上限価格**（範囲・value 入力モード）

いずれもエンターで `handleSubmit`（保存）を実行（`disabled: submitting` で二重送信防止。無効入力は `handleSubmit` 内の `validateForm()` がボタンクリック時と同様に弾く）。

**対象外**: `multiline` のカスタムメッセージ（Enter=改行を維持）、全 Select（パーセンテージ・条件タイプ・範囲タイプ・入力方式・通知頻度等）、読み取り専用の表示用 TextField。

MUI TextField 直使用のため `useEnterSubmit<HTMLDivElement>` と型引数を明示。hook は `handleSubmit` 定義の後にトップレベルで直接呼び出し。stock-tracker は `@nagiyu/react` 配線が完備済みのため infra 変更は不要。

## 関連 Issue

#3393 の Phase 4d

<!-- 作業ブランチ → integration の PR のため Closes は付けない -->

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（E2E に目標価格の Enter 保存ケースを追加）
- [ ] 関連ドキュメントを更新した（Issue 完了後にまとめて実施）
- [x] CI/CD 設定を追加・更新した（変更不要）
- [x] ローカルでテストが全て通ることを確認した（lint / format:check / build / test 220 件）
- [x] ビルドエラーがないことを確認した

## テスト内容

`tests/e2e/alert-management.spec.ts` に「目標価格入力欄でエンターキーを押すと保存処理が実行される」E2E を追加。既存の `setupAlertsEditPage` ヘルパー（API モック＋PUT カウント）を流用し、保存ボタンをクリックせず `targetPriceInput.press('Enter')` → 保存実行（PUT 発火）を検証。

ローカル検証: lint / format:check / Next.js build / jest（220 件）すべて green。E2E はローカル実行スキップ（CI で検証）。

## レビューポイント

- 数値入力は条件タイプ（単一/範囲）と入力方式（value/percentage）の分岐で表示が変わるが、value 入力時の 3 つの number TextField にのみ付与
- multiline カスタムメッセージは Enter=改行を維持（据え置き）

## 補足事項

これで stock-tracker Phase 4（4a〜4d）が完了。Issue #3393 の全 Phase（共通 hook + 各サービスの単一行入力対応）の最後の実装単位。`useEnterSubmit` は IME 変換確定中・修飾キー付き Enter では発火しない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DR96yo53TU25dqFYnksnJ1)_