### PR TITLE
[リブトーク] キャラ選択の土台（ひより1体で切り替え機構を配線）

### DIFF
--- a/services/livetalk/web/src/app/layout.tsx
+++ b/services/livetalk/web/src/app/layout.tsx
@@ -3,8 +3,10 @@ import Script from 'next/script';
 import { ServiceLayout, ServiceWorkerRegistration } from '@nagiyu/ui';
 import SessionProviderWrapper from '@/components/SessionProviderWrapper';
 import ClientErrorReporter from '@/components/ClientErrorReporter';
+import CharacterLicenseText from '@/components/CharacterLicenseText';
+import { CharacterProvider } from '@/lib/characters/CharacterContext';
 import '@nagiyu/ui/tokens.css';
-import { liveTalkTermsSections, LIVETALK_LICENSE_TEXT } from '@/lib/legal/terms-data';
+import { liveTalkTermsSections } from '@/lib/legal/terms-data';
 import { liveTalkPrivacySections } from '@/lib/legal/privacy-data';
 
 export const metadata: Metadata = {
@@ -42,21 +44,30 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           subscribeEndpoint="/api/push/subscribe"
           vapidPublicKeyEndpoint="/api/push/vapid-public-key"
         />
-        <ServiceLayout
-          headerProps={{
-            title: 'リブトーク',
-            ariaLabel: 'リブトーク ホームに戻る',
-          }}
-          footerProps={{
-            version,
-            termsContent: liveTalkTermsSections,
-            privacyContent: liveTalkPrivacySections,
-            licenseText: LIVETALK_LICENSE_TEXT,
-          }}
-        >
-          <ClientErrorReporter />
-          <SessionProviderWrapper>{children}</SessionProviderWrapper>
-        </ServiceLayout>
+        {/*
+          CharacterProvider で ServiceLayout 全体をラップする。
+          フッターは ServiceLayout 内部でレンダリングされるため、
+          CharacterLicenseText（client component）がここで生成されても
+          レンダリング位置（Provider 配下）で context が正しく解決される。
+          layout.tsx は server component のまま維持する。
+        */}
+        <CharacterProvider>
+          <ServiceLayout
+            headerProps={{
+              title: 'リブトーク',
+              ariaLabel: 'リブトーク ホームに戻る',
+            }}
+            footerProps={{
+              version,
+              termsContent: liveTalkTermsSections,
+              privacyContent: liveTalkPrivacySections,
+              licenseText: <CharacterLicenseText />,
+            }}
+          >
+            <ClientErrorReporter />
+            <SessionProviderWrapper>{children}</SessionProviderWrapper>
+          </ServiceLayout>
+        </CharacterProvider>
       </body>
     </html>
   );

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -15,6 +15,8 @@ import NotificationToggle from '@/components/NotificationToggle';
 import type { LifecycleState, SafetyResource } from '@nagiyu/livetalk-core';
 import InstallGuide from '@/components/InstallGuide';
 import NotificationPermission from '@/components/NotificationPermission';
+import CharacterSelector from '@/components/CharacterSelector';
+import { useCharacter } from '@/lib/characters/CharacterContext';
 import {
   isStandalone,
   isPushSupported,
@@ -65,6 +67,7 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
  *   （HTMLAudioElement の autoplay 制約を回避）
  */
 export default function HomePage() {
+  const { characterId } = useCharacter();
   const { data: session } = useSession();
   const isAdmin =
     !!session?.user &&
@@ -250,7 +253,10 @@ export default function HomePage() {
       sentenceReceivedRef.current = 0;
 
       try {
-        const chatBody: { text: string; knowledgeId?: string } = { text };
+        const chatBody: { text: string; characterId?: string; knowledgeId?: string } = {
+          text,
+          characterId,
+        };
         if (notifKnowledgeId) chatBody.knowledgeId = notifKnowledgeId;
 
         const response = await fetch('/api/chat', {
@@ -377,7 +383,7 @@ export default function HomePage() {
         );
       }
     },
-    [ensureAudioContextUnlocked, clearAudioQueue, advanceAudioQueue]
+    [ensureAudioContextUnlocked, clearAudioQueue, advanceAudioQueue, characterId]
   );
 
   const handlePlaybackEnd = useCallback(() => {
@@ -427,6 +433,7 @@ export default function HomePage() {
       >
         <Box sx={{ flex: '0 1 60%', minHeight: 240, mb: 1 }}>
           <Live2DCanvas
+            characterId={characterId}
             audioBuffer={audioBuffer}
             audioContext={audioContext}
             statusText={statusText}
@@ -434,6 +441,9 @@ export default function HomePage() {
             onPlaybackEnd={handlePlaybackEnd}
             onPlaybackError={handlePlaybackError}
           />
+        </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 0.5 }}>
+          <CharacterSelector disabled={phase !== 'idle'} />
         </Box>
         <Stack
           spacing={1}

--- a/services/livetalk/web/src/components/CharacterLicenseText.tsx
+++ b/services/livetalk/web/src/components/CharacterLicenseText.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useCharacter } from '@/lib/characters/CharacterContext';
+import { getCharacterLicenseText } from '@/lib/characters/client-profiles';
+
+/**
+ * 現在選択中のキャラクターのライセンス・クレジット文字列を表示するコンポーネント。
+ * フッターの licenseText に渡すことで、キャラクター切替に連動してクレジット表示が更新される。
+ * Live2D Free Material License / VOICEVOX クレジットの常時表示要件を維持する。
+ */
+export default function CharacterLicenseText() {
+  const { characterId } = useCharacter();
+  return <>{getCharacterLicenseText(characterId)}</>;
+}

--- a/services/livetalk/web/src/components/CharacterSelector.tsx
+++ b/services/livetalk/web/src/components/CharacterSelector.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
+import { useCharacter } from '@/lib/characters/CharacterContext';
+import { getCharacterDisplay, getRegisteredProfileIds } from '@/lib/characters/client-profiles';
+
+export interface CharacterSelectorProps {
+  /**
+   * 再生中・応答中など、キャラクター切替を無効化したい状態。
+   */
+  disabled?: boolean;
+}
+
+/**
+ * 登録済みキャラクターを MUI Select で一覧表示し、選択を切り替えるコンポーネント。
+ * 現状はひより 1 件のみ表示される（将来キャラが追加されると自動的に増える）。
+ */
+export default function CharacterSelector({ disabled }: CharacterSelectorProps) {
+  const { characterId, setCharacterId } = useCharacter();
+  const profileIds = getRegisteredProfileIds();
+
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    setCharacterId(event.target.value);
+  };
+
+  return (
+    <FormControl size="small" sx={{ minWidth: 140 }}>
+      <InputLabel id="character-selector-label">キャラクター</InputLabel>
+      <Select
+        labelId="character-selector-label"
+        id="character-selector"
+        value={characterId}
+        label="キャラクター"
+        onChange={handleChange}
+        disabled={disabled}
+        inputProps={{ 'aria-label': 'キャラクター選択' }}
+      >
+        {profileIds.map((id) => {
+          const display = getCharacterDisplay(id);
+          return (
+            <MenuItem key={id} value={id}>
+              {display.displayName}
+            </MenuItem>
+          );
+        })}
+      </Select>
+    </FormControl>
+  );
+}

--- a/services/livetalk/web/src/components/CharacterSelector.tsx
+++ b/services/livetalk/web/src/components/CharacterSelector.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
-import type { SelectChangeEvent } from '@mui/material';
+import { Select } from '@nagiyu/ui';
+import type { SelectOption } from '@nagiyu/ui';
 import { useCharacter } from '@/lib/characters/CharacterContext';
 import { getCharacterDisplay, getRegisteredProfileIds } from '@/lib/characters/client-profiles';
 
@@ -13,38 +13,25 @@ export interface CharacterSelectorProps {
 }
 
 /**
- * 登録済みキャラクターを MUI Select で一覧表示し、選択を切り替えるコンポーネント。
+ * 登録済みキャラクターを @nagiyu/ui の Select で一覧表示し、選択を切り替えるコンポーネント。
  * 現状はひより 1 件のみ表示される（将来キャラが追加されると自動的に増える）。
  */
 export default function CharacterSelector({ disabled }: CharacterSelectorProps) {
   const { characterId, setCharacterId } = useCharacter();
-  const profileIds = getRegisteredProfileIds();
-
-  const handleChange = (event: SelectChangeEvent<string>) => {
-    setCharacterId(event.target.value);
-  };
+  const options: SelectOption[] = getRegisteredProfileIds().map((id) => ({
+    value: id,
+    label: getCharacterDisplay(id).displayName,
+  }));
 
   return (
-    <FormControl size="small" sx={{ minWidth: 140 }}>
-      <InputLabel id="character-selector-label">キャラクター</InputLabel>
-      <Select
-        labelId="character-selector-label"
-        id="character-selector"
-        value={characterId}
-        label="キャラクター"
-        onChange={handleChange}
-        disabled={disabled}
-        inputProps={{ 'aria-label': 'キャラクター選択' }}
-      >
-        {profileIds.map((id) => {
-          const display = getCharacterDisplay(id);
-          return (
-            <MenuItem key={id} value={id}>
-              {display.displayName}
-            </MenuItem>
-          );
-        })}
-      </Select>
-    </FormControl>
+    <Select
+      size="sm"
+      label="キャラクター"
+      aria-label="キャラクター選択"
+      value={characterId}
+      onChange={setCharacterId}
+      options={options}
+      disabled={disabled}
+    />
   );
 }

--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -53,7 +53,7 @@ function layoutModel(model: Live2DModelInstance, w: number, h: number): void {
 export interface Live2DCanvasProps {
   /**
    * 表示するキャラクターの ID。省略時はレジストリの DEFAULT_CHARACTER_ID を使用する。
-   * 現在は単一キャラ運用のため、characterId 変更時の再ロードには対応していない。
+   * characterId が変更されると旧モデルを破棄し、新モデルをロードする。
    */
   characterId?: string;
   /**
@@ -217,9 +217,10 @@ export default function Live2DCanvas({
       loadedRef.current = false;
       setModelReady(false);
     };
-    // characterId は単一キャラ運用前提でマウント時に一度だけ解決する（変更時の再ロードは未対応）
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    // characterId が変更されると cleanup（旧モデル破棄）→ 再実行（新モデルロード）でリロードされる。
+    // loadedRef ガードは cleanup で false にリセットされるため、React StrictMode の
+    // 二重実行対策として温存する。
+  }, [characterId]);
 
   // audioBuffer + audioContext を受け取ったら Web Audio で再生し、AnalyserNode を
   // モデルの motionManager に差し込むことで、ライブラリ既存のリップシンク駆動ループ
@@ -383,8 +384,8 @@ export default function Live2DCanvas({
       internalModel.off?.('afterMotionUpdate', applyEyes);
       internalModel.eyeBlink = savedEyeBlink;
     };
-    // characterId は単一キャラ運用前提で固定参照とする（変更時の再適用は未対応）
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // characterId が変更されてもモデルロード effect（依存 [characterId]）が旧モデルを
+    // 破棄してから新モデルを作り直すため、この effect は lifecycleState・modelReady のみ依存で十分。
   }, [lifecycleState, modelReady]);
 
   return (

--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -386,6 +386,8 @@ export default function Live2DCanvas({
     };
     // characterId が変更されてもモデルロード effect（依存 [characterId]）が旧モデルを
     // 破棄してから新モデルを作り直すため、この effect は lifecycleState・modelReady のみ依存で十分。
+    // applyEyes は renderProfile（characterId 由来）を参照するが、上記理由で再適用不要。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lifecycleState, modelReady]);
 
   return (

--- a/services/livetalk/web/src/lib/characters/CharacterContext.tsx
+++ b/services/livetalk/web/src/lib/characters/CharacterContext.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { createContext, useContext, useState } from 'react';
+import { DEFAULT_CLIENT_CHARACTER_ID, hasCharacterProfile } from './client-profiles';
+
+/**
+ * CharacterContext 関連のエラーメッセージ定数。
+ */
+export const CHARACTER_CONTEXT_ERROR_MESSAGES = {
+  OUTSIDE_PROVIDER: 'useCharacter は CharacterProvider の配下でのみ使用できます。',
+} as const;
+
+/**
+ * キャラクター選択状態のコンテキスト型。
+ */
+interface CharacterContextValue {
+  /** 現在選択中のキャラクター ID */
+  characterId: string;
+  /**
+   * キャラクター ID を更新する。
+   * 未登録の id を渡した場合は状態を変更しない（無視する）。
+   */
+  setCharacterId: (id: string) => void;
+}
+
+const CharacterContext = createContext<CharacterContextValue | null>(null);
+
+/**
+ * キャラクター選択状態を提供する Provider。
+ * アプリ全体をラップして useCharacter() フックを使えるようにする。
+ */
+export function CharacterProvider({ children }: { children: React.ReactNode }) {
+  const [characterId, setCharacterIdState] = useState<string>(DEFAULT_CLIENT_CHARACTER_ID);
+
+  const setCharacterId = (id: string) => {
+    // 未登録の id は無視する（状態を変えない）
+    if (!hasCharacterProfile(id)) return;
+    setCharacterIdState(id);
+  };
+
+  return (
+    <CharacterContext.Provider value={{ characterId, setCharacterId }}>
+      {children}
+    </CharacterContext.Provider>
+  );
+}
+
+/**
+ * 現在選択中のキャラクター ID と更新関数を返すフック。
+ * CharacterProvider の配下でのみ使用可能。
+ */
+export function useCharacter(): CharacterContextValue {
+  const ctx = useContext(CharacterContext);
+  if (!ctx) {
+    throw new Error(CHARACTER_CONTEXT_ERROR_MESSAGES.OUTSIDE_PROVIDER);
+  }
+  return ctx;
+}

--- a/services/livetalk/web/src/lib/characters/client-profiles.ts
+++ b/services/livetalk/web/src/lib/characters/client-profiles.ts
@@ -1,4 +1,5 @@
 import type { CharacterClientProfile, CharacterDisplay, CharacterRenderProfile } from './types';
+import { LIVETALK_LICENSE_TEXT } from '../legal/terms-data';
 
 export type { CharacterClientProfile, CharacterDisplay, CharacterRenderProfile } from './types';
 
@@ -37,6 +38,7 @@ const PROFILES: Record<string, CharacterClientProfile> = {
         eyeROpen: 'ParamEyeROpen',
       },
     },
+    licenseText: LIVETALK_LICENSE_TEXT,
   },
 };
 
@@ -84,4 +86,13 @@ export function getCharacterDisplay(id?: string): CharacterDisplay {
  */
 export function getRegisteredProfileIds(): string[] {
   return Object.keys(PROFILES);
+}
+
+/**
+ * 指定 id に対応するライセンス・クレジット文字列を返す。
+ * id を省略した場合は DEFAULT_CLIENT_CHARACTER_ID を使用する。
+ * 未登録の id を指定した場合はエラーをスローする。
+ */
+export function getCharacterLicenseText(id?: string): string {
+  return getCharacterClientProfile(id).licenseText;
 }

--- a/services/livetalk/web/src/lib/characters/index.ts
+++ b/services/livetalk/web/src/lib/characters/index.ts
@@ -9,4 +9,5 @@ export {
   getCharacterClientProfile,
   hasCharacterProfile,
   getRegisteredProfileIds,
+  getCharacterLicenseText,
 } from './client-profiles';

--- a/services/livetalk/web/src/lib/characters/types.ts
+++ b/services/livetalk/web/src/lib/characters/types.ts
@@ -32,4 +32,9 @@ export interface CharacterDisplay {
 export interface CharacterClientProfile {
   display: CharacterDisplay;
   render: CharacterRenderProfile;
+  /**
+   * フッターに常時表示するライセンス・クレジット文字列。
+   * Live2D Free Material License / VOICEVOX クレジットの常時表示要件を満たす。
+   */
+  licenseText: string;
 }

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -89,6 +89,22 @@ jest.mock('@/lib/pwa/messages', () => ({
   },
 }));
 
+// CharacterContext: useCharacter を hiyori 固定でスタブ化する。
+// setCharacterId は実装不要（page.tsx では読み取りのみ）。
+jest.mock('@/lib/characters/CharacterContext', () => ({
+  useCharacter: jest.fn(() => ({
+    characterId: 'hiyori',
+    setCharacterId: jest.fn(),
+  })),
+  CharacterProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// CharacterSelector: DOM 描画のみで動作確認に不要
+jest.mock('@/components/CharacterSelector', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
 /** /api/consent が同意済みを返す fetch モックを設定する */
 function setupFetchMocks(chatOk = false, sentenceAudio?: string) {
   const encoder = new TextEncoder();
@@ -430,5 +446,46 @@ describe('通知起点の knowledgeId 受け渡し（Issue #3359 課題Y）', ()
     const secondBody = JSON.parse(chatCalls[1][1].body as string);
     expect(firstBody.knowledgeId).toBe('k-xyz');
     expect(secondBody.knowledgeId).toBeUndefined();
+  });
+});
+
+describe('characterId の chat リクエストへの反映', () => {
+  it('handleSubmit 時の fetch body に characterId が含まれる', async () => {
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url === '/api/lifecycle') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url === '/api/push/first-word') {
+        return Promise.resolve({ ok: false });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    setupMockAudioContext('running');
+    const user = userEvent.setup();
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    await user.type(input, 'こんにちは');
+    await user.click(screen.getByRole('button', { name: '送信' }));
+
+    const chatCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]: [string]) => url === '/api/chat'
+    );
+    expect(chatCall).toBeDefined();
+    const chatBody = JSON.parse(chatCall[1].body as string);
+    // useCharacter モックが 'hiyori' を返すため、body に characterId: 'hiyori' が含まれる
+    expect(chatBody.characterId).toBe('hiyori');
   });
 });

--- a/services/livetalk/web/tests/unit/components/CharacterLicenseText.test.tsx
+++ b/services/livetalk/web/tests/unit/components/CharacterLicenseText.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * CharacterLicenseText コンポーネントのユニットテスト。
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CharacterLicenseText from '@/components/CharacterLicenseText';
+import { CharacterProvider } from '@/lib/characters/CharacterContext';
+import { getCharacterLicenseText } from '@/lib/characters/client-profiles';
+import { DEFAULT_CLIENT_CHARACTER_ID } from '@/lib/characters/client-profiles';
+
+describe('CharacterLicenseText', () => {
+  it('選択中のキャラクター（既定: hiyori）の権利テキストを表示する', () => {
+    render(
+      <CharacterProvider>
+        <CharacterLicenseText />
+      </CharacterProvider>
+    );
+    const expectedText = getCharacterLicenseText(DEFAULT_CLIENT_CHARACTER_ID);
+    expect(screen.getByText(expectedText)).toBeInTheDocument();
+  });
+
+  it('VOICEVOX クレジットが含まれる', () => {
+    render(
+      <CharacterProvider>
+        <CharacterLicenseText />
+      </CharacterProvider>
+    );
+    expect(screen.getByText(/VOICEVOX/)).toBeInTheDocument();
+  });
+
+  it('Live2D クレジットが含まれる', () => {
+    render(
+      <CharacterProvider>
+        <CharacterLicenseText />
+      </CharacterProvider>
+    );
+    expect(screen.getByText(/Live2D/)).toBeInTheDocument();
+  });
+});

--- a/services/livetalk/web/tests/unit/components/CharacterSelector.test.tsx
+++ b/services/livetalk/web/tests/unit/components/CharacterSelector.test.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import CharacterSelector from '@/components/CharacterSelector';
 import { CharacterProvider } from '@/lib/characters/CharacterContext';
 import { getRegisteredProfileIds, getCharacterDisplay } from '@/lib/characters/client-profiles';
@@ -21,39 +20,32 @@ describe('CharacterSelector', () => {
   describe('登録済みキャラクターの表示', () => {
     it('現在の characterId が Select の value として選択されている', () => {
       renderWithProvider();
-      // MUI Select のデフォルト表示を確認（hiyori が表示名で表示される）
-      const profileIds = getRegisteredProfileIds();
-      const firstId = profileIds[0];
+      const firstId = getRegisteredProfileIds()[0];
       const display = getCharacterDisplay(firstId);
       expect(screen.getByText(display.displayName)).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toHaveValue(firstId);
     });
 
     it('aria-label が付いている（アクセシビリティ）', () => {
       renderWithProvider();
-      // inputProps の aria-label は native input に付く
-      const input = screen.getByRole('combobox');
-      expect(input).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-label', 'キャラクター選択');
     });
   });
 
   describe('disabled prop', () => {
-    it('disabled=true のとき Select に aria-disabled が付く', () => {
+    it('disabled=true のとき Select が無効化される', () => {
       renderWithProvider(true);
-      // MUI Select は disabled のとき aria-disabled="true" を付与する
-      const selectButton = screen.getByRole('combobox');
-      expect(selectButton).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByRole('combobox')).toBeDisabled();
     });
 
-    it('disabled=false のとき Select に aria-disabled が付かない', () => {
+    it('disabled=false のとき Select は有効', () => {
       renderWithProvider(false);
-      const selectButton = screen.getByRole('combobox');
-      expect(selectButton).not.toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByRole('combobox')).not.toBeDisabled();
     });
 
-    it('disabled 未指定のとき Select に aria-disabled が付かない', () => {
+    it('disabled 未指定のとき Select は有効', () => {
       renderWithProvider();
-      const selectButton = screen.getByRole('combobox');
-      expect(selectButton).not.toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByRole('combobox')).not.toBeDisabled();
     });
   });
 

--- a/services/livetalk/web/tests/unit/components/CharacterSelector.test.tsx
+++ b/services/livetalk/web/tests/unit/components/CharacterSelector.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * CharacterSelector コンポーネントのユニットテスト。
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CharacterSelector from '@/components/CharacterSelector';
+import { CharacterProvider } from '@/lib/characters/CharacterContext';
+import { getRegisteredProfileIds, getCharacterDisplay } from '@/lib/characters/client-profiles';
+
+/** CharacterProvider でラップしたレンダリングヘルパー */
+function renderWithProvider(disabled?: boolean) {
+  return render(
+    <CharacterProvider>
+      <CharacterSelector disabled={disabled} />
+    </CharacterProvider>
+  );
+}
+
+describe('CharacterSelector', () => {
+  describe('登録済みキャラクターの表示', () => {
+    it('現在の characterId が Select の value として選択されている', () => {
+      renderWithProvider();
+      // MUI Select のデフォルト表示を確認（hiyori が表示名で表示される）
+      const profileIds = getRegisteredProfileIds();
+      const firstId = profileIds[0];
+      const display = getCharacterDisplay(firstId);
+      expect(screen.getByText(display.displayName)).toBeInTheDocument();
+    });
+
+    it('aria-label が付いている（アクセシビリティ）', () => {
+      renderWithProvider();
+      // inputProps の aria-label は native input に付く
+      const input = screen.getByRole('combobox');
+      expect(input).toBeInTheDocument();
+    });
+  });
+
+  describe('disabled prop', () => {
+    it('disabled=true のとき Select に aria-disabled が付く', () => {
+      renderWithProvider(true);
+      // MUI Select は disabled のとき aria-disabled="true" を付与する
+      const selectButton = screen.getByRole('combobox');
+      expect(selectButton).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('disabled=false のとき Select に aria-disabled が付かない', () => {
+      renderWithProvider(false);
+      const selectButton = screen.getByRole('combobox');
+      expect(selectButton).not.toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('disabled 未指定のとき Select に aria-disabled が付かない', () => {
+      renderWithProvider();
+      const selectButton = screen.getByRole('combobox');
+      expect(selectButton).not.toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('キャラクター選択', () => {
+    it('現状はひより 1 件のみ登録されている（将来追加で増える）', () => {
+      const ids = getRegisteredProfileIds();
+      expect(ids).toHaveLength(1);
+      expect(ids[0]).toBe('hiyori');
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/characters/CharacterContext.test.tsx
+++ b/services/livetalk/web/tests/unit/lib/characters/CharacterContext.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * CharacterContext のユニットテスト。
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CharacterProvider, useCharacter, CHARACTER_CONTEXT_ERROR_MESSAGES } from '@/lib/characters/CharacterContext';
+import { DEFAULT_CLIENT_CHARACTER_ID } from '@/lib/characters/client-profiles';
+
+/** useCharacter の結果を描画するテスト用コンポーネント */
+function TestConsumer() {
+  const { characterId, setCharacterId } = useCharacter();
+  return (
+    <div>
+      <span data-testid="character-id">{characterId}</span>
+      <button onClick={() => setCharacterId('hiyori')}>hiyoriにする</button>
+      <button onClick={() => setCharacterId('unknown_id')}>未登録にする</button>
+    </div>
+  );
+}
+
+/** Provider 外で useCharacter を呼ぶコンポーネント */
+function OutsideConsumer() {
+  useCharacter();
+  return null;
+}
+
+describe('CharacterProvider と useCharacter', () => {
+  describe('初期値', () => {
+    it('既定の characterId は DEFAULT_CLIENT_CHARACTER_ID である', () => {
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+      expect(screen.getByTestId('character-id').textContent).toBe(DEFAULT_CLIENT_CHARACTER_ID);
+    });
+  });
+
+  describe('setCharacterId', () => {
+    it('登録済みの id を渡すと characterId が更新される', async () => {
+      const user = userEvent.setup();
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+      await user.click(screen.getByRole('button', { name: 'hiyoriにする' }));
+      expect(screen.getByTestId('character-id').textContent).toBe('hiyori');
+    });
+
+    it('未登録の id を渡しても characterId が変わらない（無視される）', async () => {
+      const user = userEvent.setup();
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+      const before = screen.getByTestId('character-id').textContent;
+      await user.click(screen.getByRole('button', { name: '未登録にする' }));
+      // 状態が変わっていないことを確認
+      expect(screen.getByTestId('character-id').textContent).toBe(before);
+    });
+  });
+
+  describe('Provider 外での使用', () => {
+    it('Provider の外で useCharacter を呼ぶと日本語エラーをスローする', () => {
+      // エラーによる React のコンソールエラーを抑制
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => render(<OutsideConsumer />)).toThrow(
+        CHARACTER_CONTEXT_ERROR_MESSAGES.OUTSIDE_PROVIDER
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('エラーメッセージ定数は日本語を含む', () => {
+      expect(CHARACTER_CONTEXT_ERROR_MESSAGES.OUTSIDE_PROVIDER).toMatch(/[ぁ-ん]/);
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/characters/CharacterContext.test.tsx
+++ b/services/livetalk/web/tests/unit/lib/characters/CharacterContext.test.tsx
@@ -2,9 +2,13 @@
  * CharacterContext のユニットテスト。
  */
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { CharacterProvider, useCharacter, CHARACTER_CONTEXT_ERROR_MESSAGES } from '@/lib/characters/CharacterContext';
+import {
+  CharacterProvider,
+  useCharacter,
+  CHARACTER_CONTEXT_ERROR_MESSAGES,
+} from '@/lib/characters/CharacterContext';
 import { DEFAULT_CLIENT_CHARACTER_ID } from '@/lib/characters/client-profiles';
 
 /** useCharacter の結果を描画するテスト用コンポーネント */

--- a/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
@@ -6,10 +6,12 @@ import {
   DEFAULT_CLIENT_CHARACTER_ID,
   getCharacterClientProfile,
   getCharacterDisplay,
+  getCharacterLicenseText,
   getCharacterRenderProfile,
   getRegisteredProfileIds,
   hasCharacterProfile,
 } from '@/lib/characters/client-profiles';
+import { LIVETALK_LICENSE_TEXT } from '@/lib/legal/terms-data';
 
 describe('クライアントプロファイルレジストリ', () => {
   describe('getCharacterRenderProfile', () => {
@@ -126,5 +128,30 @@ describe('クライアントプロファイルレジストリ', () => {
     it('日本語を含む', () => {
       expect(CHARACTER_PROFILE_ERROR_MESSAGES.UNKNOWN_PROFILE).toMatch(/[ぁ-ん]/);
     });
+  });
+});
+
+describe('getCharacterLicenseText', () => {
+  it('引数なしで既定キャラクター（hiyori）の権利テキストを返す', () => {
+    const text = getCharacterLicenseText();
+    expect(text).toBe(LIVETALK_LICENSE_TEXT);
+  });
+
+  it('hiyori の権利テキストは VOICEVOX クレジットと Live2D クレジットを含む', () => {
+    const text = getCharacterLicenseText(DEFAULT_CLIENT_CHARACTER_ID);
+    expect(text).toContain('VOICEVOX');
+    expect(text).toContain('Live2D');
+  });
+
+  it('未登録の id を指定すると日本語定数メッセージでスローする', () => {
+    expect(() => getCharacterLicenseText('unknown')).toThrow(
+      CHARACTER_PROFILE_ERROR_MESSAGES.UNKNOWN_PROFILE
+    );
+  });
+
+  it('プロファイルに licenseText フィールドが存在する', () => {
+    const profile = getCharacterClientProfile(DEFAULT_CLIENT_CHARACTER_ID);
+    expect(typeof profile.licenseText).toBe('string');
+    expect(profile.licenseText.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## 変更の概要

リブトークに「キャラ選択の土台」を実装した。**新キャラは追加せず**、現在の「桃瀬ひより」1 体のまま、画面内でキャラを切り替えられる機構を通しで配線し、将来キャラを追加するだけで動く構造にした（#3422 の Phase 2〜3 を新キャラ素材なしで先行）。

配線した 4 点：

- **A. 選択状態（クライアント context）**: `CharacterContext`（`CharacterProvider` / `useCharacter()`）を追加。`characterId` を保持し、未登録 id への更新は無視。Provider 外呼び出しは日本語定数エラー。
- **B. ページ内選択 UI**: `CharacterSelector`（MUI Select）を `page.tsx` の Live2D 直下に配置。登録済みキャラを列挙（現状ひより 1 件）。応答・再生中は `disabled`。
- **C. 権利表示のキャラ単位動的化**: `CharacterClientProfile` に client-safe な `licenseText` を追加（hiyori は既存 `LIVETALK_LICENSE_TEXT` と同一文字列で表示内容は不変）。`CharacterLicenseText` をフッターの `licenseText` に渡し、選択キャラ連動に。`layout.tsx`（server component のまま）で `CharacterProvider` が `ServiceLayout` 全体をラップし、フッター内の context をレンダリング位置で解決。
- **D. モデルの再ロード**: `Live2DCanvas` のモデルロード `useEffect` 依存を `[]` → `[characterId]` に変更し、`characterId` 変更時に旧モデル破棄→新モデルロード。`page.tsx` から `characterId` を `Live2DCanvas` とチャット API（`chatBody.characterId`）へ受け渡し。

チャット API は既に `characterId` 受け口・検証済み、音声は `voiceConfig` 参照で自動追従のため、サーバ側変更は不要。

## 関連 Issue

Parent: #3422 / 土台: #3413
<!-- 作業ブランチ → integration の PR のため Closes は付けない（Issue は integration → develop マージ後にクローズ） -->

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（土台のため未更新。永続化は完了後に `docs/` へ反映予定）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）— 該当なし
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（変更ファイル起因の型エラーなし）

## テスト内容

オーケストレーターが客観検証済み：

- `jest tests/unit`：**45 suites / 317 tests 全パス**
- カバレッジ：**93.61% lines / 90.9% branches / 82.52% functions**（閾値 80% 超）。新規 `CharacterContext.tsx` / `client-profiles.ts` は 100%
- `tsc --noEmit`：変更ファイル起因の型エラー **0 件**（既存の 83 件はすべて `@nagiyu/*` dist 未ビルド由来の server 系ファイル・本変更と無関係）

追加テスト：

- `CharacterContext`：既定値・更新・未登録 id 無視・Provider 外エラー
- `CharacterSelector`：登録キャラ列挙・選択変更・`disabled`
- `CharacterLicenseText`：選択キャラの権利テキスト表示
- `client-profiles`：`getCharacterLicenseText`・`licenseText` フィールド
- `page.test`：チャット fetch body に `characterId` が含まれること

## レビューポイント

- **C の context 配置**: `layout.tsx`（server）で `CharacterProvider` が `ServiceLayout` 全体をラップし、フッターの `licenseText={<CharacterLicenseText />}` が Provider 配下のレンダリング位置で context 解決される設計。layout は server component のまま。
- **C の権利テキストの持たせ方**: client-safe な `licenseText` を web のクライアントプロファイルに持たせた（core の `license` とは別系統。フッターがクライアント切替に追従するため client 側に保持）。hiyori は表示内容を変えていない。
- **D の `Live2DCanvas` 再ロード**: WebGL/pixi 依存でユニットテスト困難なため、**dev 環境での実機確認が必要**（integration で検証）。

## スクリーンショット（該当する場合）

dev デプロイ後に確認予定（ひより 1 件のセレクター表示・切替時のモデル再ロード・フッタークレジット連動）。

## 補足事項

- 新キャラ素材（Live2D モデル・VOICEVOX 話者・クレジット文言）の確保は本 PR のスコープ外。本 PR は「追加するだけで増える」土台まで。
- キャラ切替時に進行中の会話表示をクリアする等の追加挙動は最小化のためスコープ外。

https://claude.ai/code/session_01H1hEnwe1LqWn2cut9monXa

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1hEnwe1LqWn2cut9monXa)_