### PR TITLE
[リブトーク] キャラ選択ボタンの視認性改善＋ひより説明文の調整

### DIFF
--- a/services/livetalk/web/src/components/CharacterSelectButton.tsx
+++ b/services/livetalk/web/src/components/CharacterSelectButton.tsx
@@ -27,7 +27,7 @@ export default function CharacterSelectButton({ disabled }: CharacterSelectButto
     <>
       <Button
         variant="outline"
-        color="neutral"
+        color="primary"
         size="sm"
         onClick={() => setModalOpen(true)}
         disabled={disabled}

--- a/services/livetalk/web/src/lib/characters/client-profiles.ts
+++ b/services/livetalk/web/src/lib/characters/client-profiles.ts
@@ -39,8 +39,7 @@ const PROFILES: Record<string, CharacterClientProfile> = {
       },
     },
     licenseText: LIVETALK_LICENSE_TEXT,
-    description:
-      '友達になることを目標にした、優しく親しみやすい女の子。スイーツや猫、ほのぼのした時間が大好き。',
+    description: '甘いものと猫が大好きな癒し系。のんびりおしゃべりして、ほっと一息つける女の子。',
   },
 };
 


### PR DESCRIPTION
## 変更の概要

dev 実機確認のフィードバックを受けたキャラ選択 UI の小改善（#3439 の上に積む）。

- **左上ボタンの視認性改善**：`variant="outline" color="neutral"` は活性状態でも低コントラストで「非活性に見える」問題があったため、**`outline × primary`（青の枠線・青文字）** に変更。押せると明確に分かりつつ背景の Live2D を邪魔しない。
- **ひより説明文の調整**：説明口調で硬かった文面（「友達になることを目標にした…」）を、雰囲気と好きなもので魅力が伝わる文面に変更：
  > 甘いものと猫が大好きな癒し系。のんびりおしゃべりして、ほっと一息つける女の子。

※ `@nagiyu/ui` Button の disabled は `opacity:0.5` の共通仕様（基盤部品自体は変更せず）。低コントラストの主因は outline×neutral の組み合わせだったため、使用側の色変更で解消した。

## 関連 Issue

Parent: #3422 / 直前: #3439
<!-- 作業ブランチ → integration の PR のため Closes は付けない -->

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（既存テストは厳密文字列に依存しないため変更不要・全パス）
- [ ] 関連ドキュメントを更新した — 該当なし
- [ ] CI/CD 設定を追加・更新した — 該当なし
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

オーケストレーターが客観検証済み：

- `jest tests/unit --coverage`：**46 suites / 336 tests 全パス**、カバレッジ **93.21%**（閾値 80% 超）
- `prettier@3.7.4 --check`：変更ファイル green
- `tsc --noEmit`：変更ファイル起因の型エラー 0 件
- 説明文テストは `getCharacterDescription()` を動的参照しており、文言変更の影響なし

## レビューポイント

- ボタン色：`outline × primary`（青の枠線）。
- 説明文の文面。

## スクリーンショット（該当する場合）

dev デプロイ後に確認（左上ボタンの視認性・モーダル内の説明文）。

## 補足事項

- 親密度表示は引き続きスコープ外（段階表示は別フェーズの宿題）。

https://claude.ai/code/session_01H1hEnwe1LqWn2cut9monXa

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1hEnwe1LqWn2cut9monXa)_