### PR TITLE
[リブトーク] キャラ選択モーダルにモデル・音声の属性表示を追加＋キャンセルボタン改善

### DIFF
--- a/services/livetalk/web/src/components/CharacterSelectModal.tsx
+++ b/services/livetalk/web/src/components/CharacterSelectModal.tsx
@@ -17,6 +17,8 @@ import { useCharacter } from '@/lib/characters/CharacterContext';
 import {
   getCharacterDescription,
   getCharacterDisplay,
+  getCharacterModel,
+  getCharacterVoice,
   getRegisteredProfileIds,
 } from '@/lib/characters/client-profiles';
 
@@ -72,6 +74,8 @@ export default function CharacterSelectModal({ open, onClose }: CharacterSelectM
           {profileIds.map((id) => {
             const display = getCharacterDisplay(id);
             const description = getCharacterDescription(id);
+            const model = getCharacterModel(id);
+            const voice = getCharacterVoice(id);
             return (
               <FormControlLabel
                 key={id}
@@ -83,6 +87,16 @@ export default function CharacterSelectModal({ open, onClose }: CharacterSelectM
                     <Typography variant="body2" color="text.secondary">
                       {description}
                     </Typography>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block', mt: 0.5 }}
+                    >
+                      {`モデル：${model.engine}「${model.name}」`}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                      {`音声：${voice.engine}「${voice.name}」`}
+                    </Typography>
                   </Box>
                 }
               />
@@ -92,7 +106,7 @@ export default function CharacterSelectModal({ open, onClose }: CharacterSelectM
       </DialogContent>
 
       <DialogActions sx={{ px: 3, pb: 3 }}>
-        <Button variant="outline" color="neutral" onClick={handleCancel}>
+        <Button variant="solid" color="neutral" onClick={handleCancel}>
           キャンセル
         </Button>
         <Button variant="solid" color="primary" onClick={handleDecide}>

--- a/services/livetalk/web/src/lib/characters/client-profiles.ts
+++ b/services/livetalk/web/src/lib/characters/client-profiles.ts
@@ -1,7 +1,17 @@
-import type { CharacterClientProfile, CharacterDisplay, CharacterRenderProfile } from './types';
+import type {
+  CharacterAttribute,
+  CharacterClientProfile,
+  CharacterDisplay,
+  CharacterRenderProfile,
+} from './types';
 import { LIVETALK_LICENSE_TEXT } from '../legal/terms-data';
 
-export type { CharacterClientProfile, CharacterDisplay, CharacterRenderProfile } from './types';
+export type {
+  CharacterAttribute,
+  CharacterClientProfile,
+  CharacterDisplay,
+  CharacterRenderProfile,
+} from './types';
 
 /**
  * クライアント側の既定キャラクター ID。
@@ -40,6 +50,8 @@ const PROFILES: Record<string, CharacterClientProfile> = {
     },
     licenseText: LIVETALK_LICENSE_TEXT,
     description: '甘いものと猫が大好きな癒し系。のんびりおしゃべりして、ほっと一息つける女の子。',
+    model: { engine: 'Live2D', name: '桃瀬ひより' },
+    voice: { engine: 'VOICEVOX', name: '冥鳴ひまり' },
   },
 };
 
@@ -105,4 +117,22 @@ export function getCharacterLicenseText(id?: string): string {
  */
 export function getCharacterDescription(id?: string): string {
   return getCharacterClientProfile(id).description;
+}
+
+/**
+ * 指定 id に対応する見た目モデルの技術属性を返す。
+ * id を省略した場合は DEFAULT_CLIENT_CHARACTER_ID を使用する。
+ * 未登録の id を指定した場合はエラーをスローする。
+ */
+export function getCharacterModel(id?: string): CharacterAttribute {
+  return getCharacterClientProfile(id).model;
+}
+
+/**
+ * 指定 id に対応する音声の技術属性を返す。
+ * id を省略した場合は DEFAULT_CLIENT_CHARACTER_ID を使用する。
+ * 未登録の id を指定した場合はエラーをスローする。
+ */
+export function getCharacterVoice(id?: string): CharacterAttribute {
+  return getCharacterClientProfile(id).voice;
 }

--- a/services/livetalk/web/src/lib/characters/index.ts
+++ b/services/livetalk/web/src/lib/characters/index.ts
@@ -1,6 +1,11 @@
 // このバレルは client-safe なモジュールのみを再エクスポートする。
 // 定義の結合（core 依存）が必要な server コードは `./registry` を直接 import すること。
-export type { CharacterRenderProfile, CharacterDisplay, CharacterClientProfile } from './types';
+export type {
+  CharacterRenderProfile,
+  CharacterDisplay,
+  CharacterClientProfile,
+  CharacterAttribute,
+} from './types';
 export {
   DEFAULT_CLIENT_CHARACTER_ID,
   CHARACTER_PROFILE_ERROR_MESSAGES,
@@ -11,4 +16,6 @@ export {
   getRegisteredProfileIds,
   getCharacterLicenseText,
   getCharacterDescription,
+  getCharacterModel,
+  getCharacterVoice,
 } from './client-profiles';

--- a/services/livetalk/web/src/lib/characters/types.ts
+++ b/services/livetalk/web/src/lib/characters/types.ts
@@ -26,6 +26,17 @@ export interface CharacterDisplay {
 }
 
 /**
+ * キャラクターの技術属性（モデル・音声など）。
+ * 「どのエンジンで、誰／何なのか」を一目で示すための表示用情報。
+ */
+export interface CharacterAttribute {
+  /** 採用技術・エンジン名（例: 'Live2D', 'VOICEVOX'） */
+  engine: string;
+  /** 具体名（モデル名・話者名など） */
+  name: string;
+}
+
+/**
  * クライアント側で必要なキャラクター情報をまとめたプロファイル。
  * core 非依存なのでクライアントバンドルに含めても server コードを引き込まない。
  */
@@ -42,4 +53,13 @@ export interface CharacterClientProfile {
    * キャラ選択モーダルでの説明表示に使用する。
    */
   description: string;
+  /**
+   * 見た目モデルの技術属性（例: Live2D の「桃瀬ひより」）。
+   * キャラが増えても誰の何のモデルかを一目で分かるようにする。
+   */
+  model: CharacterAttribute;
+  /**
+   * 音声の技術属性（例: VOICEVOX の「冥鳴ひまり」）。
+   */
+  voice: CharacterAttribute;
 }

--- a/services/livetalk/web/tests/unit/components/CharacterSelectModal.test.tsx
+++ b/services/livetalk/web/tests/unit/components/CharacterSelectModal.test.tsx
@@ -4,6 +4,8 @@ import CharacterSelectModal from '@/components/CharacterSelectModal';
 import {
   getCharacterDescription,
   getCharacterDisplay,
+  getCharacterModel,
+  getCharacterVoice,
   getRegisteredProfileIds,
 } from '@/lib/characters/client-profiles';
 
@@ -39,6 +41,16 @@ describe('CharacterSelectModal', () => {
       for (const id of ids) {
         const desc = getCharacterDescription(id);
         expect(screen.getByText(desc)).toBeInTheDocument();
+      }
+    });
+
+    it('open=true のとき各キャラクターのモデル・音声属性が表示される', () => {
+      render(<CharacterSelectModal open={true} onClose={jest.fn()} />);
+      for (const id of getRegisteredProfileIds()) {
+        const model = getCharacterModel(id);
+        const voice = getCharacterVoice(id);
+        expect(screen.getByText(`モデル：${model.engine}「${model.name}」`)).toBeInTheDocument();
+        expect(screen.getByText(`音声：${voice.engine}「${voice.name}」`)).toBeInTheDocument();
       }
     });
 

--- a/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
@@ -8,7 +8,9 @@ import {
   getCharacterDescription,
   getCharacterDisplay,
   getCharacterLicenseText,
+  getCharacterModel,
   getCharacterRenderProfile,
+  getCharacterVoice,
   getRegisteredProfileIds,
   hasCharacterProfile,
 } from '@/lib/characters/client-profiles';
@@ -157,6 +159,37 @@ describe('getCharacterDescription', () => {
 
   it('"toString" などプロトタイプ継承プロパティ名を渡すとスローする', () => {
     expect(() => getCharacterDescription('toString')).toThrow(
+      CHARACTER_PROFILE_ERROR_MESSAGES.UNKNOWN_PROFILE
+    );
+  });
+});
+
+describe('getCharacterModel / getCharacterVoice', () => {
+  it('hiyori のモデル属性は Live2D の「桃瀬ひより」である', () => {
+    const model = getCharacterModel();
+    expect(model.engine).toBe('Live2D');
+    expect(model.name).toBe('桃瀬ひより');
+  });
+
+  it('hiyori の音声属性は VOICEVOX の「冥鳴ひまり」である', () => {
+    const voice = getCharacterVoice();
+    expect(voice.engine).toBe('VOICEVOX');
+    expect(voice.name).toBe('冥鳴ひまり');
+  });
+
+  it('プロファイルに model / voice フィールドが存在する', () => {
+    const profile = getCharacterClientProfile(DEFAULT_CLIENT_CHARACTER_ID);
+    expect(profile.model.engine.length).toBeGreaterThan(0);
+    expect(profile.model.name.length).toBeGreaterThan(0);
+    expect(profile.voice.engine.length).toBeGreaterThan(0);
+    expect(profile.voice.name.length).toBeGreaterThan(0);
+  });
+
+  it('未登録の id を指定すると日本語定数メッセージでスローする', () => {
+    expect(() => getCharacterModel('unknown')).toThrow(
+      CHARACTER_PROFILE_ERROR_MESSAGES.UNKNOWN_PROFILE
+    );
+    expect(() => getCharacterVoice('unknown')).toThrow(
       CHARACTER_PROFILE_ERROR_MESSAGES.UNKNOWN_PROFILE
     );
   });


### PR DESCRIPTION
## 変更の概要

キャラ選択モーダルの情報量とボタン視認性を改善（前 PR #3441 の上に積む）。

- **モデル・音声の属性表示を追加**：各キャラのモーダル説明の下に、見た目モデル（**Live2D** で誰か）と音声（**VOICEVOX** で何か）を表示。キャラが増えても「誰が何の属性か」を一目で分かるようにする。
  - hiyori 例：`モデル：Live2D「桃瀬ひより」` / `音声：VOICEVOX「冥鳴ひまり」`
  - データは `CharacterClientProfile` に **client-safe な構造化フィールド** `model` / `voice`（`CharacterAttribute = { engine, name }`）を追加して保持。これまで権利テキストに自由文で埋まっていた属性を構造化（今後のキャラ追加時は登録するだけで一覧に並ぶ）。
  - 取得用に `getCharacterModel` / `getCharacterVoice` を追加。
- **キャンセルボタンの視認性改善**：`outline × neutral` は「押せるか分かりにくい」ため、**`solid × neutral`（グレー塗り）** に変更し、明確にボタンと分かるように（決定＝青塗りとの主従も保つ）。

## 親密度について
引き続き**スコープ外**（合意通り）。`AffectionLevel` は内部値・上限なしのため、出すなら段階化の設計が前提（別フェーズの宿題）。

## 関連 Issue

Parent: #3422 / 直前: #3441
<!-- 作業ブランチ → integration の PR のため Closes は付けない -->

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した — 該当なし
- [ ] CI/CD 設定を追加・更新した — 該当なし
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

オーケストレーターが客観検証済み：

- `jest tests/unit --coverage`：**46 suites / 341 tests 全パス**、カバレッジ **91.45% lines / 91.04% branches / 83.01% functions**（閾値 80% 超）
- `prettier@3.7.4 --check`：変更ファイル green
- `tsc --noEmit`：変更ファイル起因の型エラー 0 件

追加テスト：

- `client-profiles`：`getCharacterModel` / `getCharacterVoice`（hiyori の値・フィールド存在・未登録 id スロー）
- `CharacterSelectModal`：モデル・音声属性の表示

## レビューポイント

- **属性の構造化**：`CharacterAttribute { engine, name }` を client profile に持たせた（権利フリーテキストとは別系統。一覧での一目視認が目的）。
- **キャンセルボタン**：`solid × neutral`。
- hiyori の音声話者名「冥鳴ひまり」は core の `voiceConfig.speakerId: 14` に対応（client 側は表示用に文言で保持）。

## スクリーンショット（該当する場合）

dev デプロイ後に確認（モーダル内のモデル・音声表示、キャンセルボタンの見え方）。

https://claude.ai/code/session_01H1hEnwe1LqWn2cut9monXa

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1hEnwe1LqWn2cut9monXa)_