### PR TITLE
通知ロジック Phase 1: クリティカル通知の再定義（AND ゲート＋睡眠帯尊重）

### DIFF
--- a/services/livetalk/batch/src/handlers/notify.ts
+++ b/services/livetalk/batch/src/handlers/notify.ts
@@ -1,11 +1,13 @@
 import { logger, toErrorMessage } from '@nagiyu/common';
 import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagiyu/aws';
 import {
+  DynamoDBInterestRepository,
   DynamoDBKnowledgeRepository,
   DynamoDBLifecycleRepository,
   DynamoDBMessageRepository,
   DynamoDBNotificationEventRepository,
   DynamoDBPushSubscriptionRepository,
+  OpenAIEmbeddingClient,
   createLLMClient,
   defaultUlidFactory,
 } from '@nagiyu/livetalk-core';
@@ -46,7 +48,9 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const knowledgeRepo = new DynamoDBKnowledgeRepository(docClient, tableName);
     const pushSubscriptionRepo = new DynamoDBPushSubscriptionRepository(docClient, tableName);
     const notifEventRepo = new DynamoDBNotificationEventRepository(docClient, tableName);
+    const interestRepo = new DynamoDBInterestRepository(docClient, tableName);
     const llmClient = createLLMClient({ openai: { apiKey } });
+    const embeddingClient = new OpenAIEmbeddingClient({ apiKey });
 
     const result = await notifyAllUsers({
       docClient,
@@ -56,7 +60,9 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       knowledgeRepo,
       pushSubscriptionRepo,
       notifEventRepo,
+      interestRepo,
       llmClient,
+      embeddingClient,
       ulidFactory: defaultUlidFactory,
     });
 

--- a/services/livetalk/batch/src/usecases/notify.usecase.ts
+++ b/services/livetalk/batch/src/usecases/notify.usecase.ts
@@ -7,7 +7,9 @@ import {
   buildNotificationMessage,
   detectCriticalKnowledge,
   shouldNotifyNow,
+  type IEmbeddingClient,
   type ILLMClient,
+  type InterestRepository,
   type KnowledgeRepository,
   type LifecycleRepository,
   type MessageRepository,
@@ -26,7 +28,9 @@ export interface NotifyAllUsersParams {
   knowledgeRepo: KnowledgeRepository;
   pushSubscriptionRepo: PushSubscriptionRepository;
   notifEventRepo: NotificationEventRepository;
+  interestRepo: InterestRepository;
   llmClient: ILLMClient;
+  embeddingClient: IEmbeddingClient;
   ulidFactory?: UlidFactory;
   now?: () => Date;
 }
@@ -47,7 +51,9 @@ export async function notifyAllUsers(params: NotifyAllUsersParams): Promise<Noti
     knowledgeRepo,
     pushSubscriptionRepo,
     notifEventRepo,
+    interestRepo,
     llmClient,
+    embeddingClient,
     ulidFactory = defaultUlidFactory,
     now = () => new Date(),
   } = params;
@@ -73,7 +79,9 @@ export async function notifyAllUsers(params: NotifyAllUsersParams): Promise<Noti
         knowledgeRepo,
         pushSubscriptionRepo,
         notifEventRepo,
+        interestRepo,
         llmClient,
+        embeddingClient,
         ulidFactory,
         vapidConfig,
         now,
@@ -105,7 +113,9 @@ interface ProcessUserParams {
   knowledgeRepo: KnowledgeRepository;
   pushSubscriptionRepo: PushSubscriptionRepository;
   notifEventRepo: NotificationEventRepository;
+  interestRepo: InterestRepository;
   llmClient: ILLMClient;
+  embeddingClient: IEmbeddingClient;
   ulidFactory: UlidFactory;
   vapidConfig: ReturnType<typeof getVapidConfig>;
   now: () => Date;
@@ -119,7 +129,9 @@ async function processUser(params: ProcessUserParams): Promise<boolean> {
     knowledgeRepo,
     pushSubscriptionRepo,
     notifEventRepo,
+    interestRepo,
     llmClient,
+    embeddingClient,
     ulidFactory,
     vapidConfig,
     now,
@@ -149,7 +161,14 @@ async function processUser(params: ProcessUserParams): Promise<boolean> {
 
   // クリティカル候補を取得して LLM 判定
   const recentKnowledge = await knowledgeRepo.list(userId, characterId, 10);
-  const escalation = await detectCriticalKnowledge(recentKnowledge, llmClient);
+  const interestCategories = await interestRepo.list(userId, characterId);
+  const escalation = await detectCriticalKnowledge({
+    knowledgeList: recentKnowledge,
+    interestCategories,
+    llmClient,
+    embeddingClient,
+    now: currentNow,
+  });
   const criticalKnowledgeId = escalation.isCritical
     ? (escalation.knowledgeId ?? undefined)
     : undefined;

--- a/services/livetalk/batch/tests/unit/handlers/notify.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/notify.test.ts
@@ -12,6 +12,8 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBKnowledgeRepository: jest.fn(),
   DynamoDBNotificationEventRepository: jest.fn(),
   DynamoDBPushSubscriptionRepository: jest.fn(),
+  DynamoDBInterestRepository: jest.fn(),
+  OpenAIEmbeddingClient: jest.fn(() => ({ embed: jest.fn() })),
   createLLMClient: jest.fn(() => ({})),
   defaultUlidFactory: jest.fn(),
 }));

--- a/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
@@ -25,6 +25,8 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   shouldNotifyNow: jest.fn(),
   defaultUlidFactory: jest.fn(() => 'ULID-0001'),
   NOTIFICATION_EVENT_TTL_SECONDS: 2592000,
+  DynamoDBInterestRepository: jest.fn(),
+  OpenAIEmbeddingClient: jest.fn(),
 }));
 
 const mockSendWebPush = jest.requireMock('@nagiyu/common/push')
@@ -97,6 +99,18 @@ function makeLlmClient() {
   return {};
 }
 
+function makeInterestRepo() {
+  return {
+    list: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function makeEmbeddingClient() {
+  return {
+    embed: jest.fn().mockResolvedValue([0, 0, 0]),
+  };
+}
+
 function makeParams(overrides = {}) {
   return {
     docClient: makeDocClient() as never,
@@ -106,7 +120,9 @@ function makeParams(overrides = {}) {
     knowledgeRepo: makeKnowledgeRepo() as never,
     pushSubscriptionRepo: makePushSubscriptionRepo() as never,
     notifEventRepo: makeNotifEventRepo() as never,
+    interestRepo: makeInterestRepo() as never,
     llmClient: makeLlmClient() as never,
+    embeddingClient: makeEmbeddingClient() as never,
     ...overrides,
   };
 }

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -258,3 +258,20 @@ export const NOTIFY_ACTIVE_WINDOW_MINUTES = 90;
  * NotificationEvent に付与する DynamoDB TTL（秒）。30日後に自動削除。
  */
 export const NOTIFICATION_EVENT_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * クリティカル通知の対象とする興味カテゴリの最小シェア（全 Weight 合計に占める割合）。
+ *
+ * dev 実データの Weight 分布（飲み物38%/スイーツ18%/ゲーム15%/映画14%/…）を根拠に暫定設定。
+ * この値を下回る弱興味カテゴリの Knowledge はクリティカル判定から除外される。
+ * 実運用データを踏まえてチューニングすること。
+ */
+export const NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD = 0.15;
+
+/**
+ * クリティカル判定の「時限性あり」とみなすイベント日程の最大日数（今日から何日以内か）。
+ *
+ * LLM が抽出した eventDate が今日から NOTIFY_CRITICAL_EVENT_HORIZON_DAYS 日以内の未来である場合のみ
+ * isUrgent=true とみなす。14 日を超える将来イベントや過去日は時限性なしとして除外する。
+ */
+export const NOTIFY_CRITICAL_EVENT_HORIZON_DAYS = 14;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -348,6 +348,7 @@ export type {
   BuildNotificationMessageInput,
   NotificationMessage,
   EscalationResult,
+  DetectCriticalInput,
 } from './notification/index.js';
 
 // 通知関連定数（Phase 5d / #3346）
@@ -362,4 +363,6 @@ export {
   NOTIFY_DAILY_CRITICAL_CAP,
   NOTIFY_ACTIVE_WINDOW_MINUTES,
   NOTIFICATION_EVENT_TTL_SECONDS,
+  NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD,
+  NOTIFY_CRITICAL_EVENT_HORIZON_DAYS,
 } from './constants.js';

--- a/services/livetalk/core/src/llm-client/schemas/escalation.schema.ts
+++ b/services/livetalk/core/src/llm-client/schemas/escalation.schema.ts
@@ -1,15 +1,19 @@
 import { z } from 'zod';
 
 /**
- * プッシュ通知クリティカル escalation 判定向け Structured Outputs スキーマ。
+ * プッシュ通知クリティカル escalation 判定向け Structured Outputs スキーマ（Phase 5d リビジョン）。
  *
- * isCritical=true: 新作・期間限定・緊急性の高い情報で時間帯外でも配信すべき
- * isCritical=false: 通常の勉強ネタ、平常通知で十分
+ * LLM には「新作リリース・期間限定イベント・締切」などの具体的な日付を抽出させる。
+ * 日付が取れた場合のみ時限性ありとみなし、「最新トレンド」「ランキング」等は null を返させる。
  *
  * @see Issue #3346
  */
 export const EscalationSchema = z.object({
-  isCritical: z.boolean(),
+  /**
+   * 発売日・開催日・締切・終了日など、この情報の最も重要な「日付」を YYYY-MM-DD で。
+   * 「最新トレンド」「ランキング」「一般的な雑学」「日付の無い新着情報」の場合は null。
+   */
+  eventDate: z.string().nullable(),
   /** 判定理由の短いメモ（ログ用） */
   reason: z.string().nullable(),
 });

--- a/services/livetalk/core/src/notification/decision.ts
+++ b/services/livetalk/core/src/notification/decision.ts
@@ -145,21 +145,34 @@ export function countTodayNotifications(
  * 平常通知の発火判定（純粋関数）。
  *
  * 判定順序:
- *   1. 停止チェック（effectiveInterval > 14日）
- *   2. 1日上限チェック
- *   3. 睡眠帯チェック
- *   4. 活動時間帯チェック
- *   5. 適応的間隔チェック
+ *   1. 睡眠帯チェック（クリティカル・平常問わず先頭で判定）
+ *   2. クリティカル判定（睡眠帯以外の時間帯・間隔ゲートをバイパス）
+ *   3. 停止チェック（effectiveInterval > 14日）
+ *   4. 1日上限チェック
+ *   5. 活動時間帯チェック
+ *   6. 適応的間隔チェック
+ *
+ * クリティカルは睡眠帯を尊重する（深夜に叩き起こさない）。
+ * 睡眠中は起床後の次回バッチで再評価され、遅延配信される。
  */
 export function shouldNotifyNow(input: NotifyDecisionInput): NotifyDecision {
   const { userMessages, lifecycle, notificationEvents, criticalKnowledgeId, now } = input;
 
-  // --- クリティカル判定（時間帯・間隔ゲートをバイパス）---
+  // 1. 睡眠帯チェック（クリティカル・平常問わず最優先）
+  const bedtime = lifecycle.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME;
+  const wakeUpTime = lifecycle.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME;
+  const lifecycleState = resolveLifecycleState(now, bedtime, wakeUpTime);
+  if (lifecycleState === 'sleeping') {
+    return { notify: false, reason: 'sleeping' };
+  }
+
+  // 2. クリティカル判定（睡眠帯以外は時間帯・間隔ゲートをバイパス）
   if (criticalKnowledgeId) {
     const todayCritical = countTodayNotifications(notificationEvents, 'critical', now);
     if (todayCritical < NOTIFY_DAILY_CRITICAL_CAP) {
       return { notify: true, kind: 'critical', knowledgeId: criticalKnowledgeId };
     }
+    // cap 到達時は平常判定へフォールスルー
   }
 
   // --- 平常通知判定 ---
@@ -184,26 +197,18 @@ export function shouldNotifyNow(input: NotifyDecisionInput): NotifyDecision {
   const effectiveIntervalMs = baseIntervalMs * Math.pow(NOTIFY_BACKOFF_BASE, missedCount);
   const maxMs = NOTIFY_MAX_INTERVAL_DAYS * 24 * 60 * 60 * 1000;
 
-  // 1. 停止チェック
+  // 3. 停止チェック
   if (effectiveIntervalMs > maxMs) {
     return { notify: false, reason: 'inactive_stopped' };
   }
 
-  // 2. 1日上限チェック
+  // 4. 1日上限チェック
   const todayNormal = countTodayNotifications(notificationEvents, 'normal', now);
   if (todayNormal >= NOTIFY_DAILY_NORMAL_CAP) {
     return { notify: false, reason: 'daily_cap' };
   }
 
-  // 3. 睡眠帯チェック
-  const bedtime = lifecycle.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME;
-  const wakeUpTime = lifecycle.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME;
-  const lifecycleState = resolveLifecycleState(now, bedtime, wakeUpTime);
-  if (lifecycleState === 'sleeping') {
-    return { notify: false, reason: 'sleeping' };
-  }
-
-  // 4. 活動時間帯チェック
+  // 5. 活動時間帯チェック
   const activityProfile = lifecycle.UserActivityProfile;
   if (activityProfile) {
     const nowMinutes = now.getHours() * 60 + now.getMinutes();
@@ -218,7 +223,7 @@ export function shouldNotifyNow(input: NotifyDecisionInput): NotifyDecision {
   }
   // UserActivityProfile 未学習なら時間帯ゲートをスキップ（活動時間が不明）
 
-  // 5. 適応的間隔チェック
+  // 6. 適応的間隔チェック
   const elapsedMs = now.getTime() - referenceTime;
   if (elapsedMs < effectiveIntervalMs) {
     return { notify: false, reason: 'not_due' };

--- a/services/livetalk/core/src/notification/escalation.ts
+++ b/services/livetalk/core/src/notification/escalation.ts
@@ -1,44 +1,230 @@
-import type { ILLMClient } from '../llm-client/types.js';
+import type { ILLMClient, IEmbeddingClient } from '../llm-client/types.js';
 import { EscalationSchema } from '../llm-client/schemas/escalation.schema.js';
 import type { KnowledgeEntity } from '../entities/knowledge.entity.js';
+import type { InterestCategoryEntity } from '../entities/interest-category.entity.js';
+import { cosineSimilarity } from '../memory/embedding.js';
+import {
+  INTEREST_DEDUP_SIMILARITY_THRESHOLD,
+  NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD,
+  NOTIFY_CRITICAL_EVENT_HORIZON_DAYS,
+} from '../constants.js';
 
 export interface EscalationResult {
   isCritical: boolean;
   knowledgeId: string | null;
 }
 
-const ESCALATION_PROMPT = `あなたは通知の緊急度を判定するアシスタントです。
-以下の知識情報が「新作リリース」「期間限定イベント」「緊急情報」に該当する場合のみ isCritical=true を返してください。
-通常の雑学・最新トレンド・一般情報は isCritical=false です。判定基準を厳しく保ち、過剰なクリティカル判定を避けてください。`;
+/**
+ * detectCriticalKnowledge の入力インターフェース。
+ */
+export interface DetectCriticalInput {
+  knowledgeList: KnowledgeEntity[];
+  /** ユーザーの興味カテゴリ（Weight 付き） */
+  interestCategories: InterestCategoryEntity[];
+  llmClient: ILLMClient;
+  embeddingClient: IEmbeddingClient;
+  /** 判定基準時刻（today 計算・LLM プロンプトの今日日付注入に使用） */
+  now: Date;
+}
 
 /**
- * KNOWLEDGE リストから時間帯外でも配信すべきクリティカル情報を LLM で判定する。
+ * JST の今日の日付を "YYYY-MM-DD" 形式で返す。
+ *
+ * Node.js は TZ=Asia/Tokyo で実行されることを前提とする。
+ */
+function toJstDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * "YYYY-MM-DD" 文字列をローカル時刻の午前 0 時として Date に変換する。解析失敗は null を返す。
+ *
+ * タイムゾーン非依存（ローカル時刻）で統一することで、本番（TZ=Asia/Tokyo）でも
+ * テスト環境（UTC）でも now.setHours(0,0,0,0) と比較できる。
+ */
+function parseDateString(dateStr: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return null;
+  const parts = dateStr.split('-').map(Number);
+  if (parts.length !== 3) return null;
+  const [year, month, day] = parts;
+  // Date コンストラクタに年月日を直接渡す（ローカル時刻の午前 0 時）
+  const d = new Date(year, month - 1, day);
+  if (isNaN(d.getTime())) return null;
+  return d;
+}
+
+/**
+ * Knowledge の RelatedCategory を interestCategories の正規カテゴリに解決する。
+ *
+ * 解決手順:
+ *   1. Category との完全一致
+ *   2. embedding 類似度で INTEREST_DEDUP_SIMILARITY_THRESHOLD 以上のカテゴリを探す
+ *   3. 解決できなければ null
+ *
+ * embed 呼び出し結果は embeddingCache にキャッシュして無駄打ちを避ける。
+ */
+async function resolveToInterestCategory(
+  relatedCategory: string,
+  interestCategories: InterestCategoryEntity[],
+  embeddingClient: IEmbeddingClient,
+  embeddingCache: Map<string, number[]>
+): Promise<InterestCategoryEntity | null> {
+  if (interestCategories.length === 0) return null;
+
+  // 1. 完全一致
+  const exact = interestCategories.find((c) => c.Category === relatedCategory);
+  if (exact) return exact;
+
+  // 2. embedding 類似度で解決
+  let relatedVec: number[];
+  const cached = embeddingCache.get(relatedCategory);
+  if (cached) {
+    relatedVec = cached;
+  } else {
+    relatedVec = await embeddingClient.embed(relatedCategory);
+    embeddingCache.set(relatedCategory, relatedVec);
+  }
+
+  let bestCategory: InterestCategoryEntity | null = null;
+  let bestSimilarity = -Infinity;
+
+  for (const category of interestCategories) {
+    // カテゴリのベクトルは entity の Embedding があれば使い、無ければ生成
+    let catVec: number[];
+    const catCached = embeddingCache.get(category.Category);
+    if (catCached) {
+      catVec = catCached;
+    } else if (category.Embedding) {
+      catVec = category.Embedding;
+      embeddingCache.set(category.Category, catVec);
+    } else {
+      catVec = await embeddingClient.embed(category.Category);
+      embeddingCache.set(category.Category, catVec);
+    }
+
+    const similarity = cosineSimilarity(relatedVec, catVec);
+    if (similarity > bestSimilarity) {
+      bestSimilarity = similarity;
+      bestCategory = category;
+    }
+  }
+
+  if (bestSimilarity >= INTEREST_DEDUP_SIMILARITY_THRESHOLD) {
+    return bestCategory;
+  }
+
+  return null;
+}
+
+/**
+ * 興味カテゴリの全 Weight 合計を計算する。
+ */
+function totalWeight(interestCategories: InterestCategoryEntity[]): number {
+  return interestCategories.reduce((sum, c) => sum + c.Weight, 0);
+}
+
+/**
+ * LLM に今日の日付を含む厳格なプロンプトで eventDate を抽出させる。
+ */
+function buildEscalationPrompt(todayStr: string): string {
+  return `あなたは通知の緊急度を判定するアシスタントです。
+今日の日付: ${todayStr}（JST）
+
+以下の知識情報から、「新作リリース・期間限定イベント・締切のある緊急情報」に関する具体的な日付（発売日・開催日・締切・終了日）を YYYY-MM-DD 形式で1つだけ抽出してください。
+
+抽出ルール:
+- 具体的な将来日付が記載されている場合のみ eventDate を返す
+- 「最新トレンド」「ランキング」「一般的な雑学」「日付の無い新着情報」「過去の情報」は eventDate=null
+- 相対表現（今週末・来月等）は今日の日付（${todayStr}）を基準に YYYY-MM-DD に変換して返す
+- 変換できない場合や日付が不明な場合は null
+- reason には判定理由を簡潔に記述する`;
+}
+
+/**
+ * isUrgent を判定する。
+ *
+ * LLM が抽出した eventDate が今日以降かつ NOTIFY_CRITICAL_EVENT_HORIZON_DAYS 以内であれば true。
+ */
+function isUrgent(eventDate: string | null, now: Date): boolean {
+  if (!eventDate) return false;
+
+  const parsed = parseDateString(eventDate);
+  if (!parsed) return false;
+
+  const todayStart = new Date(now);
+  todayStart.setHours(0, 0, 0, 0);
+
+  const horizonEnd = new Date(todayStart);
+  horizonEnd.setDate(horizonEnd.getDate() + NOTIFY_CRITICAL_EVENT_HORIZON_DAYS);
+
+  // 今日以降かつ horizon 以内（当日含む、horizon の当日含む）
+  return parsed >= todayStart && parsed <= horizonEnd;
+}
+
+/**
+ * KNOWLEDGE リストから時間帯外でも配信すべきクリティカル情報を判定する。
+ *
+ * 判定ロジック（AND ゲート）:
+ *   critical = isStrongInterest AND isUrgent
+ *
+ * - isStrongInterest: RelatedCategory を正規カテゴリに解決し、そのシェアが閾値以上か
+ * - isUrgent: LLM で抽出した eventDate が今日以降 NOTIFY_CRITICAL_EVENT_HORIZON_DAYS 以内か
+ *
+ * LLM 呼び出しは isStrongInterest=true の場合のみ行い、コストを節約する。
  *
  * - 候補が複数あっても最初の 1 件のみ返す（頻度キャップはバッチ側で担保）
- * - LLM 呼び出し失敗は best-effort（例外を握りつぶして null を返す）
+ * - LLM/embedding 呼び出し失敗は best-effort（例外を握りつぶして次の候補へ）
  */
-export async function detectCriticalKnowledge(
-  knowledgeList: KnowledgeEntity[],
-  llmClient: ILLMClient
-): Promise<EscalationResult> {
+export async function detectCriticalKnowledge(input: DetectCriticalInput): Promise<EscalationResult> {
+  const { knowledgeList, interestCategories, llmClient, embeddingClient, now } = input;
+
+  const total = totalWeight(interestCategories);
+  const embeddingCache = new Map<string, number[]>();
+  const todayStr = toJstDateString(now);
+
   for (const knowledge of knowledgeList) {
     try {
+      // (a) isStrongInterest: RelatedCategory を正規カテゴリに解決してシェアを計算
+      let strongInterest = false;
+
+      if (total > 0) {
+        const resolvedCategory = await resolveToInterestCategory(
+          knowledge.RelatedCategory,
+          interestCategories,
+          embeddingClient,
+          embeddingCache
+        );
+
+        if (resolvedCategory) {
+          const share = resolvedCategory.Weight / total;
+          strongInterest = share >= NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD;
+        }
+      }
+
+      // isStrongInterest=false の場合は LLM を呼ばずスキップ
+      if (!strongInterest) continue;
+
+      // (b) isUrgent: LLM で eventDate を抽出し、ルールゲートで判定
       const result = await llmClient.chatStructured(
         [
-          { role: 'system', content: ESCALATION_PROMPT },
+          { role: 'system', content: buildEscalationPrompt(todayStr) },
           {
             role: 'user',
             content: `トピック: ${knowledge.Topic}\n要約: ${knowledge.Summary}`,
           },
         ],
-        EscalationSchema
+        EscalationSchema,
+        { purpose: 'classify' }
       );
 
-      if (result.isCritical) {
+      if (isUrgent(result.eventDate, now)) {
         return { isCritical: true, knowledgeId: knowledge.KnowledgeID };
       }
     } catch {
-      // best-effort: LLM 失敗は無視して次の候補へ
+      // best-effort: LLM/embedding 失敗は無視して次の候補へ
     }
   }
 

--- a/services/livetalk/core/src/notification/escalation.ts
+++ b/services/livetalk/core/src/notification/escalation.ts
@@ -178,7 +178,9 @@ function isUrgent(eventDate: string | null, now: Date): boolean {
  * - 候補が複数あっても最初の 1 件のみ返す（頻度キャップはバッチ側で担保）
  * - LLM/embedding 呼び出し失敗は best-effort（例外を握りつぶして次の候補へ）
  */
-export async function detectCriticalKnowledge(input: DetectCriticalInput): Promise<EscalationResult> {
+export async function detectCriticalKnowledge(
+  input: DetectCriticalInput
+): Promise<EscalationResult> {
   const { knowledgeList, interestCategories, llmClient, embeddingClient, now } = input;
 
   const total = totalWeight(interestCategories);

--- a/services/livetalk/core/src/notification/index.ts
+++ b/services/livetalk/core/src/notification/index.ts
@@ -13,4 +13,4 @@ export { buildNotificationMessage, buildCriticalNotificationMessage } from './me
 export type { BuildNotificationMessageInput, NotificationMessage } from './message-builder.js';
 
 export { detectCriticalKnowledge } from './escalation.js';
-export type { EscalationResult } from './escalation.js';
+export type { EscalationResult, DetectCriticalInput } from './escalation.js';

--- a/services/livetalk/core/tests/unit/notification/decision.test.ts
+++ b/services/livetalk/core/tests/unit/notification/decision.test.ts
@@ -232,6 +232,25 @@ describe('shouldNotifyNow', () => {
       expect(result.notify).toBe(true);
       if (result.notify) expect(result.kind).toBe('normal');
     });
+
+    it('睡眠帯中は criticalKnowledgeId があっても sleeping を返す', () => {
+      // SLEEPING_LIFECYCLE: UTC 12:00 は睡眠帯（11:00–13:00）
+      const result = shouldNotifyNow({
+        ...baseInput(),
+        lifecycle: SLEEPING_LIFECYCLE,
+        criticalKnowledgeId: 'k1',
+      });
+      expect(result).toEqual({ notify: false, reason: 'sleeping' });
+    });
+
+    it('睡眠帯中は criticalKnowledgeId がなくても sleeping を返す', () => {
+      const result = shouldNotifyNow({
+        ...baseInput(),
+        lifecycle: SLEEPING_LIFECYCLE,
+        userMessages: [makeMsg(NOW_UTC_MS - 2 * DAY)],
+      });
+      expect(result).toEqual({ notify: false, reason: 'sleeping' });
+    });
   });
 
   describe('inactive_stopped', () => {

--- a/services/livetalk/core/tests/unit/notification/escalation.test.ts
+++ b/services/livetalk/core/tests/unit/notification/escalation.test.ts
@@ -1,0 +1,456 @@
+import { detectCriticalKnowledge } from '../../../src/notification/escalation.js';
+import type { DetectCriticalInput } from '../../../src/notification/escalation.js';
+import type { KnowledgeEntity } from '../../../src/entities/knowledge.entity.js';
+import type { InterestCategoryEntity } from '../../../src/entities/interest-category.entity.js';
+import type { ILLMClient, IEmbeddingClient } from '../../../src/llm-client/types.js';
+import {
+  NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD,
+  NOTIFY_CRITICAL_EVENT_HORIZON_DAYS,
+} from '../../../src/constants.js';
+
+// ---------------------------------------------------------------------------
+// テストフィクスチャ
+// ---------------------------------------------------------------------------
+
+/** 今日を 2026-06-07（JST）とする */
+const NOW = new Date('2026-06-07T10:00:00+09:00');
+
+/** 近未来日付（今日 + 5 日 → horizon 14 日以内） */
+const NEAR_FUTURE_DATE = '2026-06-12';
+
+/** 遠未来日付（今日 + 20 日 → horizon 超過） */
+const FAR_FUTURE_DATE = '2026-06-27';
+
+/** 過去日付 */
+const PAST_DATE = '2026-06-01';
+
+/** ホライズン境界（今日 + 14 日、当日含む） */
+const HORIZON_BOUNDARY = '2026-06-21';
+
+/** ホライズン境界翌日（today + 15 日 → 超過） */
+const OVER_HORIZON = '2026-06-22';
+
+function makeKnowledge(overrides: Partial<KnowledgeEntity> = {}): KnowledgeEntity {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    KnowledgeID: 'k1',
+    Topic: 'テストトピック',
+    Summary: 'テスト要約',
+    SourceUrls: [],
+    RawComment: 'コメント',
+    RelatedCategory: 'ゲーム',
+    CreatedAt: 1000,
+    UpdatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeInterestCategory(
+  category: string,
+  weight: number,
+  embedding?: number[]
+): InterestCategoryEntity {
+  return {
+    UserID: 'u1',
+    CharacterID: 'hiyori',
+    Category: category,
+    Weight: weight,
+    Embedding: embedding,
+    CreatedAt: 0,
+    UpdatedAt: 0,
+  };
+}
+
+function makeLlmClient(eventDate: string | null, reason = '判定理由'): ILLMClient {
+  return {
+    chatStream: jest.fn() as unknown as ILLMClient['chatStream'],
+    chatComplete: jest.fn(),
+    chatStructured: jest.fn().mockResolvedValue({ eventDate, reason }),
+    summarize: jest.fn(),
+  };
+}
+
+function makeEmbeddingClient(vectors: Map<string, number[]> = new Map()): IEmbeddingClient {
+  return {
+    embed: jest.fn().mockImplementation((text: string) => {
+      const vec = vectors.get(text);
+      if (vec) return Promise.resolve(vec);
+      // 未登録テキストはゼロベクトル（類似度 0）
+      return Promise.resolve([0, 0, 0]);
+    }),
+  };
+}
+
+function makeInput(overrides: Partial<DetectCriticalInput> = {}): DetectCriticalInput {
+  return {
+    knowledgeList: [makeKnowledge()],
+    interestCategories: [makeInterestCategory('ゲーム', 1.0)],
+    llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+    embeddingClient: makeEmbeddingClient(),
+    now: NOW,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AND ゲートテスト
+// ---------------------------------------------------------------------------
+
+describe('detectCriticalKnowledge - AND ゲート', () => {
+  it('強関心 AND 時限性 → critical', async () => {
+    const result = await detectCriticalKnowledge(makeInput());
+    expect(result.isCritical).toBe(true);
+    expect(result.knowledgeId).toBe('k1');
+  });
+
+  it('強関心あり AND 時限性なし（eventDate=null）→ 非 critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient(null) })
+    );
+    expect(result.isCritical).toBe(false);
+    expect(result.knowledgeId).toBeNull();
+  });
+
+  it('強関心なし（シェア不足）→ LLM を呼ばず非 critical', async () => {
+    // ゲーム=0.1, 合計=1.0 → シェア0.1 < NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD(0.15)
+    const llmClient = makeLlmClient(NEAR_FUTURE_DATE);
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        interestCategories: [makeInterestCategory('ゲーム', 0.1), makeInterestCategory('映画', 0.9)],
+        llmClient,
+      })
+    );
+    expect(result.isCritical).toBe(false);
+    expect(llmClient.chatStructured).not.toHaveBeenCalled();
+  });
+
+  it('どちらも無し（関心なし＋ eventDate=null）→ 非 critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        interestCategories: [makeInterestCategory('映画', 0.9), makeInterestCategory('音楽', 0.1)],
+        llmClient: makeLlmClient(null),
+      })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RelatedCategory 解決テスト
+// ---------------------------------------------------------------------------
+
+describe('detectCriticalKnowledge - RelatedCategory 解決', () => {
+  it('完全一致するカテゴリで解決 → critical になる', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        knowledgeList: [makeKnowledge({ RelatedCategory: 'ゲーム' })],
+        interestCategories: [makeInterestCategory('ゲーム', 1.0)],
+        llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+      })
+    );
+    expect(result.isCritical).toBe(true);
+  });
+
+  it('embedding 類似度が閾値以上 → 解決成功 → critical になる', async () => {
+    // 'テレビゲーム' と 'ゲーム' の embedding が類似（cosine similarity >= 0.85）を模擬
+    // ベクトルを一致させて cosine=1.0 にする
+    const vec = [1, 0, 0];
+    const vectors = new Map<string, number[]>([
+      ['テレビゲーム', vec],
+      ['ゲーム', vec],
+    ]);
+
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        knowledgeList: [makeKnowledge({ RelatedCategory: 'テレビゲーム' })],
+        interestCategories: [makeInterestCategory('ゲーム', 1.0)],
+        embeddingClient: makeEmbeddingClient(vectors),
+        llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+      })
+    );
+    expect(result.isCritical).toBe(true);
+  });
+
+  it('embedding 類似度が閾値未満 → 解決失敗 → 非 critical', async () => {
+    // 直交ベクトルで cosine=0.0 → 閾値 0.85 を下回る
+    const vectors = new Map<string, number[]>([
+      ['テレビゲーム', [1, 0, 0]],
+      ['ゲーム', [0, 1, 0]],
+    ]);
+
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        knowledgeList: [makeKnowledge({ RelatedCategory: 'テレビゲーム' })],
+        interestCategories: [makeInterestCategory('ゲーム', 1.0)],
+        embeddingClient: makeEmbeddingClient(vectors),
+        llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+      })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+
+  it('interestCategories が空 → 解決不可 → 非 critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ interestCategories: [] })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+
+  it('カテゴリ entity に Embedding がある場合は embed を呼ばず使用する', async () => {
+    const existingEmbedding = [1, 0, 0];
+    const relatedVec = [1, 0, 0]; // cosine=1.0 → 閾値以上
+    const vectors = new Map<string, number[]>([['テレビゲーム', relatedVec]]);
+    const embeddingClient = makeEmbeddingClient(vectors);
+
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        knowledgeList: [makeKnowledge({ RelatedCategory: 'テレビゲーム' })],
+        interestCategories: [makeInterestCategory('ゲーム', 1.0, existingEmbedding)],
+        embeddingClient,
+        llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+      })
+    );
+
+    expect(result.isCritical).toBe(true);
+    // カテゴリ側の embed は呼ばれないはず（entity.Embedding を使用）
+    expect((embeddingClient.embed as jest.Mock).mock.calls.map((c) => c[0])).not.toContain('ゲーム');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// シェア閾値境界テスト
+// ---------------------------------------------------------------------------
+
+describe('detectCriticalKnowledge - シェア閾値境界', () => {
+  it(`シェアが閾値（${NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD}）以上 → isStrongInterest=true → critical になりうる`, async () => {
+    // ゲーム=0.15, 合計=1.0 → シェア=0.15 = 閾値（境界値、以上なので true）
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        interestCategories: [
+          makeInterestCategory('ゲーム', NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD),
+          makeInterestCategory('映画', 1 - NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD),
+        ],
+        llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+      })
+    );
+    expect(result.isCritical).toBe(true);
+  });
+
+  it('シェアが閾値未満 → isStrongInterest=false → 非 critical', async () => {
+    // シェア = 0.14 < 0.15
+    const gameWeight = 0.14;
+    const otherWeight = 1 - gameWeight;
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        interestCategories: [
+          makeInterestCategory('ゲーム', gameWeight),
+          makeInterestCategory('映画', otherWeight),
+        ],
+        llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+      })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// eventDate ホライズン判定テスト
+// ---------------------------------------------------------------------------
+
+describe('detectCriticalKnowledge - eventDate ホライズン', () => {
+  it('近未来（今日 + 5 日）→ isUrgent=true → critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient(NEAR_FUTURE_DATE) })
+    );
+    expect(result.isCritical).toBe(true);
+  });
+
+  it('遠未来（今日 + 20 日 → horizon 超過）→ isUrgent=false → 非 critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient(FAR_FUTURE_DATE) })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+
+  it('過去日 → isUrgent=false → 非 critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient(PAST_DATE) })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+
+  it('eventDate=null → isUrgent=false → 非 critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient(null) })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+
+  it('解析不能な日付文字列 → isUrgent=false → 非 critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient('不明な日付') })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+
+  it(`ホライズン境界（今日 + ${NOTIFY_CRITICAL_EVENT_HORIZON_DAYS} 日）→ isUrgent=true → critical`, async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient(HORIZON_BOUNDARY) })
+    );
+    expect(result.isCritical).toBe(true);
+  });
+
+  it('ホライズン境界翌日（超過）→ isUrgent=false → 非 critical', async () => {
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient(OVER_HORIZON) })
+    );
+    expect(result.isCritical).toBe(false);
+  });
+
+  it('今日と同じ日付 → isUrgent=true（当日含む）→ critical', async () => {
+    const todayStr = '2026-06-07'; // NOW と同じ
+    const result = await detectCriticalKnowledge(
+      makeInput({ llmClient: makeLlmClient(todayStr) })
+    );
+    expect(result.isCritical).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// エラーハンドリングテスト
+// ---------------------------------------------------------------------------
+
+describe('detectCriticalKnowledge - エラーハンドリング', () => {
+  it('LLM が throw しても落ちず次の候補へ進む', async () => {
+    const llmClient: ILLMClient = {
+      chatStream: jest.fn() as unknown as ILLMClient['chatStream'],
+      chatComplete: jest.fn(),
+      chatStructured: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('LLM タイムアウト'))
+        .mockResolvedValueOnce({ eventDate: NEAR_FUTURE_DATE, reason: '成功' }),
+      summarize: jest.fn(),
+    };
+
+    const knowledgeList = [
+      makeKnowledge({ KnowledgeID: 'k1', RelatedCategory: 'ゲーム' }),
+      makeKnowledge({ KnowledgeID: 'k2', RelatedCategory: 'ゲーム' }),
+    ];
+
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        knowledgeList,
+        interestCategories: [makeInterestCategory('ゲーム', 1.0)],
+        llmClient,
+      })
+    );
+
+    // k1 は LLM エラーだがスキップ、k2 は成功してクリティカルになる
+    expect(result.isCritical).toBe(true);
+    expect(result.knowledgeId).toBe('k2');
+  });
+
+  it('embedding が throw しても落ちず次の候補へ進む', async () => {
+    const embeddingClient: IEmbeddingClient = {
+      embed: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('embedding エラー'))
+        .mockResolvedValue([1, 0, 0]),
+    };
+
+    const knowledgeList = [
+      makeKnowledge({ KnowledgeID: 'k1', RelatedCategory: '未知カテゴリ' }),
+      makeKnowledge({ KnowledgeID: 'k2', RelatedCategory: 'ゲーム' }),
+    ];
+
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        knowledgeList,
+        // ゲームカテゴリに embedding なし（embed を呼ぶ）
+        interestCategories: [makeInterestCategory('ゲーム', 1.0)],
+        embeddingClient,
+        llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+      })
+    );
+
+    // k1 は embedding エラーでスキップ、k2（完全一致）は成功する
+    // ※ k2 は '未知カテゴリ' → 'ゲーム' への embed で失敗するが、
+    //    k1 の embed 失敗後はキャッシュがないため k2 でも embed が呼ばれる
+    // 実際の挙動: k1 で embed('未知カテゴリ') が throw → catch して次へ
+    //           k2 の '未知カテゴリ' は k2 自体の RelatedCategory='ゲーム'
+    //           k2 は完全一致 → embed 不要 → critical
+    // 注: k1 は '未知カテゴリ' → ゲームカテゴリへの embed 解決で失敗する
+    //     k2 は 'ゲーム' → 完全一致で embed 不要 → critical
+    expect(result.isCritical).toBe(true);
+  });
+
+  it('全 Knowledge が LLM エラーでも { isCritical: false, knowledgeId: null } を返す', async () => {
+    const llmClient: ILLMClient = {
+      chatStream: jest.fn() as unknown as ILLMClient['chatStream'],
+      chatComplete: jest.fn(),
+      chatStructured: jest.fn().mockRejectedValue(new Error('全部失敗')),
+      summarize: jest.fn(),
+    };
+
+    const result = await detectCriticalKnowledge(makeInput({ llmClient }));
+    expect(result).toEqual({ isCritical: false, knowledgeId: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 複数 Knowledge: 最初の 1 件のみ返すテスト
+// ---------------------------------------------------------------------------
+
+describe('detectCriticalKnowledge - 複数 Knowledge', () => {
+  it('複数の候補があっても最初の critical を返す', async () => {
+    const knowledgeList = [
+      makeKnowledge({ KnowledgeID: 'k1', RelatedCategory: 'ゲーム' }),
+      makeKnowledge({ KnowledgeID: 'k2', RelatedCategory: 'ゲーム' }),
+    ];
+
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        knowledgeList,
+        interestCategories: [makeInterestCategory('ゲーム', 1.0)],
+        llmClient: makeLlmClient(NEAR_FUTURE_DATE),
+      })
+    );
+
+    expect(result.isCritical).toBe(true);
+    expect(result.knowledgeId).toBe('k1'); // 最初の候補
+  });
+
+  it('最初の候補が非 critical で次が critical → 次の候補を返す', async () => {
+    const llmClient: ILLMClient = {
+      chatStream: jest.fn() as unknown as ILLMClient['chatStream'],
+      chatComplete: jest.fn(),
+      chatStructured: jest
+        .fn()
+        .mockResolvedValueOnce({ eventDate: null, reason: 'k1 は時限性なし' })
+        .mockResolvedValueOnce({ eventDate: NEAR_FUTURE_DATE, reason: 'k2 は時限性あり' }),
+      summarize: jest.fn(),
+    };
+
+    const knowledgeList = [
+      makeKnowledge({ KnowledgeID: 'k1', RelatedCategory: 'ゲーム' }),
+      makeKnowledge({ KnowledgeID: 'k2', RelatedCategory: 'ゲーム' }),
+    ];
+
+    const result = await detectCriticalKnowledge(
+      makeInput({
+        knowledgeList,
+        interestCategories: [makeInterestCategory('ゲーム', 1.0)],
+        llmClient,
+      })
+    );
+
+    expect(result.isCritical).toBe(true);
+    expect(result.knowledgeId).toBe('k2');
+  });
+
+  it('knowledgeList が空 → 非 critical', async () => {
+    const result = await detectCriticalKnowledge(makeInput({ knowledgeList: [] }));
+    expect(result).toEqual({ isCritical: false, knowledgeId: null });
+  });
+});

--- a/services/livetalk/core/tests/unit/notification/escalation.test.ts
+++ b/services/livetalk/core/tests/unit/notification/escalation.test.ts
@@ -105,9 +105,7 @@ describe('detectCriticalKnowledge - AND ゲート', () => {
   });
 
   it('強関心あり AND 時限性なし（eventDate=null）→ 非 critical', async () => {
-    const result = await detectCriticalKnowledge(
-      makeInput({ llmClient: makeLlmClient(null) })
-    );
+    const result = await detectCriticalKnowledge(makeInput({ llmClient: makeLlmClient(null) }));
     expect(result.isCritical).toBe(false);
     expect(result.knowledgeId).toBeNull();
   });
@@ -117,7 +115,10 @@ describe('detectCriticalKnowledge - AND ゲート', () => {
     const llmClient = makeLlmClient(NEAR_FUTURE_DATE);
     const result = await detectCriticalKnowledge(
       makeInput({
-        interestCategories: [makeInterestCategory('ゲーム', 0.1), makeInterestCategory('映画', 0.9)],
+        interestCategories: [
+          makeInterestCategory('ゲーム', 0.1),
+          makeInterestCategory('映画', 0.9),
+        ],
         llmClient,
       })
     );
@@ -191,9 +192,7 @@ describe('detectCriticalKnowledge - RelatedCategory 解決', () => {
   });
 
   it('interestCategories が空 → 解決不可 → 非 critical', async () => {
-    const result = await detectCriticalKnowledge(
-      makeInput({ interestCategories: [] })
-    );
+    const result = await detectCriticalKnowledge(makeInput({ interestCategories: [] }));
     expect(result.isCritical).toBe(false);
   });
 
@@ -214,7 +213,9 @@ describe('detectCriticalKnowledge - RelatedCategory 解決', () => {
 
     expect(result.isCritical).toBe(true);
     // カテゴリ側の embed は呼ばれないはず（entity.Embedding を使用）
-    expect((embeddingClient.embed as jest.Mock).mock.calls.map((c) => c[0])).not.toContain('ゲーム');
+    expect((embeddingClient.embed as jest.Mock).mock.calls.map((c) => c[0])).not.toContain(
+      'ゲーム'
+    );
   });
 });
 
@@ -281,9 +282,7 @@ describe('detectCriticalKnowledge - eventDate ホライズン', () => {
   });
 
   it('eventDate=null → isUrgent=false → 非 critical', async () => {
-    const result = await detectCriticalKnowledge(
-      makeInput({ llmClient: makeLlmClient(null) })
-    );
+    const result = await detectCriticalKnowledge(makeInput({ llmClient: makeLlmClient(null) }));
     expect(result.isCritical).toBe(false);
   });
 
@@ -310,9 +309,7 @@ describe('detectCriticalKnowledge - eventDate ホライズン', () => {
 
   it('今日と同じ日付 → isUrgent=true（当日含む）→ critical', async () => {
     const todayStr = '2026-06-07'; // NOW と同じ
-    const result = await detectCriticalKnowledge(
-      makeInput({ llmClient: makeLlmClient(todayStr) })
-    );
+    const result = await detectCriticalKnowledge(makeInput({ llmClient: makeLlmClient(todayStr) }));
     expect(result.isCritical).toBe(true);
   });
 });


### PR DESCRIPTION
## 変更の概要

リブトーク通知ロジック見直し（#3444）の Phase 1。「通知が事実上すべてクリティカルになる」問題を解消するため、クリティカル通知の判定を **ハード AND ゲート**で再定義し、ユーザー中心かつ厳格にする。

```
critical = isStrongInterest AND isUrgent
```

- **isStrongInterest（相対 Weight 閾値）**: Knowledge の `RelatedCategory` を、完全一致 → embedding 類似度（既存 `INTEREST_DEDUP_SIMILARITY_THRESHOLD=0.85` 流用）の順で正規カテゴリに解決。解決できたカテゴリの **Weight シェアが `NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD`(0.15) 以上**なら強い関心。解決不能なら critical にしない。
- **isUrgent（LLM 抽出＋ルールゲート）**: LLM に `eventDate`(YYYY-MM-DD) を構造化抽出させ、「今日以降かつ `NOTIFY_CRITICAL_EVENT_HORIZON_DAYS`(14日) 以内の未来日付」のときのみ urgent と**ルール側で判定**。日付の無い「最新トレンド・ランキング・雑学」は除外。LLM 呼び出しは強関心の Knowledge に限定（コスト節約）。
- **睡眠帯の尊重**: `shouldNotifyNow` の判定順序を変更し、睡眠帯チェックを先頭へ。クリティカルも睡眠中は配信せず、起床後の次回バッチで再評価・遅延配信する（間隔・活動時間帯ゲートは従来通りバイパス）。

> 背景: dev DynamoDB で直近通知 6/6 がすべて critical・毎日1発で、適応的間隔ロジックが死んでいることを確認済み。原因は緩い緊急度判定・Knowledge の新作志向・Weight 未使用。

※ 頻度設計（intensityFactor・cap 緩和・interval 短縮）は **Phase 2** の範囲で、本 PR では未変更。

## 関連 Issue

#3444（Phase 1）
<!-- 作業ブランチ → integration の PR のため Closes は付けない（Issue は integration → develop マージ後にクローズ） -->

## 変更種別

- [x] リファクタリング
- [x] バグ修正
- [ ] 新規機能
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（永続ドキュメント反映は機能確定後に実施予定）
- [x] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）※対象なし
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `escalation.test.ts`（新規・25ケース）: AND ゲートの全組み合わせ、RelatedCategory 解決（完全一致 / embedding 閾値以上・未満 / 空 / entity.Embedding 再利用）、シェア閾値の境界（0.15/0.14）、eventDate ホライズン（近未来 / 遠未来 / 過去 / null / 解析不能 / 境界）、LLM・embedding が throw しても次候補へ継続。
- `decision.test.ts`（追加）: 睡眠帯中は `criticalKnowledgeId` 有無に関わらず `{ notify:false, reason:'sleeping' }` を返す。
- 検証結果（オーケストレーターが再実行して確認）: **core 969 passed / batch 41 passed**、core カバレッジ **92.27%**（閾値80%クリア）。

## レビューポイント

- シェア閾値 `0.15` とホライズン `14日` は dev 実データの Weight 分布（飲み物38%/スイーツ18%/ゲーム15%/映画14%/…）を根拠にした**暫定値**。チューニング余地あり。
- 日付比較はローカル時刻（本番 `TZ=Asia/Tokyo` 前提）で統一。テスト環境（UTC）との整合を `parseDateString` / `isUrgent` で担保。
- 「解決不能な RelatedCategory は critical にしない」という保守的な既定の妥当性。

## 補足事項

dev 環境で配信カデンスを観察するため integration ブランチ（`integration/3444-livetalk-notification`）をターゲットにしている。Phase 2（頻度設計）は別 PR で続ける。

https://claude.ai/code/session_01FksuoEcdrU9xhU6aJjwKyr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FksuoEcdrU9xhU6aJjwKyr)_