### PR TITLE
B-3 #3296 お問い合わせページの整備（Google フォーム導線）

### DIFF
--- a/services/portal/web/src/app/contact/page.tsx
+++ b/services/portal/web/src/app/contact/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from 'next';
+import { Container, Typography, Box } from '@mui/material';
+import { Link, Button } from '@nagiyu/ui';
+import {
+  CONTACT_FORM_URL,
+  GITHUB_ISSUES_URL,
+  CONTACT_USE_CASES,
+  CONTACT_NOTES,
+} from '@/lib/contact';
+
+export const metadata: Metadata = {
+  title: 'お問い合わせ',
+  description:
+    'nagiyu へのお問い合わせはGoogle フォームからお気軽にどうぞ。サービスへのご意見・不具合報告・記事の誤り指摘など、幅広くお受けしています。',
+  alternates: {
+    canonical: 'https://nagiyu.com/contact',
+  },
+};
+
+export default function ContactPage() {
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom align="center">
+        お問い合わせ
+      </Typography>
+
+      <Typography variant="body1" sx={{ mb: 4, textAlign: 'center', color: 'text.secondary' }}>
+        ご意見・ご感想・不具合報告など、お気軽にお送りください。
+      </Typography>
+
+      {/* メイン手段: Google フォーム */}
+      <Box sx={{ mb: 5 }}>
+        <Typography variant="h6" component="h2" gutterBottom sx={{ fontWeight: 600 }}>
+          お問い合わせフォーム
+        </Typography>
+        <Typography variant="body1" sx={{ mb: 3 }}>
+          以下のフォームからお問い合わせいただけます。Google フォームを利用しており、 Google
+          アカウントなしでもご利用いただけます。
+        </Typography>
+        <Box sx={{ textAlign: 'center', mb: 3 }}>
+          <Button variant="solid" asChild>
+            <a href={CONTACT_FORM_URL} target="_blank" rel="noopener noreferrer">
+              お問い合わせフォームを開く
+            </a>
+          </Button>
+        </Box>
+      </Box>
+
+      {/* どんな用件で連絡してよいか */}
+      <Box sx={{ mb: 5 }}>
+        <Typography variant="h6" component="h2" gutterBottom sx={{ fontWeight: 600 }}>
+          こんな場合にご利用ください
+        </Typography>
+        <Box component="ul" sx={{ pl: 3 }}>
+          {CONTACT_USE_CASES.map((useCase) => (
+            <Box component="li" key={useCase.title} sx={{ mb: 2 }}>
+              <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                {useCase.title}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {useCase.description}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+
+      {/* 注意事項 */}
+      <Box sx={{ mb: 5 }}>
+        <Typography variant="h6" component="h2" gutterBottom sx={{ fontWeight: 600 }}>
+          注意事項
+        </Typography>
+        <Box component="ul" sx={{ pl: 3 }}>
+          {CONTACT_NOTES.map((note) => (
+            <Box component="li" key={note} sx={{ mb: 1 }}>
+              <Typography variant="body1">{note}</Typography>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+
+      {/* 補足: GitHub Issues（技術者向け） */}
+      <Box
+        sx={{
+          mb: 4,
+          p: 2,
+          backgroundColor: 'grey.100',
+          borderRadius: 1,
+          borderLeft: 4,
+          borderColor: 'grey.400',
+        }}
+      >
+        <Typography variant="subtitle2" gutterBottom sx={{ fontWeight: 600 }}>
+          技術者の方へ
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          バグ報告・機能要望・技術的な議論は{' '}
+          <Link href={GITHUB_ISSUES_URL} target="_blank" rel="noopener noreferrer">
+            GitHub Issues
+          </Link>{' '}
+          でも受け付けています。コードレベルの詳細なやりとりに適しています。
+        </Typography>
+      </Box>
+    </Container>
+  );
+}

--- a/services/portal/web/src/app/layout.tsx
+++ b/services/portal/web/src/app/layout.tsx
@@ -109,7 +109,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             >
               {children}
             </Box>
-            <Footer version={version} contactHref="/about" />
+            <Footer version={version} contactHref="/contact" />
           </Box>
         </AppThemeProvider>
       </body>

--- a/services/portal/web/src/lib/contact.ts
+++ b/services/portal/web/src/lib/contact.ts
@@ -1,0 +1,61 @@
+/**
+ * お問い合わせページで使用するデータ定数
+ *
+ * Google フォームを主たる手段として前面に出し、
+ * GitHub Issues は技術者向け補助手段として併記する。
+ */
+
+export const ERROR_MESSAGES = {
+  CONTACT_DATA_NOT_FOUND: 'お問い合わせページのデータが見つかりません',
+} as const;
+
+/** Google フォームの URL（運営者公開の正規 URL） */
+export const CONTACT_FORM_URL = 'https://forms.gle/oxzHNFBWBpFGNaKm7' as const;
+
+/** GitHub Issues の URL */
+export const GITHUB_ISSUES_URL = 'https://github.com/nagiyu/nagiyu-platform/issues' as const;
+
+/**
+ * お問い合わせ用途の説明
+ */
+export type ContactUseCase = {
+  /** 用途の見出し */
+  title: string;
+  /** 詳細説明 */
+  description: string;
+};
+
+/**
+ * Google フォームで受け付けるお問い合わせの用途一覧
+ */
+export const CONTACT_USE_CASES: ContactUseCase[] = [
+  {
+    title: 'サービスへのご意見・ご感想',
+    description:
+      '各サービスの使い勝手や改善点など、ご自由にお送りください。いただいたご意見は今後の開発の参考にします。',
+  },
+  {
+    title: '不具合・動作がおかしい場合',
+    description:
+      'サービスが正常に動作しない・表示がおかしいなど、不具合と思われる場合はフォームからご連絡ください。',
+  },
+  {
+    title: '記事の誤りや情報の修正依頼',
+    description: '技術記事の内容に誤りや古い情報が含まれていた場合、ご指摘いただけると助かります。',
+  },
+  {
+    title: 'その他のお問い合わせ',
+    description:
+      '上記以外のご連絡もお気軽にどうぞ。個人での運営のため、返信にお時間をいただく場合があります。',
+  },
+] as const;
+
+/**
+ * 注意事項の一覧
+ */
+export const CONTACT_NOTES: string[] = [
+  '個人で運営しているため、すべてのご要望にお応えできるわけではありません。',
+  '返信が必要な場合は、フォーム内にご連絡先をご記入ください。',
+  '返信までにお時間をいただく場合があります。',
+  '技術的なサポートやカスタマイズ対応は承っておりません。',
+] as const;

--- a/services/portal/web/tests/unit/lib/contact.test.ts
+++ b/services/portal/web/tests/unit/lib/contact.test.ts
@@ -1,0 +1,103 @@
+import {
+  ERROR_MESSAGES,
+  CONTACT_FORM_URL,
+  GITHUB_ISSUES_URL,
+  CONTACT_USE_CASES,
+  CONTACT_NOTES,
+} from '@/lib/contact';
+
+describe('contact', () => {
+  describe('ERROR_MESSAGES', () => {
+    it('エラーメッセージ定数が定義されている', () => {
+      expect(ERROR_MESSAGES.CONTACT_DATA_NOT_FOUND).toBe(
+        'お問い合わせページのデータが見つかりません'
+      );
+    });
+  });
+
+  describe('CONTACT_FORM_URL', () => {
+    it('Google フォームの URL が定義されている', () => {
+      expect(CONTACT_FORM_URL).toBe('https://forms.gle/oxzHNFBWBpFGNaKm7');
+    });
+
+    it('Google フォームの URL が https:// で始まる', () => {
+      expect(CONTACT_FORM_URL.startsWith('https://')).toBe(true);
+    });
+
+    it('Google フォームの URL が forms.gle ドメインを含む', () => {
+      expect(CONTACT_FORM_URL).toContain('forms.gle');
+    });
+  });
+
+  describe('GITHUB_ISSUES_URL', () => {
+    it('GitHub Issues の URL が定義されている', () => {
+      expect(GITHUB_ISSUES_URL).toBe('https://github.com/nagiyu/nagiyu-platform/issues');
+    });
+
+    it('GitHub Issues の URL が https:// で始まる', () => {
+      expect(GITHUB_ISSUES_URL.startsWith('https://')).toBe(true);
+    });
+
+    it('GitHub Issues の URL が github.com を含む', () => {
+      expect(GITHUB_ISSUES_URL).toContain('github.com');
+    });
+  });
+
+  describe('CONTACT_USE_CASES', () => {
+    it('用途一覧が空でない', () => {
+      expect(CONTACT_USE_CASES.length).toBeGreaterThan(0);
+    });
+
+    it('各用途に title と description が含まれる', () => {
+      CONTACT_USE_CASES.forEach((useCase) => {
+        expect(typeof useCase.title).toBe('string');
+        expect(useCase.title.length).toBeGreaterThan(0);
+        expect(typeof useCase.description).toBe('string');
+        expect(useCase.description.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('サービスへのご意見・ご感想が含まれる', () => {
+      const titles = CONTACT_USE_CASES.map((u) => u.title);
+      expect(titles).toContain('サービスへのご意見・ご感想');
+    });
+
+    it('不具合報告に関する用途が含まれる', () => {
+      const hasBugReport = CONTACT_USE_CASES.some((u) => u.title.includes('不具合'));
+      expect(hasBugReport).toBe(true);
+    });
+
+    it('記事の誤り指摘に関する用途が含まれる', () => {
+      const hasArticleCorrection = CONTACT_USE_CASES.some((u) => u.title.includes('記事'));
+      expect(hasArticleCorrection).toBe(true);
+    });
+
+    it('その他のお問い合わせが含まれる', () => {
+      const hasOther = CONTACT_USE_CASES.some((u) => u.title.includes('その他'));
+      expect(hasOther).toBe(true);
+    });
+  });
+
+  describe('CONTACT_NOTES', () => {
+    it('注意事項リストが空でない', () => {
+      expect(CONTACT_NOTES.length).toBeGreaterThan(0);
+    });
+
+    it('各注意事項が文字列である', () => {
+      CONTACT_NOTES.forEach((note) => {
+        expect(typeof note).toBe('string');
+        expect(note.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('個人運営に関する注意事項が含まれる', () => {
+      const hasPersonal = CONTACT_NOTES.some((n) => n.includes('個人'));
+      expect(hasPersonal).toBe(true);
+    });
+
+    it('返信に関する注意事項が含まれる', () => {
+      const hasReply = CONTACT_NOTES.some((n) => n.includes('返信'));
+      expect(hasReply).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

Issue #3296「お問い合わせ手段の整備（現状調査 + Google フォーム導線）（B3）」の実装。AdSense 観点の「連絡可能なサイト」要件を満たすため、Portal にお問い合わせページを新規作成した。

### 現状調査結果

- **Google フォーム URL**: `https://forms.gle/oxzHNFBWBpFGNaKm7`
  - 既存使用箇所: `services/tools/src/app/contact/page.tsx` / `libs/ui/src/data/privacyPolicyData.ts`
  - 運営者公開の正規 URL として再利用
- Portal には contact ページが未存在 → 本 PR で新規作成
- `layout.tsx` の `Footer` には `contactHref="/about"` という記述があり（URL 不整合）、本 PR で `/contact` に修正

### 実装内容

| 項目 | 内容 |
|---|---|
| 主たる連絡手段 | Google フォームを最上部に大きく配置（一般読者向け） |
| 補助的手段 | GitHub Issues は「技術者の方へ」というセクションに格下げ |
| 用途説明 | 「こんな場合にご利用ください」セクションで連絡が想定される用途を例示 |
| 注意事項 | 個人プロジェクトのため即時対応不可・回答に時間を要する旨を明示 |
| Footer 導線 | `layout.tsx` の `Footer contactHref` を `/about` → `/contact` に修正 |

## 関連 Issue

#3296（親: #3262）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ 98.93%、contact.ts は 100%）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した（73 件 pass）
- [x] ビルドエラーがないことを確認した（`tsc --noEmit` / `prettier --check` / `lint` 全 pass）

## 設計判断サマリ

### UI / ロジック分離
- ビジネスロジック（フォーム URL・用途リスト・注意事項リスト）は `src/lib/contact.ts` に集約
- UI コンポーネントは `src/app/contact/page.tsx` 単一ページ（過度な分割は避けた）
- `ERROR_MESSAGES` も定義（規約準拠）

### Tools 版 contact との順序の違い
| サービス | 主たる導線 | 補助的導線 |
|---|---|---|
| Tools | GitHub Issues（技術者向け） | Google フォーム |
| **Portal（本 PR）** | **Google フォーム（一般読者向け）** | GitHub Issues |

運営者意向（Issue 本文記載）に基づき、Portal では Google フォームを前面に配置。

### Button の外部リンク実装
`@nagiyu/ui` の `Button` は `href` プロパティを持たないため、`asChild` パターン（Radix Slot）で `<a target="_blank" rel="noopener noreferrer">` を子要素として渡す方式を採用。

### B-4 (#3297) との関係
- フッター本体の整備は B-4 タスク
- 本 PR は `Footer contactHref` の URL 不整合修正のみ（既存 props の値変更）
- B-4 で Footer 構造を改修する際の差分は限定的

### B-1 (#3449) / B-2 (#3450) との関係
- 本 PR は contact ページの新規作成 + `layout.tsx` の Footer prop 値修正のみ
- B-1（`page.tsx`）/ B-2（`about/page.tsx`）と編集ファイルが重ならず、conflict なしで併走可能

## テスト内容

- `contact.ts` の全エクスポート（`CONTACT_FORM_URL` / `GITHUB_ISSUES_URL` / `CONTACT_USE_CASES` / `CONTACT_NOTES` / `ERROR_MESSAGES`）に対する単体テスト
- カバレッジ: contact.ts は 100%、全体 98.93%
- 全 73 テスト pass

## レビューポイント

- Google フォーム URL（`https://forms.gle/oxzHNFBWBpFGNaKm7`）が運営者の意図する正規 URL か（既存 Tools / privacyPolicyData と同一の URL を採用）
- 「こんな場合にご利用ください」「注意事項」の文言が一般読者向けとして適切か
- Footer の `contactHref` 修正（`/about` → `/contact`）が他箇所に影響しないか
- Header ナビゲーションへの contact リンク追加を見送った判断（B-4 との重複回避）

## スクリーンショット（該当する場合）

スクリーンショット取得環境未整備のため省略。dev 環境デプロイ後に視覚確認を実施推奨。

## 補足事項

- Google フォーム iframe 埋め込みは行わず外部リンクのみ（スパム対策・プライバシー配慮）
- `Footer contactHref` の修正は B-4 のフッター構造改修と独立した値変更であり、B-4 の作業を妨げない

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBSbcDz8CTXatR3zxq2yEq)_