### PR TITLE
C-3 #3312 Core Web Vitals 静的解析・軽微修正・実測手順ドキュメント化

### DIFF
--- a/docs/development/core-web-vitals.md
+++ b/docs/development/core-web-vitals.md
@@ -1,0 +1,120 @@
+# Core Web Vitals 実測手順
+
+Portal サイトの Core Web Vitals を Lighthouse / PageSpeed Insights で測定する手順をまとめる。
+
+## 測定指標と基準値
+
+| 指標 | Good | Needs Improvement | Poor |
+|------|------|-------------------|------|
+| LCP（Largest Contentful Paint） | ≤ 2.5s | 2.5s〜4.0s | > 4.0s |
+| CLS（Cumulative Layout Shift） | ≤ 0.1 | 0.1〜0.25 | > 0.25 |
+| INP（Interaction to Next Paint） | ≤ 200ms | 200ms〜500ms | > 500ms |
+| FCP（First Contentful Paint） | ≤ 1.8s | 1.8s〜3.0s | > 3.0s |
+| TTFB（Time to First Byte） | ≤ 800ms | 800ms〜1800ms | > 1800ms |
+
+基準値は `src/lib/coreWebVitals.ts` の `CWV_THRESHOLDS` で定数化している。
+
+## 方法 1: PageSpeed Insights（外部サービス、推奨）
+
+1. [PageSpeed Insights](https://pagespeed.web.dev/) にアクセス
+2. 測定対象 URL を入力して「分析」
+
+### 測定対象ページ
+
+| ページ | URL |
+|--------|-----|
+| トップページ | `https://nagiyu.com/` |
+| 技術記事一覧 | `https://nagiyu.com/tech` |
+| 技術記事詳細（例） | `https://nagiyu.com/tech/{slug}` |
+| カテゴリ別ハブ（例） | `https://nagiyu.com/tech/category/{slug}` |
+| タグページ（例） | `https://nagiyu.com/tech/tags/{slug}` |
+| サービス一覧 | `https://nagiyu.com/services` |
+| サービス詳細（例） | `https://nagiyu.com/services/{slug}` |
+| About | `https://nagiyu.com/about` |
+
+### 測定のポイント
+
+- **モバイル / デスクトップ両方**で測定すること（Google は主にモバイルを評価基準とする）
+- ページがデプロイ済みでないと PSI は測定できない（dev 環境 URL または本番 URL を使用）
+- 「フィールドデータ」（実際のユーザーデータ）と「ラボデータ」（シミュレーション）の両方を確認する
+
+## 方法 2: Chrome DevTools Lighthouse（ローカル）
+
+### 前提条件
+
+- dev サーバーが起動していること
+- `npm run dev` を実行して `http://localhost:3000` にアクセスできること
+
+### shared libs のビルド（必須）
+
+```bash
+npm run build --workspace=@nagiyu/common
+npm run build --workspace=@nagiyu/browser
+npm run build --workspace=@nagiyu/ui
+npm run build --workspace=@nagiyu/nextjs
+```
+
+### dev サーバー起動
+
+```bash
+cd services/portal/web
+npm run dev
+```
+
+### Lighthouse 実行
+
+1. Chrome で `http://localhost:3000` を開く
+2. DevTools を開く（F12）
+3. 「Lighthouse」タブを選択
+4. 「モバイル」または「デスクトップ」を選択
+5. 「レポートを生成」をクリック
+
+**注意**: ローカルの dev サーバーでは本番環境と差が生じることがある。以下の点に注意：
+- `NODE_ENV=production` の場合のみ AdSense スクリプトが読み込まれる
+- サーバー応答時間はローカル環境が実際よりも速い場合がある
+
+## 方法 3: Lighthouse CLI
+
+```bash
+# Lighthouse CLI のインストール
+npm install -g lighthouse
+
+# モバイル測定
+lighthouse http://localhost:3000 --preset=perf --form-factor=mobile --output=html --output-path=./lighthouse-mobile.html
+
+# デスクトップ測定
+lighthouse http://localhost:3000 --preset=perf --form-factor=desktop --output=html --output-path=./lighthouse-desktop.html
+```
+
+## モバイル UX チェックリスト
+
+Lighthouse スコア以外に、以下をマニュアルで確認する：
+
+- [ ] タップ領域が 48px × 48px 以上（Google 推奨）
+- [ ] 本文フォントサイズが 14px 以上
+- [ ] `<meta name="viewport">` が設定されている（Next.js App Router では自動設定）
+- [ ] ズームなしで全コンテンツが閲覧できる
+- [ ] 横スクロールが発生しない
+
+## PR Description への記録フォーマット
+
+測定結果を PR の Description に以下のフォーマットで記録する：
+
+```markdown
+## Core Web Vitals 測定結果
+
+測定日: YYYY-MM-DD
+環境: dev / 本番
+測定ツール: PageSpeed Insights / Lighthouse
+
+| ページ | LCP | CLS | INP | FCP | スコア（モバイル）|
+|--------|-----|-----|-----|-----|----------|
+| トップページ | - | - | - | - | - |
+| 技術記事詳細 | - | - | - | - | - |
+| ...    | -   | -   | -   | -   | -        |
+```
+
+## 関連ファイル
+
+- 基準値定数: `services/portal/web/src/lib/coreWebVitals.ts`
+- Issue: #3312（Core Web Vitals / モバイル UX 実測と軽微修正）

--- a/services/portal/web/src/app/tech/[slug]/page.tsx
+++ b/services/portal/web/src/app/tech/[slug]/page.tsx
@@ -60,7 +60,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
           : new Date(article.publishedAt).toISOString(),
         authors: [AUTHOR.url],
         tags: article.tags,
-        images: ['/og-default.png'],
+        images: [{ url: '/og-default.png', width: 1200, height: 630, alt: article.title }],
       },
       twitter: {
         card: 'summary_large_image',

--- a/services/portal/web/src/app/tech/category/[category]/page.tsx
+++ b/services/portal/web/src/app/tech/category/[category]/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
         url,
         title: category.title,
         description: category.description,
-        images: ['/og-default.png'],
+        images: [{ url: '/og-default.png', width: 1200, height: 630, alt: category.title }],
       },
     };
   } catch {

--- a/services/portal/web/src/app/tech/tags/[tag]/page.tsx
+++ b/services/portal/web/src/app/tech/tags/[tag]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
       url,
       title: `${tag} の記事一覧`,
       description: `nagiyu の技術記事のうち「${tag}」タグが付いた記事の一覧です。`,
-      images: ['/og-default.png'],
+      images: [{ url: '/og-default.png', width: 1200, height: 630, alt: `${tag} の記事一覧` }],
     },
   };
 }

--- a/services/portal/web/src/lib/coreWebVitals.ts
+++ b/services/portal/web/src/lib/coreWebVitals.ts
@@ -1,0 +1,87 @@
+/**
+ * Core Web Vitals の基準値定数
+ *
+ * Google が定める「Good」評価の閾値を定義する。
+ * https://web.dev/articles/vitals
+ */
+
+/** Core Web Vitals 各指標の上限値（「Good」評価の閾値） */
+export const CWV_THRESHOLDS = {
+  /** LCP（Largest Contentful Paint）: 2.5 秒以内が Good */
+  LCP_GOOD_MS: 2500,
+  /** LCP（Largest Contentful Paint）: 4.0 秒を超えると Poor */
+  LCP_POOR_MS: 4000,
+
+  /** CLS（Cumulative Layout Shift）: 0.1 以下が Good */
+  CLS_GOOD: 0.1,
+  /** CLS（Cumulative Layout Shift）: 0.25 を超えると Poor */
+  CLS_POOR: 0.25,
+
+  /** INP（Interaction to Next Paint）: 200ms 以内が Good */
+  INP_GOOD_MS: 200,
+  /** INP（Interaction to Next Paint）: 500ms を超えると Poor */
+  INP_POOR_MS: 500,
+
+  /** FCP（First Contentful Paint）: 1.8 秒以内が Good */
+  FCP_GOOD_MS: 1800,
+  /** FCP（First Contentful Paint）: 3.0 秒を超えると Poor */
+  FCP_POOR_MS: 3000,
+
+  /** TTFB（Time to First Byte）: 800ms 以内が Good */
+  TTFB_GOOD_MS: 800,
+  /** TTFB（Time to First Byte）: 1800ms を超えると Poor */
+  TTFB_POOR_MS: 1800,
+} as const;
+
+/** Core Web Vitals の評価ラベル */
+export type CwvRating = 'good' | 'needs-improvement' | 'poor';
+
+/**
+ * LCP 値を評価ラベルに変換する
+ * @param ms - LCP ミリ秒
+ */
+export function rateLcp(ms: number): CwvRating {
+  if (ms <= CWV_THRESHOLDS.LCP_GOOD_MS) return 'good';
+  if (ms <= CWV_THRESHOLDS.LCP_POOR_MS) return 'needs-improvement';
+  return 'poor';
+}
+
+/**
+ * CLS 値を評価ラベルに変換する
+ * @param value - CLS スコア（無次元）
+ */
+export function rateCls(value: number): CwvRating {
+  if (value <= CWV_THRESHOLDS.CLS_GOOD) return 'good';
+  if (value <= CWV_THRESHOLDS.CLS_POOR) return 'needs-improvement';
+  return 'poor';
+}
+
+/**
+ * INP 値を評価ラベルに変換する
+ * @param ms - INP ミリ秒
+ */
+export function rateInp(ms: number): CwvRating {
+  if (ms <= CWV_THRESHOLDS.INP_GOOD_MS) return 'good';
+  if (ms <= CWV_THRESHOLDS.INP_POOR_MS) return 'needs-improvement';
+  return 'poor';
+}
+
+/**
+ * FCP 値を評価ラベルに変換する
+ * @param ms - FCP ミリ秒
+ */
+export function rateFcp(ms: number): CwvRating {
+  if (ms <= CWV_THRESHOLDS.FCP_GOOD_MS) return 'good';
+  if (ms <= CWV_THRESHOLDS.FCP_POOR_MS) return 'needs-improvement';
+  return 'poor';
+}
+
+/**
+ * TTFB 値を評価ラベルに変換する
+ * @param ms - TTFB ミリ秒
+ */
+export function rateTtfb(ms: number): CwvRating {
+  if (ms <= CWV_THRESHOLDS.TTFB_GOOD_MS) return 'good';
+  if (ms <= CWV_THRESHOLDS.TTFB_POOR_MS) return 'needs-improvement';
+  return 'poor';
+}

--- a/services/portal/web/tests/unit/lib/coreWebVitals.test.ts
+++ b/services/portal/web/tests/unit/lib/coreWebVitals.test.ts
@@ -1,0 +1,165 @@
+import {
+  CWV_THRESHOLDS,
+  rateLcp,
+  rateCls,
+  rateInp,
+  rateFcp,
+  rateTtfb,
+  type CwvRating,
+} from '@/lib/coreWebVitals';
+
+describe('coreWebVitals', () => {
+  describe('CWV_THRESHOLDS', () => {
+    it('LCP の Good 閾値が 2500ms である', () => {
+      expect(CWV_THRESHOLDS.LCP_GOOD_MS).toBe(2500);
+    });
+
+    it('LCP の Poor 閾値が 4000ms である', () => {
+      expect(CWV_THRESHOLDS.LCP_POOR_MS).toBe(4000);
+    });
+
+    it('CLS の Good 閾値が 0.1 である', () => {
+      expect(CWV_THRESHOLDS.CLS_GOOD).toBe(0.1);
+    });
+
+    it('CLS の Poor 閾値が 0.25 である', () => {
+      expect(CWV_THRESHOLDS.CLS_POOR).toBe(0.25);
+    });
+
+    it('INP の Good 閾値が 200ms である', () => {
+      expect(CWV_THRESHOLDS.INP_GOOD_MS).toBe(200);
+    });
+
+    it('INP の Poor 閾値が 500ms である', () => {
+      expect(CWV_THRESHOLDS.INP_POOR_MS).toBe(500);
+    });
+
+    it('FCP の Good 閾値が 1800ms である', () => {
+      expect(CWV_THRESHOLDS.FCP_GOOD_MS).toBe(1800);
+    });
+
+    it('FCP の Poor 閾値が 3000ms である', () => {
+      expect(CWV_THRESHOLDS.FCP_POOR_MS).toBe(3000);
+    });
+
+    it('TTFB の Good 閾値が 800ms である', () => {
+      expect(CWV_THRESHOLDS.TTFB_GOOD_MS).toBe(800);
+    });
+
+    it('TTFB の Poor 閾値が 1800ms である', () => {
+      expect(CWV_THRESHOLDS.TTFB_POOR_MS).toBe(1800);
+    });
+  });
+
+  describe('rateLcp', () => {
+    it('Good 閾値以内（2500ms）は good を返す', () => {
+      expect(rateLcp(2500)).toBe<CwvRating>('good');
+    });
+
+    it('Good 閾値より小さい値は good を返す', () => {
+      expect(rateLcp(1000)).toBe<CwvRating>('good');
+      expect(rateLcp(0)).toBe<CwvRating>('good');
+    });
+
+    it('Good 超 Poor 未満（2501ms〜4000ms）は needs-improvement を返す', () => {
+      expect(rateLcp(2501)).toBe<CwvRating>('needs-improvement');
+      expect(rateLcp(3000)).toBe<CwvRating>('needs-improvement');
+      expect(rateLcp(4000)).toBe<CwvRating>('needs-improvement');
+    });
+
+    it('Poor 閾値超（4001ms 以上）は poor を返す', () => {
+      expect(rateLcp(4001)).toBe<CwvRating>('poor');
+      expect(rateLcp(10000)).toBe<CwvRating>('poor');
+    });
+  });
+
+  describe('rateCls', () => {
+    it('Good 閾値以内（0.1）は good を返す', () => {
+      expect(rateCls(0.1)).toBe<CwvRating>('good');
+    });
+
+    it('Good 閾値より小さい値は good を返す', () => {
+      expect(rateCls(0)).toBe<CwvRating>('good');
+      expect(rateCls(0.05)).toBe<CwvRating>('good');
+    });
+
+    it('Good 超 Poor 未満（0.1〜0.25）は needs-improvement を返す', () => {
+      // rateCls は <= で判定するため 0.1 は good になる
+      // Good 超は 0.1 より大きい値
+      expect(rateCls(0.11)).toBe<CwvRating>('needs-improvement');
+      expect(rateCls(0.2)).toBe<CwvRating>('needs-improvement');
+      expect(rateCls(0.25)).toBe<CwvRating>('needs-improvement');
+    });
+
+    it('Poor 閾値超（0.25 より大きい値）は poor を返す', () => {
+      expect(rateCls(0.26)).toBe<CwvRating>('poor');
+      expect(rateCls(1.0)).toBe<CwvRating>('poor');
+    });
+  });
+
+  describe('rateInp', () => {
+    it('Good 閾値以内（200ms）は good を返す', () => {
+      expect(rateInp(200)).toBe<CwvRating>('good');
+    });
+
+    it('Good 閾値より小さい値は good を返す', () => {
+      expect(rateInp(0)).toBe<CwvRating>('good');
+      expect(rateInp(100)).toBe<CwvRating>('good');
+    });
+
+    it('Good 超 Poor 未満（201ms〜500ms）は needs-improvement を返す', () => {
+      expect(rateInp(201)).toBe<CwvRating>('needs-improvement');
+      expect(rateInp(350)).toBe<CwvRating>('needs-improvement');
+      expect(rateInp(500)).toBe<CwvRating>('needs-improvement');
+    });
+
+    it('Poor 閾値超（501ms 以上）は poor を返す', () => {
+      expect(rateInp(501)).toBe<CwvRating>('poor');
+      expect(rateInp(2000)).toBe<CwvRating>('poor');
+    });
+  });
+
+  describe('rateFcp', () => {
+    it('Good 閾値以内（1800ms）は good を返す', () => {
+      expect(rateFcp(1800)).toBe<CwvRating>('good');
+    });
+
+    it('Good 閾値より小さい値は good を返す', () => {
+      expect(rateFcp(0)).toBe<CwvRating>('good');
+      expect(rateFcp(900)).toBe<CwvRating>('good');
+    });
+
+    it('Good 超 Poor 未満（1801ms〜3000ms）は needs-improvement を返す', () => {
+      expect(rateFcp(1801)).toBe<CwvRating>('needs-improvement');
+      expect(rateFcp(2500)).toBe<CwvRating>('needs-improvement');
+      expect(rateFcp(3000)).toBe<CwvRating>('needs-improvement');
+    });
+
+    it('Poor 閾値超（3001ms 以上）は poor を返す', () => {
+      expect(rateFcp(3001)).toBe<CwvRating>('poor');
+      expect(rateFcp(5000)).toBe<CwvRating>('poor');
+    });
+  });
+
+  describe('rateTtfb', () => {
+    it('Good 閾値以内（800ms）は good を返す', () => {
+      expect(rateTtfb(800)).toBe<CwvRating>('good');
+    });
+
+    it('Good 閾値より小さい値は good を返す', () => {
+      expect(rateTtfb(0)).toBe<CwvRating>('good');
+      expect(rateTtfb(400)).toBe<CwvRating>('good');
+    });
+
+    it('Good 超 Poor 未満（801ms〜1800ms）は needs-improvement を返す', () => {
+      expect(rateTtfb(801)).toBe<CwvRating>('needs-improvement');
+      expect(rateTtfb(1200)).toBe<CwvRating>('needs-improvement');
+      expect(rateTtfb(1800)).toBe<CwvRating>('needs-improvement');
+    });
+
+    it('Poor 閾値超（1801ms 以上）は poor を返す', () => {
+      expect(rateTtfb(1801)).toBe<CwvRating>('poor');
+      expect(rateTtfb(5000)).toBe<CwvRating>('poor');
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

Issue #3312「Core Web Vitals / モバイル UX 実測と軽微修正（C3）」の実装。Agent 環境では Lighthouse / PSI 実測が困難なため、**静的解析による軽微修正 + 実測手順のドキュメント化 + 評価ロジック常設** に再スコープした。

### 実施内容

| 項目 | 内容 |
|---|---|
| 静的解析 | `<img>` / フォント / AdSense Script / viewport / MUI import / `@nagiyu/ui` 経由を確認 |
| 軽微修正 | OG 画像メタデータ（3 ページの `tech/[slug]`, `tech/category/[category]`, `tech/tags/[tag]`）に `width: 1200, height: 630, alt` を追加（`layout.tsx` との一貫性確保） |
| 評価ロジック追加 | `src/lib/coreWebVitals.ts` に CWV 基準値定数と評価関数（`rateLcp` / `rateCls` / `rateInp` / `rateFcp` / `rateTtfb`）を追加 |
| ドキュメント追加 | `docs/development/core-web-vitals.md` に Lighthouse 実測手順（PSI / DevTools / CLI）・モバイル UX チェックリスト・PR Description 記録フォーマットを記載 |

### 静的解析結果

| 観点 | 結果 |
|---|---|
| 生 `<img>` 使用 | なし（`portal/web/src` 配下に存在せず） |
| `loading="lazy"` 必要箇所 | なし（生 `<img>` 自体がないため） |
| フォント読み込み | 外部フォントなし、MUI システムフォントのみ → 現状問題なし |
| AdSense Script | `strategy="afterInteractive"` で適切に遅延読み込み済み |
| viewport | `Viewport` 型で `themeColor` 設定済み、Next.js App Router が自動対応 |
| `@mui/material` の `Chip` / `Button` / `Link` 直 import | なし（`@nagiyu/ui` 経由で適切） |
| OG 画像メタデータの整合性 | 3 ページで `width` / `height` / `alt` 未指定 → 修正対象 |

## 関連 Issue

#3312（親: #3262）

## 変更種別

- [x] 新規機能（CWV 評価ロジック）
- [ ] バグ修正
- [x] リファクタリング（OG 画像メタデータの一貫性修正）
- [x] ドキュメント更新（`core-web-vitals.md` 新規）
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（86 件全 pass、`coreWebVitals.ts` カバレッジ 100%、全体 98.98%）
- [x] 関連ドキュメントを更新した（`docs/development/core-web-vitals.md`）
- [ ] CI/CD 設定を追加・更新した（不要、実測は人手）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## Lighthouse / PSI 実測について

**本 PR は実測を含まない**。Agent 環境では Lighthouse 実行に必要な dev サーバー + Chrome + Lighthouse CLI のセットアップが困難。代替として：

- 実測手順を `docs/development/core-web-vitals.md` に記載（PSI / DevTools / CLI の 3 方法）
- 評価ロジック（基準値判定）を `src/lib/coreWebVitals.ts` に常設、将来の自動計測ジョブで利用可能
- 実測自体は **dev 環境デプロイ後に人手で実施** することを推奨

## 別 Issue 推奨項目（本 PR スコープ外）

| タイトル候補 | 優先度 | 理由 |
|---|---|---|
| Portal 画像を WebP/AVIF 形式に変換して LCP を改善 | 中 | `og-default.png`（21KB）の WebP 化、Markdown 内画像の最適化 |
| MUI フルパッケージ import をパス別 import に移行してバンドルサイズを削減 | 低 | 効果が tree shaking 設定依存。移行コストに対して効果が不確実 |
| `MarkdownContent.tsx` の `dangerouslySetInnerHTML` を DOMPurify ラッパーコンポーネントに置換 | 低 | 現状 `markdownToHtml()` 内で `DOMPurify.sanitize()` 済みだが、規約厳格適用なら別コンポーネント化 |

## 設計判断サマリ

### スコープ再定義（実測 → 静的解析）
Agent 環境制約により Lighthouse 実測を断念。代わりに：
- 静的解析で問題候補を特定 → 軽微修正
- 評価ロジックを `lib/` に常設（基準値判定の共通化）
- 実測手順を docs に整備

### OG 画像メタデータの一貫性
`layout.tsx` では `[{ url, width: 1200, height: 630, alt }]` 形式だったのに対し、3 ページの `generateMetadata` で `['/og-default.png']` の文字列配列形式だった → 揃えた。

### MarkdownContent.tsx は本 PR では触らない
`Box` への `dangerouslySetInnerHTML` 直接渡しは、`markdownToHtml()` 内で `DOMPurify.sanitize()` 済み。規約「DOMPurify 経由のみ」はサニタイズ処理の存在を指すと解釈、別 Issue 推奨に留めた（共通コンポーネント変更は併走 PR 影響大）。

## 他 PR との関係

本 PR は以下のファイルを **触っていない**（conflict 回避）：
- `src/app/page.tsx`（B-1 が改修中）
- `src/app/about/page.tsx`（B-2 が改修中）
- `src/app/contact/page.tsx`（B-3 が新規）
- `src/app/layout.tsx`（B-3 / B-4 が変更）
- `libs/ui/...`（B-4 が拡張）

A-4 PR #3448 が integration にマージ済みのため、本 PR は A-4 の FAQPage 実装を含む状態から分岐している。

## テスト内容

- `coreWebVitals.ts` の全評価関数に対する境界値テスト（86 件中の一部）
- カバレッジ: branches / funcs / lines 100%、全体 98.98%
- 全 86 テスト pass

## レビューポイント

- OG 画像メタデータの統一形式が `layout.tsx` のパターンに沿っているか
- `coreWebVitals.ts` の閾値（Good / Needs Improvement / Poor）が CWV 公式仕様に沿っているか
- `core-web-vitals.md` の実測手順が実用的か（PSI 推奨など）
- 別 Issue 推奨項目の優先度判断

## スクリーンショット（該当する場合）

UI 変更なし。OG 画像メタデータの修正は内部実装のみ。

## 補足事項

- 実測は dev 環境デプロイ後に PSI または DevTools で実施推奨
- 別 Issue 推奨 3 項目は本 PR ではスコープ外とし、必要に応じて運営者判断で起票

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBSbcDz8CTXatR3zxq2yEq)_