### PR TITLE
C-4 #3313 robots.txt/sitemap.xml 検証テストと GSC 登録手順書整備

### DIFF
--- a/docs/development/seo-search-console.md
+++ b/docs/development/seo-search-console.md
@@ -1,0 +1,192 @@
+# SEO: Google Search Console 登録・運用手順
+
+> **注意: 本手順はすべて人力で実施する。Claude は Google Search Console へのアクセス・操作ができないため、以下の作業は人が直接行うこと。**
+
+---
+
+## 前提
+
+- 対象サイト: `https://nagiyu.com`
+- サイトマップ: `https://nagiyu.com/sitemap.xml`
+- robots.txt: `https://nagiyu.com/robots.txt`
+
+---
+
+## 1. robots.txt / sitemap.xml の構成
+
+### robots.txt
+
+`src/app/robots.ts` で Next.js `MetadataRoute.Robots` を使用して動的生成している。
+
+現在の設定:
+
+- `User-agent: *` に `Allow: /` を設定（全クローラに対してサイト全体を許可）
+- `Disallow` は設定なし（全クローラのアクセスを妨げていない）
+- `sitemap`: `https://nagiyu.com/sitemap.xml`
+- `host`: `https://nagiyu.com`
+
+**AdSense クローラ (`Mediapartners-Google`) に対する個別ルールは存在しない**。全クローラ許可ルールにより AdSense クローラのアクセスは許可されている。
+
+### sitemap.xml
+
+`src/app/sitemap.ts` で Next.js `MetadataRoute.Sitemap` を使用して動的生成している。
+
+含まれるエントリー:
+
+| エントリー種別       | URL パターン                                                         | 備考                                         |
+| -------------------- | -------------------------------------------------------------------- | -------------------------------------------- |
+| 静的ページ           | `/`, `/about`, `/privacy`, `/terms`, `/services`, `/tech`            | 優先度 0.3 〜 1.0                            |
+| サービスドキュメント | `/services/{slug}`, `/services/{slug}/guide`, `/services/{slug}/faq` | 全サービス slug × 3 パス                     |
+| 技術記事             | `/tech/{slug}`                                                       | `getAllArticles()` の全件                    |
+| タグページ           | `/tech/tags/{slug}`                                                  | count >= 2 かつ ASCII スラッグのタグのみ     |
+| カテゴリ別ハブ       | `/tech/category/{slug}`                                              | `getAllTechCategoryMetas()` の全件 (A2 対応) |
+
+---
+
+## 2. Google Search Console プロパティ登録
+
+### 2.1 ドメインプロパティの推奨
+
+`nagiyu.com` ドメイン全体（サブドメインを含む）を対象とする **ドメインプロパティ** の使用を推奨する。
+
+URL プレフィックスプロパティ（`https://nagiyu.com/` など）よりも、ドメインプロパティは以下の点で優れている:
+
+- すべてのサブドメイン（`tools.nagiyu.com` 等）をカバーする
+- HTTP / HTTPS を区別しない
+- サイト全体のインデックス状況を一元管理できる
+
+### 2.2 登録手順
+
+1. [Google Search Console](https://search.google.com/search-console) にアクセスする
+2. 「プロパティを追加」をクリックする
+3. 「ドメイン」タブを選択し、`nagiyu.com` を入力する
+4. 「続行」をクリックする
+5. 表示された DNS TXT レコードをコピーする
+   - 例: `google-site-verification=XXXXXXXXXXXX`
+6. ドメインの DNS 設定画面（Route 53 等）を開き、TXT レコードを追加する
+7. DNS 伝播を待ち（最大 48 時間）、Search Console で「確認」をクリックする
+
+### 2.3 URL プレフィックスプロパティ（代替手段）
+
+ドメインプロパティの DNS 確認が難しい場合、URL プレフィックスプロパティを代替として使用できる。
+
+1. 「プロパティを追加」から「URL プレフィックス」を選択する
+2. `https://nagiyu.com/` を入力する
+3. 「HTML タグ」による確認方法を選択する
+4. 表示された `<meta name="google-site-verification" content="XXXX">` タグを確認する
+5. `src/app/layout.tsx` の `metadata` オブジェクトに以下を追加する（人力で実施）:
+
+```typescript
+export const metadata: Metadata = {
+  // 既存の設定...
+  verification: {
+    google: 'XXXXXXXXXXXX', // Search Console から取得した値
+  },
+};
+```
+
+6. デプロイ後、Search Console で「確認」をクリックする
+
+---
+
+## 3. サイトマップ送信
+
+1. Search Console のプロパティを選択する
+2. 左メニューから「サイトマップ」を開く
+3. 「新しいサイトマップの追加」に以下を入力する:
+   ```
+   sitemap.xml
+   ```
+   （プロパティ URL に連結され `https://nagiyu.com/sitemap.xml` として送信される）
+4. 「送信」をクリックする
+5. ステータスが「成功しました」になることを確認する
+
+### 送信後の確認
+
+- ステータス: 「成功しました」
+- 検出された URL 数が期待値と大きく乖離していないか確認する
+- エラーが表示された場合は、ステータス行をクリックして詳細を確認する
+
+---
+
+## 4. インデックス状況の確認方法
+
+### 4.1 URL 検査ツール
+
+1. Search Console の「URL 検査」を開く
+2. 確認したい URL を入力する（例: `https://nagiyu.com/tech/some-article`）
+3. 「Google インデックス」欄でインデックス状況を確認する
+4. インデックス未登録の場合は「インデックス登録をリクエスト」をクリックする
+
+### 4.2 カバレッジレポート
+
+1. Search Console の「インデックス作成」>「ページ」を開く
+2. 「インデックスに登録されていない理由」を確認する
+3. 主な対応が必要なステータス:
+   - **クロール済み - 現在インデックス未登録**: Google がクロールしたが、価値が低いと判断している
+   - **検出済み - 現在インデックス未登録**: クロールキューに入っているが、まだ処理されていない
+   - **リダイレクト**: 意図しないリダイレクトが発生していないか確認する
+
+### 4.3 検索パフォーマンス
+
+1. Search Console の「検索パフォーマンス」を開く
+2. クリック数・表示回数・CTR・平均掲載順位を確認する
+3. 「ページ」タブで各 URL のパフォーマンスを確認する
+
+---
+
+## 5. AdSense との連携確認
+
+### 5.1 AdSense クローラのアクセス確認
+
+1. Search Console の「設定」>「クロール統計情報」を開く
+2. `Mediapartners-Google`（AdSense クローラ）のアクセスログを確認する
+   - ※ Search Console では Googlebot のみ表示されることが多い
+3. AdSense 管理画面にログインし、「サイト」>「サイトの確認」を確認する
+
+### 5.2 robots.txt のテスト
+
+1. Search Console の「設定」>「robots.txt」を開く
+2. 「テスト」タブで任意の URL と User-agent を指定して確認できる
+3. `Mediapartners-Google` で主要 URL（`/`, `/tech/`, `/services/`）を確認し、「クロール可」になっていることを確認する
+
+---
+
+## 6. 実施後チェックリスト
+
+以下をすべて確認してから完了とする。
+
+- [ ] Search Console プロパティが「確認済み」になっている
+- [ ] サイトマップ送信のステータスが「成功しました」になっている
+- [ ] サイトマップで検出された URL 数が 0 でない
+- [ ] URL 検査でトップページ（`https://nagiyu.com/`）がインデックス済みになっている
+- [ ] robots.txt テストで `Mediapartners-Google` が主要 URL にアクセス可であることを確認した
+- [ ] AdSense 管理画面でサイトが「確認済み」の状態になっている
+
+---
+
+## 7. トラブルシューティング
+
+### サイトマップが「取得できません」になる
+
+- `https://nagiyu.com/sitemap.xml` に実際にアクセスして XML が返ることを確認する
+- デプロイが完了しているか確認する
+
+### インデックスが増えない
+
+- クロール頻度が低い場合、「URL 検査」>「インデックス登録をリクエスト」を主要 URL に対して実施する
+- コンテンツの品質・E-E-A-T（経験・専門性・権威性・信頼性）を見直す
+
+### AdSense 審査が通らない
+
+- コンテンツが「有用性の低いコンテンツ」と判定される場合、記事の質・量を改善する
+- AdSense ポリシー違反がないか確認する
+- 申請から審査完了まで数日〜数週間かかることがある
+
+---
+
+## 関連ドキュメント
+
+- [Portal アーキテクチャ](../../services/portal/architecture.md) - AdSense 対応の経緯・ADR-001
+- [Portal 要件定義書](../../services/portal/requirements.md) - ビジネスゴール
+- [SEO 再検証メモ](./seo-revalidation-notes.md) - C-2 で追加したメタデータ・sitemap 検証ユーティリティの使い方（integration マージ後に参照可能）

--- a/services/portal/web/tests/unit/app/robots.test.ts
+++ b/services/portal/web/tests/unit/app/robots.test.ts
@@ -1,0 +1,127 @@
+/**
+ * robots.ts のユニットテスト
+ *
+ * Next.js の MetadataRoute.Robots 出力内容を検証する。
+ * - すべてのクローラを許可していること（AdSense クローラを含む）
+ * - sitemap URL が正しく設定されていること
+ * - host が正しく設定されていること
+ */
+
+import robots from '@/app/robots';
+
+describe('robots', () => {
+  const SITE_URL = 'https://nagiyu.com';
+
+  describe('rules', () => {
+    it('rules が 1 件以上返る', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      expect(rules.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('全クローラ（"*"）に対するルールが存在する', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      const globalRule = rules.find(
+        (rule) => rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
+      );
+      expect(globalRule).toBeDefined();
+    });
+
+    it('全クローラにサイト全体へのアクセスを許可している（Disallow が "/" を含まない）', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+
+      for (const rule of rules) {
+        const disallow = rule.disallow;
+        if (disallow === undefined) continue;
+
+        const disallowList = Array.isArray(disallow) ? disallow : [disallow];
+        // "/" を Disallow にしていないことを確認（全サイトブロックの防止）
+        expect(disallowList).not.toContain('/');
+      }
+    });
+
+    it('全クローラに "/" への allow が設定されている', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      const globalRule = rules.find(
+        (rule) => rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
+      );
+      expect(globalRule).toBeDefined();
+      if (!globalRule) return;
+
+      const allow = globalRule.allow;
+      const allowList = Array.isArray(allow) ? allow : allow !== undefined ? [allow] : [];
+      expect(allowList).toContain('/');
+    });
+
+    it('Googlebot-Image を個別に Disallow していない（画像クロール許可）', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+
+      const googlebotImageRule = rules.find((rule) => {
+        const agents = Array.isArray(rule.userAgent) ? rule.userAgent : [rule.userAgent];
+        return agents.includes('Googlebot-Image');
+      });
+
+      if (googlebotImageRule) {
+        // 存在する場合、Disallow が設定されていないか空であることを確認
+        const disallow = googlebotImageRule.disallow;
+        if (disallow !== undefined) {
+          const disallowList = Array.isArray(disallow) ? disallow : [disallow];
+          const nonEmptyDisallows = disallowList.filter((d) => d !== '');
+          expect(nonEmptyDisallows).toHaveLength(0);
+        }
+      } else {
+        // ルールが存在しない場合はデフォルトで許可されているため合格
+        expect(googlebotImageRule).toBeUndefined();
+      }
+    });
+
+    it('Mediapartners-Google（AdSense クローラ）を個別に Disallow していない', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+
+      const adSenseRule = rules.find((rule) => {
+        const agents = Array.isArray(rule.userAgent) ? rule.userAgent : [rule.userAgent];
+        return agents.includes('Mediapartners-Google');
+      });
+
+      if (adSenseRule) {
+        // 存在する場合、Disallow が設定されていないか空であることを確認
+        const disallow = adSenseRule.disallow;
+        if (disallow !== undefined) {
+          const disallowList = Array.isArray(disallow) ? disallow : [disallow];
+          const nonEmptyDisallows = disallowList.filter((d) => d !== '');
+          expect(nonEmptyDisallows).toHaveLength(0);
+        }
+      } else {
+        // ルールが存在しない場合はデフォルトで許可（全クローラ許可ルールにより）
+        expect(adSenseRule).toBeUndefined();
+      }
+    });
+  });
+
+  describe('sitemap', () => {
+    it('sitemap URL が正しく設定されている', () => {
+      const result = robots();
+      expect(result.sitemap).toBe(`${SITE_URL}/sitemap.xml`);
+    });
+  });
+
+  describe('host', () => {
+    it('host が正しく設定されている', () => {
+      const result = robots();
+      expect(result.host).toBe(SITE_URL);
+    });
+  });
+
+  describe('出力の形式', () => {
+    it('MetadataRoute.Robots の必須プロパティをすべて持つ', () => {
+      const result = robots();
+      expect(result).toHaveProperty('rules');
+      expect(result).toHaveProperty('sitemap');
+    });
+  });
+});

--- a/services/portal/web/tests/unit/app/robots.test.ts
+++ b/services/portal/web/tests/unit/app/robots.test.ts
@@ -23,7 +23,8 @@ describe('robots', () => {
       const result = robots();
       const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
       const globalRule = rules.find(
-        (rule) => rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
+        (rule) =>
+          rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
       );
       expect(globalRule).toBeDefined();
     });
@@ -46,7 +47,8 @@ describe('robots', () => {
       const result = robots();
       const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
       const globalRule = rules.find(
-        (rule) => rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
+        (rule) =>
+          rule.userAgent === '*' || (Array.isArray(rule.userAgent) && rule.userAgent.includes('*'))
       );
       expect(globalRule).toBeDefined();
       if (!globalRule) return;

--- a/services/portal/web/tests/unit/app/sitemap.test.ts
+++ b/services/portal/web/tests/unit/app/sitemap.test.ts
@@ -1,0 +1,222 @@
+/**
+ * sitemap.ts のユニットテスト
+ *
+ * Next.js の MetadataRoute.Sitemap 出力内容を検証する。
+ * - 静的エントリーが含まれること
+ * - A2 で追加されたカテゴリ別ハブページが含まれること
+ * - サービスドキュメント（overview / guide / faq）が含まれること
+ * - 技術記事エントリーが含まれること
+ * - タグページが含まれること
+ * - sitemap.xml の URL 形式が正しいこと
+ */
+
+import sitemap from '@/app/sitemap';
+
+// content モジュールをモック化する（ファイルシステムアクセスを回避）
+jest.mock('@/lib/content', () => ({
+  getAllArticles: jest.fn(() => [
+    {
+      slug: 'test-article-1',
+      title: 'テスト記事1',
+      description: 'テスト',
+      publishedAt: '2026-04-10',
+      updatedAt: '2026-04-15',
+      tags: ['AWS', 'Next.js'],
+      categories: ['aws'],
+    },
+    {
+      slug: 'test-article-2',
+      title: 'テスト記事2',
+      description: 'テスト',
+      publishedAt: '2026-04-05',
+      tags: ['AWS'],
+      categories: ['aws', 'nextjs'],
+    },
+  ]),
+  getAllServiceSlugs: jest.fn(() => ['tools', 'quick-clip']),
+  getAllTags: jest.fn(() => [
+    { tag: 'AWS', count: 3 },
+    { tag: 'Next.js', count: 2 },
+    { tag: '単一記事タグ', count: 1 }, // count < 2 のためリンク化対象外
+  ]),
+  getAllTechCategoryMetas: jest.fn(() => [
+    { slug: 'aws', title: 'AWS インフラ運用ノート', description: 'AWS の解説' },
+    { slug: 'nextjs', title: 'Next.js 実践ガイド', description: 'Next.js の解説' },
+  ]),
+  isLinkableTag: jest.fn((tag: string) => {
+    // ASCII のみのスラッグに変換できるタグのみ true
+    const slug = tag.toLowerCase().replace(/[\s/]+/g, '-');
+    return /^[a-z0-9.@_-]+$/.test(slug);
+  }),
+  tagToSlug: jest.fn((tag: string) =>
+    tag
+      .toLowerCase()
+      .replace(/[\s/]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+  ),
+}));
+
+describe('sitemap', () => {
+  const SITE_URL = 'https://nagiyu.com';
+
+  describe('静的エントリー', () => {
+    it('トップページ（/）が含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/`);
+    });
+
+    it('about ページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/about`);
+    });
+
+    it('privacy ページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/privacy`);
+    });
+
+    it('terms ページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/terms`);
+    });
+
+    it('services 一覧ページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/services`);
+    });
+
+    it('tech 一覧ページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/tech`);
+    });
+  });
+
+  describe('サービスドキュメントエントリー', () => {
+    it('各サービスの overview（/services/{slug}）が含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/services/tools`);
+      expect(urls).toContain(`${SITE_URL}/services/quick-clip`);
+    });
+
+    it('各サービスの guide ページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/services/tools/guide`);
+      expect(urls).toContain(`${SITE_URL}/services/quick-clip/guide`);
+    });
+
+    it('各サービスの faq ページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/services/tools/faq`);
+      expect(urls).toContain(`${SITE_URL}/services/quick-clip/faq`);
+    });
+  });
+
+  describe('技術記事エントリー', () => {
+    it('記事エントリーが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/tech/test-article-1`);
+      expect(urls).toContain(`${SITE_URL}/tech/test-article-2`);
+    });
+
+    it('updatedAt がある記事は lastModified に updatedAt を使用する', () => {
+      const entries = sitemap();
+      const article1 = entries.find((e) => e.url === `${SITE_URL}/tech/test-article-1`);
+      expect(article1).toBeDefined();
+      if (!article1) return;
+      expect(article1.lastModified).toEqual(new Date('2026-04-15'));
+    });
+
+    it('updatedAt がない記事は lastModified に publishedAt を使用する', () => {
+      const entries = sitemap();
+      const article2 = entries.find((e) => e.url === `${SITE_URL}/tech/test-article-2`);
+      expect(article2).toBeDefined();
+      if (!article2) return;
+      expect(article2.lastModified).toEqual(new Date('2026-04-05'));
+    });
+  });
+
+  describe('タグページエントリー', () => {
+    it('count >= 2 かつ isLinkableTag が true のタグページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      // AWS（count=3, isLinkable=true）→ 含まれる
+      expect(urls).toContain(`${SITE_URL}/tech/tags/aws`);
+    });
+
+    it('count >= 2 かつ isLinkableTag が true の複数タグページが含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      // Next.js（count=2, isLinkable=true）→ 含まれる
+      expect(urls).toContain(`${SITE_URL}/tech/tags/next.js`);
+    });
+
+    it('count < 2 のタグページは含まれない', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      // 単一記事タグ（count=1）→ 含まれない
+      expect(urls.some((u) => u.includes('단일'))).toBe(false);
+    });
+  });
+
+  describe('A2 カテゴリ別ハブエントリー', () => {
+    it('カテゴリ別ハブページ（/tech/category/{slug}）が含まれる', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      expect(urls).toContain(`${SITE_URL}/tech/category/aws`);
+      expect(urls).toContain(`${SITE_URL}/tech/category/nextjs`);
+    });
+
+    it('getAllTechCategoryMetas が返すすべてのカテゴリが含まれる', () => {
+      const entries = sitemap();
+      const categoryUrls = entries.map((e) => e.url).filter((u) => u.includes('/tech/category/'));
+      // モックが ['aws', 'nextjs'] を返すため 2 件
+      expect(categoryUrls).toHaveLength(2);
+    });
+  });
+
+  describe('URL 形式', () => {
+    it('すべてのエントリーが https://nagiyu.com で始まる', () => {
+      const entries = sitemap();
+      entries.forEach((entry) => {
+        expect(entry.url).toMatch(/^https:\/\/nagiyu\.com/);
+      });
+    });
+
+    it('重複した URL が存在しない', () => {
+      const entries = sitemap();
+      const urls = entries.map((e) => e.url);
+      const unique = new Set(urls);
+      expect(unique.size).toBe(urls.length);
+    });
+
+    it('空の配列を返さない（エントリーが 1 件以上ある）', () => {
+      const entries = sitemap();
+      expect(entries.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('priority および changeFrequency', () => {
+    it('トップページの priority が 1.0', () => {
+      const entries = sitemap();
+      const top = entries.find((e) => e.url === `${SITE_URL}/`);
+      expect(top?.priority).toBe(1.0);
+    });
+
+    it('tech 一覧ページの priority が 0.9', () => {
+      const entries = sitemap();
+      const tech = entries.find((e) => e.url === `${SITE_URL}/tech`);
+      expect(tech?.priority).toBe(0.9);
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

Issue #3313「robots.txt / sitemap.xml の出力確認と Search Console 登録手順整備（C4）」の実装。AdSense 観点で重要な GSC 登録・サイトマップ送信を **人力実施** できるよう手順書を整備し、出力ロジックの検証テストを追加した。

### 実施内容

| 項目 | 内容 |
|---|---|
| robots.ts の出力検証テスト | 全クローラ許可 / Disallow なし / `Mediapartners-Google`（AdSense クローラ）への個別ルールなし / sitemap / host URL の正確性（8 件） |
| sitemap.ts の出力検証テスト | 静的エントリー 6 件 / サービスドキュメント / 技術記事 / タグページ / **A2 カテゴリハブ URL 包含** / URL 形式 / 重複なし / priority（22 件） |
| GSC 登録手順書 | `docs/development/seo-search-console.md` 新規。GSC 登録・サイトマップ送信・インデックス確認・AdSense 連携・実施後チェックリストを網羅。**「本手順はすべて人力で実施。Claude 不可」を冒頭明示** |

### 確認結果

#### robots.txt
- `User-agent: *` + `Allow: /`（Disallow なし）
- `Mediapartners-Google`（AdSense クローラ）への個別 Disallow なし → 全クローラ許可で通過
- `sitemap`: `https://nagiyu.com/sitemap.xml` / `host`: `https://nagiyu.com`
- **AdSense クローラを妨げる設定は存在しない**

#### sitemap.xml
- **A2 カテゴリハブ**: `getAllTechCategoryMetas()` の全件が `/tech/category/{slug}` として出力 ✓
- **A5 削除記事**: `ArticleMeta` 型に削除フラグはなく、ファイル削除 = sitemap から自動除外される設計。残留問題なし ✓

## 関連 Issue

#3313（親: #3262）

## 変更種別

- [x] 新規機能（検証テスト）
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新（GSC 登録手順書）
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（30 件追加、全 103 件 pass、カバレッジ Stmts 99.05% / Branches 100% / Funcs 100%）
- [x] 関連ドキュメントを更新した（`seo-search-console.md` 新規）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## docs 配置場所と理由

`docs/development/seo-search-console.md` に配置：
- `docs/operation/` が存在しないため
- `docs/development/` には `validation.md` / `testing.md` 等の開発・運用ドキュメントが既に集約されており整合性が取れる

## C-2 (#3454) との重複回避

C-2 の `seoValidation.ts` テストは「`validateSitemapCoverage` という抽象関数への入力・出力の単体テスト」であり、`sitemap.ts` の実出力内容は検証していない。本 PR は `sitemap.ts` 関数そのものをモック経由で実行し、URL の包含・priority・重複なしを検証する「出力内容のテスト」を追加。**重複なし**。

## A-4 (#3448) との関係

本 PR は A-4 マージ後の `integration/3262-portal-adsense-improvement` から分岐しており、A-4 の変更（FAQPage JSON-LD ヘルパー）を含む状態。FAQPage 関連の sitemap 出力（FAQ ページの URL 包含）はテストで網羅済み。

## 他 PR との関係

- C-1 PR #3453（内部リンクチェック）: 編集ファイル重複なし
- C-2 PR #3454（メタデータ検証）: 上記の通り重複回避
- C-3 PR #3455（CWV）: 編集ファイル重複なし

## レビューポイント

- `seo-search-console.md` の手順網羅性（運営者が実施できるレベルか）
- robots.ts / sitemap.ts の検証粒度が適切か
- GSC ドメインプロパティ vs URL プレフィックスの選定推奨

## スクリーンショット（該当する場合）

UI 変更なし。

## 補足事項

- 本 PR の本質的価値は **検証ロジック常設 + 人力手順整備**
- GSC への実登録・サイトマップ送信は本 PR の対象外（運営者が `seo-search-console.md` の手順で人力実施）

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBSbcDz8CTXatR3zxq2yEq)_