### PR TITLE
リブトーク: OpenAI TTS プロバイダ基盤を追加（Phase 1 / #3470）

### DIFF
--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -1,6 +1,7 @@
 // TTS プロバイダ非依存ポート（IVoiceClient / VoiceConfig）
 export * from './voice/index.js';
 export * from './voicevox/index.js';
+export * from './openai-voice/index.js';
 export * from './llm-client/index.js';
 export type { SummarizeInput, SummarizeResult, MemoryCandidate } from './llm-client/types.js';
 export * from './constants.js';

--- a/services/livetalk/core/src/openai-voice/index.ts
+++ b/services/livetalk/core/src/openai-voice/index.ts
@@ -1,0 +1,8 @@
+/**
+ * OpenAI TTS クライアント。
+ *
+ * プロバイダ非依存のインターフェース（IVoiceClient / VoiceConfig）は voice/ に配置されている。
+ */
+
+export { OpenAIVoiceClient, OPENAI_VOICE_ERROR_MESSAGES } from './openai-voice-client.js';
+export type { OpenAIVoiceClientOptions } from './types.js';

--- a/services/livetalk/core/src/openai-voice/openai-voice-client.ts
+++ b/services/livetalk/core/src/openai-voice/openai-voice-client.ts
@@ -48,8 +48,10 @@ export class OpenAIVoiceClient implements IVoiceClient {
 
     // voice が省略された場合、または provider が openai でない場合は既定値を使用する
     const resolvedVoice = voice && voice.provider === 'openai' ? voice.voice : this.defaultVoice;
-    const resolvedModel = voice && voice.provider === 'openai' ? (voice.model ?? this.defaultModel) : this.defaultModel;
-    const resolvedInstructions = voice && voice.provider === 'openai' ? voice.instructions : undefined;
+    const resolvedModel =
+      voice && voice.provider === 'openai' ? (voice.model ?? this.defaultModel) : this.defaultModel;
+    const resolvedInstructions =
+      voice && voice.provider === 'openai' ? voice.instructions : undefined;
 
     try {
       const requestParams: Parameters<typeof this.client.audio.speech.create>[0] = {

--- a/services/livetalk/core/src/openai-voice/openai-voice-client.ts
+++ b/services/livetalk/core/src/openai-voice/openai-voice-client.ts
@@ -1,0 +1,74 @@
+import OpenAI from 'openai';
+import type { IVoiceClient, VoiceConfig } from '../voice/types.js';
+import type { OpenAIVoiceClientOptions } from './types.js';
+
+/**
+ * OpenAI TTS クライアント周りのエラーメッセージ（日本語、定数化）。
+ */
+export const OPENAI_VOICE_ERROR_MESSAGES = {
+  EMPTY_TEXT: 'テキストが空です',
+  EMPTY_API_KEY: 'OpenAI API キーが指定されていません',
+  SYNTHESIS_FAILED: 'OpenAI TTS の音声合成に失敗しました',
+} as const;
+
+const DEFAULT_MODEL = 'gpt-4o-mini-tts';
+const DEFAULT_VOICE = 'alloy';
+
+/**
+ * OpenAI TTS API を {@link IVoiceClient} 形にラップする実装。
+ *
+ * - `audio.speech.create` で MP3 バイナリを取得し、ArrayBuffer として返す。
+ * - `voice.provider === 'openai'` の場合のみ voice / instructions / model を解釈する。
+ *   それ以外（voicevox 等）は既定値で合成する（VoicevoxClient と同じ寛容さ）。
+ * - リトライは行わない（呼び出し側の責務）。maxRetries: 0 を設定する。
+ */
+export class OpenAIVoiceClient implements IVoiceClient {
+  private readonly client: OpenAI;
+  private readonly defaultModel: string;
+  private readonly defaultVoice: string;
+
+  constructor(options: OpenAIVoiceClientOptions = {}) {
+    if (options.client) {
+      this.client = options.client;
+    } else {
+      if (!options.apiKey) {
+        throw new Error(OPENAI_VOICE_ERROR_MESSAGES.EMPTY_API_KEY);
+      }
+      this.client = new OpenAI({ apiKey: options.apiKey, maxRetries: 0 });
+    }
+    this.defaultModel = options.defaultModel ?? DEFAULT_MODEL;
+    this.defaultVoice = options.defaultVoice ?? DEFAULT_VOICE;
+  }
+
+  public async synthesize(text: string, voice?: VoiceConfig): Promise<ArrayBuffer> {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      throw new Error(OPENAI_VOICE_ERROR_MESSAGES.EMPTY_TEXT);
+    }
+
+    // voice が省略された場合、または provider が openai でない場合は既定値を使用する
+    const resolvedVoice = voice && voice.provider === 'openai' ? voice.voice : this.defaultVoice;
+    const resolvedModel = voice && voice.provider === 'openai' ? (voice.model ?? this.defaultModel) : this.defaultModel;
+    const resolvedInstructions = voice && voice.provider === 'openai' ? voice.instructions : undefined;
+
+    try {
+      const requestParams: Parameters<typeof this.client.audio.speech.create>[0] = {
+        model: resolvedModel,
+        voice: resolvedVoice as Parameters<typeof this.client.audio.speech.create>[0]['voice'],
+        input: trimmed,
+        response_format: 'mp3',
+      };
+
+      // instructions は値がある場合のみ渡す
+      if (resolvedInstructions !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (requestParams as any).instructions = resolvedInstructions;
+      }
+
+      const response = await this.client.audio.speech.create(requestParams);
+      return response.arrayBuffer();
+    } catch (error) {
+      throw new Error(OPENAI_VOICE_ERROR_MESSAGES.SYNTHESIS_FAILED, { cause: error });
+    }
+  }
+}

--- a/services/livetalk/core/src/openai-voice/types.ts
+++ b/services/livetalk/core/src/openai-voice/types.ts
@@ -1,0 +1,22 @@
+import type OpenAI from 'openai';
+
+/**
+ * OpenAIVoiceClient の構築オプション。
+ * client を渡す場合は apiKey 不要（テスト・差し替え用）。
+ */
+export interface OpenAIVoiceClientOptions {
+  /** OpenAI API キー。`client` を渡す場合は不要 */
+  apiKey?: string;
+  /** テスト・差し替え用に既存の OpenAI クライアントを注入できる */
+  client?: OpenAI;
+  /**
+   * 既定で使用するモデル名。省略時は 'gpt-4o-mini-tts'。
+   * synthesize 呼び出し時に voice.model を指定した場合はそちらが優先される。
+   */
+  defaultModel?: string;
+  /**
+   * 既定で使用する voice 名。省略時は 'alloy'。
+   * synthesize 呼び出し時に voice.voice を指定した場合はそちらが優先される。
+   */
+  defaultVoice?: string;
+}

--- a/services/livetalk/core/src/voice/composite-voice-client.ts
+++ b/services/livetalk/core/src/voice/composite-voice-client.ts
@@ -1,0 +1,84 @@
+import type { IVoiceClient, VoiceConfig } from './types.js';
+
+/**
+ * CompositeVoiceClient のエラーメッセージ（日本語、定数化）。
+ */
+export const COMPOSITE_VOICE_ERROR_MESSAGES = {
+  UNKNOWN_PROVIDER: '指定された音声プロバイダのクライアントが登録されていません',
+} as const;
+
+/**
+ * CompositeVoiceClient の構築オプション。
+ */
+export interface CompositeVoiceClientOptions {
+  /**
+   * provider 名をキーとするクライアントマップ。
+   * 値として IVoiceClient インスタンスまたは遅延ファクトリ（初回利用時に生成・キャッシュ）を受け付ける。
+   * 遅延ファクトリを使うと、キー不在等で構築できないプロバイダを登録しなくて済む。
+   */
+  clients: Partial<Record<VoiceConfig['provider'], IVoiceClient | (() => IVoiceClient)>>;
+  /** voice 未指定時に使用する既定プロバイダ */
+  defaultProvider: VoiceConfig['provider'];
+}
+
+/**
+ * 複数プロバイダを束ね、voice.provider に応じて適切なクライアントへ委譲する合成クライアント。
+ *
+ * - voice.provider が指定されている場合はそのクライアントへ委譲する。
+ * - voice が省略された場合は defaultProvider のクライアントへ委譲する。
+ * - clients の値がファクトリ関数の場合、初回呼び出し時に生成・キャッシュする（遅延初期化）。
+ *   これにより、voicevox のみのリクエストで OPENAI_API_KEY が不在でも落ちない。
+ */
+export class CompositeVoiceClient implements IVoiceClient {
+  private readonly clientFactories: Partial<
+    Record<VoiceConfig['provider'], IVoiceClient | (() => IVoiceClient)>
+  >;
+  private readonly resolvedClients: Partial<Record<VoiceConfig['provider'], IVoiceClient>> = {};
+  private readonly defaultProvider: VoiceConfig['provider'];
+
+  constructor(options: CompositeVoiceClientOptions) {
+    this.clientFactories = options.clients;
+    this.defaultProvider = options.defaultProvider;
+  }
+
+  public async synthesize(text: string, voice?: VoiceConfig): Promise<ArrayBuffer> {
+    const provider = voice?.provider ?? this.defaultProvider;
+    const client = this.resolveClient(provider);
+    if (!client) {
+      throw new Error(
+        `${COMPOSITE_VOICE_ERROR_MESSAGES.UNKNOWN_PROVIDER}: provider=${provider}`
+      );
+    }
+    return client.synthesize(text, voice);
+  }
+
+  /**
+   * 指定 provider のクライアントを返す。
+   * ファクトリ関数が登録されている場合は初回呼び出し時に生成してキャッシュする。
+   */
+  private resolveClient(
+    provider: VoiceConfig['provider']
+  ): IVoiceClient | undefined {
+    // 既に解決済みのクライアントがある場合はそれを返す
+    const cached = this.resolvedClients[provider];
+    if (cached) {
+      return cached;
+    }
+
+    const entry = this.clientFactories[provider];
+    if (!entry) {
+      return undefined;
+    }
+
+    // ファクトリ関数の場合は実行してキャッシュする
+    if (typeof entry === 'function') {
+      const created = entry();
+      this.resolvedClients[provider] = created;
+      return created;
+    }
+
+    // IVoiceClient インスタンスの場合はそのままキャッシュする
+    this.resolvedClients[provider] = entry;
+    return entry;
+  }
+}

--- a/services/livetalk/core/src/voice/composite-voice-client.ts
+++ b/services/livetalk/core/src/voice/composite-voice-client.ts
@@ -45,9 +45,7 @@ export class CompositeVoiceClient implements IVoiceClient {
     const provider = voice?.provider ?? this.defaultProvider;
     const client = this.resolveClient(provider);
     if (!client) {
-      throw new Error(
-        `${COMPOSITE_VOICE_ERROR_MESSAGES.UNKNOWN_PROVIDER}: provider=${provider}`
-      );
+      throw new Error(`${COMPOSITE_VOICE_ERROR_MESSAGES.UNKNOWN_PROVIDER}: provider=${provider}`);
     }
     return client.synthesize(text, voice);
   }
@@ -56,9 +54,7 @@ export class CompositeVoiceClient implements IVoiceClient {
    * 指定 provider のクライアントを返す。
    * ファクトリ関数が登録されている場合は初回呼び出し時に生成してキャッシュする。
    */
-  private resolveClient(
-    provider: VoiceConfig['provider']
-  ): IVoiceClient | undefined {
+  private resolveClient(provider: VoiceConfig['provider']): IVoiceClient | undefined {
     // 既に解決済みのクライアントがある場合はそれを返す
     const cached = this.resolvedClients[provider];
     if (cached) {

--- a/services/livetalk/core/src/voice/index.ts
+++ b/services/livetalk/core/src/voice/index.ts
@@ -2,3 +2,8 @@
  * TTS（音声合成）プロバイダ非依存ポートの公開エントリポイント。
  */
 export type { IVoiceClient, VoiceConfig } from './types.js';
+export {
+  CompositeVoiceClient,
+  COMPOSITE_VOICE_ERROR_MESSAGES,
+} from './composite-voice-client.js';
+export type { CompositeVoiceClientOptions } from './composite-voice-client.js';

--- a/services/livetalk/core/src/voice/index.ts
+++ b/services/livetalk/core/src/voice/index.ts
@@ -2,8 +2,5 @@
  * TTS（音声合成）プロバイダ非依存ポートの公開エントリポイント。
  */
 export type { IVoiceClient, VoiceConfig } from './types.js';
-export {
-  CompositeVoiceClient,
-  COMPOSITE_VOICE_ERROR_MESSAGES,
-} from './composite-voice-client.js';
+export { CompositeVoiceClient, COMPOSITE_VOICE_ERROR_MESSAGES } from './composite-voice-client.js';
 export type { CompositeVoiceClientOptions } from './composite-voice-client.js';

--- a/services/livetalk/core/src/voice/types.ts
+++ b/services/livetalk/core/src/voice/types.ts
@@ -4,14 +4,25 @@
 
 /**
  * キャラが用いる音声の選択情報。プロバイダごとに必要項目が異なるため discriminated union とし、
- * 各 IVoiceClient 実装は自分の provider のみ解釈する。将来 openai 等の variant を追加する。
+ * 各 IVoiceClient 実装は自分の provider のみ解釈する。
  */
-export type VoiceConfig = {
-  provider: 'voicevox';
-  /** VOICEVOX の話者 ID（例: 14 = 冥鳴ひまり） */
-  speakerId: number;
-};
-// 将来: | { provider: 'openai'; voice: string; instructions?: string; model?: string }
+export type VoiceConfig =
+  | {
+      /** VOICEVOX プロバイダを使用する */
+      provider: 'voicevox';
+      /** VOICEVOX の話者 ID（例: 14 = 冥鳴ひまり） */
+      speakerId: number;
+    }
+  | {
+      /** OpenAI TTS プロバイダを使用する */
+      provider: 'openai';
+      /** OpenAI TTS の voice 名（例: 'nova', 'shimmer', 'coral', 'alloy'） */
+      voice: string;
+      /** voice の話し方を自然言語で指示する（gpt-4o-mini-tts のみ有効、任意） */
+      instructions?: string;
+      /** 使用モデル。省略時はクライアント実装側の既定（gpt-4o-mini-tts） */
+      model?: string;
+    };
 
 /**
  * 音声合成（TTS）クライアントの抽象インターフェース。

--- a/services/livetalk/core/tests/unit/openai-voice/openai-voice-client.test.ts
+++ b/services/livetalk/core/tests/unit/openai-voice/openai-voice-client.test.ts
@@ -1,0 +1,252 @@
+import OpenAI from 'openai';
+import {
+  OpenAIVoiceClient,
+  OPENAI_VOICE_ERROR_MESSAGES,
+} from '../../../src/openai-voice/openai-voice-client.js';
+
+/**
+ * OpenAI TTS クライアント用モックファクトリ。
+ * audio.speech.create の呼び出しを記録し、任意の応答を返す。
+ */
+function makeMockOpenAI(responseBuffer: ArrayBuffer = new ArrayBuffer(16)): {
+  client: OpenAI;
+  create: jest.Mock;
+} {
+  const create = jest.fn().mockResolvedValue({
+    arrayBuffer: async () => responseBuffer,
+  });
+  const client = {
+    audio: {
+      speech: { create },
+    },
+  } as unknown as OpenAI;
+  return { client, create };
+}
+
+describe('OpenAIVoiceClient', () => {
+  describe('コンストラクタ', () => {
+    it('apiKey を指定して生成できる', () => {
+      expect(() => new OpenAIVoiceClient({ apiKey: 'sk-test' })).not.toThrow();
+    });
+
+    it('client を注入して生成できる（apiKey 不要）', () => {
+      const { client } = makeMockOpenAI();
+      expect(() => new OpenAIVoiceClient({ client })).not.toThrow();
+    });
+
+    it('apiKey も client も無い場合は EMPTY_API_KEY を投げる', () => {
+      expect(() => new OpenAIVoiceClient({})).toThrow(
+        OPENAI_VOICE_ERROR_MESSAGES.EMPTY_API_KEY
+      );
+    });
+  });
+
+  describe('synthesize', () => {
+    it('正常なテキストで ArrayBuffer を返す', async () => {
+      const expected = new ArrayBuffer(16);
+      const { client } = makeMockOpenAI(expected);
+      const ttsClient = new OpenAIVoiceClient({ client });
+
+      const result = await ttsClient.synthesize('こんにちは');
+
+      expect(result).toBe(expected);
+    });
+
+    it('空文字は EMPTY_TEXT で reject される', async () => {
+      const { client } = makeMockOpenAI();
+      const ttsClient = new OpenAIVoiceClient({ client });
+
+      await expect(ttsClient.synthesize('  ')).rejects.toThrow(
+        OPENAI_VOICE_ERROR_MESSAGES.EMPTY_TEXT
+      );
+    });
+
+    it('空文字では create が呼ばれない', async () => {
+      const { client, create } = makeMockOpenAI();
+      const ttsClient = new OpenAIVoiceClient({ client });
+
+      await expect(ttsClient.synthesize('')).rejects.toThrow();
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    describe('voice パラメータの解決', () => {
+      it('voice.provider === openai の場合、voice.voice / model を渡す', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        await ttsClient.synthesize('テスト', {
+          provider: 'openai',
+          voice: 'nova',
+          model: 'gpt-4o-mini-tts',
+        });
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            voice: 'nova',
+            model: 'gpt-4o-mini-tts',
+            input: 'テスト',
+            response_format: 'mp3',
+          })
+        );
+      });
+
+      it('voice.provider === openai かつ instructions あり → instructions を渡す', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        await ttsClient.synthesize('テスト', {
+          provider: 'openai',
+          voice: 'shimmer',
+          instructions: 'ゆっくり話してください',
+        });
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            voice: 'shimmer',
+            instructions: 'ゆっくり話してください',
+          })
+        );
+      });
+
+      it('voice.provider === openai かつ instructions なし → instructions を渡さない', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        await ttsClient.synthesize('テスト', {
+          provider: 'openai',
+          voice: 'coral',
+        });
+
+        const calledWith = create.mock.calls[0][0] as Record<string, unknown>;
+        expect(calledWith.instructions).toBeUndefined();
+      });
+
+      it('voice.provider === openai かつ model 省略 → defaultModel を使用する', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({ client, defaultModel: 'custom-tts-model' });
+
+        await ttsClient.synthesize('テスト', {
+          provider: 'openai',
+          voice: 'alloy',
+        });
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model: 'custom-tts-model',
+          })
+        );
+      });
+
+      it('voice 省略時は defaultVoice / defaultModel を使用する', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({
+          client,
+          defaultVoice: 'onyx',
+          defaultModel: 'tts-1',
+        });
+
+        await ttsClient.synthesize('テスト');
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            voice: 'onyx',
+            model: 'tts-1',
+          })
+        );
+      });
+
+      it('voice.provider === voicevox の場合は既定値で合成する（寛容な振る舞い）', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({
+          client,
+          defaultVoice: 'alloy',
+          defaultModel: 'gpt-4o-mini-tts',
+        });
+
+        await ttsClient.synthesize('テスト', { provider: 'voicevox', speakerId: 14 });
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            voice: 'alloy',
+            model: 'gpt-4o-mini-tts',
+          })
+        );
+      });
+
+      it('既定の defaultVoice は alloy', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        await ttsClient.synthesize('テスト');
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({ voice: 'alloy' })
+        );
+      });
+
+      it('既定の defaultModel は gpt-4o-mini-tts', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        await ttsClient.synthesize('テスト');
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({ model: 'gpt-4o-mini-tts' })
+        );
+      });
+
+      it('response_format は mp3', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        await ttsClient.synthesize('テスト');
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({ response_format: 'mp3' })
+        );
+      });
+
+      it('前後の空白を除去してから合成する', async () => {
+        const { client, create } = makeMockOpenAI();
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        await ttsClient.synthesize('  テスト  ');
+
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({ input: 'テスト' })
+        );
+      });
+    });
+
+    describe('エラーハンドリング', () => {
+      it('create が例外を投げると SYNTHESIS_FAILED を throw する', async () => {
+        const create = jest.fn().mockRejectedValue(new Error('API エラー'));
+        const client = {
+          audio: { speech: { create } },
+        } as unknown as OpenAI;
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        await expect(ttsClient.synthesize('テスト')).rejects.toThrow(
+          OPENAI_VOICE_ERROR_MESSAGES.SYNTHESIS_FAILED
+        );
+      });
+
+      it('SYNTHESIS_FAILED エラーは cause に元の例外を含む', async () => {
+        const originalError = new Error('オリジナルエラー');
+        const create = jest.fn().mockRejectedValue(originalError);
+        const client = {
+          audio: { speech: { create } },
+        } as unknown as OpenAI;
+        const ttsClient = new OpenAIVoiceClient({ client });
+
+        try {
+          await ttsClient.synthesize('テスト');
+          fail('例外が投げられるべき');
+        } catch (err) {
+          expect(err).toBeInstanceOf(Error);
+          expect((err as Error & { cause?: unknown }).cause).toBe(originalError);
+        }
+      });
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/openai-voice/openai-voice-client.test.ts
+++ b/services/livetalk/core/tests/unit/openai-voice/openai-voice-client.test.ts
@@ -35,9 +35,7 @@ describe('OpenAIVoiceClient', () => {
     });
 
     it('apiKey も client も無い場合は EMPTY_API_KEY を投げる', () => {
-      expect(() => new OpenAIVoiceClient({})).toThrow(
-        OPENAI_VOICE_ERROR_MESSAGES.EMPTY_API_KEY
-      );
+      expect(() => new OpenAIVoiceClient({})).toThrow(OPENAI_VOICE_ERROR_MESSAGES.EMPTY_API_KEY);
     });
   });
 
@@ -179,9 +177,7 @@ describe('OpenAIVoiceClient', () => {
 
         await ttsClient.synthesize('テスト');
 
-        expect(create).toHaveBeenCalledWith(
-          expect.objectContaining({ voice: 'alloy' })
-        );
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ voice: 'alloy' }));
       });
 
       it('既定の defaultModel は gpt-4o-mini-tts', async () => {
@@ -190,9 +186,7 @@ describe('OpenAIVoiceClient', () => {
 
         await ttsClient.synthesize('テスト');
 
-        expect(create).toHaveBeenCalledWith(
-          expect.objectContaining({ model: 'gpt-4o-mini-tts' })
-        );
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-4o-mini-tts' }));
       });
 
       it('response_format は mp3', async () => {
@@ -201,9 +195,7 @@ describe('OpenAIVoiceClient', () => {
 
         await ttsClient.synthesize('テスト');
 
-        expect(create).toHaveBeenCalledWith(
-          expect.objectContaining({ response_format: 'mp3' })
-        );
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ response_format: 'mp3' }));
       });
 
       it('前後の空白を除去してから合成する', async () => {
@@ -212,9 +204,7 @@ describe('OpenAIVoiceClient', () => {
 
         await ttsClient.synthesize('  テスト  ');
 
-        expect(create).toHaveBeenCalledWith(
-          expect.objectContaining({ input: 'テスト' })
-        );
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ input: 'テスト' }));
       });
     });
 

--- a/services/livetalk/core/tests/unit/voice/composite-voice-client.test.ts
+++ b/services/livetalk/core/tests/unit/voice/composite-voice-client.test.ts
@@ -1,0 +1,184 @@
+import {
+  CompositeVoiceClient,
+  COMPOSITE_VOICE_ERROR_MESSAGES,
+} from '../../../src/voice/composite-voice-client.js';
+import type { IVoiceClient, VoiceConfig } from '../../../src/voice/types.js';
+
+/**
+ * テスト用モッククライアントのファクトリ。
+ * synthesize の呼び出し引数を記録する。
+ */
+function makeMockClient(returnValue: ArrayBuffer = new ArrayBuffer(0)): {
+  client: IVoiceClient;
+  synthesize: jest.Mock;
+} {
+  const synthesize = jest.fn().mockResolvedValue(returnValue);
+  const client: IVoiceClient = { synthesize };
+  return { client, synthesize };
+}
+
+describe('CompositeVoiceClient', () => {
+  describe('provider の振り分け', () => {
+    it('voice.provider === voicevox のとき voicevox クライアントに委譲する', async () => {
+      const voicevoxBuf = new ArrayBuffer(4);
+      const openAiBuf = new ArrayBuffer(8);
+      const { client: voicevoxClient, synthesize: voicevoxSynthesize } =
+        makeMockClient(voicevoxBuf);
+      const { client: openaiClient, synthesize: openaiSynthesize } = makeMockClient(openAiBuf);
+
+      const composite = new CompositeVoiceClient({
+        clients: { voicevox: voicevoxClient, openai: openaiClient },
+        defaultProvider: 'voicevox',
+      });
+
+      const voice: VoiceConfig = { provider: 'voicevox', speakerId: 14 };
+      const result = await composite.synthesize('こんにちは', voice);
+
+      expect(result).toBe(voicevoxBuf);
+      expect(voicevoxSynthesize).toHaveBeenCalledWith('こんにちは', voice);
+      expect(openaiSynthesize).not.toHaveBeenCalled();
+    });
+
+    it('voice.provider === openai のとき openai クライアントに委譲する', async () => {
+      const openAiBuf = new ArrayBuffer(8);
+      const { client: voicevoxClient, synthesize: voicevoxSynthesize } = makeMockClient();
+      const { client: openaiClient, synthesize: openaiSynthesize } = makeMockClient(openAiBuf);
+
+      const composite = new CompositeVoiceClient({
+        clients: { voicevox: voicevoxClient, openai: openaiClient },
+        defaultProvider: 'voicevox',
+      });
+
+      const voice: VoiceConfig = { provider: 'openai', voice: 'nova' };
+      const result = await composite.synthesize('テスト', voice);
+
+      expect(result).toBe(openAiBuf);
+      expect(openaiSynthesize).toHaveBeenCalledWith('テスト', voice);
+      expect(voicevoxSynthesize).not.toHaveBeenCalled();
+    });
+
+    it('voice 未指定のとき defaultProvider に委譲する', async () => {
+      const voicevoxBuf = new ArrayBuffer(4);
+      const { client: voicevoxClient, synthesize: voicevoxSynthesize } =
+        makeMockClient(voicevoxBuf);
+
+      const composite = new CompositeVoiceClient({
+        clients: { voicevox: voicevoxClient },
+        defaultProvider: 'voicevox',
+      });
+
+      const result = await composite.synthesize('テスト');
+
+      expect(result).toBe(voicevoxBuf);
+      expect(voicevoxSynthesize).toHaveBeenCalledWith('テスト', undefined);
+    });
+
+    it('defaultProvider が openai のとき voice 未指定で openai に委譲する', async () => {
+      const { client: openaiClient, synthesize: openaiSynthesize } = makeMockClient();
+
+      const composite = new CompositeVoiceClient({
+        clients: { openai: openaiClient },
+        defaultProvider: 'openai',
+      });
+
+      await composite.synthesize('テスト');
+
+      expect(openaiSynthesize).toHaveBeenCalledWith('テスト', undefined);
+    });
+  });
+
+  describe('未登録プロバイダ', () => {
+    it('voice.provider に対応するクライアントが無い場合は UNKNOWN_PROVIDER を投げる', async () => {
+      const { client: voicevoxClient } = makeMockClient();
+
+      const composite = new CompositeVoiceClient({
+        clients: { voicevox: voicevoxClient },
+        defaultProvider: 'voicevox',
+      });
+
+      const voice: VoiceConfig = { provider: 'openai', voice: 'alloy' };
+      await expect(composite.synthesize('テスト', voice)).rejects.toThrow(
+        COMPOSITE_VOICE_ERROR_MESSAGES.UNKNOWN_PROVIDER
+      );
+    });
+
+    it('defaultProvider に対応するクライアントが無い場合も UNKNOWN_PROVIDER を投げる', async () => {
+      const composite = new CompositeVoiceClient({
+        clients: {},
+        defaultProvider: 'voicevox',
+      });
+
+      await expect(composite.synthesize('テスト')).rejects.toThrow(
+        COMPOSITE_VOICE_ERROR_MESSAGES.UNKNOWN_PROVIDER
+      );
+    });
+  });
+
+  describe('遅延ファクトリ', () => {
+    it('ファクトリ関数を登録した場合、初回呼び出し時にクライアントが生成される', async () => {
+      const factoryBuf = new ArrayBuffer(12);
+      const { client: openaiClient, synthesize: openaiSynthesize } = makeMockClient(factoryBuf);
+      const factory = jest.fn().mockReturnValue(openaiClient);
+
+      const composite = new CompositeVoiceClient({
+        clients: { openai: factory },
+        defaultProvider: 'openai',
+      });
+
+      // 初回呼び出し前はファクトリが実行されていない
+      expect(factory).not.toHaveBeenCalled();
+
+      const result = await composite.synthesize('テスト');
+
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(result).toBe(factoryBuf);
+      expect(openaiSynthesize).toHaveBeenCalled();
+    });
+
+    it('ファクトリは2回目以降呼ばれない（キャッシュされる）', async () => {
+      const { client: openaiClient } = makeMockClient();
+      const factory = jest.fn().mockReturnValue(openaiClient);
+
+      const composite = new CompositeVoiceClient({
+        clients: { openai: factory },
+        defaultProvider: 'openai',
+      });
+
+      await composite.synthesize('1回目');
+      await composite.synthesize('2回目');
+      await composite.synthesize('3回目');
+
+      expect(factory).toHaveBeenCalledTimes(1);
+    });
+
+    it('voicevox クライアントが IVoiceClient インスタンス、openai がファクトリのとき voicevox は openai ファクトリを実行しない', async () => {
+      const { client: voicevoxClient } = makeMockClient();
+      const openaiFactory = jest.fn();
+
+      const composite = new CompositeVoiceClient({
+        clients: { voicevox: voicevoxClient, openai: openaiFactory },
+        defaultProvider: 'voicevox',
+      });
+
+      await composite.synthesize('テスト', { provider: 'voicevox', speakerId: 14 });
+
+      expect(openaiFactory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('voice の受け渡し', () => {
+    it('委譲時に元の voice オブジェクトをそのまま渡す', async () => {
+      const { client, synthesize } = makeMockClient();
+
+      const composite = new CompositeVoiceClient({
+        clients: { voicevox: client },
+        defaultProvider: 'voicevox',
+      });
+
+      const voice: VoiceConfig = { provider: 'voicevox', speakerId: 99 };
+      await composite.synthesize('テスト', voice);
+
+      expect(synthesize).toHaveBeenCalledWith('テスト', voice);
+    });
+  });
+});

--- a/services/livetalk/web/src/lib/server/voice.ts
+++ b/services/livetalk/web/src/lib/server/voice.ts
@@ -1,8 +1,4 @@
-import {
-  VoicevoxClient,
-  OpenAIVoiceClient,
-  CompositeVoiceClient,
-} from '@nagiyu/livetalk-core';
+import { VoicevoxClient, OpenAIVoiceClient, CompositeVoiceClient } from '@nagiyu/livetalk-core';
 import type { IVoiceClient } from '@nagiyu/livetalk-core';
 
 let cachedClient: IVoiceClient | null = null;

--- a/services/livetalk/web/src/lib/server/voice.ts
+++ b/services/livetalk/web/src/lib/server/voice.ts
@@ -1,11 +1,19 @@
-import { VoicevoxClient } from '@nagiyu/livetalk-core';
+import {
+  VoicevoxClient,
+  OpenAIVoiceClient,
+  CompositeVoiceClient,
+} from '@nagiyu/livetalk-core';
 import type { IVoiceClient } from '@nagiyu/livetalk-core';
 
 let cachedClient: IVoiceClient | null = null;
 
 /**
- * TTS クライアントのシングルトン。環境変数 TTS_PROVIDER でプロバイダを選択（既定: voicevox）。
- * ECS Task 内では VOICEVOX サイドカー（同 Task の localhost:50021）に接続される。
+ * TTS クライアントのシングルトン。
+ * CompositeVoiceClient を返し、voice.provider に応じて VOICEVOX / OpenAI を自動振り分けする。
+ *
+ * - defaultProvider は 'voicevox'（後方互換）。
+ * - OpenAIVoiceClient は OPENAI_API_KEY が存在する場合のみ遅延登録する。
+ *   キーが不在の状態で voicevox のリクエストが来ても正常に動作する。
  */
 export function getVoiceClient(): IVoiceClient {
   if (!cachedClient) cachedClient = createVoiceClient();
@@ -13,14 +21,20 @@ export function getVoiceClient(): IVoiceClient {
 }
 
 function createVoiceClient(): IVoiceClient {
-  const provider = process.env.TTS_PROVIDER ?? 'voicevox';
-  switch (provider) {
-    case 'voicevox':
-      return new VoicevoxClient({ baseUrl: process.env.VOICEVOX_URL });
-    default:
-      // 未知のプロバイダ指定時は VOICEVOX にフォールバック（振る舞い不変を優先）
-      return new VoicevoxClient({ baseUrl: process.env.VOICEVOX_URL });
-  }
+  // OpenAI TTS は API キーが存在する場合のみ遅延ファクトリとして登録する。
+  // ファクトリは初回利用時に実行されるため、VOICEVOX のみのリクエストでは
+  // OPENAI_API_KEY 不在でも OpenAIVoiceClient が生成されず、エラーにならない。
+  const openaiClientFactory: (() => IVoiceClient) | undefined = process.env.OPENAI_API_KEY
+    ? () => new OpenAIVoiceClient({ apiKey: process.env.OPENAI_API_KEY })
+    : undefined;
+
+  return new CompositeVoiceClient({
+    clients: {
+      voicevox: new VoicevoxClient({ baseUrl: process.env.VOICEVOX_URL }),
+      ...(openaiClientFactory ? { openai: openaiClientFactory } : {}),
+    },
+    defaultProvider: 'voicevox',
+  });
 }
 
 /**

--- a/services/livetalk/web/tests/unit/lib/server/voice.test.ts
+++ b/services/livetalk/web/tests/unit/lib/server/voice.test.ts
@@ -2,18 +2,19 @@
  * @jest-environment node
  */
 import { getVoiceClient, setVoiceClientForTesting } from '@/lib/server/voice';
+import type { IVoiceClient } from '@nagiyu/livetalk-core';
 
 describe('getVoiceClient', () => {
   beforeEach(() => {
     // 各テスト前にキャッシュをクリアする
     setVoiceClientForTesting(null);
-    // TTS_PROVIDER 環境変数をリセットする
-    delete process.env.TTS_PROVIDER;
+    // OPENAI_API_KEY 環境変数をリセットする
+    delete process.env.OPENAI_API_KEY;
   });
 
   afterEach(() => {
     setVoiceClientForTesting(null);
-    delete process.env.TTS_PROVIDER;
+    delete process.env.OPENAI_API_KEY;
   });
 
   it('同じインスタンスをキャッシュして返す', () => {
@@ -30,27 +31,35 @@ describe('getVoiceClient', () => {
   });
 
   it('差し替えた client をそのまま返す', () => {
-    const stub = { synthesize: async () => new ArrayBuffer(0) };
+    const stub: IVoiceClient = { synthesize: async () => new ArrayBuffer(0) };
     setVoiceClientForTesting(stub);
     expect(getVoiceClient()).toBe(stub);
   });
 
-  it('TTS_PROVIDER 未指定時は VOICEVOX クライアントを生成する', () => {
-    const client = getVoiceClient();
-    // VoicevoxClient のインスタンスであることを確認（synthesize メソッドを持つ）
-    expect(typeof client.synthesize).toBe('function');
-  });
-
-  it('TTS_PROVIDER=voicevox でも VOICEVOX クライアントを生成する', () => {
-    process.env.TTS_PROVIDER = 'voicevox';
+  it('synthesize メソッドを持つクライアントを返す', () => {
     const client = getVoiceClient();
     expect(typeof client.synthesize).toBe('function');
   });
 
-  it('TTS_PROVIDER に未知の値を指定しても VOICEVOX にフォールバックする', () => {
-    process.env.TTS_PROVIDER = 'unknown-provider';
-    const client = getVoiceClient();
-    // フォールバックで VOICEVOX クライアントが生成されることを確認
-    expect(typeof client.synthesize).toBe('function');
+  it('OPENAI_API_KEY 不在でも getVoiceClient が例外を投げない（voicevox は動作する）', () => {
+    // OPENAI_API_KEY を未設定の状態でクライアントが生成できることを確認する
+    delete process.env.OPENAI_API_KEY;
+    expect(() => getVoiceClient()).not.toThrow();
+  });
+
+  it('OPENAI_API_KEY がある場合も getVoiceClient が例外を投げない', () => {
+    process.env.OPENAI_API_KEY = 'sk-test-key';
+    // キャッシュをクリアして新しくクライアントを生成する
+    setVoiceClientForTesting(null);
+    expect(() => getVoiceClient()).not.toThrow();
+  });
+
+  it('setVoiceClientForTesting に null を渡すと次回 getVoiceClient で再生成する', () => {
+    const first = getVoiceClient();
+    setVoiceClientForTesting(null);
+    const second = getVoiceClient();
+    // 再生成されるため別インスタンスになる
+    expect(second).not.toBe(first);
+    expect(typeof second.synthesize).toBe('function');
   });
 });


### PR DESCRIPTION
## 変更の概要

リブトークに **OpenAI TTS（音声合成）プロバイダの基盤**を追加する。これまで VOICEVOX 固定で `VoiceConfig` の `openai` variant は型コメントのみだったため、キャラの `voiceConfig.provider` に応じて VOICEVOX / OpenAI を自動振り分けできるようにした。

- `VoiceConfig` を discriminated union 化（`voicevox` | `openai`）
- `OpenAIVoiceClient`（`IVoiceClient` 実装）を新規追加。`audio.speech.create`（既定モデル `gpt-4o-mini-tts`・MP3 出力）でブラウザ再生可能な音声バイナリを返す
- `CompositeVoiceClient` を追加。`voice.provider` で適切なクライアントへ委譲し、**遅延ファクトリ**に対応（`OPENAI_API_KEY` 不在でも VOICEVOX のリクエストは正常動作）
- web の `getVoiceClient()` を `CompositeVoiceClient` ベースに変更（`defaultProvider: 'voicevox'`、`TTS_PROVIDER` env 依存を廃止）

桃瀬ひより（VOICEVOX）の既存挙動は不変。**インフラ変更なし**（既存の `OPENAI_API_KEY` を流用）。

Phase 3 で追加する新キャラがこの基盤を使って OpenAI 音声で喋る。

## 関連 Issue

親 Issue #3470（Phase 1）

## 変更種別

- [x] 新規機能
- [x] リファクタリング

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（音声プロバイダの整理は Phase 3 完了時にまとめて反映予定）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `OpenAIVoiceClient`: 空文字 throw・voice/instructions/model の受け渡し・arrayBuffer 返却・例外時の `SYNTHESIS_FAILED` を検証（モック OpenAI client 注入）
- `CompositeVoiceClient`: provider 振り分け（voicevox/openai）・voice 未指定時の defaultProvider・遅延ファクトリの初回生成とキャッシュ・未登録 provider の throw を検証
- web `getVoiceClient`: シングルトンキャッシュ・`setVoiceClientForTesting`・`OPENAI_API_KEY` 不在でも例外を投げないことを検証
- オーケストレーター検証: core `tsc --noEmit` クリーン / core 音声テスト 38 件通過 / core ビルド成功 / web voice テスト 7 件通過（既存の無関係テスト型エラーを除き voice 関連はクリーン）

## レビューポイント

- `OpenAIVoiceClient.synthesize` で `instructions` を SDK 型に渡す箇所で `as any` を使用（`gpt-4o-mini-tts` 専用パラメータのため）。SDK 型が対応次第外せる。
- `CompositeVoiceClient` の遅延ファクトリ設計（`IVoiceClient | (() => IVoiceClient)`）の妥当性。
- MP3 出力の採用（VOICEVOX は WAV。クライアントは Web Audio の `decodeAudioData` でデコードするため両対応で、転送量の小さい MP3 を選択）。

## 補足事項

これは Phase 1（基盤）の PR。Phase 2（キャラ描画 Renderer 抽象化）/ Phase 3（新ギャルキャラ定義）は後続の小さな Draft PR で integration に積む。

---
_Generated by [Claude Code](https://claude.ai/code/session_011zBgQhzZhaQX3jUVUcBbPp)_