### PR TITLE
リブトーク: 新キャラ「早瀬アゲハ」を追加（Phase 3 / #3470）

### DIFF
--- a/services/livetalk/core/src/characters/ageha.ts
+++ b/services/livetalk/core/src/characters/ageha.ts
@@ -1,0 +1,47 @@
+import type { CharacterDefinition } from './types.js';
+
+/**
+ * 早瀬アゲハ の CharacterDefinition 実装。
+ *
+ * 音声は OpenAI TTS（nova）を使用。Live2D モデル未用意のため
+ * web 側は PlaceholderCanvas で描画する（Phase 2 で整備済みの renderer 基盤を活用）。
+ */
+export const ageha: CharacterDefinition = {
+  id: 'ageha',
+  displayName: '早瀬アゲハ',
+  personality: {
+    basePrompt: `あなたは「早瀬アゲハ」です。ユーザーのテンションを上げて背中を押す、相棒のようなギャルです。
+ユーザーが落ち込んでいても、明るく笑い飛ばして「いけるっしょ！」と前向きに励ましてください。
+質問で相手を問い詰めるのではなく、自分のノリや気持ちを乗せて会話を盛り上げましょう。
+話す長さは 1〜3 文程度にとどめ、テンポよく勢いのあるやり取りを続けてください。
+AI であることを積極的に宣言する必要はありませんが、嘘をつくことは避けてください。`,
+    speechStyle:
+      '一人称は「ウチ」。ギャル特有のタメ口でテンション高め。明るくフレンドリーに、ノリよく話す。語尾はわざとらしく作り込みすぎず、自然なギャル口調にする。',
+    preferences: {
+      likes: [
+        'カラオケや音楽フェス',
+        'コスメ・ネイル・おしゃれ',
+        'カフェ巡りとタピオカ・スイーツ',
+        '友達とワイワイ盛り上がること',
+        '推し活',
+      ],
+      dislikes: [
+        'うじうじ・ネガティブ思考',
+        '地味で単調な作業',
+        '早起き',
+        '湿気で髪が決まらないこと',
+      ],
+    },
+  },
+  voiceConfig: {
+    provider: 'openai',
+    voice: 'nova',
+    instructions:
+      '明るく元気な若い女性。やや早口でテンション高め。フレンドリーでノリがよく、語尾を軽く弾ませる。',
+  },
+  license: {
+    displayText:
+      '音声：OpenAI TTS による AI 生成音声（人間の音声ではありません）\nキャラクター：早瀬アゲハ',
+    creditName: '早瀬アゲハ',
+  },
+};

--- a/services/livetalk/core/src/characters/index.ts
+++ b/services/livetalk/core/src/characters/index.ts
@@ -1,5 +1,6 @@
 export type { CharacterDefinition, PersonalityDefinition } from './types.js';
 export { hiyori } from './hiyori.js';
+export { ageha } from './ageha.js';
 export {
   buildSystemPrompt,
   buildChatMessages,

--- a/services/livetalk/core/tests/unit/characters/ageha.test.ts
+++ b/services/livetalk/core/tests/unit/characters/ageha.test.ts
@@ -1,0 +1,106 @@
+import { ageha } from '../../../src/characters/ageha.js';
+
+/**
+ * 早瀬アゲハ の CharacterDefinition 検証テスト。
+ *
+ * キャラ定義の整合性（ID・displayName・voiceConfig・personality・license）を
+ * 仕様通りに実装されていることを確認する。
+ */
+describe('早瀬アゲハ CharacterDefinition', () => {
+  describe('基本情報', () => {
+    it('id が "ageha" である', () => {
+      expect(ageha.id).toBe('ageha');
+    });
+
+    it('displayName が "早瀬アゲハ" である', () => {
+      expect(ageha.displayName).toBe('早瀬アゲハ');
+    });
+  });
+
+  describe('voiceConfig', () => {
+    it('provider が "openai" である', () => {
+      expect(ageha.voiceConfig.provider).toBe('openai');
+    });
+
+    it('voice が "nova" である', () => {
+      if (ageha.voiceConfig.provider === 'openai') {
+        expect(ageha.voiceConfig.voice).toBe('nova');
+      } else {
+        fail('provider が openai でない');
+      }
+    });
+
+    it('instructions が設定されている', () => {
+      if (ageha.voiceConfig.provider === 'openai') {
+        expect(ageha.voiceConfig.instructions).toBeDefined();
+        expect(typeof ageha.voiceConfig.instructions).toBe('string');
+        expect((ageha.voiceConfig.instructions as string).length).toBeGreaterThan(0);
+      } else {
+        fail('provider が openai でない');
+      }
+    });
+  });
+
+  describe('personality', () => {
+    it('basePrompt が設定されている（日本語を含む）', () => {
+      expect(ageha.personality.basePrompt).toBeTruthy();
+      // 日本語文字が含まれる
+      expect(ageha.personality.basePrompt).toMatch(/[ぁ-ん]/);
+    });
+
+    it('basePrompt に「早瀬アゲハ」が含まれる', () => {
+      expect(ageha.personality.basePrompt).toContain('早瀬アゲハ');
+    });
+
+    it('speechStyle が設定されている', () => {
+      expect(ageha.personality.speechStyle).toBeTruthy();
+      expect(typeof ageha.personality.speechStyle).toBe('string');
+    });
+
+    it('speechStyle に一人称「ウチ」が含まれる', () => {
+      expect(ageha.personality.speechStyle).toContain('ウチ');
+    });
+
+    it('likes が 1 件以上ある', () => {
+      expect(ageha.personality.preferences.likes.length).toBeGreaterThan(0);
+    });
+
+    it('dislikes が 1 件以上ある', () => {
+      expect(ageha.personality.preferences.dislikes.length).toBeGreaterThan(0);
+    });
+
+    it('likes の各要素が空でない文字列である', () => {
+      for (const like of ageha.personality.preferences.likes) {
+        expect(typeof like).toBe('string');
+        expect(like.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('dislikes の各要素が空でない文字列である', () => {
+      for (const dislike of ageha.personality.preferences.dislikes) {
+        expect(typeof dislike).toBe('string');
+        expect(dislike.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('license', () => {
+    it('displayText が設定されている', () => {
+      expect(ageha.license.displayText).toBeTruthy();
+      expect(typeof ageha.license.displayText).toBe('string');
+    });
+
+    it('displayText に AI 生成音声であることの明示が含まれる', () => {
+      // OpenAI 利用規約上、AI 生成音声であることの明示は必須
+      expect(ageha.license.displayText).toContain('AI 生成音声');
+    });
+
+    it('displayText に OpenAI TTS の記述が含まれる', () => {
+      expect(ageha.license.displayText).toContain('OpenAI TTS');
+    });
+
+    it('creditName が "早瀬アゲハ" である', () => {
+      expect(ageha.license.creditName).toBe('早瀬アゲハ');
+    });
+  });
+});

--- a/services/livetalk/web/src/lib/characters/client-profiles.ts
+++ b/services/livetalk/web/src/lib/characters/client-profiles.ts
@@ -24,6 +24,12 @@ export type {
 export const DEFAULT_CLIENT_CHARACTER_ID = 'hiyori';
 
 /**
+ * 早瀬アゲハ のライセンス・クレジット文字列。
+ * OpenAI TTS を使用するため AI 生成音声であることの明示は OpenAI 利用規約上必須。
+ */
+export const AGEHA_LICENSE_TEXT = '音声：OpenAI TTS による AI 生成音声（人間の音声ではありません）';
+
+/**
  * クライアントプロファイルのエラーメッセージ定数。
  */
 export const CHARACTER_PROFILE_ERROR_MESSAGES = {
@@ -53,6 +59,20 @@ const PROFILES: Record<string, CharacterClientProfile> = {
     description: '甘いものと猫が大好きな癒し系。のんびりおしゃべりして、ほっと一息つける女の子。',
     model: { engine: 'Live2D', name: '桃瀬ひより' },
     voice: { engine: 'VOICEVOX', name: '冥鳴ひまり' },
+  },
+  ageha: {
+    display: {
+      displayName: '早瀬アゲハ',
+      shortName: 'アゲハ',
+    },
+    render: {
+      renderer: 'placeholder',
+    },
+    licenseText: AGEHA_LICENSE_TEXT,
+    description:
+      'テンション高めで背中を押してくれる相棒ギャル。落ち込んでも隣でアゲてくれる、ノリのいい女の子。',
+    model: { engine: 'プレースホルダー', name: '仮アバター（シルエット）' },
+    voice: { engine: 'OpenAI TTS', name: 'nova' },
   },
 };
 

--- a/services/livetalk/web/src/lib/characters/registry.ts
+++ b/services/livetalk/web/src/lib/characters/registry.ts
@@ -1,4 +1,4 @@
-import { hiyori, DEFAULT_CHARACTER_ID } from '@nagiyu/livetalk-core';
+import { hiyori, ageha, DEFAULT_CHARACTER_ID } from '@nagiyu/livetalk-core';
 import type { CharacterDefinition } from '@nagiyu/livetalk-core';
 import {
   getCharacterRenderProfile,
@@ -30,6 +30,7 @@ export interface CharacterEntry {
  */
 const DEFINITIONS: Record<string, CharacterDefinition> = {
   [hiyori.id]: hiyori,
+  [ageha.id]: ageha,
 };
 
 /**

--- a/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
@@ -138,6 +138,10 @@ describe('クライアントプロファイルレジストリ', () => {
       expect(getRegisteredProfileIds()).toContain(DEFAULT_CLIENT_CHARACTER_ID);
     });
 
+    it('"ageha" を含む', () => {
+      expect(getRegisteredProfileIds()).toContain('ageha');
+    });
+
     it('配列を返す', () => {
       expect(Array.isArray(getRegisteredProfileIds())).toBe(true);
     });
@@ -147,6 +151,63 @@ describe('クライアントプロファイルレジストリ', () => {
     it('日本語を含む', () => {
       expect(CHARACTER_PROFILE_ERROR_MESSAGES.UNKNOWN_PROFILE).toMatch(/[ぁ-ん]/);
     });
+  });
+});
+
+describe('早瀬アゲハ クライアントプロファイル', () => {
+  it('"ageha" のプロファイルが登録されている', () => {
+    expect(hasCharacterProfile('ageha')).toBe(true);
+  });
+
+  it('getCharacterClientProfile("ageha") でプロファイルを取得できる', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile).toBeDefined();
+  });
+
+  it('display.displayName が "早瀬アゲハ" である', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.display.displayName).toBe('早瀬アゲハ');
+  });
+
+  it('display.shortName が "アゲハ" である', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.display.shortName).toBe('アゲハ');
+  });
+
+  it('render.renderer が "placeholder" である（Live2D モデル未用意）', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.render.renderer).toBe('placeholder');
+  });
+
+  it('getCharacterRenderProfile("ageha") も placeholder を返す', () => {
+    const render = getCharacterRenderProfile('ageha');
+    expect(render.renderer).toBe('placeholder');
+  });
+
+  it('licenseText に AI 生成音声の明示が含まれる（OpenAI 利用規約上必須）', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.licenseText).toContain('AI 生成音声');
+  });
+
+  it('description が設定されている', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(typeof profile.description).toBe('string');
+    expect(profile.description.length).toBeGreaterThan(0);
+  });
+
+  it('model.engine が "プレースホルダー" である', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.model.engine).toBe('プレースホルダー');
+  });
+
+  it('voice.engine が "OpenAI TTS" である', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.voice.engine).toBe('OpenAI TTS');
+  });
+
+  it('voice.name が "nova" である', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.voice.name).toBe('nova');
   });
 });
 

--- a/services/livetalk/web/tests/unit/lib/characters/registry.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/registry.test.ts
@@ -45,6 +45,14 @@ describe('キャラクターレジストリ', () => {
       }
     });
 
+    it('"ageha" を指定すると定義と描画設定の両方を返す', () => {
+      const entry = getCharacterEntry('ageha');
+      expect(entry.definition.id).toBe('ageha');
+      expect(entry.definition.displayName).toBe('早瀬アゲハ');
+      // ageha は placeholder renderer を使用する
+      expect(entry.render.renderer).toBe('placeholder');
+    });
+
     it('未登録の characterId を指定すると日本語定数メッセージで Error をスローする', () => {
       expect(() => getCharacterEntry('unknown')).toThrow(
         CHARACTER_REGISTRY_ERROR_MESSAGES.UNKNOWN_CHARACTER
@@ -77,6 +85,18 @@ describe('キャラクターレジストリ', () => {
       expect(definition.license).toBeDefined();
     });
 
+    it('"ageha" を指定すると早瀬アゲハの CharacterDefinition を返す', () => {
+      const definition = getCharacterDefinition('ageha');
+      expect(definition.id).toBe('ageha');
+      expect(definition.displayName).toBe('早瀬アゲハ');
+      expect(definition.voiceConfig.provider).toBe('openai');
+      if (definition.voiceConfig.provider === 'openai') {
+        expect(definition.voiceConfig.voice).toBe('nova');
+      }
+      expect(definition.personality).toBeDefined();
+      expect(definition.license).toBeDefined();
+    });
+
     it('未登録の id を指定するとスローする', () => {
       expect(() => getCharacterDefinition('unknown')).toThrow(
         CHARACTER_REGISTRY_ERROR_MESSAGES.UNKNOWN_CHARACTER
@@ -87,6 +107,10 @@ describe('キャラクターレジストリ', () => {
   describe('hasCharacter', () => {
     it('"hiyori" は登録済みなので true を返す', () => {
       expect(hasCharacter('hiyori')).toBe(true);
+    });
+
+    it('"ageha" は登録済みなので true を返す', () => {
+      expect(hasCharacter('ageha')).toBe(true);
     });
 
     it('未登録の id は false を返す', () => {


### PR DESCRIPTION
## 変更の概要

リブトークに新キャラクター **「早瀬アゲハ」**（呼び名：アゲハ）を追加する。Phase 1（OpenAI TTS 基盤）と Phase 2（描画 Renderer 抽象化＋プレースホルダー Renderer）の基盤を使い、**キャラ定義と登録のみ**を行う（基盤コードは変更なし）。

- core: `characters/ageha.ts` を新規追加し `characters/index.ts` から export
  - コンセプト: テンションを上げて背中を押す相棒ギャル（桃瀬ひより＝癒し系との対比）
  - 一人称「ウチ」、ギャル・タメ口・テンション高めの口調（語尾は縛らず自然に）
  - `voiceConfig`: OpenAI TTS（`voice: 'nova'`、instructions でテンション高めの話し方を指定）
- web: `registry.ts` の `DEFINITIONS` と `client-profiles.ts` の `PROFILES` に ageha を登録
  - 描画は `renderer: 'placeholder'`（シルエット＋名前ラベル。画像は後日差し替え）
  - キャラ選択モーダルに自動で 2 キャラ目として表示される

既定キャラは **hiyori のまま変更なし**（`DEFAULT_CHARACTER_ID` / `DEFAULT_CLIENT_CHARACTER_ID` 不変）。アゲハは追加キャラ。

### クレジット表記（OpenAI 規約遵守）

OpenAI 公式 TTS ガイドで「TTS 音声が AI 生成であり人間の声でないことをエンドユーザーに明確開示すること」が必須と確認したため、フッターのクレジットに **「音声：OpenAI TTS による AI 生成音声（人間の音声ではありません）」** を表示する。

## 関連 Issue

親 Issue #3470（Phase 3）

## 変更種別

- [x] 新規機能

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ 80% 以上を維持）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- core `ageha.test.ts`: id / displayName / `voiceConfig.provider === 'openai'` / `voice === 'nova'` / instructions 有り / preferences 非空 / license に AI 生成音声の明示を含む
- web `registry.test.ts` / `client-profiles.test.ts`: `hasCharacter('ageha')`、core 登録 id と web プロファイル id の同期、ageha の render が `placeholder`、voiceConfig が openai、プロファイル各フィールド
- オーケストレーター検証: core ビルド成功 / `tsc` クリーン / core ageha テスト 17 件通過 / web characters テスト 67 件通過 / lint・format:check クリーン（実装側報告で core 1031 件・web 383 件・カバレッジ 90.7%）

## レビューポイント

- アゲハの性格・口調・instructions の方向性（ユーザーと対話で確定済み：相棒ギャル／一人称ウチ／nova／テンション高め）。実音声は dev で聞いて微調整可能。
- クレジットの AI 生成音声開示の文言。

## スクリーンショット（該当する場合）

プレースホルダー描画（シルエット＋名前ラベル）。実画像は今後差し替え予定。dev 環境でキャラ選択 →「早瀬アゲハ」選択で確認可能。

## 補足事項

これで親 Issue #3470 の Phase 1〜3 が出揃う。integration → develop の PR は人の確認を得てから別途作成する。

---
_Generated by [Claude Code](https://claude.ai/code/session_011zBgQhzZhaQX3jUVUcBbPp)_