### PR TITLE
リブトーク: 規約・プライバシー・同意の「桃瀬ひより」表記を AI キャラクターに一般化（#3470）

### DIFF
--- a/services/livetalk/web/src/components/ConsentModal.tsx
+++ b/services/livetalk/web/src/components/ConsentModal.tsx
@@ -63,7 +63,7 @@ export default function ConsentModal({ open, onConsented }: ConsentModalProps) {
 
       <DialogContent>
         <Typography variant="body2" sx={{ mb: 3 }}>
-          AI キャラクター「桃瀬ひより」との会話サービスを始める前に、以下をご確認ください。
+          AI キャラクターとの会話サービスを始める前に、以下をご確認ください。
         </Typography>
 
         <Box

--- a/services/livetalk/web/src/lib/legal/privacy-data.ts
+++ b/services/livetalk/web/src/lib/legal/privacy-data.ts
@@ -43,7 +43,7 @@ export const liveTalkPrivacySections: PolicySection[] = [
             subContent: '会話履歴',
             subItems: [
               'ユーザーが入力したテキストメッセージ',
-              'AI キャラクター「桃瀬ひより」からの返答テキスト',
+              'AI キャラクターからの返答テキスト',
               'メッセージの送受信日時',
             ],
           },

--- a/services/livetalk/web/src/lib/legal/terms-data.ts
+++ b/services/livetalk/web/src/lib/legal/terms-data.ts
@@ -26,7 +26,7 @@ export const liveTalkTermsSections: TermSection[] = [
     contents: [
       {
         mainContent:
-          'リブトーク（LiveTalk）は、AI キャラクター「桃瀬ひより」と音声・テキストで会話できる PWA（プログレッシブウェブアプリ）サービスです。本利用規約（以下「本規約」）は、当社が提供するリブトークの利用に関する条件を定めるものです。',
+          'リブトーク（LiveTalk）は、AI キャラクターと音声・テキストで会話できる PWA（プログレッシブウェブアプリ）サービスです。本利用規約（以下「本規約」）は、当社が提供するリブトークの利用に関する条件を定めるものです。',
       },
       {
         mainContent:
@@ -83,7 +83,7 @@ export const liveTalkTermsSections: TermSection[] = [
     contents: [
       {
         mainContent:
-          '「桃瀬ひより」は AI によって動作するキャラクターです。ユーザーとの会話は、大規模言語モデル（LLM）を用いて生成されており、実在の人物ではありません。',
+          '本サービスに登場する AI キャラクターは、AI によって動作するキャラクターです。ユーザーとの会話は、大規模言語モデル（LLM）を用いて生成されており、実在の人物ではありません。',
       },
       {
         mainContent:


### PR DESCRIPTION
## 変更の概要

利用規約・プライバシーポリシー・同意モーダルの本文で、サービスを「桃瀬ひより」1 キャラに固定していた記述を、複数キャラ運用（早瀬アゲハ追加）に合わせて **「AI キャラクター」へ一般化**する。

一般化した 4 箇所:
- `lib/legal/terms-data.ts`（サービス概要）: 「AIキャラクター**「桃瀬ひより」**と音声・テキストで…」→「AI キャラクターと音声・テキストで…」
- `lib/legal/terms-data.ts`（AI の性質）: 「**「桃瀬ひより」**は AI によって動作する…」→「本サービスに登場する AI キャラクターは、AI によって動作する…」
- `lib/legal/privacy-data.ts`（取得データ）: 「AIキャラクター**「桃瀬ひより」**からの返答テキスト」→「AI キャラクターからの返答テキスト」
- `components/ConsentModal.tsx`（導入文）: 「AIキャラクター**「桃瀬ひより」**との会話サービスを…」→「AI キャラクターとの会話サービスを…」

### 不変にしたもの（意図的）
- **バージョン定数**: `LIVETALK_TERMS_VERSION` / `LIVETALK_PRIVACY_VERSION`（1.0.0）は据え置き。実質改定ではない文言の一般化のため**再同意は発生させない**（現状ユーザーは権限保有者のみで、権利を狭める変更でもない）。将来の本改定時は版を上げれば既存ユーザーへ再同意モーダルが自動再表示される仕組みが既にある（`isConsentValid` がバージョン一致で判定）。
- **ひより固有クレジット**: `LIVETALK_LICENSE_TEXT`（VOICEVOX 冥鳴ひまり / Live2D 桃瀬ひより ©2010 Live2D Inc.）は素材の権利表記なので変更しない。

## 関連 Issue

親 Issue #3470（dev フィードバック反映 / 法務文言の複数キャラ対応）

## 変更種別

- [x] ドキュメント更新（規約・プライバシー・同意の文言）

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（該当文言を assert するテストは存在せず、更新不要を確認）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- 文言変更のみ（規約/プライバシー/同意本文）。これらを assert する専用テストは存在しないことを確認（`LIVETALK_LICENSE_TEXT` を検証するテストは対象外として不変）。
- オーケストレーター検証: 差分は 3 ファイル 4 行のみ／版定数・LICENSE_TEXT に差分なし／web 全テスト 409 件通過（実装側報告、カバレッジ 80% 超）／format:check クリーン。

## レビューポイント

- 版据え置き（再同意なし）の判断でよいか。本改定として扱うなら版バンプに切り替え可能。
- 「本サービスに登場する AI キャラクターは…」の言い回し。

## 補足事項

dev フィードバック対応の一環。これで integration 上に Phase 1〜3 ＋ 各種修正＋法務一般化が揃う。dev 総合確認 OK 後、人の確認のうえ integration → develop（`Closes #3470`）へ。

---
_Generated by [Claude Code](https://claude.ai/code/session_011zBgQhzZhaQX3jUVUcBbPp)_