### PR TITLE
リブトーク: キャラクター選択を localStorage に永続化（遷移・リロードで保持）（#3470）

### DIFF
--- a/services/livetalk/web/src/lib/characters/CharacterContext.tsx
+++ b/services/livetalk/web/src/lib/characters/CharacterContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { getItem, setItem } from '@nagiyu/browser';
 import { DEFAULT_CLIENT_CHARACTER_ID, hasCharacterProfile } from './client-profiles';
 
 /**
@@ -38,22 +39,19 @@ const CharacterContext = createContext<CharacterContextValue | null>(null);
  *   ハイドレーション不一致を避けるため、useState 初期化子では localStorage を読まない）。
  * - マウント後に useEffect で localStorage から保存値を復元する。
  * - setCharacterId で有効な id を選択すると localStorage に保存する。
+ *
+ * localStorage アクセスは共通部品 `@nagiyu/browser` の getItem/setItem 経由で行う
+ * （SSR ガード・例外処理を共通化するため。素の localStorage を直接触らない）。
  */
 export function CharacterProvider({ children }: { children: React.ReactNode }) {
   const [characterId, setCharacterIdState] = useState<string>(DEFAULT_CLIENT_CHARACTER_ID);
 
   // マウント後（クライアントのみ）に localStorage から保存値を復元する。
-  // SSR 時は window が存在しないため typeof window ガードで保護する。
-  // プライベートモード等で localStorage へのアクセスが例外になっても落ちないよう try/catch する。
+  // getItem は SSR/未対応環境・例外時に null を返すため、ここでの追加ガードは不要。
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      const stored = localStorage.getItem(CHARACTER_STORAGE_KEY);
-      if (stored !== null && hasCharacterProfile(stored)) {
-        setCharacterIdState(stored);
-      }
-    } catch {
-      // localStorage アクセスが拒否された場合は既定値のまま継続する
+    const stored = getItem<string>(CHARACTER_STORAGE_KEY);
+    if (stored !== null && hasCharacterProfile(stored)) {
+      setCharacterIdState(stored);
     }
   }, []);
 
@@ -61,12 +59,12 @@ export function CharacterProvider({ children }: { children: React.ReactNode }) {
     // 未登録の id は無視する（状態を変えない）
     if (!hasCharacterProfile(id)) return;
     setCharacterIdState(id);
-    // 選択した id を localStorage に保存する（SSR 環境・例外時はスキップ）
-    if (typeof window === 'undefined') return;
+    // 選択した id を localStorage に保存する。
+    // setItem は容量超過等で例外を投げ得るが、選択自体は維持したいので握りつぶす。
     try {
-      localStorage.setItem(CHARACTER_STORAGE_KEY, id);
+      setItem(CHARACTER_STORAGE_KEY, id);
     } catch {
-      // localStorage への書き込みが拒否された場合はサイレントに無視する
+      // 保存失敗時も選択状態は維持する
     }
   };
 

--- a/services/livetalk/web/src/lib/characters/CharacterContext.tsx
+++ b/services/livetalk/web/src/lib/characters/CharacterContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import { DEFAULT_CLIENT_CHARACTER_ID, hasCharacterProfile } from './client-profiles';
 
 /**
@@ -9,6 +9,11 @@ import { DEFAULT_CLIENT_CHARACTER_ID, hasCharacterProfile } from './client-profi
 export const CHARACTER_CONTEXT_ERROR_MESSAGES = {
   OUTSIDE_PROVIDER: 'useCharacter は CharacterProvider の配下でのみ使用できます。',
 } as const;
+
+/**
+ * localStorage に選択キャラクター ID を保存するキー定数。
+ */
+export const CHARACTER_STORAGE_KEY = 'livetalk:selectedCharacterId';
 
 /**
  * キャラクター選択状態のコンテキスト型。
@@ -28,14 +33,41 @@ const CharacterContext = createContext<CharacterContextValue | null>(null);
 /**
  * キャラクター選択状態を提供する Provider。
  * アプリ全体をラップして useCharacter() フックを使えるようにする。
+ *
+ * - 初期値は DEFAULT_CLIENT_CHARACTER_ID（SSR・初回クライアント描画を一致させ
+ *   ハイドレーション不一致を避けるため、useState 初期化子では localStorage を読まない）。
+ * - マウント後に useEffect で localStorage から保存値を復元する。
+ * - setCharacterId で有効な id を選択すると localStorage に保存する。
  */
 export function CharacterProvider({ children }: { children: React.ReactNode }) {
   const [characterId, setCharacterIdState] = useState<string>(DEFAULT_CLIENT_CHARACTER_ID);
+
+  // マウント後（クライアントのみ）に localStorage から保存値を復元する。
+  // SSR 時は window が存在しないため typeof window ガードで保護する。
+  // プライベートモード等で localStorage へのアクセスが例外になっても落ちないよう try/catch する。
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = localStorage.getItem(CHARACTER_STORAGE_KEY);
+      if (stored !== null && hasCharacterProfile(stored)) {
+        setCharacterIdState(stored);
+      }
+    } catch {
+      // localStorage アクセスが拒否された場合は既定値のまま継続する
+    }
+  }, []);
 
   const setCharacterId = (id: string) => {
     // 未登録の id は無視する（状態を変えない）
     if (!hasCharacterProfile(id)) return;
     setCharacterIdState(id);
+    // 選択した id を localStorage に保存する（SSR 環境・例外時はスキップ）
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(CHARACTER_STORAGE_KEY, id);
+    } catch {
+      // localStorage への書き込みが拒否された場合はサイレントに無視する
+    }
   };
 
   return (

--- a/services/livetalk/web/tests/unit/lib/characters/CharacterContext.test.tsx
+++ b/services/livetalk/web/tests/unit/lib/characters/CharacterContext.test.tsx
@@ -2,12 +2,13 @@
  * CharacterContext のユニットテスト。
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   CharacterProvider,
   useCharacter,
   CHARACTER_CONTEXT_ERROR_MESSAGES,
+  CHARACTER_STORAGE_KEY,
 } from '@/lib/characters/CharacterContext';
 import { DEFAULT_CLIENT_CHARACTER_ID } from '@/lib/characters/client-profiles';
 
@@ -18,6 +19,7 @@ function TestConsumer() {
     <div>
       <span data-testid="character-id">{characterId}</span>
       <button onClick={() => setCharacterId('hiyori')}>hiyoriにする</button>
+      <button onClick={() => setCharacterId('ageha')}>agehaにする</button>
       <button onClick={() => setCharacterId('unknown_id')}>未登録にする</button>
     </div>
   );
@@ -30,14 +32,22 @@ function OutsideConsumer() {
 }
 
 describe('CharacterProvider と useCharacter', () => {
+  // 各テストの前に localStorage をクリアしてテスト間の干渉を防ぐ
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   describe('初期値', () => {
-    it('既定の characterId は DEFAULT_CLIENT_CHARACTER_ID である', () => {
+    it('既定の characterId は DEFAULT_CLIENT_CHARACTER_ID である', async () => {
       render(
         <CharacterProvider>
           <TestConsumer />
         </CharacterProvider>
       );
-      expect(screen.getByTestId('character-id').textContent).toBe(DEFAULT_CLIENT_CHARACTER_ID);
+      // useEffect による復元後も localStorage が空なら既定値のまま
+      await waitFor(() => {
+        expect(screen.getByTestId('character-id').textContent).toBe(DEFAULT_CLIENT_CHARACTER_ID);
+      });
     });
   });
 
@@ -60,10 +70,116 @@ describe('CharacterProvider と useCharacter', () => {
           <TestConsumer />
         </CharacterProvider>
       );
+      await waitFor(() => {
+        expect(screen.getByTestId('character-id').textContent).toBe(DEFAULT_CLIENT_CHARACTER_ID);
+      });
       const before = screen.getByTestId('character-id').textContent;
       await user.click(screen.getByRole('button', { name: '未登録にする' }));
       // 状態が変わっていないことを確認
       expect(screen.getByTestId('character-id').textContent).toBe(before);
+    });
+  });
+
+  describe('localStorage への保存', () => {
+    it('setCharacterId で有効な id を指定すると localStorage に保存される', async () => {
+      const user = userEvent.setup();
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+      await user.click(screen.getByRole('button', { name: 'agehaにする' }));
+      expect(localStorage.getItem(CHARACTER_STORAGE_KEY)).toBe('ageha');
+    });
+
+    it('未登録の id を setCharacterId に渡しても localStorage に保存されない', async () => {
+      const user = userEvent.setup();
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+      await user.click(screen.getByRole('button', { name: '未登録にする' }));
+      expect(localStorage.getItem(CHARACTER_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe('localStorage からの復元', () => {
+    it('有効な id が localStorage に保存されている場合、マウント時に復元される', async () => {
+      // 事前に有効な id を localStorage に設定
+      localStorage.setItem(CHARACTER_STORAGE_KEY, 'ageha');
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+      // useEffect による非同期復元を待つ
+      await waitFor(() => {
+        expect(screen.getByTestId('character-id').textContent).toBe('ageha');
+      });
+    });
+
+    it('localStorage に無効・未登録の id が入っている場合は既定値にフォールバックする', async () => {
+      localStorage.setItem(CHARACTER_STORAGE_KEY, 'invalid_character_id');
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('character-id').textContent).toBe(DEFAULT_CLIENT_CHARACTER_ID);
+      });
+    });
+
+    it('localStorage の値が null（未設定）の場合は既定値のまま', async () => {
+      // localStorage には何も設定しない
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('character-id').textContent).toBe(DEFAULT_CLIENT_CHARACTER_ID);
+      });
+    });
+  });
+
+  describe('localStorage アクセスエラー時の安全動作', () => {
+    it('localStorage.getItem が例外をスローしても既定値で動作を継続する', async () => {
+      const getItemSpy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('localStorage へのアクセスが拒否されました');
+      });
+
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('character-id').textContent).toBe(DEFAULT_CLIENT_CHARACTER_ID);
+      });
+
+      getItemSpy.mockRestore();
+    });
+
+    it('localStorage.setItem が例外をスローしても状態更新は正常に行われる', async () => {
+      const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('localStorage への書き込みが拒否されました');
+      });
+      const user = userEvent.setup();
+
+      render(
+        <CharacterProvider>
+          <TestConsumer />
+        </CharacterProvider>
+      );
+
+      // 例外が発生しても状態更新は正常に完了する
+      await user.click(screen.getByRole('button', { name: 'agehaにする' }));
+      expect(screen.getByTestId('character-id').textContent).toBe('ageha');
+
+      setItemSpy.mockRestore();
     });
   });
 
@@ -81,6 +197,12 @@ describe('CharacterProvider と useCharacter', () => {
 
     it('エラーメッセージ定数は日本語を含む', () => {
       expect(CHARACTER_CONTEXT_ERROR_MESSAGES.OUTSIDE_PROVIDER).toMatch(/[ぁ-ん]/);
+    });
+  });
+
+  describe('CHARACTER_STORAGE_KEY 定数', () => {
+    it('CHARACTER_STORAGE_KEY が定義されている', () => {
+      expect(CHARACTER_STORAGE_KEY).toBe('livetalk:selectedCharacterId');
     });
   });
 });


### PR DESCRIPTION
## 変更の概要

キャラクター選択がページ遷移・リロードをまたいで保持されない不具合を修正する。

### 原因
- `@nagiyu/ui` の `Link` は素の `<a>`（フルページリロード）。ホームのフッターから `/memory`・`/notes` へ遷移するとページ全体が再読み込みされる。
- `CharacterContext` は `useState`（既定 hiyori）の**揮発性**で永続化していなかったため、リロードのたびに hiyori に戻り、`/memory`・`/notes` が常に hiyori で問い合わせていた。
- ※ DynamoDB のデータ自体はキャラ別に正しく分離されている（dev で確認済み。アゲハは新規のため記憶・ノートがまだ無いのが正しい状態）。UI が誤った characterId を送っていただけ。

### 修正
- `CharacterContext` で選択キャラ ID を **localStorage に永続化**し、`CharacterProvider` 起動時に復元する。
  - `CHARACTER_STORAGE_KEY = 'livetalk:selectedCharacterId'`
  - **SSR セーフ**: `useState` 初期値は既定キャラのまま（ハイドレーション不一致回避）、マウント後の `useEffect` で localStorage から復元
  - `setCharacterId` で有効な id 選択時に保存（`hasCharacterProfile` で検証、未登録は無視）
  - `typeof window` ガード ＋ `getItem`/`setItem` を try/catch（プライベートモード等で例外でも既定値で継続）

これで遷移・リロード後も選択が保持され、`/memory`・`/notes` が選択キャラで問い合わせる。

## 関連 Issue

親 Issue #3470（dev フィードバック反映 / キャラ選択の永続化）

## 変更種別

- [x] バグ修正

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ 80% 以上を維持）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `setCharacterId` 後に localStorage へ保存／未登録 id は保存しない
- localStorage に有効な id がある状態でマウントすると復元される／無効・未登録はフォールバック
- `getItem`/`setItem` 例外時も既定値・状態更新が壊れない
- オーケストレーター検証: CharacterContext テスト 13 件通過 / web 全 417 件（実装側報告、カバレッジ 80% 超）/ tsc・lint・format:check クリーン

## レビューポイント

- SSR セーフな復元（初期値=既定、useEffect で localStorage 復元）の方針。
- フッター `<Link>` のフルリロード自体は据え置き（永続化で不具合は解消。クライアント遷移化は別途の UX 改善余地）。

## 補足事項

dev フィードバック対応。次に「ステータスページ＋ホームのアバター生活サイクル（/api/lifecycle）のキャラ別化」を別 PR で予定。

---
_Generated by [Claude Code](https://claude.ai/code/session_011zBgQhzZhaQX3jUVUcBbPp)_