### PR TITLE
[Feature] 予測精度: 閾値可変・再集計（生 ActualReturn からの再計算）

### DIFF
--- a/services/stock-tracker/core/src/services/prediction-aggregator.ts
+++ b/services/stock-tracker/core/src/services/prediction-aggregator.ts
@@ -16,6 +16,7 @@
 
 import type { DailySummaryEntity } from '../entities/daily-summary.entity.js';
 import type { AiAnalysisResult, InvestmentSignal } from '../ai-analysis-result.js';
+import { classifyHit } from './prediction-judger.js';
 
 /**
  * 採点済み DailySummary 型（Evaluation* と AiAnalysisResult が埋まっていることを保証）
@@ -37,6 +38,11 @@ export type EvaluatedDailySummary = DailySummaryEntity & {
  */
 export interface AggregateInput {
   evaluated: EvaluatedDailySummary[];
+  /**
+   * Hit 再計算に使う閾値 (%)。省略時は 0.5（後方互換）。
+   * 保存済みの `Hit` フィールドは使用せず、`ActualReturn` から再計算する。
+   */
+  thresholdPercent?: number;
 }
 
 /**
@@ -64,6 +70,8 @@ export interface AggregateOutput {
     /** その日の判定済み件数（NEUTRAL を含む） */
     judgedCount: number;
   }>;
+  /** 集計に使用した閾値 (%) */
+  thresholdPercent: number;
 }
 
 /**
@@ -71,13 +79,21 @@ export interface AggregateOutput {
  */
 const SIGNAL_ORDER: readonly InvestmentSignal[] = ['BULLISH', 'NEUTRAL', 'BEARISH'];
 
+/** Hit 再計算に使うデフォルト閾値 (%) */
+const DEFAULT_THRESHOLD_PERCENT = 0.5;
+
 /**
  * 採点済み DailySummary 配列を集計する。
  *
+ * 保存済みの `Hit` フィールドは使用せず、`ActualReturn` と `thresholdPercent` から
+ * `classifyHit` で Hit を再計算する。`thresholdPercent` 省略時は 0.5（後方互換）。
+ *
  * @param input - 集計入力
- * @returns KPI / bySignal / dailyTrend を含む集計結果
+ * @returns KPI / bySignal / dailyTrend / thresholdPercent を含む集計結果
  */
 export function aggregateEvaluatedSummaries(input: AggregateInput): AggregateOutput {
+  const thresholdPercent = input.thresholdPercent ?? DEFAULT_THRESHOLD_PERCENT;
+
   // 防御的フィルタ：AiAnalysisError ありや AiAnalysisResult 不在を除外
   const evaluated = input.evaluated.filter(
     (summary) => summary.AiAnalysisResult !== undefined && summary.AiAnalysisError === undefined
@@ -86,7 +102,8 @@ export function aggregateEvaluatedSummaries(input: AggregateInput): AggregateOut
   const judgedCount = evaluated.length;
 
   // KPI: totalAccuracy
-  const totalAccuracy = judgedCount === 0 ? null : toPercent(countHits(evaluated), judgedCount);
+  const totalAccuracy =
+    judgedCount === 0 ? null : toPercent(countHits(evaluated, thresholdPercent), judgedCount);
 
   // KPI: directionalAccuracy
   const directional = evaluated.filter(
@@ -95,7 +112,9 @@ export function aggregateEvaluatedSummaries(input: AggregateInput): AggregateOut
       summary.AiAnalysisResult.investmentJudgment.signal === 'BEARISH'
   );
   const directionalAccuracy =
-    directional.length === 0 ? null : toPercent(countHits(directional), directional.length);
+    directional.length === 0
+      ? null
+      : toPercent(countHits(directional, thresholdPercent), directional.length);
 
   // bySignal
   const bySignal = SIGNAL_ORDER.map((signal) => {
@@ -104,7 +123,8 @@ export function aggregateEvaluatedSummaries(input: AggregateInput): AggregateOut
     );
     return {
       signal,
-      accuracy: subset.length === 0 ? null : toPercent(countHits(subset), subset.length),
+      accuracy:
+        subset.length === 0 ? null : toPercent(countHits(subset, thresholdPercent), subset.length),
       count: subset.length,
     };
   });
@@ -132,7 +152,10 @@ export function aggregateEvaluatedSummaries(input: AggregateInput): AggregateOut
         directionalAccuracy:
           directionalSubset.length === 0
             ? null
-            : toPercent(countHits(directionalSubset), directionalSubset.length),
+            : toPercent(
+                countHits(directionalSubset, thresholdPercent),
+                directionalSubset.length
+              ),
         judgedCount: list.length,
       };
     })
@@ -146,11 +169,27 @@ export function aggregateEvaluatedSummaries(input: AggregateInput): AggregateOut
     },
     bySignal,
     dailyTrend,
+    thresholdPercent,
   };
 }
 
-function countHits(summaries: EvaluatedDailySummary[]): number {
-  return summaries.reduce((acc, summary) => acc + (summary.Hit ? 1 : 0), 0);
+/**
+ * `classifyHit` を使って Hit 数を数える。
+ * 保存済みの `Hit` フィールドは参照しない。
+ */
+function countHits(summaries: EvaluatedDailySummary[], thresholdPercent: number): number {
+  return summaries.reduce(
+    (acc, summary) =>
+      acc +
+      (classifyHit(
+        summary.AiAnalysisResult.investmentJudgment.signal,
+        summary.ActualReturn,
+        thresholdPercent
+      )
+        ? 1
+        : 0),
+    0
+  );
 }
 
 /**

--- a/services/stock-tracker/core/src/services/prediction-aggregator.ts
+++ b/services/stock-tracker/core/src/services/prediction-aggregator.ts
@@ -152,10 +152,7 @@ export function aggregateEvaluatedSummaries(input: AggregateInput): AggregateOut
         directionalAccuracy:
           directionalSubset.length === 0
             ? null
-            : toPercent(
-                countHits(directionalSubset, thresholdPercent),
-                directionalSubset.length
-              ),
+            : toPercent(countHits(directionalSubset, thresholdPercent), directionalSubset.length),
         judgedCount: list.length,
       };
     })

--- a/services/stock-tracker/core/src/services/prediction-judger.ts
+++ b/services/stock-tracker/core/src/services/prediction-judger.ts
@@ -52,6 +52,39 @@ export interface JudgeResult {
 }
 
 /**
+ * シグナル・実績リターン・閾値から Hit を返す純粋関数。
+ *
+ * 境界値仕様（design.md §3.4）:
+ * - BULLISH: actualReturn >= threshold（境界値を成功に含める）
+ * - BEARISH: actualReturn <= -threshold（境界値を成功に含める）
+ * - NEUTRAL: -threshold < actualReturn < +threshold（境界値は方向側に分類）
+ *
+ * @param signal - 投資判断シグナル
+ * @param actualReturn - 実績リターン (%)
+ * @param thresholdPercent - Hit 判定閾値 (%)。正の有限数であること
+ * @returns Hit 判定
+ * @throws Error - signal が不正な場合
+ */
+export function classifyHit(
+  signal: InvestmentSignal,
+  actualReturn: number,
+  thresholdPercent: number
+): boolean {
+  switch (signal) {
+    case 'BULLISH':
+      return actualReturn >= thresholdPercent;
+    case 'BEARISH':
+      return actualReturn <= -thresholdPercent;
+    case 'NEUTRAL':
+      return actualReturn > -thresholdPercent && actualReturn < thresholdPercent;
+    default: {
+      const exhaustive: never = signal;
+      throw new Error(`${PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_SIGNAL}: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
  * 投資判断シグナルと翌営業日終値リターンから Hit / Miss を判定する。
  *
  * @param input - 判定入力
@@ -79,22 +112,7 @@ export function judgePrediction(input: JudgeInput): JudgeResult {
 
   const actualReturn = ((evaluationClose - baseClose) / baseClose) * 100;
 
-  let hit: boolean;
-  switch (signal) {
-    case 'BULLISH':
-      hit = actualReturn >= thresholdPercent;
-      break;
-    case 'BEARISH':
-      hit = actualReturn <= -thresholdPercent;
-      break;
-    case 'NEUTRAL':
-      hit = actualReturn > -thresholdPercent && actualReturn < thresholdPercent;
-      break;
-    default: {
-      const exhaustive: never = signal;
-      throw new Error(`${PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_SIGNAL}: ${String(exhaustive)}`);
-    }
-  }
+  const hit = classifyHit(signal, actualReturn, thresholdPercent);
 
   return { actualReturn, hit };
 }

--- a/services/stock-tracker/core/tests/unit/services/prediction-aggregator.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/prediction-aggregator.test.ts
@@ -357,7 +357,10 @@ describe('Prediction Aggregator Service', () => {
       ];
 
       const withDefault = aggregateEvaluatedSummaries({ evaluated: summaries });
-      const withExplicit = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 0.5 });
+      const withExplicit = aggregateEvaluatedSummaries({
+        evaluated: summaries,
+        thresholdPercent: 0.5,
+      });
 
       expect(withDefault.kpi).toEqual(withExplicit.kpi);
       expect(withDefault.bySignal).toEqual(withExplicit.bySignal);
@@ -374,8 +377,14 @@ describe('Prediction Aggregator Service', () => {
         makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true, actualReturn: 0.6 }),
       ];
 
-      const resultLow = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 0.5 });
-      const resultHigh = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 1.0 });
+      const resultLow = aggregateEvaluatedSummaries({
+        evaluated: summaries,
+        thresholdPercent: 0.5,
+      });
+      const resultHigh = aggregateEvaluatedSummaries({
+        evaluated: summaries,
+        thresholdPercent: 1.0,
+      });
 
       expect(resultLow.kpi.totalAccuracy).toBe(100);
       expect(resultHigh.kpi.totalAccuracy).toBe(0);
@@ -391,8 +400,14 @@ describe('Prediction Aggregator Service', () => {
         makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: true, actualReturn: 0.4 }),
       ];
 
-      const resultLow = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 0.5 });
-      const resultHigh = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 0.3 });
+      const resultLow = aggregateEvaluatedSummaries({
+        evaluated: summaries,
+        thresholdPercent: 0.5,
+      });
+      const resultHigh = aggregateEvaluatedSummaries({
+        evaluated: summaries,
+        thresholdPercent: 0.3,
+      });
 
       expect(resultLow.kpi.totalAccuracy).toBe(100);
       expect(resultHigh.kpi.totalAccuracy).toBe(0);

--- a/services/stock-tracker/core/tests/unit/services/prediction-aggregator.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/prediction-aggregator.test.ts
@@ -14,7 +14,23 @@ import type { InvestmentSignal } from '../../../src/ai-analysis-result.js';
 /**
  * テスト用の採点済み DailySummary を生成するヘルパ。
  * 不要な既存フィールドはデフォルト値で埋める。
+ *
+ * `actualReturn` は省略時、signal × hit の組み合わせに応じてデフォルト値を設定する。
+ * threshold=0.5 での classifyHit の結果が `hit` と一致するよう設計している:
+ *   - BULLISH  + hit=true  → 1.0  (>= 0.5 → Hit)
+ *   - BULLISH  + hit=false → 0.0  (< 0.5  → Miss)
+ *   - BEARISH  + hit=true  → -1.0 (<= -0.5 → Hit)
+ *   - BEARISH  + hit=false → 0.0  (> -0.5 → Miss)
+ *   - NEUTRAL  + hit=true  → 0.0  (-0.5 < 0.0 < 0.5 → Hit)
+ *   - NEUTRAL  + hit=false → 1.0  (>= 0.5 → Miss)
  */
+function defaultActualReturn(signal: InvestmentSignal, hit: boolean): number {
+  if (signal === 'BEARISH') return hit ? -1.0 : 0.0;
+  if (signal === 'NEUTRAL') return hit ? 0.0 : 1.0;
+  // BULLISH
+  return hit ? 1.0 : 0.0;
+}
+
 const makeEvaluated = (overrides: {
   tickerId?: string;
   exchangeId?: string;
@@ -32,7 +48,7 @@ const makeEvaluated = (overrides: {
   Close: 100,
   EvaluationDate: '2026-05-12',
   EvaluationClose: 101,
-  ActualReturn: overrides.actualReturn ?? (overrides.hit ? 1.0 : 0.0),
+  ActualReturn: overrides.actualReturn ?? defaultActualReturn(overrides.signal, overrides.hit),
   Hit: overrides.hit,
   EvaluationThresholdPercent: 0.5,
   EvaluatedAt: 1_715_000_000_000,
@@ -318,6 +334,73 @@ describe('Prediction Aggregator Service', () => {
 
       expect(result.kpi.judgedCount).toBe(1);
       expect(result.kpi.totalAccuracy).toBe(100);
+    });
+  });
+
+  describe('aggregateEvaluatedSummaries - thresholdPercent', () => {
+    it('出力に thresholdPercent が含まれる', () => {
+      const result = aggregateEvaluatedSummaries({ evaluated: [] });
+      expect(typeof result.thresholdPercent).toBe('number');
+    });
+
+    it('threshold 省略時は 0.5 が適用される', () => {
+      const result = aggregateEvaluatedSummaries({ evaluated: [] });
+      expect(result.thresholdPercent).toBe(0.5);
+    });
+
+    it('threshold=0.5 指定時と省略時で同じ結果を返す（後方互換）', () => {
+      // ActualReturn=1.0 は threshold=0.5 で BULLISH=Hit
+      const summaries = [
+        makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true, actualReturn: 1.0 }),
+        makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: false, actualReturn: 0.3 }),
+        makeEvaluated({ date: '2026-05-10', signal: 'BEARISH', hit: true, actualReturn: -0.7 }),
+      ];
+
+      const withDefault = aggregateEvaluatedSummaries({ evaluated: summaries });
+      const withExplicit = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 0.5 });
+
+      expect(withDefault.kpi).toEqual(withExplicit.kpi);
+      expect(withDefault.bySignal).toEqual(withExplicit.bySignal);
+      expect(withDefault.dailyTrend).toEqual(withExplicit.dailyTrend);
+      expect(withDefault.thresholdPercent).toBe(0.5);
+      expect(withExplicit.thresholdPercent).toBe(0.5);
+    });
+
+    it('threshold を変えると Hit 集計が変わる', () => {
+      // ActualReturn=0.6 のケース:
+      //   threshold=0.5 なら BULLISH は Hit（0.6 >= 0.5）
+      //   threshold=1.0 なら BULLISH は Miss（0.6 < 1.0）
+      const summaries = [
+        makeEvaluated({ date: '2026-05-10', signal: 'BULLISH', hit: true, actualReturn: 0.6 }),
+      ];
+
+      const resultLow = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 0.5 });
+      const resultHigh = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 1.0 });
+
+      expect(resultLow.kpi.totalAccuracy).toBe(100);
+      expect(resultHigh.kpi.totalAccuracy).toBe(0);
+      expect(resultLow.thresholdPercent).toBe(0.5);
+      expect(resultHigh.thresholdPercent).toBe(1.0);
+    });
+
+    it('NEUTRAL シグナルでも threshold 変更で Hit/Miss が切り替わる', () => {
+      // ActualReturn=0.4 のケース:
+      //   threshold=0.5 なら NEUTRAL は Hit（-0.5 < 0.4 < 0.5）
+      //   threshold=0.3 なら NEUTRAL は Miss（0.4 >= 0.3）
+      const summaries = [
+        makeEvaluated({ date: '2026-05-10', signal: 'NEUTRAL', hit: true, actualReturn: 0.4 }),
+      ];
+
+      const resultLow = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 0.5 });
+      const resultHigh = aggregateEvaluatedSummaries({ evaluated: summaries, thresholdPercent: 0.3 });
+
+      expect(resultLow.kpi.totalAccuracy).toBe(100);
+      expect(resultHigh.kpi.totalAccuracy).toBe(0);
+    });
+
+    it('thresholdPercent を明示指定した値が出力に反映される', () => {
+      const result = aggregateEvaluatedSummaries({ evaluated: [], thresholdPercent: 1.5 });
+      expect(result.thresholdPercent).toBe(1.5);
     });
   });
 

--- a/services/stock-tracker/core/tests/unit/services/prediction-judger.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/prediction-judger.test.ts
@@ -3,13 +3,123 @@
  *
  * 採点判定ロジックのユニットテスト。シグナル × 境界値の網羅
  * （境界値ちょうど + 内側 + 外側）と入力バリデーションをカバーする。
+ * `classifyHit` の独立テストも含む。
  */
 
 import {
   judgePrediction,
+  classifyHit,
   PREDICTION_JUDGER_ERROR_MESSAGES,
   type JudgeInput,
 } from '../../../src/services/prediction-judger.js';
+
+describe('classifyHit - 純粋 Hit 判定関数', () => {
+  describe('BULLISH（境界値: >= +threshold）', () => {
+    it('actualReturn が threshold ちょうどなら Hit', () => {
+      expect(classifyHit('BULLISH', 0.5, 0.5)).toBe(true);
+    });
+
+    it('actualReturn が threshold より大きければ Hit', () => {
+      expect(classifyHit('BULLISH', 0.51, 0.5)).toBe(true);
+    });
+
+    it('actualReturn が threshold 未満なら Miss', () => {
+      expect(classifyHit('BULLISH', 0.49, 0.5)).toBe(false);
+    });
+
+    it('threshold = 1.0 のとき actualReturn = 1.0 なら Hit', () => {
+      expect(classifyHit('BULLISH', 1.0, 1.0)).toBe(true);
+    });
+
+    it('threshold = 1.0 のとき actualReturn = 0.99 なら Miss', () => {
+      expect(classifyHit('BULLISH', 0.99, 1.0)).toBe(false);
+    });
+
+    it('actualReturn = 0 なら Miss', () => {
+      expect(classifyHit('BULLISH', 0, 0.5)).toBe(false);
+    });
+
+    it('actualReturn が負なら Miss', () => {
+      expect(classifyHit('BULLISH', -0.5, 0.5)).toBe(false);
+    });
+  });
+
+  describe('BEARISH（境界値: <= -threshold）', () => {
+    it('actualReturn が -threshold ちょうどなら Hit', () => {
+      expect(classifyHit('BEARISH', -0.5, 0.5)).toBe(true);
+    });
+
+    it('actualReturn が -threshold より小さければ Hit', () => {
+      expect(classifyHit('BEARISH', -0.51, 0.5)).toBe(true);
+    });
+
+    it('actualReturn が -threshold より大きければ Miss', () => {
+      expect(classifyHit('BEARISH', -0.49, 0.5)).toBe(false);
+    });
+
+    it('threshold = 1.0 のとき actualReturn = -1.0 なら Hit', () => {
+      expect(classifyHit('BEARISH', -1.0, 1.0)).toBe(true);
+    });
+
+    it('threshold = 1.0 のとき actualReturn = -0.99 なら Miss', () => {
+      expect(classifyHit('BEARISH', -0.99, 1.0)).toBe(false);
+    });
+
+    it('actualReturn = 0 なら Miss', () => {
+      expect(classifyHit('BEARISH', 0, 0.5)).toBe(false);
+    });
+
+    it('actualReturn が正なら Miss', () => {
+      expect(classifyHit('BEARISH', 0.5, 0.5)).toBe(false);
+    });
+  });
+
+  describe('NEUTRAL（境界値: -threshold < r < +threshold）', () => {
+    it('actualReturn = 0 なら Hit', () => {
+      expect(classifyHit('NEUTRAL', 0, 0.5)).toBe(true);
+    });
+
+    it('actualReturn が正の境界値の内側なら Hit', () => {
+      expect(classifyHit('NEUTRAL', 0.49, 0.5)).toBe(true);
+    });
+
+    it('actualReturn が負の境界値の内側なら Hit', () => {
+      expect(classifyHit('NEUTRAL', -0.49, 0.5)).toBe(true);
+    });
+
+    it('actualReturn が +threshold ちょうどなら Miss（境界値は方向側）', () => {
+      expect(classifyHit('NEUTRAL', 0.5, 0.5)).toBe(false);
+    });
+
+    it('actualReturn が -threshold ちょうどなら Miss（境界値は方向側）', () => {
+      expect(classifyHit('NEUTRAL', -0.5, 0.5)).toBe(false);
+    });
+
+    it('actualReturn が threshold より大きければ Miss', () => {
+      expect(classifyHit('NEUTRAL', 0.51, 0.5)).toBe(false);
+    });
+
+    it('actualReturn が -threshold より小さければ Miss', () => {
+      expect(classifyHit('NEUTRAL', -0.51, 0.5)).toBe(false);
+    });
+
+    it('threshold = 1.0 のとき actualReturn = 0.5 なら Hit', () => {
+      expect(classifyHit('NEUTRAL', 0.5, 1.0)).toBe(true);
+    });
+
+    it('threshold = 1.0 のとき actualReturn = 1.0 なら Miss', () => {
+      expect(classifyHit('NEUTRAL', 1.0, 1.0)).toBe(false);
+    });
+  });
+
+  describe('不正シグナル', () => {
+    it('未知のシグナル値は INVALID_SIGNAL エラー', () => {
+      expect(() => classifyHit('UNKNOWN' as 'BULLISH', 0, 0.5)).toThrow(
+        PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_SIGNAL
+      );
+    });
+  });
+});
 
 describe('Prediction Judger Service', () => {
   /**

--- a/services/stock-tracker/web/app/api/prediction-evaluation/summary/route.ts
+++ b/services/stock-tracker/web/app/api/prediction-evaluation/summary/route.ts
@@ -20,8 +20,12 @@ const EVALUATION_PERIODS = ['7d', '30d', '90d', 'all'] as const;
 
 const ERROR_MESSAGES = {
   INVALID_PERIOD: `period は ${EVALUATION_PERIODS.join(' / ')} のいずれかを指定してください`,
+  INVALID_THRESHOLD: 'threshold は正の有限な数値を指定してください',
   INTERNAL_ERROR: '予測精度サマリーの取得に失敗しました',
 } as const;
+
+/** threshold 省略時のデフォルト値 (%) */
+const DEFAULT_THRESHOLD_PERCENT = 0.5;
 
 function isEvaluationPeriod(value: string | null): value is EvaluationPeriod {
   return EVALUATION_PERIODS.includes(value as EvaluationPeriod);
@@ -74,6 +78,23 @@ export const GET = withAuth(
         );
       }
 
+      // threshold パラメータのパース・バリデーション
+      const thresholdRaw = searchParams.get('threshold');
+      let thresholdPercent = DEFAULT_THRESHOLD_PERCENT;
+      if (thresholdRaw !== null) {
+        const parsed = parseFloat(thresholdRaw);
+        if (!isFinite(parsed) || parsed <= 0) {
+          return NextResponse.json(
+            {
+              error: 'VALIDATION_ERROR',
+              message: ERROR_MESSAGES.INVALID_THRESHOLD,
+            },
+            { status: 400 }
+          );
+        }
+        thresholdPercent = parsed;
+      }
+
       const { fromDate, toDate } = resolveDateRange(period);
 
       const exchangeRepository = createExchangeRepository();
@@ -91,11 +112,12 @@ export const GET = withAuth(
 
       const evaluated = allSummaries.filter(isEvaluatedDailySummary);
 
-      const aggregated = aggregateEvaluatedSummaries({ evaluated });
+      const aggregated = aggregateEvaluatedSummaries({ evaluated, thresholdPercent });
 
       const response: SummaryResponse = {
         period,
         evaluatedAt: Date.now(),
+        threshold: aggregated.thresholdPercent,
         kpi: aggregated.kpi,
         dailyTrend: aggregated.dailyTrend,
         bySignal: aggregated.bySignal,

--- a/services/stock-tracker/web/app/prediction-evaluation/page.tsx
+++ b/services/stock-tracker/web/app/prediction-evaluation/page.tsx
@@ -6,6 +6,7 @@ import { ErrorAlert, LoadingState } from '@nagiyu/ui';
 import { useSession } from 'next-auth/react';
 import { hasPermission } from '@nagiyu/common';
 import PeriodSelector from '@/components/prediction-evaluation/PeriodSelector';
+import ThresholdSelector from '@/components/prediction-evaluation/ThresholdSelector';
 import DailyTrendChart from '@/components/prediction-evaluation/DailyTrendChart';
 import SignalAccuracyChart from '@/components/prediction-evaluation/SignalAccuracyChart';
 import { usePredictionEvaluationSummary } from '@/lib/prediction-evaluation/use-prediction-evaluation';
@@ -16,14 +17,16 @@ import {
 import type { EvaluationPeriod } from '@/lib/prediction-evaluation/types';
 
 const DEFAULT_PERIOD: EvaluationPeriod = '30d';
+const DEFAULT_THRESHOLD = 0.5;
 
 const UNAUTHORIZED_MESSAGE = '予測精度ダッシュボードを表示する権限がありません。';
 
 function PredictionEvaluationContent() {
   const { data: session, status } = useSession();
   const [period, setPeriod] = useState<EvaluationPeriod>(DEFAULT_PERIOD);
+  const [threshold, setThreshold] = useState<number>(DEFAULT_THRESHOLD);
 
-  const summary = usePredictionEvaluationSummary(period);
+  const summary = usePredictionEvaluationSummary(period, threshold);
 
   if (status === 'loading') {
     return <LoadingState message="セッション情報を確認中..." />;
@@ -63,8 +66,9 @@ function PredictionEvaluationContent() {
         </Typography>
       </Box>
 
-      <Box sx={{ mb: 3 }}>
+      <Box sx={{ mb: 3, display: 'flex', flexWrap: 'wrap', gap: 2 }}>
         <PeriodSelector value={period} onChange={setPeriod} />
+        <ThresholdSelector value={threshold} onChange={setThreshold} />
       </Box>
 
       {summary.error && <ErrorAlert message={summary.error} />}

--- a/services/stock-tracker/web/components/prediction-evaluation/ThresholdSelector.tsx
+++ b/services/stock-tracker/web/components/prediction-evaluation/ThresholdSelector.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { Select } from '@nagiyu/ui';
+
+/** 閾値プリセット一覧 (%) */
+export const THRESHOLD_PRESETS = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0] as const;
+
+export type ThresholdPreset = (typeof THRESHOLD_PRESETS)[number];
+
+/** プリセットラベル */
+const THRESHOLD_LABELS: Record<ThresholdPreset, string> = {
+  0.25: '0.25%',
+  0.5: '0.50%（デフォルト）',
+  0.75: '0.75%',
+  1.0: '1.00%',
+  1.5: '1.50%',
+  2.0: '2.00%',
+};
+
+export interface ThresholdSelectorProps {
+  /** 現在の閾値 (%) */
+  value: number;
+  /** 閾値変更時のコールバック */
+  onChange: (v: number) => void;
+}
+
+const isThresholdPreset = (value: number): value is ThresholdPreset =>
+  (THRESHOLD_PRESETS as readonly number[]).includes(value);
+
+export default function ThresholdSelector({ value, onChange }: ThresholdSelectorProps) {
+  const handleChange = (next: string) => {
+    const parsed = parseFloat(next);
+    if (isThresholdPreset(parsed)) {
+      onChange(parsed);
+    }
+  };
+
+  return (
+    <Box sx={{ minWidth: 200, maxWidth: 320 }}>
+      <Select
+        id="prediction-evaluation-threshold"
+        label="Hit 判定閾値"
+        size="sm"
+        fullWidth
+        value={String(value)}
+        onChange={handleChange}
+        options={THRESHOLD_PRESETS.map((preset) => ({
+          value: String(preset),
+          label: THRESHOLD_LABELS[preset],
+        }))}
+      />
+    </Box>
+  );
+}

--- a/services/stock-tracker/web/lib/prediction-evaluation/types.ts
+++ b/services/stock-tracker/web/lib/prediction-evaluation/types.ts
@@ -49,6 +49,8 @@ export interface SummaryResponse {
   period: EvaluationPeriod;
   /** 集計時刻（unix timestamp ms） */
   evaluatedAt: number;
+  /** 集計に使用した Hit 判定閾値 (%) */
+  threshold: number;
   kpi: KpiSummary;
   dailyTrend: DailyTrendPoint[];
   bySignal: SignalAccuracyEntry[];

--- a/services/stock-tracker/web/lib/prediction-evaluation/use-prediction-evaluation.ts
+++ b/services/stock-tracker/web/lib/prediction-evaluation/use-prediction-evaluation.ts
@@ -24,7 +24,8 @@ function resolveErrorMessage(status: number): string {
 }
 
 export function usePredictionEvaluationSummary(
-  period: EvaluationPeriod
+  period: EvaluationPeriod,
+  threshold: number = 0.5
 ): FetchState<SummaryResponse> {
   const [state, setState] = useState<FetchState<SummaryResponse>>({
     data: null,
@@ -36,7 +37,7 @@ export function usePredictionEvaluationSummary(
     const controller = new AbortController();
     setState({ data: null, loading: true, error: null });
 
-    fetch(`/api/prediction-evaluation/summary?period=${period}`, {
+    fetch(`/api/prediction-evaluation/summary?period=${period}&threshold=${threshold}`, {
       signal: controller.signal,
     })
       .then(async (res) => {
@@ -55,7 +56,7 @@ export function usePredictionEvaluationSummary(
     return () => {
       controller.abort();
     };
-  }, [period]);
+  }, [period, threshold]);
 
   return state;
 }

--- a/services/stock-tracker/web/tests/unit/app/api/prediction-evaluation/summary-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/prediction-evaluation/summary-route.test.ts
@@ -118,7 +118,9 @@ describe('GET /api/prediction-evaluation/summary', () => {
 
     it('threshold が負の値の場合は 400 を返す', async () => {
       const response = await GET(
-        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d&threshold=-0.5')
+        new NextRequest(
+          'http://localhost/api/prediction-evaluation/summary?period=30d&threshold=-0.5'
+        )
       );
       const body = await response.json();
 
@@ -128,7 +130,9 @@ describe('GET /api/prediction-evaluation/summary', () => {
 
     it('threshold が数値に変換できない文字列の場合は 400 を返す', async () => {
       const response = await GET(
-        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d&threshold=abc')
+        new NextRequest(
+          'http://localhost/api/prediction-evaluation/summary?period=30d&threshold=abc'
+        )
       );
       const body = await response.json();
 
@@ -172,7 +176,9 @@ describe('GET /api/prediction-evaluation/summary', () => {
       mockGetAllExchanges.mockResolvedValue([]);
 
       const response = await GET(
-        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d&threshold=1.0')
+        new NextRequest(
+          'http://localhost/api/prediction-evaluation/summary?period=30d&threshold=1.0'
+        )
       );
       const body = await response.json();
 

--- a/services/stock-tracker/web/tests/unit/app/api/prediction-evaluation/summary-route.test.ts
+++ b/services/stock-tracker/web/tests/unit/app/api/prediction-evaluation/summary-route.test.ts
@@ -104,6 +104,37 @@ describe('GET /api/prediction-evaluation/summary', () => {
       expect(response.status).toBe(400);
       expect(body.error).toBe('VALIDATION_ERROR');
     });
+
+    it('threshold が 0 の場合は 400 を返す', async () => {
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d&threshold=0')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('VALIDATION_ERROR');
+      expect(body.message).toContain('threshold');
+    });
+
+    it('threshold が負の値の場合は 400 を返す', async () => {
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d&threshold=-0.5')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('VALIDATION_ERROR');
+    });
+
+    it('threshold が数値に変換できない文字列の場合は 400 を返す', async () => {
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d&threshold=abc')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('VALIDATION_ERROR');
+    });
   });
 
   describe('正常系', () => {
@@ -123,6 +154,30 @@ describe('GET /api/prediction-evaluation/summary', () => {
       expect(body.kpi.totalAccuracy).toBe(100);
       expect(Array.isArray(body.dailyTrend)).toBe(true);
       expect(body.bySignal).toHaveLength(3);
+    });
+
+    it('threshold 未指定時はデフォルト 0.5 がレスポンスに含まれる', async () => {
+      mockGetAllExchanges.mockResolvedValue([]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.threshold).toBe(0.5);
+    });
+
+    it('threshold=1.0 を指定した場合はレスポンスに 1.0 が含まれる', async () => {
+      mockGetAllExchanges.mockResolvedValue([]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/prediction-evaluation/summary?period=30d&threshold=1.0')
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.threshold).toBe(1.0);
     });
 
     it('複数の取引所のデータを統合して集計する', async () => {

--- a/services/stock-tracker/web/tests/unit/components/prediction-evaluation/threshold-selector.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/prediction-evaluation/threshold-selector.test.ts
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ThresholdSelector, {
+  THRESHOLD_PRESETS,
+} from '../../../../components/prediction-evaluation/ThresholdSelector';
+
+describe('ThresholdSelector', () => {
+  it('ラベルを表示し現在の値を反映する', () => {
+    render(React.createElement(ThresholdSelector, { value: 0.5, onChange: jest.fn() }));
+    expect(screen.getByText('Hit 判定閾値')).toBeTruthy();
+    const select = screen.getByLabelText('Hit 判定閾値') as HTMLSelectElement;
+    expect(select.value).toBe('0.5');
+  });
+
+  it('値変更時に onChange が数値で呼ばれる', () => {
+    const onChange = jest.fn();
+    render(React.createElement(ThresholdSelector, { value: 0.5, onChange }));
+
+    const select = screen.getByLabelText('Hit 判定閾値') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '1' } });
+
+    expect(onChange).toHaveBeenCalledWith(1.0);
+  });
+
+  it('プリセット以外の値が来ても onChange を呼ばない', () => {
+    const onChange = jest.fn();
+    render(React.createElement(ThresholdSelector, { value: 0.5, onChange }));
+
+    const select = screen.getByLabelText('Hit 判定閾値') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '99' } });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('すべてのプリセット値（0.25 / 0.5 / 0.75 / 1.0 / 1.5 / 2.0）がオプションとして存在する', () => {
+    render(React.createElement(ThresholdSelector, { value: 0.5, onChange: jest.fn() }));
+    const select = screen.getByLabelText('Hit 判定閾値') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => parseFloat(o.value));
+
+    for (const preset of THRESHOLD_PRESETS) {
+      expect(optionValues).toContain(preset);
+    }
+  });
+
+  it('初期値として 0.25 を指定できる', () => {
+    render(React.createElement(ThresholdSelector, { value: 0.25, onChange: jest.fn() }));
+    const select = screen.getByLabelText('Hit 判定閾値') as HTMLSelectElement;
+    expect(select.value).toBe('0.25');
+  });
+
+  it('初期値として 2.0 を指定できる', () => {
+    render(React.createElement(ThresholdSelector, { value: 2.0, onChange: jest.fn() }));
+    const select = screen.getByLabelText('Hit 判定閾値') as HTMLSelectElement;
+    expect(select.value).toBe('2');
+  });
+});

--- a/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/use-prediction-evaluation-hook.test.ts
+++ b/services/stock-tracker/web/tests/unit/lib/prediction-evaluation/use-prediction-evaluation-hook.test.ts
@@ -12,6 +12,7 @@ jest.mock('next/navigation', () => ({
 const MOCK_SUMMARY: SummaryResponse = {
   period: '7d',
   evaluatedAt: 1_000_000,
+  threshold: 0.5,
   kpi: { totalAccuracy: 65.0, directionalAccuracy: 63.0, judgedCount: 40 },
   dailyTrend: [{ date: '2026-05-10', directionalAccuracy: 63.0, judgedCount: 10 }],
   bySignal: [
@@ -40,6 +41,56 @@ describe('usePredictionEvaluationSummary', () => {
     expect(result.current.loading).toBe(true);
     expect(result.current.data).toBeNull();
     expect(result.current.error).toBeNull();
+  });
+
+  it('threshold を省略した場合、クエリに threshold=0.5 が含まれる', async () => {
+    mockFetch(200);
+    renderHook(() => usePredictionEvaluationSummary('7d'));
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('threshold=0.5'),
+        expect.any(Object)
+      )
+    );
+  });
+
+  it('threshold を指定した場合、クエリに指定値が含まれる', async () => {
+    mockFetch(200);
+    renderHook(() => usePredictionEvaluationSummary('7d', 1.0));
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('threshold=1'),
+        expect.any(Object)
+      )
+    );
+  });
+
+  it('threshold 変更時に新しい URL でリクエストを送る', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce({ ...MOCK_SUMMARY, threshold: 0.5 }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce({ ...MOCK_SUMMARY, threshold: 1.0 }),
+      } as unknown as Response);
+
+    const { result, rerender } = renderHook(
+      ({ threshold }) => usePredictionEvaluationSummary('7d', threshold),
+      { initialProps: { threshold: 0.5 } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    rerender({ threshold: 1.0 });
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
   it('200 レスポンスで data が返り loading=false になる', async () => {


### PR DESCRIPTION
## 変更の概要

予測精度ダッシュボードの集計を、採点時に 0.5% で確定した保存済み `Hit` の読み出しから、**保存済みの生 `ActualReturn` と指定閾値からの再計算**に変更し、閾値を可変にした。ダッシュボードから閾値を切り替えて精度を再集計できる。

- core: Hit 判定の境界仕様を純粋関数 `classifyHit(signal, actualReturn, thresholdPercent)` に集約し、`judgePrediction` も内部でこれを使用（単一情報源化）。
- core: `aggregateEvaluatedSummaries` が `thresholdPercent`（省略時 0.5）を受け取り、`ActualReturn` から Hit を再計算。出力に適用閾値を含める。
- web API: `?threshold=` を受理（未指定は 0.5、0 以下・非有限・非数値は 400）。レスポンスに `threshold` を含める。
- web: フックに threshold 引数を追加。`ThresholdSelector`（プリセット 0.25/0.5/0.75/1.0/1.5/2.0）をダッシュボードに追加。

関連 Issue: #3480（親 #3479）

## 関連 Issue

<!-- 作業ブランチ → integration の PR では Closes を付けない（クローズは integration → develop で実施） -->
Refs #3480, #3479

## 変更種別

- [x] 新規機能
- [x] リファクタリング（`classifyHit` 抽出）

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ 80% 以上を確保）
- [ ] 関連ドキュメントを更新した（指標の意味づけ更新は子 Issue A 側でまとめて反映予定）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `classifyHit` の境界値テスト（各シグナルで閾値ちょうど・直上・直下）。
- 集計の閾値違いで Hit 集計が変わること、threshold 省略＝0.5 で従来結果と一致すること（**後方互換**）、出力に thresholdPercent が反映されること。
- API: threshold 未指定（デフォルト 0.5）・有効値・無効値（0・負・非数値）、レスポンスに threshold が含まれること。
- フック: threshold がクエリ文字列に乗ること。
- `ThresholdSelector` の表示・選択テスト。

検証（オーケストレーターによる客観確認）:
- `npm run build -w @nagiyu/stock-tracker-core` 成功
- `npm test -w @nagiyu/stock-tracker-core` 846 件全通過
- `npm test -w @nagiyu/stock-tracker-web` 234 件全通過
- `lint`（core / web）クリーン

## レビューポイント

- 集計が保存済み `Hit` を一切参照せず `ActualReturn` から再計算する設計に変わった点（採点バッチが書く `Hit` フィールドは集計では未使用になる）。
- threshold バリデーションの境界（0 以下・非有限の扱い）。
- `classifyHit` への境界仕様集約で `judgePrediction` の挙動が不変であること。

## スクリーンショット（該当する場合）

UI（閾値セレクタ追加）の dev 環境での見え方は、子 Issue A の表示更新とあわせて integration デプロイ後に確認予定。

## 補足事項

本 PR は親 Issue #3479（計測の信頼性向上）の子 B。続く子 A（#3481、指標再設計：ベースライン比較・NEUTRAL 比率）が本 PR の閾値機構の上に積まれる。Issue のクローズは integration → develop の PR で `Closes #3479 #3480 #3481` をまとめて行う方針。

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9x8AYD3aFc3McxEmRwNLz)_