### PR TITLE
リブトーク: 記憶・ノートのキャラ別取得レース修正＋説明文のキャラ追従（#3470）

### DIFF
--- a/services/livetalk/web/src/app/memory/page.tsx
+++ b/services/livetalk/web/src/app/memory/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, Box, Container, Typography } from '@mui/material';
 import type { Tier } from '@nagiyu/livetalk-core';
 import MemoryTierTabs from '@/components/MemoryTierTabs';
@@ -8,7 +8,7 @@ import MemoryList from '@/components/MemoryList';
 import MemoryDeleteDialog from '@/components/MemoryDeleteDialog';
 import type { MemoryListItem } from '@/lib/memory/types';
 import { deleteMemory, fetchMemories, pinMemory } from '@/lib/memory/api-client';
-import { MEMORY_PAGE_GUIDANCE } from '@/lib/memory/messages';
+import { getMemoryPageGuidance } from '@/lib/memory/messages';
 import { useCharacter } from '@/lib/characters/CharacterContext';
 
 /**
@@ -28,18 +28,24 @@ export default function MemoryPage() {
   const [deleting, setDeleting] = useState<MemoryListItem | null>(null);
   const [deletePending, setDeletePending] = useState(false);
 
+  // レースコンディション対策: 最新リクエストのみ state を更新する
+  const reqIdRef = useRef(0);
+
   const load = useCallback(
     async (target: Tier) => {
+      const reqId = ++reqIdRef.current;
       setLoading(true);
       setError(null);
       try {
         const items = await fetchMemories(target, characterId);
+        if (reqId !== reqIdRef.current) return; // 古いリクエストは破棄
         setMemories(items);
       } catch (e) {
+        if (reqId !== reqIdRef.current) return; // 古いリクエストは破棄
         setError(e instanceof Error ? e.message : '記憶の取得に失敗しました');
         setMemories([]);
       } finally {
-        setLoading(false);
+        if (reqId === reqIdRef.current) setLoading(false);
       }
     },
     [characterId]
@@ -83,7 +89,7 @@ export default function MemoryPage() {
         私が覚えていること
       </Typography>
       <Alert severity="info" icon={false} sx={{ mb: 2, fontSize: '0.875rem', py: 0.5 }}>
-        {MEMORY_PAGE_GUIDANCE}
+        {getMemoryPageGuidance(characterId)}
       </Alert>
 
       <MemoryTierTabs value={tier} onChange={setTier} />
@@ -107,6 +113,7 @@ export default function MemoryPage() {
         loading={deletePending}
         onConfirm={handleDeleteConfirm}
         onCancel={() => setDeleting(null)}
+        characterId={characterId}
       />
     </Container>
   );

--- a/services/livetalk/web/src/app/notes/page.tsx
+++ b/services/livetalk/web/src/app/notes/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, Box, Container, Typography } from '@mui/material';
 import { Link } from '@nagiyu/ui';
 import NoteList from '@/components/NoteList';
 import type { NoteListItem } from '@/lib/notes/types';
 import { fetchNotes } from '@/lib/notes/api-client';
-import { NOTE_PAGE_GUIDANCE } from '@/lib/notes/messages';
+import { getNotePageGuidance } from '@/lib/notes/messages';
 import { useCharacter } from '@/lib/characters/CharacterContext';
 
 /**
@@ -22,17 +22,23 @@ export default function NotesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // レースコンディション対策: 最新リクエストのみ state を更新する
+  const reqIdRef = useRef(0);
+
   const load = useCallback(async () => {
+    const reqId = ++reqIdRef.current;
     setLoading(true);
     setError(null);
     try {
       const items = await fetchNotes(characterId);
+      if (reqId !== reqIdRef.current) return; // 古いリクエストは破棄
       setNotes(items);
     } catch (e) {
+      if (reqId !== reqIdRef.current) return; // 古いリクエストは破棄
       setError(e instanceof Error ? e.message : 'ノートの取得に失敗しました');
       setNotes([]);
     } finally {
-      setLoading(false);
+      if (reqId === reqIdRef.current) setLoading(false);
     }
   }, [characterId]);
 
@@ -46,7 +52,7 @@ export default function NotesPage() {
         ノート
       </Typography>
       <Alert severity="info" icon={false} sx={{ mb: 2, fontSize: '0.875rem', py: 0.5 }}>
-        {NOTE_PAGE_GUIDANCE}
+        {getNotePageGuidance(characterId)}
       </Alert>
 
       <Box>
@@ -55,7 +61,7 @@ export default function NotesPage() {
             {error}
           </Typography>
         )}
-        <NoteList notes={notes} loading={loading} />
+        <NoteList notes={notes} loading={loading} characterId={characterId} />
       </Box>
 
       <Box sx={{ textAlign: 'center', mt: 3 }}>

--- a/services/livetalk/web/src/components/MemoryDeleteDialog.tsx
+++ b/services/livetalk/web/src/components/MemoryDeleteDialog.tsx
@@ -10,13 +10,15 @@ import {
 } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import type { MemoryListItem } from '@/lib/memory/types';
-import { MEMORY_DELETE_ANNOTATION } from '@/lib/memory/messages';
+import { getMemoryDeleteAnnotation } from '@/lib/memory/messages';
 
 export interface MemoryDeleteDialogProps {
   memory: MemoryListItem | null;
   loading?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  /** 選択中のキャラクター ID。省略時は既定キャラクターを使用する。 */
+  characterId?: string;
 }
 
 /**
@@ -30,6 +32,7 @@ export default function MemoryDeleteDialog({
   loading = false,
   onConfirm,
   onCancel,
+  characterId,
 }: MemoryDeleteDialogProps) {
   return (
     <Dialog open={memory !== null} onClose={onCancel} maxWidth="sm" fullWidth>
@@ -41,7 +44,7 @@ export default function MemoryDeleteDialog({
           </DialogContentText>
         )}
         <Alert severity="warning" data-testid="delete-annotation">
-          {MEMORY_DELETE_ANNOTATION}
+          {getMemoryDeleteAnnotation(characterId)}
         </Alert>
       </DialogContent>
       <DialogActions>

--- a/services/livetalk/web/src/components/NoteList.tsx
+++ b/services/livetalk/web/src/components/NoteList.tsx
@@ -2,18 +2,20 @@
 
 import { Box, CircularProgress, Stack, Typography } from '@mui/material';
 import type { NoteListItem } from '@/lib/notes/types';
-import { NOTE_EMPTY_MESSAGE } from '@/lib/notes/messages';
+import { getNoteEmptyMessage } from '@/lib/notes/messages';
 import NoteCard from './NoteCard';
 
 export interface NoteListProps {
   notes: NoteListItem[];
   loading: boolean;
+  /** 選択中のキャラクター ID。省略時は既定キャラクターを使用する。 */
+  characterId?: string;
 }
 
 /**
  * ノートカードの一覧表示。ローディング・空状態を内包する。
  */
-export default function NoteList({ notes, loading }: NoteListProps) {
+export default function NoteList({ notes, loading, characterId }: NoteListProps) {
   if (loading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }} data-testid="note-loading">
@@ -25,7 +27,7 @@ export default function NoteList({ notes, loading }: NoteListProps) {
   if (notes.length === 0) {
     return (
       <Box sx={{ textAlign: 'center', py: 4, color: 'text.secondary' }} data-testid="note-empty">
-        <Typography variant="body2">{NOTE_EMPTY_MESSAGE}</Typography>
+        <Typography variant="body2">{getNoteEmptyMessage(characterId)}</Typography>
       </Box>
     );
   }

--- a/services/livetalk/web/src/lib/memory/messages.ts
+++ b/services/livetalk/web/src/lib/memory/messages.ts
@@ -1,19 +1,29 @@
 /**
- * 記憶ページで使用するユーザー向け文言定数。
+ * 記憶ページで使用するユーザー向け文言生成関数。
  *
  * lib/ に集約することでカバレッジ計測対象に含めつつ、コンポーネント間で文言を統一する。
  * 「編集機能を廃止し会話による訂正に誘導する」設計方針（Issue #3308）に基づく文言。
+ * characterId を受け取り選択キャラの shortName を使うことで、キャラに追従した文言を返す。
  */
-import { getCharacterDisplay } from '@/lib/characters/client-profiles';
-
-const { shortName } = getCharacterDisplay();
-
-/** 記憶ページ冒頭に表示するガイダンス。編集 UI を廃止したためキャラへの訂正依頼を促す。 */
-export const MEMORY_PAGE_GUIDANCE = `内容を変えたい場合は、${shortName}ちゃんに話しかけて訂正してね。`;
+import { getCharacterDisplay } from '../characters/client-profiles';
 
 /**
- * 削除確認ダイアログに表示する注釈。
+ * 記憶ページ冒頭に表示するガイダンスを返す。
+ * 編集 UI を廃止したためキャラへの訂正依頼を促す。
+ * @param characterId - 対象キャラクター ID。省略時は既定キャラクターを使用する。
+ */
+export function getMemoryPageGuidance(characterId?: string): string {
+  const { shortName } = getCharacterDisplay(characterId);
+  return `内容を変えたい場合は、${shortName}ちゃんに話しかけて訂正してね。`;
+}
+
+/**
+ * 削除確認ダイアログに表示する注釈を返す。
  * MemoryEntity を削除しても MemorySummary（圧縮要約）・Messages（直近会話）には
  * 即時反映されないため、ユーザーが混乱しないよう明示する。
+ * @param characterId - 対象キャラクター ID。省略時は既定キャラクターを使用する。
  */
-export const MEMORY_DELETE_ANNOTATION = `削除しても、直近の会話や圧縮要約にはすぐ反映されないよ。完全に忘れてほしい場合は、${shortName}ちゃんに直接話しかけて訂正をお願いしてね。`;
+export function getMemoryDeleteAnnotation(characterId?: string): string {
+  const { shortName } = getCharacterDisplay(characterId);
+  return `削除しても、直近の会話や圧縮要約にはすぐ反映されないよ。完全に忘れてほしい場合は、${shortName}ちゃんに直接話しかけて訂正をお願いしてね。`;
+}

--- a/services/livetalk/web/src/lib/notes/messages.ts
+++ b/services/livetalk/web/src/lib/notes/messages.ts
@@ -1,17 +1,29 @@
 /**
- * ノートページで使用するユーザー向け文言定数。
+ * ノートページで使用するユーザー向け文言生成関数。
  *
  * lib/ に集約することでカバレッジ計測対象に含めつつ、コンポーネント間で文言を統一する。
+ * characterId を受け取り選択キャラの shortName を使うことで、キャラに追従した文言を返す。
  */
-import { getCharacterDisplay } from '@/lib/characters/client-profiles';
+import { getCharacterDisplay } from '../characters/client-profiles';
 
-const { shortName } = getCharacterDisplay();
+/**
+ * ノート一覧冒頭に表示するガイダンスを返す。
+ * 「これ、あなたのために調べたの」というプレゼント体験の文脈。
+ * @param characterId - 対象キャラクター ID。省略時は既定キャラクターを使用する。
+ */
+export function getNotePageGuidance(characterId?: string): string {
+  const { shortName } = getCharacterDisplay(characterId);
+  return `${shortName}ちゃんがあなたのために調べてまとめたノートだよ。`;
+}
 
-/** ノート一覧冒頭に表示するガイダンス。「これ、あなたのために調べたの」というプレゼント体験の文脈。 */
-export const NOTE_PAGE_GUIDANCE = `${shortName}ちゃんがあなたのために調べてまとめたノートだよ。`;
-
-/** ノートが 1 件も無いときの空状態メッセージ。 */
-export const NOTE_EMPTY_MESSAGE = `まだノートはないよ。${shortName}ちゃんがいろいろ調べてくれるのを待っててね。`;
+/**
+ * ノートが 1 件も無いときの空状態メッセージを返す。
+ * @param characterId - 対象キャラクター ID。省略時は既定キャラクターを使用する。
+ */
+export function getNoteEmptyMessage(characterId?: string): string {
+  const { shortName } = getCharacterDisplay(characterId);
+  return `まだノートはないよ。${shortName}ちゃんがいろいろ調べてくれるのを待っててね。`;
+}
 
 /**
  * createdAt（Unix ms）を日本語の日付文字列に整形する。

--- a/services/livetalk/web/tests/unit/app/memory/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/memory/page.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import MemoryPage from '@/app/memory/page';
 import { fetchMemories, deleteMemory, pinMemory } from '@/lib/memory/api-client';
 import { useCharacter } from '@/lib/characters/CharacterContext';
+import MemoryList from '@/components/MemoryList';
 
 // api-client をモック
 jest.mock('@/lib/memory/api-client', () => ({
@@ -41,15 +42,17 @@ jest.mock('@/components/MemoryDeleteDialog', () => ({
   default: jest.fn(() => null),
 }));
 
-// messages のモジュールは getCharacterDisplay を呼ぶため client-profiles 経由でモック
+// messages のモジュールは getCharacterDisplay を呼ぶため関数ごとモック
 jest.mock('@/lib/memory/messages', () => ({
-  MEMORY_PAGE_GUIDANCE: 'テストガイダンス',
+  getMemoryPageGuidance: jest.fn(() => 'テストガイダンス'),
+  getMemoryDeleteAnnotation: jest.fn(() => 'テスト注釈'),
 }));
 
 const mockFetchMemories = fetchMemories as jest.MockedFunction<typeof fetchMemories>;
 const mockDeleteMemory = deleteMemory as jest.MockedFunction<typeof deleteMemory>;
 const mockPinMemory = pinMemory as jest.MockedFunction<typeof pinMemory>;
 const mockUseCharacter = useCharacter as jest.MockedFunction<typeof useCharacter>;
+const mockMemoryList = jest.mocked(MemoryList);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -57,6 +60,10 @@ beforeEach(() => {
   mockDeleteMemory.mockResolvedValue(undefined);
   mockPinMemory.mockResolvedValue({ id: 'x', tier: 'A' } as never);
   mockUseCharacter.mockReturnValue({ characterId: 'hiyori', setCharacterId: jest.fn() });
+  // デフォルトのモック実装（loaded/loading 表示）に戻す
+  mockMemoryList.mockImplementation(({ loading }) => (
+    <div data-testid="memory-list">{loading ? 'loading' : 'loaded'}</div>
+  ));
 });
 
 describe('MemoryPage（characterId 連携）', () => {
@@ -102,5 +109,64 @@ describe('MemoryPage（characterId 連携）', () => {
       const errorAlert = alerts.find((el) => el.textContent === '記憶の取得に失敗しました');
       expect(errorAlert).toBeTruthy();
     });
+  });
+});
+
+describe('MemoryPage レースコンディション対策', () => {
+  it('古い fetch が後から解決しても最新の characterId の結果だけが反映される', async () => {
+    // hiyori の取得を遅延（解決させない Promise で制御）
+    let resolveHiyori!: (value: never[]) => void;
+    const hiyoriPromise = new Promise<never[]>((resolve) => {
+      resolveHiyori = resolve;
+    });
+
+    // MemoryList をメモリ内容を確認できる実装に差し替える
+    mockMemoryList.mockImplementation(
+      ({
+        memories,
+        loading,
+      }: {
+        memories: Array<{ id: string; content: string }>;
+        loading: boolean;
+      }) => (
+        <div data-testid="memory-list">
+          {loading ? 'loading' : memories.map((m) => <span key={m.id}>{m.content}</span>)}
+        </div>
+      )
+    );
+
+    // 1回目（hiyori）は遅延、2回目（ageha）は即時解決
+    mockFetchMemories.mockReturnValueOnce(hiyoriPromise).mockResolvedValueOnce([
+      {
+        id: 'mem-ageha-1',
+        tier: 'A',
+        category: 'test',
+        content: 'アゲハの記憶',
+        confidence: 0.9,
+        referencedCount: 0,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+
+    // まず hiyori として描画（1回目の fetch が始まる）
+    mockUseCharacter.mockReturnValue({ characterId: 'hiyori', setCharacterId: jest.fn() });
+    const { rerender } = render(<MemoryPage />);
+
+    // ageha に切り替えて再描画（2回目の fetch が始まる）
+    mockUseCharacter.mockReturnValue({ characterId: 'ageha', setCharacterId: jest.fn() });
+    rerender(<MemoryPage />);
+
+    // 2回目（ageha）が先に解決するのを待つ
+    await waitFor(() => {
+      expect(screen.getByTestId('memory-list')).toHaveTextContent('アゲハの記憶');
+    });
+
+    // 遅れて 1回目（hiyori）を解決しても画面は変わらない
+    resolveHiyori([]);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // ageha の結果が表示されたままであること
+    expect(screen.getByTestId('memory-list')).toHaveTextContent('アゲハの記憶');
   });
 });

--- a/services/livetalk/web/tests/unit/app/notes/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/notes/page.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import NotesPage from '@/app/notes/page';
 import { fetchNotes } from '@/lib/notes/api-client';
 import { useCharacter } from '@/lib/characters/CharacterContext';
+import NoteList from '@/components/NoteList';
 
 // api-client をモック
 jest.mock('@/lib/notes/api-client', () => ({
@@ -33,19 +34,25 @@ jest.mock('@nagiyu/ui', () => ({
   )),
 }));
 
-// messages のモジュールは getCharacterDisplay を呼ぶため直接モック
+// messages のモジュールは getCharacterDisplay を呼ぶため関数ごとモック
 jest.mock('@/lib/notes/messages', () => ({
-  NOTE_PAGE_GUIDANCE: 'テストノートガイダンス',
+  getNotePageGuidance: jest.fn(() => 'テストノートガイダンス'),
+  getNoteEmptyMessage: jest.fn(() => 'テスト空メッセージ'),
   formatNoteDate: jest.fn((ts: number) => String(ts)),
 }));
 
 const mockFetchNotes = fetchNotes as jest.MockedFunction<typeof fetchNotes>;
 const mockUseCharacter = useCharacter as jest.MockedFunction<typeof useCharacter>;
+const mockNoteList = jest.mocked(NoteList);
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockFetchNotes.mockResolvedValue([]);
   mockUseCharacter.mockReturnValue({ characterId: 'hiyori', setCharacterId: jest.fn() });
+  // デフォルトのモック実装（loaded/loading 表示）に戻す
+  mockNoteList.mockImplementation(({ loading }) => (
+    <div data-testid="note-list">{loading ? 'loading' : 'loaded'}</div>
+  ));
 });
 
 describe('NotesPage（characterId 連携）', () => {
@@ -90,5 +97,51 @@ describe('NotesPage（characterId 連携）', () => {
       const errorAlert = alerts.find((el) => el.textContent === 'ノートの取得に失敗しました');
       expect(errorAlert).toBeTruthy();
     });
+  });
+});
+
+describe('NotesPage レースコンディション対策', () => {
+  it('古い fetch が後から解決しても最新の characterId の結果だけが反映される', async () => {
+    // hiyori の取得を遅延（解決させない Promise で制御）
+    let resolveHiyori!: (value: never[]) => void;
+    const hiyoriPromise = new Promise<never[]>((resolve) => {
+      resolveHiyori = resolve;
+    });
+
+    // NoteList をノート内容を確認できる実装に差し替える
+    mockNoteList.mockImplementation(
+      ({ notes, loading }: { notes: Array<{ id: string; title: string }>; loading: boolean }) => (
+        <div data-testid="note-list">
+          {loading ? 'loading' : notes.map((n) => <span key={n.id}>{n.title}</span>)}
+        </div>
+      )
+    );
+
+    // 1回目（hiyori）は遅延、2回目（ageha）は即時解決
+    mockFetchNotes
+      .mockReturnValueOnce(hiyoriPromise)
+      .mockResolvedValueOnce([
+        { id: 'note-ageha-1', title: 'アゲハのノート', relatedCategory: 'test', createdAt: 1 },
+      ]);
+
+    // まず hiyori として描画（1回目の fetch が始まる）
+    mockUseCharacter.mockReturnValue({ characterId: 'hiyori', setCharacterId: jest.fn() });
+    const { rerender } = render(<NotesPage />);
+
+    // ageha に切り替えて再描画（2回目の fetch が始まる）
+    mockUseCharacter.mockReturnValue({ characterId: 'ageha', setCharacterId: jest.fn() });
+    rerender(<NotesPage />);
+
+    // 2回目（ageha）が先に解決するのを待つ
+    await waitFor(() => {
+      expect(screen.getByTestId('note-list')).toHaveTextContent('アゲハのノート');
+    });
+
+    // 遅れて 1回目（hiyori）を解決しても画面は変わらない
+    resolveHiyori([]);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // ageha の結果が表示されたままであること
+    expect(screen.getByTestId('note-list')).toHaveTextContent('アゲハのノート');
   });
 });

--- a/services/livetalk/web/tests/unit/components/MemoryDeleteDialog.test.tsx
+++ b/services/livetalk/web/tests/unit/components/MemoryDeleteDialog.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import MemoryDeleteDialog from '@/components/MemoryDeleteDialog';
 import type { MemoryListItem } from '@/lib/memory/types';
-import { MEMORY_DELETE_ANNOTATION } from '@/lib/memory/messages';
+import { getMemoryDeleteAnnotation } from '@/lib/memory/messages';
 
 const memory: MemoryListItem = {
   id: 'enc-id',
@@ -25,11 +25,25 @@ describe('MemoryDeleteDialog', () => {
     expect(screen.getByText(/コーヒーが好き/)).toBeInTheDocument();
   });
 
-  it('即時反映されない旨の注釈を表示する', () => {
+  it('即時反映されない旨の注釈を表示する（既定キャラクター）', () => {
     render(<MemoryDeleteDialog memory={memory} onConfirm={jest.fn()} onCancel={jest.fn()} />);
     const annotation = screen.getByTestId('delete-annotation');
     expect(annotation).toBeInTheDocument();
-    expect(annotation).toHaveTextContent(MEMORY_DELETE_ANNOTATION);
+    expect(annotation).toHaveTextContent(getMemoryDeleteAnnotation());
+  });
+
+  it('characterId に ageha を指定するとアゲハの注釈を表示する', () => {
+    render(
+      <MemoryDeleteDialog
+        memory={memory}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+        characterId="ageha"
+      />
+    );
+    const annotation = screen.getByTestId('delete-annotation');
+    expect(annotation).toHaveTextContent(getMemoryDeleteAnnotation('ageha'));
+    expect(annotation.textContent).toContain('アゲハ');
   });
 
   it('削除ボタンクリックで onConfirm を呼ぶ', () => {

--- a/services/livetalk/web/tests/unit/lib/memory/messages.test.ts
+++ b/services/livetalk/web/tests/unit/lib/memory/messages.test.ts
@@ -1,17 +1,41 @@
-import { MEMORY_DELETE_ANNOTATION, MEMORY_PAGE_GUIDANCE } from '@/lib/memory/messages';
+import { getMemoryDeleteAnnotation, getMemoryPageGuidance } from '@/lib/memory/messages';
 
-describe('MEMORY_DELETE_ANNOTATION', () => {
+describe('getMemoryDeleteAnnotation', () => {
   it('即時反映されないことを説明する文言を含む', () => {
-    expect(MEMORY_DELETE_ANNOTATION).toContain('すぐ反映されない');
+    expect(getMemoryDeleteAnnotation()).toContain('すぐ反映されない');
   });
 
   it('会話による訂正を案内する', () => {
-    expect(MEMORY_DELETE_ANNOTATION).toContain('話しかけて');
+    expect(getMemoryDeleteAnnotation()).toContain('話しかけて');
+  });
+
+  it('characterId 未指定時は既定キャラクター（ひより）の shortName を使う', () => {
+    expect(getMemoryDeleteAnnotation()).toContain('ひより');
+  });
+
+  it('characterId に ageha を指定すると「アゲハ」を含む文言を返す', () => {
+    expect(getMemoryDeleteAnnotation('ageha')).toContain('アゲハ');
+  });
+
+  it('ageha の文言は「ひより」を含まない', () => {
+    expect(getMemoryDeleteAnnotation('ageha')).not.toContain('ひより');
   });
 });
 
-describe('MEMORY_PAGE_GUIDANCE', () => {
+describe('getMemoryPageGuidance', () => {
   it('会話での訂正を案内する', () => {
-    expect(MEMORY_PAGE_GUIDANCE).toContain('話しかけて');
+    expect(getMemoryPageGuidance()).toContain('話しかけて');
+  });
+
+  it('characterId 未指定時は既定キャラクター（ひより）の shortName を使う', () => {
+    expect(getMemoryPageGuidance()).toContain('ひより');
+  });
+
+  it('characterId に ageha を指定すると「アゲハ」を含む文言を返す', () => {
+    expect(getMemoryPageGuidance('ageha')).toContain('アゲハ');
+  });
+
+  it('ageha の文言は「ひより」を含まない', () => {
+    expect(getMemoryPageGuidance('ageha')).not.toContain('ひより');
   });
 });

--- a/services/livetalk/web/tests/unit/lib/notes/messages.test.ts
+++ b/services/livetalk/web/tests/unit/lib/notes/messages.test.ts
@@ -1,9 +1,38 @@
-import { NOTE_EMPTY_MESSAGE, NOTE_PAGE_GUIDANCE, formatNoteDate } from '@/lib/notes/messages';
+import { formatNoteDate, getNoteEmptyMessage, getNotePageGuidance } from '@/lib/notes/messages';
 
-describe('notes messages', () => {
-  it('ガイダンス文言が定義されている', () => {
-    expect(NOTE_PAGE_GUIDANCE).toContain('ノート');
-    expect(NOTE_EMPTY_MESSAGE).toContain('ノート');
+describe('getNotePageGuidance', () => {
+  it('ノートに関するガイダンス文言を含む', () => {
+    expect(getNotePageGuidance()).toContain('ノート');
+  });
+
+  it('characterId 未指定時は既定キャラクター（ひより）の shortName を使う', () => {
+    expect(getNotePageGuidance()).toContain('ひより');
+  });
+
+  it('characterId に ageha を指定すると「アゲハ」を含む文言を返す', () => {
+    expect(getNotePageGuidance('ageha')).toContain('アゲハ');
+  });
+
+  it('ageha の文言は「ひより」を含まない', () => {
+    expect(getNotePageGuidance('ageha')).not.toContain('ひより');
+  });
+});
+
+describe('getNoteEmptyMessage', () => {
+  it('ノートに関する空状態メッセージを含む', () => {
+    expect(getNoteEmptyMessage()).toContain('ノート');
+  });
+
+  it('characterId 未指定時は既定キャラクター（ひより）の shortName を使う', () => {
+    expect(getNoteEmptyMessage()).toContain('ひより');
+  });
+
+  it('characterId に ageha を指定すると「アゲハ」を含む文言を返す', () => {
+    expect(getNoteEmptyMessage('ageha')).toContain('アゲハ');
+  });
+
+  it('ageha の文言は「ひより」を含まない', () => {
+    expect(getNoteEmptyMessage('ageha')).not.toContain('ひより');
   });
 });
 


### PR DESCRIPTION
## 変更の概要

記憶（/memory）・ノート（/notes）画面の dev 不具合 2 件を修正する。

### ① キャラ別取得が不安定（レース条件）→ 修正
ページ初期描画は既定キャラ（hiyori）で取得を開始し、その直後に localStorage 復元で選択キャラ（例 ageha）へ変わって再取得する。2 つの fetch が並走し**後に解決した方が画面に反映**されるため、毎回 hiyori/ageha が入れ替わって見えていた。
- `memory/page.tsx`・`notes/page.tsx` の取得に **request id ガード**（`useRef` で採番し、最新リクエスト以外の結果は破棄）を追加。effect の二度撃ち・delete/pin 後の再取得・キャラ切替が起きても、常に最新 characterId（memory は tier も）の結果だけが反映される。

### ② 記憶/ノートの説明文が「ひよりちゃん」固定 → 修正
`lib/memory/messages.ts`・`lib/notes/messages.ts` が**モジュール読込時に一度だけ** `getCharacterDisplay()`（既定 hiyori）で文言を焼き込んでいたため、選択キャラに追従しなかった。
- 定数を **characterId を受け取る関数**に変更（`getMemoryPageGuidance` / `getMemoryDeleteAnnotation` / `getNotePageGuidance` / `getNoteEmptyMessage`）
- 消費側（`memory/page.tsx`・`notes/page.tsx`・`MemoryDeleteDialog`・`NoteList`）が選択 characterId を渡すよう更新（名前が選択キャラに追従。「アゲハちゃん」等）。トーン・文面は維持。

## 関連 Issue

親 Issue #3470（dev フィードバック反映 / 記憶・ノートのレース＋説明文）

## 変更種別

- [x] バグ修正

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ 80% 以上を維持）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- レースガード回帰テスト: 1 回目（hiyori）を遅延・2 回目（ageha）を即時解決させ、最終表示が ageha になること（古い結果が上書きしない）
- 説明文: `getMemoryPageGuidance('ageha')` 等が「アゲハ」を含む／既定で「ひより」を含む
- MemoryDeleteDialog / NoteList の characterId 経由の文言
- オーケストレーター検証: 該当スイート 36 件通過 / web 全 444 件（実装側報告、カバレッジ 91%）/ tsc・lint・format:check クリーン

## レビューポイント

- request id ガードの方式（最新リクエストのみ state 反映）。
- 文言は名前のみキャラ追従（トーンは現状の柔らかい口調のまま。キャラ別トーンは将来余地）。

## 補足事項

dev フィードバック対応。通知履歴のキャラ非依存（NotificationEvent に characterId 無し）は仕様として据え置き（自分用のため対応不要との判断）。

---
_Generated by [Claude Code](https://claude.ai/code/session_011zBgQhzZhaQX3jUVUcBbPp)_