### PR TITLE
feat(stock-tracker): AI 予測タスクを評価基準に整合（予測リターン+確信度・signal 決定的導出）

### DIFF
--- a/services/stock-tracker/batch/src/lib/openai-client.ts
+++ b/services/stock-tracker/batch/src/lib/openai-client.ts
@@ -3,6 +3,10 @@ import { zodTextFormat } from 'openai/helpers/zod';
 import { z } from 'zod';
 import { withRetry } from '@nagiyu/common';
 import type { AiAnalysisResult } from '@nagiyu/stock-tracker-core';
+import {
+  deriveSignalFromReturn,
+  PREDICTION_SIGNAL_THRESHOLD_PERCENT,
+} from '@nagiyu/stock-tracker-core';
 
 const OPENAI_MODEL = 'gpt-5-mini';
 const MAX_RETRIES = 3;
@@ -52,7 +56,8 @@ const aiAnalysisResultSchema = z.object({
   resistanceLevels: z.array(z.number()).length(3),
   relatedMarketTrend: z.string(),
   investmentJudgment: z.object({
-    signal: z.enum(['BULLISH', 'NEUTRAL', 'BEARISH']),
+    predictedReturn: z.number(),
+    confidence: z.number(),
     reason: z.string(),
   }),
 });
@@ -100,10 +105,21 @@ export async function generateAiAnalysis(
     throw new Error(ERROR_MESSAGES.INVALID_RESPONSE);
   }
 
+  const { predictedReturn, confidence, reason } = response.output_parsed.investmentJudgment;
+  const signal = deriveSignalFromReturn(predictedReturn, PREDICTION_SIGNAL_THRESHOLD_PERCENT);
+  // confidence は [0,1] にクランプ
+  const clampedConfidence = Math.min(1, Math.max(0, confidence));
+
   return {
     ...response.output_parsed,
     supportLevels: toLevelTuple(response.output_parsed.supportLevels),
     resistanceLevels: toLevelTuple(response.output_parsed.resistanceLevels),
+    investmentJudgment: {
+      signal,
+      predictedReturn,
+      confidence: clampedConfidence,
+      reason,
+    },
   };
 }
 
@@ -141,8 +157,10 @@ function createPrompt(input: AiAnalysisInput): string {
     '- supportLevels: サポートレベルの価格を3件（数値）',
     '- resistanceLevels: レジスタンスレベルの価格を3件（数値）',
     '- relatedMarketTrend: 関連する市場・セクター動向（必ずWeb検索を利用して最新情報を取得し、可能であれば決算発表・重要経済指標など直近ニュースも根拠に含める）',
-    '- investmentJudgment.signal: BULLISH / NEUTRAL / BEARISH のいずれか',
-    '- investmentJudgment.reason: 投資判断の理由',
+    '- investmentJudgment.predictedReturn: 翌営業日の終値が当日終値に対して何%変化するかの予測（数値・%）。例: +1.2 は翌営業日終値が当日比 +1.2% の予測。',
+    '- investmentJudgment.confidence: 上記予測リターンに対する確信度（0〜1 の数値、1 が最も確信が高い）。',
+    '- investmentJudgment.reason: 予測リターンと確信度の根拠。',
+    '予測対象は翌営業日の終値（当日終値からの close-to-close リターン、保有期間 1 営業日）。predictedReturn が +0.5% 以上なら強気、−0.5% 以下なら弱気、その間は中立として解釈される。',
     `ティッカーID: ${input.tickerId}`,
     `銘柄名: ${input.name}`,
     `日付: ${input.date}`,

--- a/services/stock-tracker/batch/tests/unit/lib/openai-client.test.ts
+++ b/services/stock-tracker/batch/tests/unit/lib/openai-client.test.ts
@@ -44,6 +44,18 @@ const testInput = {
   ],
 };
 
+/** predictedReturn から signal を導出したレスポンスを生成するヘルパー */
+const mockOutputParsed = (predictedReturn: number, confidence = 0.7) => ({
+  output_parsed: {
+    priceMovementAnalysis: '当日の値動き分析',
+    patternAnalysis: 'パターン分析',
+    supportLevels: [100, 99, 98],
+    resistanceLevels: [110, 111, 112],
+    relatedMarketTrend: '市場動向',
+    investmentJudgment: { predictedReturn, confidence, reason: 'テスト理由' },
+  },
+});
+
 describe('generateAiAnalysis', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -55,16 +67,7 @@ describe('generateAiAnalysis', () => {
   });
 
   it('正常系: AI解析テキストを返す', async () => {
-    mockParse.mockResolvedValue({
-      output_parsed: {
-        priceMovementAnalysis: '当日の値動き分析',
-        patternAnalysis: 'パターン分析',
-        supportLevels: [100, 99, 98],
-        resistanceLevels: [110, 111, 112],
-        relatedMarketTrend: '市場動向',
-        investmentJudgment: { signal: 'NEUTRAL', reason: '様子見' },
-      },
-    });
+    mockParse.mockResolvedValue(mockOutputParsed(0.2));
 
     const result = await generateAiAnalysis('test-api-key', testInput);
 
@@ -145,17 +148,124 @@ describe('generateAiAnalysis', () => {
     );
   });
 
-  it('出来高未設定時は当日データと過去データで "-" を出力する', async () => {
-    mockParse.mockResolvedValue({
-      output_parsed: {
-        priceMovementAnalysis: '出来高未設定の解析テキスト',
-        patternAnalysis: 'パターン分析',
-        supportLevels: [100, 99, 98],
-        resistanceLevels: [110, 111, 112],
-        relatedMarketTrend: '市場動向',
-        investmentJudgment: { signal: 'NEUTRAL', reason: '様子見' },
-      },
+  it('プロンプトに predictedReturn / confidence の指示文が含まれる', async () => {
+    mockParse.mockResolvedValue(mockOutputParsed(0.5));
+
+    await generateAiAnalysis('test-api-key', testInput);
+
+    const promptText = mockParse.mock.calls[0][0].input[0].content[0].text;
+    expect(promptText).toContain('investmentJudgment.predictedReturn');
+    expect(promptText).toContain('investmentJudgment.confidence');
+    expect(promptText).toContain('close-to-close リターン');
+    expect(promptText).toContain('+0.5% 以上なら強気');
+    // signal の直接指示が含まれていないこと
+    expect(promptText).not.toContain('investmentJudgment.signal');
+  });
+
+  describe('predictedReturn から signal が正しく導出される', () => {
+    it('predictedReturn = +1.0 → BULLISH', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(1.0));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.signal).toBe('BULLISH');
+      expect(result.investmentJudgment.predictedReturn).toBe(1.0);
     });
+
+    it('predictedReturn = +0.5（境界値）→ BULLISH', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(0.5));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.signal).toBe('BULLISH');
+    });
+
+    it('predictedReturn = +0.2 → NEUTRAL', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(0.2));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.signal).toBe('NEUTRAL');
+    });
+
+    it('predictedReturn = 0 → NEUTRAL', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(0));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.signal).toBe('NEUTRAL');
+    });
+
+    it('predictedReturn = -0.2 → NEUTRAL', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(-0.2));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.signal).toBe('NEUTRAL');
+    });
+
+    it('predictedReturn = -0.5（境界値）→ BEARISH', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(-0.5));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.signal).toBe('BEARISH');
+    });
+
+    it('predictedReturn = -1.0 → BEARISH', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(-1.0));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.signal).toBe('BEARISH');
+      expect(result.investmentJudgment.predictedReturn).toBe(-1.0);
+    });
+  });
+
+  describe('confidence のクランプ', () => {
+    it('confidence = 0.72 → そのまま 0.72', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(0.5, 0.72));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.confidence).toBe(0.72);
+    });
+
+    it('confidence = 1.5 → 1 にクランプ', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(0.5, 1.5));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.confidence).toBe(1);
+    });
+
+    it('confidence = -0.1 → 0 にクランプ', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(0.5, -0.1));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.confidence).toBe(0);
+    });
+
+    it('confidence = 0 → そのまま 0', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(0.5, 0));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.confidence).toBe(0);
+    });
+
+    it('confidence = 1 → そのまま 1', async () => {
+      mockParse.mockResolvedValue(mockOutputParsed(0.5, 1));
+
+      const result = await generateAiAnalysis('test-api-key', testInput);
+
+      expect(result.investmentJudgment.confidence).toBe(1);
+    });
+  });
+
+  it('出来高未設定時は当日データと過去データで "-" を出力する', async () => {
+    mockParse.mockResolvedValue(mockOutputParsed(0));
 
     await generateAiAnalysis('test-api-key', {
       ...testInput,
@@ -178,16 +288,7 @@ describe('generateAiAnalysis', () => {
   });
 
   it('対応形式のチャート画像がある場合は input_image を付与する', async () => {
-    mockParse.mockResolvedValue({
-      output_parsed: {
-        priceMovementAnalysis: '当日の値動き分析',
-        patternAnalysis: 'パターン分析',
-        supportLevels: [100, 99, 98],
-        resistanceLevels: [110, 111, 112],
-        relatedMarketTrend: '市場動向',
-        investmentJudgment: { signal: 'BULLISH', reason: '上昇継続' },
-      },
-    });
+    mockParse.mockResolvedValue(mockOutputParsed(1.0));
 
     await generateAiAnalysis('test-api-key', {
       ...testInput,
@@ -217,16 +318,7 @@ describe('generateAiAnalysis', () => {
   });
 
   it('非対応形式のチャート画像は input_image に含めない', async () => {
-    mockParse.mockResolvedValue({
-      output_parsed: {
-        priceMovementAnalysis: '当日の値動き分析',
-        patternAnalysis: 'パターン分析',
-        supportLevels: [100, 99, 98],
-        resistanceLevels: [110, 111, 112],
-        relatedMarketTrend: '市場動向',
-        investmentJudgment: { signal: 'BEARISH', reason: '下落リスク' },
-      },
-    });
+    mockParse.mockResolvedValue(mockOutputParsed(-1.0));
 
     await generateAiAnalysis('test-api-key', {
       ...testInput,
@@ -262,16 +354,9 @@ describe('generateAiAnalysis', () => {
   });
 
   it('リトライ: 失敗後の再試行で成功する', async () => {
-    mockParse.mockRejectedValueOnce(new Error('temporary error')).mockResolvedValue({
-      output_parsed: {
-        priceMovementAnalysis: '当日の値動き分析',
-        patternAnalysis: 'パターン分析',
-        supportLevels: [100, 99, 98],
-        resistanceLevels: [110, 111, 112],
-        relatedMarketTrend: '市場動向',
-        investmentJudgment: { signal: 'NEUTRAL', reason: '様子見' },
-      },
-    });
+    mockParse
+      .mockRejectedValueOnce(new Error('temporary error'))
+      .mockResolvedValue(mockOutputParsed(0.2));
 
     const promise = generateAiAnalysis('test-api-key', testInput);
     await jest.runAllTimersAsync();
@@ -300,7 +385,7 @@ describe('generateAiAnalysis', () => {
         supportLevels: [100, 99],
         resistanceLevels: [110, 111, 112],
         relatedMarketTrend: '市場動向',
-        investmentJudgment: { signal: 'NEUTRAL', reason: '様子見' },
+        investmentJudgment: { predictedReturn: 0.2, confidence: 0.7, reason: '様子見' },
       },
     });
 

--- a/services/stock-tracker/core/src/ai-analysis-result.ts
+++ b/services/stock-tracker/core/src/ai-analysis-result.ts
@@ -8,6 +8,10 @@ export interface AiAnalysisResult {
   relatedMarketTrend: string;
   investmentJudgment: {
     signal: InvestmentSignal;
+    /** 予測リターン (%): 翌営業日終値の当日終値比。signal はこの値から閾値で導出される */
+    predictedReturn?: number;
+    /** 確信度 (0〜1)。1 が最も確信が高い */
+    confidence?: number;
     reason: string;
   };
 }

--- a/services/stock-tracker/core/src/mappers/daily-summary.mapper.ts
+++ b/services/stock-tracker/core/src/mappers/daily-summary.mapper.ts
@@ -64,14 +64,10 @@ function isAiAnalysisResult(value: unknown): value is AiAnalysisResult {
       (investmentJudgment as Record<string, unknown>).signal as string
     ) &&
     typeof (investmentJudgment as Record<string, unknown>).reason === 'string' &&
-    (
-      (investmentJudgment as Record<string, unknown>).predictedReturn === undefined ||
-      typeof (investmentJudgment as Record<string, unknown>).predictedReturn === 'number'
-    ) &&
-    (
-      (investmentJudgment as Record<string, unknown>).confidence === undefined ||
-      typeof (investmentJudgment as Record<string, unknown>).confidence === 'number'
-    )
+    ((investmentJudgment as Record<string, unknown>).predictedReturn === undefined ||
+      typeof (investmentJudgment as Record<string, unknown>).predictedReturn === 'number') &&
+    ((investmentJudgment as Record<string, unknown>).confidence === undefined ||
+      typeof (investmentJudgment as Record<string, unknown>).confidence === 'number')
   );
 }
 

--- a/services/stock-tracker/core/src/mappers/daily-summary.mapper.ts
+++ b/services/stock-tracker/core/src/mappers/daily-summary.mapper.ts
@@ -63,7 +63,15 @@ function isAiAnalysisResult(value: unknown): value is AiAnalysisResult {
     ['BULLISH', 'NEUTRAL', 'BEARISH'].includes(
       (investmentJudgment as Record<string, unknown>).signal as string
     ) &&
-    typeof (investmentJudgment as Record<string, unknown>).reason === 'string'
+    typeof (investmentJudgment as Record<string, unknown>).reason === 'string' &&
+    (
+      (investmentJudgment as Record<string, unknown>).predictedReturn === undefined ||
+      typeof (investmentJudgment as Record<string, unknown>).predictedReturn === 'number'
+    ) &&
+    (
+      (investmentJudgment as Record<string, unknown>).confidence === undefined ||
+      typeof (investmentJudgment as Record<string, unknown>).confidence === 'number'
+    )
   );
 }
 

--- a/services/stock-tracker/core/src/services/prediction-judger.ts
+++ b/services/stock-tracker/core/src/services/prediction-judger.ts
@@ -25,7 +25,50 @@ export const PREDICTION_JUDGER_ERROR_MESSAGES = {
   INVALID_EVALUATION_CLOSE: '無効な採点終値です。採点終値は正の有限な数値である必要があります',
   INVALID_THRESHOLD: '無効な閾値です。閾値は正の有限な数値である必要があります',
   INVALID_SIGNAL: '無効な投資判断シグナルです',
+  INVALID_PREDICTED_RETURN: '無効な予測リターンです。予測リターンは有限な数値である必要があります',
 } as const;
+
+/**
+ * signal 導出に使う既定閾値 (%)
+ *
+ * 採点側の 0.5% と意味を揃えた共有閾値。
+ * predictedReturn がこの閾値以上なら BULLISH、以下（負）なら BEARISH、その間は NEUTRAL。
+ */
+export const PREDICTION_SIGNAL_THRESHOLD_PERCENT = 0.5;
+
+/**
+ * 予測リターン (%) から投資判断シグナルを決定的に導出する純粋関数。
+ *
+ * 境界値仕様（classifyHit の成功条件と揃える）:
+ * - predictedReturn >= +threshold → 'BULLISH'
+ * - predictedReturn <= -threshold → 'BEARISH'
+ * - それ以外 → 'NEUTRAL'
+ *
+ * @param predictedReturn - 翌営業日終値の当日比予測リターン (%)。有限数であること
+ * @param thresholdPercent - 閾値 (%)。正の有限数であること
+ * @returns 導出されたシグナル
+ * @throws Error - 入力値が不正な場合
+ */
+export function deriveSignalFromReturn(
+  predictedReturn: number,
+  thresholdPercent: number
+): InvestmentSignal {
+  if (typeof thresholdPercent !== 'number' || !isFinite(thresholdPercent) || thresholdPercent <= 0) {
+    throw new Error(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_THRESHOLD);
+  }
+
+  if (typeof predictedReturn !== 'number' || !isFinite(predictedReturn)) {
+    throw new Error(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_PREDICTED_RETURN);
+  }
+
+  if (predictedReturn >= thresholdPercent) {
+    return 'BULLISH';
+  }
+  if (predictedReturn <= -thresholdPercent) {
+    return 'BEARISH';
+  }
+  return 'NEUTRAL';
+}
 
 /**
  * `judgePrediction` の入力

--- a/services/stock-tracker/core/src/services/prediction-judger.ts
+++ b/services/stock-tracker/core/src/services/prediction-judger.ts
@@ -53,7 +53,11 @@ export function deriveSignalFromReturn(
   predictedReturn: number,
   thresholdPercent: number
 ): InvestmentSignal {
-  if (typeof thresholdPercent !== 'number' || !isFinite(thresholdPercent) || thresholdPercent <= 0) {
+  if (
+    typeof thresholdPercent !== 'number' ||
+    !isFinite(thresholdPercent) ||
+    thresholdPercent <= 0
+  ) {
     throw new Error(PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_THRESHOLD);
   }
 

--- a/services/stock-tracker/core/tests/unit/mappers/daily-summary.mapper.test.ts
+++ b/services/stock-tracker/core/tests/unit/mappers/daily-summary.mapper.test.ts
@@ -589,4 +589,146 @@ describe('DailySummaryMapper', () => {
       expect(convertedEntity).toEqual(entity);
     });
   });
+
+  describe('AiAnalysisResult の新フィールド（predictedReturn / confidence）', () => {
+    it('新フィールドあり: predictedReturn と confidence を含む AiAnalysisResult の round-trip', () => {
+      const aiAnalysisResultWithNewFields = {
+        priceMovementAnalysis: '当日の値動き分析',
+        patternAnalysis: 'パターン分析',
+        supportLevels: [100, 99, 98] as [number, number, number],
+        resistanceLevels: [110, 111, 112] as [number, number, number],
+        relatedMarketTrend: '関連市場動向',
+        investmentJudgment: {
+          signal: 'BULLISH' as const,
+          predictedReturn: 1.23,
+          confidence: 0.72,
+          reason: '上昇シグナルが複数点灯',
+        },
+      };
+
+      const entity: DailySummaryEntity = {
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        AiAnalysisResult: aiAnalysisResultWithNewFields,
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1708992000000,
+      };
+
+      const item = mapper.toItem(entity);
+      const convertedEntity = mapper.toEntity(item);
+
+      expect(convertedEntity.AiAnalysisResult).toEqual(aiAnalysisResultWithNewFields);
+      expect(convertedEntity.AiAnalysisResult?.investmentJudgment.predictedReturn).toBe(1.23);
+      expect(convertedEntity.AiAnalysisResult?.investmentJudgment.confidence).toBe(0.72);
+    });
+
+    it('旧レコード（新フィールドなし）の parse が成功する（後方互換）', () => {
+      const legacyAiAnalysisResult = {
+        priceMovementAnalysis: '当日の値動き分析',
+        patternAnalysis: 'パターン分析',
+        supportLevels: [100, 99, 98],
+        resistanceLevels: [110, 111, 112],
+        relatedMarketTrend: '関連市場動向',
+        investmentJudgment: {
+          signal: 'NEUTRAL',
+          reason: '様子見',
+          // predictedReturn / confidence を持たない旧レコード
+        },
+      };
+
+      const item: DynamoDBItem = {
+        PK: 'SUMMARY#NSDQ:AAPL',
+        SK: 'DATE#2026-02-27',
+        Type: 'DailySummary',
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        AiAnalysisResult: JSON.stringify(legacyAiAnalysisResult),
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1708992000000,
+      };
+
+      // エラーなしで parse できること
+      expect(() => mapper.toEntity(item)).not.toThrow();
+      const entity = mapper.toEntity(item);
+      expect(entity.AiAnalysisResult?.investmentJudgment.signal).toBe('NEUTRAL');
+      expect(entity.AiAnalysisResult?.investmentJudgment.predictedReturn).toBeUndefined();
+      expect(entity.AiAnalysisResult?.investmentJudgment.confidence).toBeUndefined();
+    });
+
+    it('predictedReturn が数値でない場合は reject される', () => {
+      const invalidAiAnalysisResult = {
+        priceMovementAnalysis: '当日の値動き分析',
+        patternAnalysis: 'パターン分析',
+        supportLevels: [100, 99, 98],
+        resistanceLevels: [110, 111, 112],
+        relatedMarketTrend: '関連市場動向',
+        investmentJudgment: {
+          signal: 'NEUTRAL',
+          predictedReturn: '1.23', // 文字列は不正
+          reason: '様子見',
+        },
+      };
+
+      const item: DynamoDBItem = {
+        PK: 'SUMMARY#NSDQ:AAPL',
+        SK: 'DATE#2026-02-27',
+        Type: 'DailySummary',
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        AiAnalysisResult: JSON.stringify(invalidAiAnalysisResult),
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1708992000000,
+      };
+
+      expect(() => mapper.toEntity(item)).toThrow();
+    });
+
+    it('confidence が数値でない場合は reject される', () => {
+      const invalidAiAnalysisResult = {
+        priceMovementAnalysis: '当日の値動き分析',
+        patternAnalysis: 'パターン分析',
+        supportLevels: [100, 99, 98],
+        resistanceLevels: [110, 111, 112],
+        relatedMarketTrend: '関連市場動向',
+        investmentJudgment: {
+          signal: 'NEUTRAL',
+          confidence: 'high', // 文字列は不正
+          reason: '様子見',
+        },
+      };
+
+      const item: DynamoDBItem = {
+        PK: 'SUMMARY#NSDQ:AAPL',
+        SK: 'DATE#2026-02-27',
+        Type: 'DailySummary',
+        TickerID: 'NSDQ:AAPL',
+        ExchangeID: 'NASDAQ',
+        Date: '2026-02-27',
+        Open: 182.15,
+        High: 183.92,
+        Low: 181.44,
+        Close: 183.31,
+        AiAnalysisResult: JSON.stringify(invalidAiAnalysisResult),
+        CreatedAt: 1708992000000,
+        UpdatedAt: 1708992000000,
+      };
+
+      expect(() => mapper.toEntity(item)).toThrow();
+    });
+  });
 });

--- a/services/stock-tracker/core/tests/unit/services/prediction-judger.test.ts
+++ b/services/stock-tracker/core/tests/unit/services/prediction-judger.test.ts
@@ -9,9 +9,115 @@
 import {
   judgePrediction,
   classifyHit,
+  deriveSignalFromReturn,
+  PREDICTION_SIGNAL_THRESHOLD_PERCENT,
   PREDICTION_JUDGER_ERROR_MESSAGES,
   type JudgeInput,
 } from '../../../src/services/prediction-judger.js';
+
+describe('PREDICTION_SIGNAL_THRESHOLD_PERCENT - 共有閾値定数', () => {
+  it('0.5 であること', () => {
+    expect(PREDICTION_SIGNAL_THRESHOLD_PERCENT).toBe(0.5);
+  });
+});
+
+describe('deriveSignalFromReturn - 予測リターンからシグナルを導出', () => {
+  describe('BULLISH（predictedReturn >= +threshold）', () => {
+    it('predictedReturn が threshold ちょうど (+0.5%) なら BULLISH', () => {
+      expect(deriveSignalFromReturn(0.5, 0.5)).toBe('BULLISH');
+    });
+
+    it('predictedReturn が threshold より大きければ BULLISH', () => {
+      expect(deriveSignalFromReturn(0.51, 0.5)).toBe('BULLISH');
+    });
+
+    it('predictedReturn が極大値でも BULLISH', () => {
+      expect(deriveSignalFromReturn(100, 0.5)).toBe('BULLISH');
+    });
+  });
+
+  describe('BEARISH（predictedReturn <= -threshold）', () => {
+    it('predictedReturn が -threshold ちょうど (-0.5%) なら BEARISH', () => {
+      expect(deriveSignalFromReturn(-0.5, 0.5)).toBe('BEARISH');
+    });
+
+    it('predictedReturn が -threshold より小さければ BEARISH', () => {
+      expect(deriveSignalFromReturn(-0.51, 0.5)).toBe('BEARISH');
+    });
+
+    it('predictedReturn が極小値でも BEARISH', () => {
+      expect(deriveSignalFromReturn(-100, 0.5)).toBe('BEARISH');
+    });
+  });
+
+  describe('NEUTRAL（-threshold < predictedReturn < +threshold）', () => {
+    it('predictedReturn = 0 なら NEUTRAL', () => {
+      expect(deriveSignalFromReturn(0, 0.5)).toBe('NEUTRAL');
+    });
+
+    it('predictedReturn が正の境界値の内側 (+0.49%) なら NEUTRAL', () => {
+      expect(deriveSignalFromReturn(0.49, 0.5)).toBe('NEUTRAL');
+    });
+
+    it('predictedReturn が負の境界値の内側 (-0.49%) なら NEUTRAL', () => {
+      expect(deriveSignalFromReturn(-0.49, 0.5)).toBe('NEUTRAL');
+    });
+
+    it('threshold = 1.0 のとき predictedReturn = 0.5 なら NEUTRAL', () => {
+      expect(deriveSignalFromReturn(0.5, 1.0)).toBe('NEUTRAL');
+    });
+  });
+
+  describe('異なる閾値', () => {
+    it('threshold = 1.0 のとき predictedReturn = 1.0 なら BULLISH', () => {
+      expect(deriveSignalFromReturn(1.0, 1.0)).toBe('BULLISH');
+    });
+
+    it('threshold = 1.0 のとき predictedReturn = -1.0 なら BEARISH', () => {
+      expect(deriveSignalFromReturn(-1.0, 1.0)).toBe('BEARISH');
+    });
+
+    it('threshold = 0.1 のとき predictedReturn = 0.05 なら NEUTRAL', () => {
+      expect(deriveSignalFromReturn(0.05, 0.1)).toBe('NEUTRAL');
+    });
+  });
+
+  describe('入力バリデーション', () => {
+    describe('thresholdPercent が不正な場合は INVALID_THRESHOLD エラー', () => {
+      it.each([0, -0.5, NaN, Infinity, -Infinity])(
+        '不正値 (%p) は INVALID_THRESHOLD エラー',
+        (value) => {
+          expect(() => deriveSignalFromReturn(1.0, value as number)).toThrow(
+            PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_THRESHOLD
+          );
+        }
+      );
+
+      it('文字列型の thresholdPercent は INVALID_THRESHOLD エラー', () => {
+        expect(() => deriveSignalFromReturn(1.0, '0.5' as unknown as number)).toThrow(
+          PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_THRESHOLD
+        );
+      });
+    });
+
+    describe('predictedReturn が不正な場合は INVALID_PREDICTED_RETURN エラー', () => {
+      it.each([NaN, Infinity, -Infinity])(
+        '不正値 (%p) は INVALID_PREDICTED_RETURN エラー',
+        (value) => {
+          expect(() => deriveSignalFromReturn(value as number, 0.5)).toThrow(
+            PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_PREDICTED_RETURN
+          );
+        }
+      );
+
+      it('文字列型の predictedReturn は INVALID_PREDICTED_RETURN エラー', () => {
+        expect(() => deriveSignalFromReturn('1.0' as unknown as number, 0.5)).toThrow(
+          PREDICTION_JUDGER_ERROR_MESSAGES.INVALID_PREDICTED_RETURN
+        );
+      });
+    });
+  });
+});
 
 describe('classifyHit - 純粋 Hit 判定関数', () => {
   describe('BULLISH（境界値: >= +threshold）', () => {

--- a/services/stock-tracker/web/components/SummaryDetailDialog.tsx
+++ b/services/stock-tracker/web/components/SummaryDetailDialog.tsx
@@ -415,23 +415,29 @@ export default function SummaryDetailDialog({
                           ]
                         }
                       </Chip>
-                      {typeof summary.aiAnalysisResult.investmentJudgment.predictedReturn === 'number' && (
+                      {typeof summary.aiAnalysisResult.investmentJudgment.predictedReturn ===
+                        'number' && (
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
                           <Typography variant="body2" color="text.secondary">
                             予測リターン:
                           </Typography>
                           <Typography variant="body2" data-testid="predicted-return">
-                            {formatPredictedReturn(summary.aiAnalysisResult.investmentJudgment.predictedReturn)}
+                            {formatPredictedReturn(
+                              summary.aiAnalysisResult.investmentJudgment.predictedReturn
+                            )}
                           </Typography>
                         </Box>
                       )}
-                      {typeof summary.aiAnalysisResult.investmentJudgment.confidence === 'number' && (
+                      {typeof summary.aiAnalysisResult.investmentJudgment.confidence ===
+                        'number' && (
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
                           <Typography variant="body2" color="text.secondary">
                             確信度:
                           </Typography>
                           <Typography variant="body2" data-testid="confidence">
-                            {formatConfidence(summary.aiAnalysisResult.investmentJudgment.confidence)}
+                            {formatConfidence(
+                              summary.aiAnalysisResult.investmentJudgment.confidence
+                            )}
                           </Typography>
                         </Box>
                       )}

--- a/services/stock-tracker/web/components/SummaryDetailDialog.tsx
+++ b/services/stock-tracker/web/components/SummaryDetailDialog.tsx
@@ -27,6 +27,7 @@ import StockChart from './StockChart';
 import type { PatternDetail, TickerSummary } from '@/types/stock';
 import type { AlertMode } from '@/types/alert';
 import { ERROR_MESSAGES } from '@/lib/error-messages';
+import { formatPredictedReturn, formatConfidence } from '@/lib/ai-analysis-format';
 
 interface SummaryDetailDialogProps {
   open: boolean;
@@ -414,6 +415,26 @@ export default function SummaryDetailDialog({
                           ]
                         }
                       </Chip>
+                      {typeof summary.aiAnalysisResult.investmentJudgment.predictedReturn === 'number' && (
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
+                          <Typography variant="body2" color="text.secondary">
+                            予測リターン:
+                          </Typography>
+                          <Typography variant="body2" data-testid="predicted-return">
+                            {formatPredictedReturn(summary.aiAnalysisResult.investmentJudgment.predictedReturn)}
+                          </Typography>
+                        </Box>
+                      )}
+                      {typeof summary.aiAnalysisResult.investmentJudgment.confidence === 'number' && (
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
+                          <Typography variant="body2" color="text.secondary">
+                            確信度:
+                          </Typography>
+                          <Typography variant="body2" data-testid="confidence">
+                            {formatConfidence(summary.aiAnalysisResult.investmentJudgment.confidence)}
+                          </Typography>
+                        </Box>
+                      )}
                       <AiAnalysisMarkdown
                         content={summary.aiAnalysisResult.investmentJudgment.reason}
                       />

--- a/services/stock-tracker/web/jest.config.ts
+++ b/services/stock-tracker/web/jest.config.ts
@@ -25,6 +25,7 @@ const config: Config = {
   collectCoverageFrom: [
     'lib/repository-factory.ts',
     'lib/percentage-helper.ts',
+    'lib/ai-analysis-format.ts',
     'lib/prediction-evaluation/**/*.ts',
     'components/prediction-evaluation/**/*.tsx',
   ],

--- a/services/stock-tracker/web/lib/ai-analysis-format.ts
+++ b/services/stock-tracker/web/lib/ai-analysis-format.ts
@@ -1,0 +1,32 @@
+/**
+ * AI 解析結果フォーマッタ
+ *
+ * 投資判断の予測リターン・確信度を表示用文字列に変換する純粋関数。
+ * UI 層から呼び出される表示ロジックを lib に分離する。
+ */
+
+/**
+ * 予測リターンを符号付き・小数2桁・% 形式の文字列にフォーマットする。
+ *
+ * @param value - 予測リターン (%)。任意の有限数を受け付ける
+ * @returns フォーマットされた文字列（例: "+1.23%", "-0.40%", "+0.00%"）
+ */
+export function formatPredictedReturn(value: number): string {
+  const formatted = Math.abs(value).toFixed(2);
+  const sign = value >= 0 ? '+' : '-';
+  return `${sign}${formatted}%`;
+}
+
+/**
+ * 確信度を整数パーセント形式の文字列にフォーマットする。
+ *
+ * [0,1] 外の値も破綻しない実装（クランプは呼び出し側で担保されている前提だが、
+ * ここでは計算のみ行い範囲外でも数値を返す）。
+ *
+ * @param value - 確信度 (0〜1)。0.72 → "72%"
+ * @returns フォーマットされた文字列（例: "72%", "0%", "100%"）
+ */
+export function formatConfidence(value: number): string {
+  const percent = Math.round(value * 100);
+  return `${percent}%`;
+}

--- a/services/stock-tracker/web/tests/unit/components/summary-detail-dialog.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/summary-detail-dialog.test.ts
@@ -1,0 +1,230 @@
+/** @jest-environment jsdom */
+/**
+ * SummaryDetailDialog - 予測リターン・確信度表示 Unit Tests
+ *
+ * 新フィールド（predictedReturn / confidence）の表示・非表示を検証する。
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+// 依存コンポーネントのモック
+jest.mock('../../../components/StockChart', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', null, 'StockChartMock'),
+}));
+
+jest.mock('../../../components/AlertSettingsModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../../../components/AiAnalysisMarkdown', () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => React.createElement('span', null, content),
+}));
+
+jest.mock('@mui/material', () => {
+  const createEl = (tag: string) => {
+    const Comp = ({ children, ...props }: Record<string, unknown>) => {
+      const { sx, ...rest } = props as { sx?: unknown } & Record<string, unknown>;
+      void sx;
+      return React.createElement(tag, rest, children as React.ReactNode);
+    };
+    Comp.displayName = `Mock_${tag}`;
+    return Comp;
+  };
+
+  return {
+    Box: createEl('div'),
+    Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+      open ? React.createElement('div', { role: 'dialog' }, children) : null,
+    DialogContent: createEl('div'),
+    DialogTitle: createEl('div'),
+    Divider: () => React.createElement('hr'),
+    IconButton: createEl('button'),
+    Menu: () => null,
+    MenuItem: createEl('li'),
+    Table: createEl('table'),
+    TableBody: createEl('tbody'),
+    TableCell: createEl('td'),
+    TableContainer: createEl('div'),
+    TableRow: createEl('tr'),
+    Tooltip: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    Typography: createEl('span'),
+  };
+});
+
+jest.mock('@nagiyu/ui', () => ({
+  Button: ({ children, ...props }: Record<string, unknown>) =>
+    React.createElement('button', props, children as React.ReactNode),
+  Chip: ({ children, ...props }: Record<string, unknown>) =>
+    React.createElement('span', props, children as React.ReactNode),
+}));
+
+jest.mock('@mui/icons-material', () => ({
+  Close: () => React.createElement('span', null, 'X'),
+}));
+
+import SummaryDetailDialog from '../../../components/SummaryDetailDialog';
+import type { TickerSummary } from '../../../types/stock';
+
+/** ベースとなる TickerSummary を生成するヘルパー */
+const buildSummary = (overrides: Partial<TickerSummary> = {}): TickerSummary => ({
+  tickerId: 'NSDQ:AAPL',
+  symbol: 'AAPL',
+  name: 'Apple Inc.',
+  open: 100,
+  high: 110,
+  low: 95,
+  close: 105,
+  volume: 1000000,
+  updatedAt: '2026-03-04T00:00:00.000Z',
+  buyPatternCount: 0,
+  sellPatternCount: 0,
+  buyAlertCount: { enabled: 0, disabled: 0 },
+  sellAlertCount: { enabled: 0, disabled: 0 },
+  patternDetails: [],
+  holding: null,
+  ...overrides,
+});
+
+describe('SummaryDetailDialog - 予測リターン・確信度の表示', () => {
+  it('predictedReturn と confidence がある場合に表示される', () => {
+    const summary = buildSummary({
+      aiAnalysisResult: {
+        priceMovementAnalysis: '値動き分析',
+        patternAnalysis: 'パターン分析',
+        supportLevels: [100, 99, 98],
+        resistanceLevels: [110, 111, 112],
+        relatedMarketTrend: '市場動向',
+        investmentJudgment: {
+          signal: 'BULLISH',
+          predictedReturn: 1.23,
+          confidence: 0.72,
+          reason: '上昇シグナル',
+        },
+      },
+    });
+
+    render(
+      React.createElement(SummaryDetailDialog, {
+        open: true,
+        summary,
+        onClose: jest.fn(),
+      })
+    );
+
+    // 予測リターンが表示されること
+    expect(screen.getByTestId('predicted-return').textContent).toBe('+1.23%');
+    // 確信度が表示されること
+    expect(screen.getByTestId('confidence').textContent).toBe('72%');
+    // ラベルが表示されること
+    expect(screen.getByText('予測リターン:')).toBeTruthy();
+    expect(screen.getByText('確信度:')).toBeTruthy();
+  });
+
+  it('predictedReturn がない旧レコードでは予測リターン行が表示されない', () => {
+    const summary = buildSummary({
+      aiAnalysisResult: {
+        priceMovementAnalysis: '値動き分析',
+        patternAnalysis: 'パターン分析',
+        supportLevels: [100, 99, 98],
+        resistanceLevels: [110, 111, 112],
+        relatedMarketTrend: '市場動向',
+        investmentJudgment: {
+          signal: 'NEUTRAL',
+          reason: '様子見',
+          // predictedReturn と confidence を持たない旧レコード
+        },
+      },
+    });
+
+    render(
+      React.createElement(SummaryDetailDialog, {
+        open: true,
+        summary,
+        onClose: jest.fn(),
+      })
+    );
+
+    // 旧レコードでは表示されないこと
+    expect(screen.queryByTestId('predicted-return')).toBeNull();
+    expect(screen.queryByTestId('confidence')).toBeNull();
+    expect(screen.queryByText('予測リターン:')).toBeNull();
+    expect(screen.queryByText('確信度:')).toBeNull();
+  });
+
+  it('aiAnalysisResult がない場合は投資判断セクション全体が非表示', () => {
+    const summary = buildSummary({ aiAnalysisResult: undefined });
+
+    render(
+      React.createElement(SummaryDetailDialog, {
+        open: true,
+        summary,
+        onClose: jest.fn(),
+      })
+    );
+
+    expect(screen.queryByTestId('predicted-return')).toBeNull();
+    expect(screen.queryByTestId('confidence')).toBeNull();
+  });
+
+  it('predictedReturn のみあって confidence がない場合は predictedReturn のみ表示', () => {
+    const summary = buildSummary({
+      aiAnalysisResult: {
+        priceMovementAnalysis: '値動き分析',
+        patternAnalysis: 'パターン分析',
+        supportLevels: [100, 99, 98],
+        resistanceLevels: [110, 111, 112],
+        relatedMarketTrend: '市場動向',
+        investmentJudgment: {
+          signal: 'BULLISH',
+          predictedReturn: 0.5,
+          reason: '上昇シグナル',
+          // confidence なし
+        },
+      },
+    });
+
+    render(
+      React.createElement(SummaryDetailDialog, {
+        open: true,
+        summary,
+        onClose: jest.fn(),
+      })
+    );
+
+    expect(screen.getByTestId('predicted-return').textContent).toBe('+0.50%');
+    expect(screen.queryByTestId('confidence')).toBeNull();
+  });
+
+  it('confidence のみあって predictedReturn がない場合は confidence のみ表示', () => {
+    const summary = buildSummary({
+      aiAnalysisResult: {
+        priceMovementAnalysis: '値動き分析',
+        patternAnalysis: 'パターン分析',
+        supportLevels: [100, 99, 98],
+        resistanceLevels: [110, 111, 112],
+        relatedMarketTrend: '市場動向',
+        investmentJudgment: {
+          signal: 'BEARISH',
+          confidence: 0.9,
+          reason: '下落シグナル',
+          // predictedReturn なし
+        },
+      },
+    });
+
+    render(
+      React.createElement(SummaryDetailDialog, {
+        open: true,
+        summary,
+        onClose: jest.fn(),
+      })
+    );
+
+    expect(screen.queryByTestId('predicted-return')).toBeNull();
+    expect(screen.getByTestId('confidence').textContent).toBe('90%');
+  });
+});

--- a/services/stock-tracker/web/tests/unit/lib/ai-analysis-format.test.ts
+++ b/services/stock-tracker/web/tests/unit/lib/ai-analysis-format.test.ts
@@ -1,0 +1,90 @@
+/**
+ * AI 解析フォーマッタ Unit Tests
+ *
+ * formatPredictedReturn / formatConfidence の動作を検証。
+ */
+
+import { formatPredictedReturn, formatConfidence } from '../../../lib/ai-analysis-format';
+
+describe('formatPredictedReturn', () => {
+  describe('正常系: 正の値', () => {
+    it('+1.23% を "+1.23%" にフォーマットする', () => {
+      expect(formatPredictedReturn(1.23)).toBe('+1.23%');
+    });
+
+    it('+0.50% を "+0.50%" にフォーマットする', () => {
+      expect(formatPredictedReturn(0.5)).toBe('+0.50%');
+    });
+
+    it('+0.00% を "+0.00%" にフォーマットする', () => {
+      expect(formatPredictedReturn(0)).toBe('+0.00%');
+    });
+
+    it('大きな正の値 +100.00% を正しくフォーマットする', () => {
+      expect(formatPredictedReturn(100)).toBe('+100.00%');
+    });
+  });
+
+  describe('正常系: 負の値', () => {
+    it('-0.40% を "-0.40%" にフォーマットする', () => {
+      expect(formatPredictedReturn(-0.4)).toBe('-0.40%');
+    });
+
+    it('-1.00% を "-1.00%" にフォーマットする', () => {
+      expect(formatPredictedReturn(-1.0)).toBe('-1.00%');
+    });
+
+    it('大きな負の値 -50.00% を正しくフォーマットする', () => {
+      expect(formatPredictedReturn(-50)).toBe('-50.00%');
+    });
+  });
+
+  describe('正常系: 小数の丸め', () => {
+    it('小数点2桁以降を四捨五入する', () => {
+      // 1.234567 → "+1.23%"（toFixed(2) の挙動）
+      expect(formatPredictedReturn(1.234567)).toBe('+1.23%');
+    });
+
+    it('0に非常に近い正の値は "+0.00%" になる', () => {
+      expect(formatPredictedReturn(0.001)).toBe('+0.00%');
+    });
+  });
+});
+
+describe('formatConfidence', () => {
+  describe('正常系: [0,1] 範囲内', () => {
+    it('0.72 → "72%"', () => {
+      expect(formatConfidence(0.72)).toBe('72%');
+    });
+
+    it('0 → "0%"', () => {
+      expect(formatConfidence(0)).toBe('0%');
+    });
+
+    it('1 → "100%"', () => {
+      expect(formatConfidence(1)).toBe('100%');
+    });
+
+    it('0.5 → "50%"', () => {
+      expect(formatConfidence(0.5)).toBe('50%');
+    });
+
+    it('0.999 → "100%"（Math.round）', () => {
+      expect(formatConfidence(0.999)).toBe('100%');
+    });
+
+    it('0.001 → "0%"（Math.round）', () => {
+      expect(formatConfidence(0.001)).toBe('0%');
+    });
+  });
+
+  describe('正常系: [0,1] 外の値でも破綻しない', () => {
+    it('1.5 → "150%"（範囲外でも計算結果を返す）', () => {
+      expect(formatConfidence(1.5)).toBe('150%');
+    });
+
+    it('-0.1 → "-10%"（範囲外でも計算結果を返す）', () => {
+      expect(formatConfidence(-0.1)).toBe('-10%');
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

AI の投資判断を「翌営業日終値の当日比リターン（%）の数値予測（`predictedReturn`）＋確信度（`confidence`）」に変更し、`signal`（BULLISH/NEUTRAL/BEARISH）を `predictedReturn` から採点と同一の閾値（0.5%）で**決定的に導出**するようにした。これにより AI が解く問いと採点で測る基準を一致させ、`signal` と `predictedReturn` を常に整合させる。プロンプトには予測対象（翌営業日 close-to-close・1 営業日保有）と帯の定義を明示した。新フィールドは任意とし既存レコードとの後方互換を維持。サマリー詳細 UI に予測リターン・確信度を表示する。

## 関連 Issue

#3492

（作業ブランチ → integration の PR のため `Closes` は付けない。Issue は integration → develop マージ後にクローズ）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（※ docs 反映は integration → develop 前に別途検討）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- core `deriveSignalFromReturn`：境界値（±0.5 ちょうど・間・極値）と不正入力（閾値・予測リターン）で 90 ケース。
- core mapper：新フィールドあり round-trip／旧レコード（新フィールド無し）の parse 成功／非 number の reject。
- batch `openai-client`：新スキーマのモックで signal 導出の妥当性（+1.0→BULLISH、0.2→NEUTRAL、−1.0→BEARISH、±0.5 境界）、confidence クランプ、プロンプト内容を検証。
- web：`formatPredictedReturn`/`formatConfidence` の単体テスト、サマリー詳細ダイアログの表示／旧レコード非表示分岐。
- ローカル実行結果：core 890 / batch 146 / web 273 すべて pass。core ビルド成功。

## レビューポイント

- **signal 導出の境界**を `classifyHit` の成功条件（BULLISH: `>= +t`、BEARISH: `<= -t`、NEUTRAL: その間）と揃えている点。これにより predictedReturn と signal、採点 Hit が一貫する。
- 新フィールドを**任意**にして既存レコードの読み取り・集計を壊さない後方互換設計（mapper 検証は存在時のみ number を要求）。
- モデル出力スキーマから `signal` を外し、コード側で決定的に導出する方針（モデルが signal と return で矛盾を出せない）。

## スクリーンショット（該当する場合）

サマリー詳細ダイアログの「投資判断」に「予測リターン」「確信度」を追加表示（新フィールドを持つレコードのみ）。dev 環境で新規予測が蓄積後に確認予定。

## 補足事項

- dev 検証ポイント：サマリー生成バッチ実行後、新規 `AiAnalysisResult` が `predictedReturn`/`confidence` を保持し、導出 signal・表示が妥当かを確認する。
- 効果（NEUTRAL 比率・方向精度の変化）は数日分の新規予測が蓄積してから #3479 の物差しで評価する。本 PR 自体は的中率を即上げる施策ではなく、問いと評価の整合が目的。

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9x8AYD3aFc3McxEmRwNLz)_