### PR TITLE
通知マルチキャラ対応 Phase C: 配信・消化（#3491）

### DIFF
--- a/services/livetalk/web/public/sw.js
+++ b/services/livetalk/web/public/sw.js
@@ -9,8 +9,9 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('push', (event) => {
+  // デフォルト文面: payload.title / payload.body が優先されるため汎用表現にする
   let data = {
-    title: 'ひよりより',
+    title: 'お知らせ',
     body: 'お知らせがあるよ',
     icon: '/icon-192x192.png',
     badge: '/icon-192x192.png',

--- a/services/livetalk/web/src/app/api/push/first-word/route.ts
+++ b/services/livetalk/web/src/app/api/push/first-word/route.ts
@@ -1,21 +1,35 @@
 /**
- * GET /api/push/first-word — 未消化の最新通知を返す。
+ * GET /api/push/first-word — 指定キャラクターの未消化の最新通知を返す。
  *
- * 起動時にキャラ第一声として表示する通知本文を返す。
- * 未消化（ConsumedAt 未設定）の最新 NotificationEvent が対象。
- * なければ 204 を返す。
+ * クエリパラメータ:
+ *   - characterId: 取得対象のキャラクター ID。
+ *     指定時: そのキャラクターの未消化最新 NotificationEvent を返す。
+ *     未指定時: キャラクター概念がないため 204 を返す（呼び出し側は必ず characterId を付与する設計）。
+ *
+ * レスポンスに characterId を含めることで、page 側でクロス汚染ガードを行える。
  */
 import { NextResponse } from 'next/server';
 import { withAuth } from '@nagiyu/nextjs';
 import { getSession } from '@/lib/server/session';
 import { getNotificationEventRepository } from '@/lib/server/repositories';
 
-export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
+export const GET = withAuth(getSession, 'livetalk:chat', async (session, request: Request) => {
+  const url = new URL(request.url);
+  const characterId = url.searchParams.get('characterId');
+
+  // characterId 未指定時は 204 を返す（呼び出し側は必ず characterId を付与する設計）
+  if (!characterId) {
+    return new NextResponse(null, { status: 204 });
+  }
+
   const userId = session.user.googleId;
   const repo = getNotificationEventRepository();
   const events = await repo.listByUser(userId, 20);
 
-  const unconsumed = events.find((e) => e.ConsumedAt === undefined);
+  // 指定キャラクターの未消化最新を返す
+  const unconsumed = events.find(
+    (e) => e.CharacterID === characterId && e.ConsumedAt === undefined
+  );
   if (!unconsumed) {
     return new NextResponse(null, { status: 204 });
   }
@@ -25,6 +39,7 @@ export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
       notifId: unconsumed.NotifID,
       body: unconsumed.Body,
       knowledgeId: unconsumed.KnowledgeID ?? null,
+      characterId: unconsumed.CharacterID,
     },
     { status: 200 }
   );

--- a/services/livetalk/web/src/app/api/push/pending/route.ts
+++ b/services/livetalk/web/src/app/api/push/pending/route.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/push/pending — 未消化通知をキャラクターごとに集約して返す。
+ *
+ * 自前起動時に「他キャラクターからの未消化通知」を提示するために使用する。
+ * 各キャラクターの最新未消化通知（1 件）を返す。
+ *
+ * レスポンス例:
+ *   [{ characterId: 'ageha', notifId: 'n1', body: 'アゲハより' }]
+ *
+ * 未消化通知がない場合は空配列を返す。
+ */
+import { NextResponse } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import { getSession } from '@/lib/server/session';
+import { getNotificationEventRepository } from '@/lib/server/repositories';
+
+/**
+ * 未消化通知の集約結果の型。
+ */
+export interface PendingNotification {
+  /** 通知元キャラクター ID */
+  characterId: string;
+  /** 通知 ID */
+  notifId: string;
+  /** 通知本文 */
+  body: string;
+}
+
+export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
+  const userId = session.user.googleId;
+  const repo = getNotificationEventRepository();
+  // 全件取得して未消化をキャラクターごとに集約する
+  // listByUser は CreatedAt 降順で返すため、最初に見つかったものが最新となる
+  const events = await repo.listByUser(userId, 100);
+
+  // 未消化イベントのみ抽出し、キャラクターごとに最新 1 件を集約する
+  const latestByCharacter = new Map<string, PendingNotification>();
+  for (const e of events) {
+    if (e.ConsumedAt !== undefined) continue;
+    // すでに同キャラクターのエントリがあればスキップ（降順なので最初が最新）
+    if (latestByCharacter.has(e.CharacterID)) continue;
+    latestByCharacter.set(e.CharacterID, {
+      characterId: e.CharacterID,
+      notifId: e.NotifID,
+      body: e.Body,
+    });
+  }
+
+  const result: PendingNotification[] = Array.from(latestByCharacter.values());
+  return NextResponse.json(result, { status: 200 });
+});

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { Box, Container, Stack } from '@mui/material';
+import { Box, Container, Stack, Typography } from '@mui/material';
 import { Link } from '@nagiyu/ui';
 import { hasPermission } from '@nagiyu/common';
 import ChatInput from '@/components/ChatInput';
@@ -16,6 +17,7 @@ import InstallGuide from '@/components/InstallGuide';
 import NotificationPermission from '@/components/NotificationPermission';
 import CharacterSelectButton from '@/components/CharacterSelectButton';
 import { useCharacter } from '@/lib/characters/CharacterContext';
+import { getCharacterDisplay, hasCharacterProfile } from '@/lib/characters/client-profiles';
 import {
   isStandalone,
   isPushSupported,
@@ -24,6 +26,18 @@ import {
 } from '@/lib/pwa/standalone';
 import { PWA_MESSAGES } from '@/lib/pwa/messages';
 import { reportClientError } from '@/lib/client-logger';
+
+/**
+ * pending API のレスポンス型（キャラクターごとの未消化通知）。
+ */
+interface PendingNotification {
+  /** 通知元キャラクター ID */
+  characterId: string;
+  /** 通知 ID */
+  notifId: string;
+  /** 通知本文 */
+  body: string;
+}
 
 type ChatPhase = 'idle' | 'loading' | 'streaming';
 type ConsentPhase = 'checking' | 'required' | 'done';
@@ -61,7 +75,8 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
  *   （HTMLAudioElement の autoplay 制約を回避）
  */
 export default function HomePage() {
-  const { characterId } = useCharacter();
+  const { characterId, setCharacterId } = useCharacter();
+  const searchParams = useSearchParams();
   const { data: session } = useSession();
   const isAdmin =
     !!session?.user &&
@@ -86,6 +101,10 @@ export default function HomePage() {
   const [firstWordText, setFirstWordText] = useState<string | null>(null);
   // 第一声の元となった KnowledgeID（次の chat 送信時に文脈として渡す）
   const firstWordKnowledgeIdRef = useRef<string | null>(null);
+  // 第一声の通知元キャラクター ID（クロス汚染防止のためカレントと照合する）
+  const firstWordCharacterIdRef = useRef<string | null>(null);
+  // 他キャラクターの未消化通知（自前起動時に提示する）
+  const [pendingNotifications, setPendingNotifications] = useState<PendingNotification[]>([]);
 
   const audioQueueRef = useRef<AudioBuffer[]>([]);
   const isPlayingRef = useRef(false);
@@ -109,22 +128,65 @@ export default function HomePage() {
       });
   }, []);
 
-  // 起動時に未消化の通知があればキャラ第一声として表示する。
+  // push クリック起動時: URL の ?character=<id> を読み、カレントキャラを切替える。
+  // searchParams は Next.js の useSearchParams で取得。
+  // 依存配列に searchParams を含めることで、SPA 遷移でも正しく動作する。
   useEffect(() => {
-    fetch('/api/push/first-word')
+    const characterQuery = searchParams.get('character');
+    if (characterQuery && hasCharacterProfile(characterQuery)) {
+      setCharacterId(characterQuery);
+    }
+    // searchParams の変化のみに依存する（setCharacterId は安定した関数参照）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  // カレント characterId の未消化通知を第一声として取得・表示する。
+  // characterId が変わるたびに再取得し、前のキャラの knowledgeId をクリアする。
+  useEffect(() => {
+    // キャラクター切替時は前のキャラの第一声 knowledgeId をクリアする（クロス汚染防止）
+    firstWordKnowledgeIdRef.current = null;
+    firstWordCharacterIdRef.current = null;
+    setFirstWordText(null);
+
+    fetch(`/api/push/first-word?characterId=${encodeURIComponent(characterId)}`)
       .then((res) => (res.ok ? res.json() : null))
-      .then((data: { notifId: string; body: string; knowledgeId?: string | null } | null) => {
-        if (!data) return;
-        setFirstWordText(data.body);
-        firstWordKnowledgeIdRef.current = data.knowledgeId ?? null;
-        // 消化済みマーク
-        fetch('/api/push/consumed', {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ notifId: data.notifId }),
-        }).catch(() => {});
+      .then(
+        (
+          data: {
+            notifId: string;
+            body: string;
+            knowledgeId?: string | null;
+            characterId: string;
+          } | null
+        ) => {
+          if (!data) return;
+          setFirstWordText(data.body);
+          firstWordKnowledgeIdRef.current = data.knowledgeId ?? null;
+          // 通知元キャラクター ID を保存（クロス汚染防止のためカレントと照合する）
+          firstWordCharacterIdRef.current = data.characterId;
+          // 消化済みマーク
+          fetch('/api/push/consumed', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ notifId: data.notifId }),
+          }).catch(() => {});
+        }
+      )
+      .catch(() => {});
+  }, [characterId]);
+
+  // 自前起動時: カレント以外に未消化通知があれば提示する。
+  // このエフェクトはマウント時（初回起動）にのみ実行する。
+  useEffect(() => {
+    fetch('/api/push/pending')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: PendingNotification[] | null) => {
+        if (!data || data.length === 0) return;
+        setPendingNotifications(data);
       })
       .catch(() => {});
+    // マウント時のみ実行（依存配列は空）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // 同意完了後にオンボーディング（ホーム画面追加・通知許可）の表示要否を判定する。
@@ -232,9 +294,14 @@ export default function HomePage() {
       const controller = new AbortController();
       abortControllerRef.current = controller;
 
-      // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）
-      const notifKnowledgeId = firstWordKnowledgeIdRef.current;
+      // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）。
+      // クロス汚染防止: カレントキャラ == 通知元キャラのときのみ渡す（C3-3）。
+      const firstWordNotifCharId = firstWordCharacterIdRef.current;
+      const rawKnowledgeId = firstWordKnowledgeIdRef.current;
+      const notifKnowledgeId =
+        rawKnowledgeId !== null && firstWordNotifCharId === characterId ? rawKnowledgeId : null;
       firstWordKnowledgeIdRef.current = null;
+      firstWordCharacterIdRef.current = null;
 
       setUserText(text);
       setResponseText('');
@@ -472,6 +539,27 @@ export default function HomePage() {
               onSkip={handleNotificationSkip}
             />
           )}
+          {/* 他キャラクターの未消化通知をヒントとして提示する（consume はしない）。
+              ユーザーがそのキャラに切替えると first-word effect が走り第一声が表示・consume される。 */}
+          {pendingNotifications
+            .filter((n) => n.characterId !== characterId)
+            .map((n) => {
+              const display = hasCharacterProfile(n.characterId)
+                ? getCharacterDisplay(n.characterId)
+                : null;
+              const name = display?.shortName ?? n.characterId;
+              return (
+                <Typography
+                  key={n.characterId}
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ textAlign: 'center', display: 'block' }}
+                  data-testid={`pending-notification-${n.characterId}`}
+                >
+                  {name}から連絡が来てるよ
+                </Typography>
+              );
+            })}
           <ChatInput
             onSubmit={handleSubmit}
             disabled={phase !== 'idle' || consentPhase !== 'done'}

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { Box, Container, Stack, Typography } from '@mui/material';
@@ -73,8 +73,11 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
  * - iOS Safari 対策として AudioContext を user gesture で resume し、
  *   CharacterCanvas に AudioBuffer + AudioContext を渡して Web Audio で再生する
  *   （HTMLAudioElement の autoplay 制約を回避）
+ *
+ * useSearchParams を使うため、ページ本体は Suspense 境界の内側に置く
+ * （App Router の prerender 要件。下部の default export でラップする）。
  */
-export default function HomePage() {
+function HomePageInner() {
   const { characterId, setCharacterId } = useCharacter();
   const searchParams = useSearchParams();
   const { data: session } = useSession();
@@ -573,5 +576,18 @@ export default function HomePage() {
         </Stack>
       </Container>
     </>
+  );
+}
+
+/**
+ * ページのエントリポイント。
+ * useSearchParams を含む HomePageInner を Suspense 境界でラップする
+ * （App Router の prerender 要件を満たすため）。
+ */
+export default function HomePage() {
+  return (
+    <Suspense fallback={null}>
+      <HomePageInner />
+    </Suspense>
   );
 }

--- a/services/livetalk/web/tests/unit/app/api/push/first-word.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/push/first-word.test.ts
@@ -1,0 +1,209 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * GET /api/push/first-word のユニットテスト。
+ *
+ * Phase C 追加仕様:
+ *   - ?characterId=<id> クエリで指定キャラクターの未消化最新を返す
+ *   - レスポンスに characterId を含む
+ *   - characterId 未指定時は 204 を返す
+ *   - 未消化なし（全消化済み）の場合は 204 を返す
+ */
+import { GET } from '@/app/api/push/first-word/route';
+import { getSession } from '@/lib/server/session';
+import { getNotificationEventRepository } from '@/lib/server/repositories';
+import type { NotificationEventEntity, NotificationEventRepository } from '@nagiyu/livetalk-core';
+
+jest.mock('@/lib/server/session', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@/lib/server/repositories', () => ({
+  getNotificationEventRepository: jest.fn(),
+}));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetNotificationEventRepo = getNotificationEventRepository as jest.MockedFunction<
+  typeof getNotificationEventRepository
+>;
+
+/** テスト用有効セッション */
+const validSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'u@example.com',
+    name: 'U',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+/** 通知イベントエンティティのファクトリ */
+function makeEvent(overrides: Partial<NotificationEventEntity> = {}): NotificationEventEntity {
+  return {
+    UserID: 'g1',
+    NotifID: 'n1',
+    CharacterID: 'hiyori',
+    Kind: 'normal',
+    Title: 'ひよりより',
+    Body: 'テスト本文',
+    KnowledgeID: undefined,
+    ConsumedAt: undefined,
+    CreatedAt: Date.now(),
+    Ttl: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+/** リポジトリモックのファクトリ */
+function makeRepo(events: NotificationEventEntity[]): NotificationEventRepository {
+  return {
+    listByUser: jest.fn(async () => events),
+    put: jest.fn(),
+    get: jest.fn(),
+    markConsumed: jest.fn(),
+  } as unknown as NotificationEventRepository;
+}
+
+/** GET リクエストを組み立てるヘルパー */
+function buildGetRequest(characterId?: string): Request {
+  const url = characterId
+    ? `http://localhost/api/push/first-word?characterId=${encodeURIComponent(characterId)}`
+    : 'http://localhost/api/push/first-word';
+  return new Request(url, { method: 'GET' });
+}
+
+describe('GET /api/push/first-word', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('未認証は 401 を返す', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(buildGetRequest('hiyori'));
+    expect(res.status).toBe(401);
+  });
+
+  it('characterId 未指定時は 204 を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    // characterId なしで呼ぶ（呼び出し側は常に characterId を付ける設計）
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(204);
+  });
+
+  it('指定キャラクターの未消化最新通知を返す（characterId フィルタ）', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const hiyoriEvent = makeEvent({
+      NotifID: 'n-hiyori',
+      CharacterID: 'hiyori',
+      Body: 'ひよりの本文',
+      KnowledgeID: 'k-hiyori',
+    });
+    const agehaEvent = makeEvent({
+      NotifID: 'n-ageha',
+      CharacterID: 'ageha',
+      Body: 'アゲハの本文',
+    });
+    // listByUser は降順で返すため、最初が最新
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([hiyoriEvent, agehaEvent]));
+
+    const res = await GET(buildGetRequest('hiyori'));
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    // hiyori の通知が返る
+    expect(json.notifId).toBe('n-hiyori');
+    expect(json.body).toBe('ひよりの本文');
+    expect(json.knowledgeId).toBe('k-hiyori');
+    // レスポンスに characterId が含まれる（クロス汚染防止のため）
+    expect(json.characterId).toBe('hiyori');
+  });
+
+  it('他キャラクター(ageha)のみ未消化の場合、hiyori を指定すると 204 を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const agehaEvent = makeEvent({
+      NotifID: 'n-ageha',
+      CharacterID: 'ageha',
+      Body: 'アゲハの本文',
+    });
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([agehaEvent]));
+
+    const res = await GET(buildGetRequest('hiyori'));
+    expect(res.status).toBe(204);
+  });
+
+  it('全通知が消化済みの場合は 204 を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const consumedEvent = makeEvent({
+      CharacterID: 'hiyori',
+      ConsumedAt: Date.now() - 1000,
+    });
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([consumedEvent]));
+
+    const res = await GET(buildGetRequest('hiyori'));
+    expect(res.status).toBe(204);
+  });
+
+  it('通知がない場合は 204 を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([]));
+
+    const res = await GET(buildGetRequest('hiyori'));
+    expect(res.status).toBe(204);
+  });
+
+  it('knowledgeId がない通知の場合、レスポンスの knowledgeId は null になる', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const event = makeEvent({
+      CharacterID: 'hiyori',
+      KnowledgeID: undefined,
+    });
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([event]));
+
+    const res = await GET(buildGetRequest('hiyori'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.knowledgeId).toBeNull();
+  });
+
+  it('消化済みと未消化が混在する場合、未消化の最新を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    // 降順: 最新が先頭（消化済み）、次が未消化
+    const consumedEvent = makeEvent({
+      NotifID: 'n-consumed',
+      CharacterID: 'hiyori',
+      ConsumedAt: Date.now() - 500,
+    });
+    const unconsumedEvent = makeEvent({
+      NotifID: 'n-unconsumed',
+      CharacterID: 'hiyori',
+      Body: '未消化の本文',
+    });
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([consumedEvent, unconsumedEvent]));
+
+    const res = await GET(buildGetRequest('hiyori'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // 消化済みをスキップして未消化を返す
+    expect(json.notifId).toBe('n-unconsumed');
+    expect(json.body).toBe('未消化の本文');
+  });
+
+  it('ageha 指定時は ageha の未消化通知を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const agehaEvent = makeEvent({
+      NotifID: 'n-ageha',
+      CharacterID: 'ageha',
+      Body: 'アゲハの本文',
+    });
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([agehaEvent]));
+
+    const res = await GET(buildGetRequest('ageha'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.notifId).toBe('n-ageha');
+    expect(json.characterId).toBe('ageha');
+  });
+});

--- a/services/livetalk/web/tests/unit/app/api/push/pending.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/push/pending.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * GET /api/push/pending のユニットテスト。
+ *
+ * Phase C 追加 API:
+ *   - 未消化通知をキャラクターごとに集約し、各キャラ最新 1 件を返す
+ *   - 未消化なしの場合は空配列を返す
+ *   - consume 済みはスキップする
+ */
+import { GET } from '@/app/api/push/pending/route';
+import { getSession } from '@/lib/server/session';
+import { getNotificationEventRepository } from '@/lib/server/repositories';
+import type { NotificationEventEntity, NotificationEventRepository } from '@nagiyu/livetalk-core';
+
+jest.mock('@/lib/server/session', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@/lib/server/repositories', () => ({
+  getNotificationEventRepository: jest.fn(),
+}));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetNotificationEventRepo = getNotificationEventRepository as jest.MockedFunction<
+  typeof getNotificationEventRepository
+>;
+
+/** テスト用有効セッション */
+const validSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'u@example.com',
+    name: 'U',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+/** 通知イベントエンティティのファクトリ */
+function makeEvent(overrides: Partial<NotificationEventEntity> = {}): NotificationEventEntity {
+  return {
+    UserID: 'g1',
+    NotifID: 'n1',
+    CharacterID: 'hiyori',
+    Kind: 'normal',
+    Title: 'ひよりより',
+    Body: 'テスト本文',
+    KnowledgeID: undefined,
+    ConsumedAt: undefined,
+    CreatedAt: Date.now(),
+    Ttl: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+/** リポジトリモックのファクトリ */
+function makeRepo(events: NotificationEventEntity[]): NotificationEventRepository {
+  return {
+    listByUser: jest.fn(async () => events),
+    put: jest.fn(),
+    get: jest.fn(),
+    markConsumed: jest.fn(),
+  } as unknown as NotificationEventRepository;
+}
+
+/** GET リクエストを組み立てるヘルパー */
+function buildGetRequest(): Request {
+  return new Request('http://localhost/api/push/pending', { method: 'GET' });
+}
+
+describe('GET /api/push/pending', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('未認証は 401 を返す', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('未消化通知がない場合は空配列を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([]));
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([]);
+  });
+
+  it('全通知が消化済みの場合は空配列を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const consumedEvent = makeEvent({
+      CharacterID: 'hiyori',
+      ConsumedAt: Date.now() - 1000,
+    });
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([consumedEvent]));
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual([]);
+  });
+
+  it('キャラクターごとに最新未消化通知 1 件を集約して返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+
+    // hiyori: 2 件の未消化（降順なので n-hiyori-1 が最新）
+    const hiyoriEvent1 = makeEvent({
+      NotifID: 'n-hiyori-1',
+      CharacterID: 'hiyori',
+      Body: 'ひよりの最新本文',
+    });
+    const hiyoriEvent2 = makeEvent({
+      NotifID: 'n-hiyori-2',
+      CharacterID: 'hiyori',
+      Body: 'ひよりの古い本文',
+    });
+    // ageha: 1 件の未消化
+    const agehaEvent = makeEvent({
+      NotifID: 'n-ageha',
+      CharacterID: 'ageha',
+      Body: 'アゲハの本文',
+    });
+
+    // listByUser は CreatedAt 降順で返す（最新が先頭）
+    mockGetNotificationEventRepo.mockReturnValue(
+      makeRepo([hiyoriEvent1, agehaEvent, hiyoriEvent2])
+    );
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    // 2 キャラ分のエントリが返る
+    expect(json).toHaveLength(2);
+
+    // hiyori の最新（n-hiyori-1）が含まれる
+    const hiyoriResult = json.find(
+      (item: { characterId: string }) => item.characterId === 'hiyori'
+    );
+    expect(hiyoriResult).toBeDefined();
+    expect(hiyoriResult.notifId).toBe('n-hiyori-1');
+    expect(hiyoriResult.body).toBe('ひよりの最新本文');
+
+    // ageha のエントリが含まれる
+    const agehaResult = json.find((item: { characterId: string }) => item.characterId === 'ageha');
+    expect(agehaResult).toBeDefined();
+    expect(agehaResult.notifId).toBe('n-ageha');
+  });
+
+  it('消化済みと未消化が混在する場合、未消化のみ集約する', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+
+    // hiyori: 消化済みが先頭（最新）、未消化が 2 番目
+    const consumedEvent = makeEvent({
+      NotifID: 'n-consumed',
+      CharacterID: 'hiyori',
+      ConsumedAt: Date.now() - 500,
+    });
+    const unconsumedEvent = makeEvent({
+      NotifID: 'n-unconsumed',
+      CharacterID: 'hiyori',
+      Body: '未消化の本文',
+    });
+
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([consumedEvent, unconsumedEvent]));
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    // 未消化のみが集約される
+    expect(json).toHaveLength(1);
+    expect(json[0].notifId).toBe('n-unconsumed');
+  });
+
+  it('レスポンスの各エントリに characterId, notifId, body が含まれる', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const event = makeEvent({
+      NotifID: 'n1',
+      CharacterID: 'hiyori',
+      Body: '本文テスト',
+    });
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([event]));
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(json[0]).toMatchObject({
+      characterId: 'hiyori',
+      notifId: 'n1',
+      body: '本文テスト',
+    });
+  });
+
+  it('複数キャラクター全員未消化の場合、全キャラ分を返す', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const hiyoriEvent = makeEvent({ NotifID: 'n-h', CharacterID: 'hiyori' });
+    const agehaEvent = makeEvent({ NotifID: 'n-a', CharacterID: 'ageha' });
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([hiyoriEvent, agehaEvent]));
+
+    const res = await GET(buildGetRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toHaveLength(2);
+
+    const characterIds = json.map((item: { characterId: string }) => item.characterId);
+    expect(characterIds).toContain('hiyori');
+    expect(characterIds).toContain('ageha');
+  });
+});

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -71,6 +71,15 @@ jest.mock('next-auth/react', () => ({
   SessionProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+// next/navigation の useSearchParams をモック化する。
+// デフォルトはクエリなし（自前起動）として設定する。
+const mockSearchParamsGet = jest.fn().mockReturnValue(null);
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(() => ({
+    get: mockSearchParamsGet,
+  })),
+}));
+
 // オンボーディング判定がチャットテストに干渉しないようにスタブ化する
 jest.mock('@/lib/pwa/standalone', () => ({
   isStandalone: jest.fn().mockReturnValue(false),
@@ -90,11 +99,12 @@ jest.mock('@/lib/pwa/messages', () => ({
 }));
 
 // CharacterContext: useCharacter を hiyori 固定でスタブ化する。
-// setCharacterId は実装不要（page.tsx では読み取りのみ）。
+// setCharacterId のスパイを外部から差し替えられるよう、モジュール変数として保持する。
+const mockSetCharacterId = jest.fn();
 jest.mock('@/lib/characters/CharacterContext', () => ({
   useCharacter: jest.fn(() => ({
     characterId: 'hiyori',
-    setCharacterId: jest.fn(),
+    setCharacterId: mockSetCharacterId,
   })),
   CharacterProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
@@ -142,8 +152,16 @@ function setupFetchMocks(chatOk = false, sentenceAudio?: string) {
         json: () => Promise.resolve({ state: 'awake' }),
       });
     }
-    if (url === '/api/push/first-word') {
+    // first-word は characterId クエリ付きで呼ばれる（Phase C 対応）
+    if (url.startsWith('/api/push/first-word')) {
       return Promise.resolve({ ok: false });
+    }
+    // pending は空配列を返す（デフォルト）
+    if (url === '/api/push/pending') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
     }
     return Promise.resolve({ ok: chatOk, body: chatStream });
   });
@@ -181,6 +199,8 @@ function removeAudioContext() {
 afterEach(() => {
   jest.clearAllMocks();
   removeAudioContext();
+  // デフォルトのクエリなし状態に戻す
+  mockSearchParamsGet.mockReturnValue(null);
 });
 
 /** 同意チェック完了を待ち、有効化された入力欄を返す */
@@ -339,8 +359,14 @@ describe('handlePlaybackError のデバッグログ', () => {
   });
 });
 
-describe('通知起点の knowledgeId 受け渡し（Issue #3359 課題Y）', () => {
-  it('first-word に knowledgeId がある場合、次の chat リクエストに含まれる', async () => {
+describe('Phase C: push クリック起動（URL ?character=<id> あり）', () => {
+  it('URL に ?character=ageha があるとき setCharacterId(ageha) が呼ばれる', async () => {
+    // searchParams の get('character') が 'ageha' を返すように設定
+    mockSearchParamsGet.mockImplementation((key: string) => {
+      if (key === 'character') return 'ageha';
+      return null;
+    });
+
     const encoder = new TextEncoder();
     const chatStream = new ReadableStream({
       start(controller) {
@@ -356,17 +382,267 @@ describe('通知起点の knowledgeId 受け渡し（Issue #3359 課題Y）', ()
       if (url.startsWith('/api/lifecycle')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
       }
-      if (url === '/api/push/first-word') {
+      if (url.startsWith('/api/push/first-word')) {
+        return Promise.resolve({ ok: false });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    // searchParams の 'character' が 'ageha' なので setCharacterId('ageha') が呼ばれる
+    expect(mockSetCharacterId).toHaveBeenCalledWith('ageha');
+  });
+
+  it('URL に ?character=unknown（未登録 ID）があっても setCharacterId は呼ばれない', async () => {
+    mockSearchParamsGet.mockImplementation((key: string) => {
+      if (key === 'character') return 'unknown-character-xyz';
+      return null;
+    });
+
+    setupFetchMocks();
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    expect(mockSetCharacterId).not.toHaveBeenCalled();
+  });
+});
+
+describe('Phase C: first-word 取得のキャラクター依存化', () => {
+  it('first-word を ?characterId=hiyori 付きで取得する', async () => {
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url.startsWith('/api/lifecycle')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url.startsWith('/api/push/first-word')) {
+        return Promise.resolve({ ok: false });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    // first-word が characterId=hiyori クエリ付きで呼ばれることを確認
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+      expect(calls.some((url) => url.includes('/api/push/first-word?characterId=hiyori'))).toBe(
+        true
+      );
+    });
+  });
+
+  it('カレントキャラの未消化通知を第一声として表示し consume する', async () => {
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url.startsWith('/api/lifecycle')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url.startsWith('/api/push/first-word')) {
         return Promise.resolve({
           ok: true,
           json: () =>
-            Promise.resolve({ notifId: 'n1', body: 'テスト第一声', knowledgeId: 'k-xyz' }),
+            Promise.resolve({
+              notifId: 'n1',
+              body: 'ひよりの第一声',
+              knowledgeId: 'k-hiyori',
+              characterId: 'hiyori',
+            }),
         });
       }
       if (url === '/api/push/consumed') {
         return Promise.resolve({ ok: true });
       }
-      // /api/chat
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    // first-word が取得されたら consume も呼ばれる
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+      expect(calls.some((url) => url === '/api/push/consumed')).toBe(true);
+    });
+
+    // PATCH /api/push/consumed が notifId: 'n1' で呼ばれることを確認
+    const consumedCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]: [string]) => url === '/api/push/consumed'
+    );
+    expect(consumedCall).toBeDefined();
+    const consumedBody = JSON.parse(consumedCall[1].body as string);
+    expect(consumedBody.notifId).toBe('n1');
+  });
+});
+
+describe('Phase C: 自前起動で他キャラに未消化通知がある場合の提示', () => {
+  it('カレント=hiyori、ageha に未消化通知 → アゲハからの通知ヒントが表示される（consume しない）', async () => {
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url.startsWith('/api/lifecycle')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url.startsWith('/api/push/first-word')) {
+        return Promise.resolve({ ok: false });
+      }
+      if (url === '/api/push/consumed') {
+        return Promise.resolve({ ok: true });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([{ characterId: 'ageha', notifId: 'n2', body: 'アゲハより' }]),
+        });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    // ageha の未消化通知ヒントが表示される
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-notification-ageha')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('pending-notification-ageha')).toHaveTextContent(
+      'アゲハから連絡が来てるよ'
+    );
+
+    // consume は呼ばれていない（即 consume しない設計）
+    const consumedCalls = (global.fetch as jest.Mock).mock.calls.filter(
+      ([url]: [string]) => url === '/api/push/consumed'
+    );
+    expect(consumedCalls).toHaveLength(0);
+  });
+
+  it('pending が空配列のとき他キャラ通知ヒントは表示されない', async () => {
+    setupFetchMocks();
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    // 他キャラ通知ヒントは表示されない
+    await waitFor(() => {
+      expect(screen.queryByTestId('pending-notification-ageha')).not.toBeInTheDocument();
+    });
+  });
+
+  it('pending にカレントキャラ(hiyori)自身の通知が含まれても表示されない（カレント除外）', async () => {
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url.startsWith('/api/lifecycle')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url.startsWith('/api/push/first-word')) {
+        return Promise.resolve({ ok: false });
+      }
+      if (url === '/api/push/pending') {
+        // カレント(hiyori)のみ pending にある状態
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([{ characterId: 'hiyori', notifId: 'n1', body: 'ひよりより' }]),
+        });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    render(<HomePage />);
+    await waitForInputEnabled();
+
+    // hiyori はカレントなので pending ヒントは表示されない
+    await waitFor(() => {
+      expect(screen.queryByTestId('pending-notification-hiyori')).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('Phase C: クロス汚染防止（knowledgeId の chat 送信制御）', () => {
+  it('カレントキャラ(hiyori)の first-word knowledgeId → 次の chat に含まれる', async () => {
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url.startsWith('/api/lifecycle')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url.startsWith('/api/push/first-word')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              notifId: 'n1',
+              body: 'テスト第一声',
+              knowledgeId: 'k-xyz',
+              characterId: 'hiyori', // カレント(hiyori)と一致
+            }),
+        });
+      }
+      if (url === '/api/push/consumed') {
+        return Promise.resolve({ ok: true });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
       return Promise.resolve({ ok: true, body: chatStream });
     });
 
@@ -376,7 +652,10 @@ describe('通知起点の knowledgeId 受け渡し（Issue #3359 課題Y）', ()
     const input = await waitForInputEnabled();
 
     // first-word 取得を待つ
-    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/push/first-word'));
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+      expect(calls.some((url) => url.startsWith('/api/push/first-word'))).toBe(true);
+    });
 
     await user.type(input, 'ありがとう');
     await user.click(screen.getByRole('button', { name: '送信' }));
@@ -407,15 +686,23 @@ describe('通知起点の knowledgeId 受け渡し（Issue #3359 課題Y）', ()
       if (url.startsWith('/api/lifecycle')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
       }
-      if (url === '/api/push/first-word') {
+      if (url.startsWith('/api/push/first-word')) {
         return Promise.resolve({
           ok: true,
           json: () =>
-            Promise.resolve({ notifId: 'n1', body: 'テスト第一声', knowledgeId: 'k-xyz' }),
+            Promise.resolve({
+              notifId: 'n1',
+              body: 'テスト第一声',
+              knowledgeId: 'k-xyz',
+              characterId: 'hiyori',
+            }),
         });
       }
       if (url === '/api/push/consumed') {
         return Promise.resolve({ ok: true });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
       }
       chatCallCount++;
       return Promise.resolve({ ok: true, body: makeChatStream() });
@@ -426,7 +713,10 @@ describe('通知起点の knowledgeId 受け渡し（Issue #3359 課題Y）', ()
     render(<HomePage />);
     const input = await waitForInputEnabled();
 
-    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/push/first-word'));
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+      expect(calls.some((url) => url.startsWith('/api/push/first-word'))).toBe(true);
+    });
 
     // 1 回目送信
     await user.type(input, '1回目');
@@ -466,8 +756,11 @@ describe('characterId の chat リクエストへの反映', () => {
       if (url.startsWith('/api/lifecycle')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
       }
-      if (url === '/api/push/first-word') {
+      if (url.startsWith('/api/push/first-word')) {
         return Promise.resolve({ ok: false });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
       }
       return Promise.resolve({ ok: true, body: chatStream });
     });


### PR DESCRIPTION
## 変更の概要

リブトーク通知マルチキャラ対応（#3491、深さ(2)）の **Phase C: 配信・消化（web + service worker）**。最終フェーズ。「起動経路で出し分け」体験とクロス汚染の構造的防止を実装する。

**この PR は Phase B（#3495）の上にスタックしている**（base = `claude/3491-phase-b-generation`）。Phase A → B → C の順にマージし、最終的に integration へ載せる想定。

- **service worker**（`public/sw.js`）: `notificationclick` は payload の `data.url`（= `/?character=<id>`、Phase B で付与）へ遷移。デフォルトタイトルの `'ひより'` ハードコードを汎用 `'お知らせ'` に（payload.title 優先のためフォールバックのみ）。
- **first-word API**: `?characterId=<id>` を受け取り、そのキャラの未消化最新のみ返す（`CharacterID` 一致 + 未消化）。レスポンスに `characterId` を含める。未指定時は 204（呼び出し側は常に characterId 付与）。
- **pending API**（新規 `GET /api/push/pending`）: 未消化通知をキャラごとに最新 1 件へ集約して返す。自前起動時の「他キャラからの連絡」提示に使用。
- **page.tsx（起動経路で出し分け）**:
  - URL `?character=<id>`（push クリック起動）→ `setCharacterId` でカレントを通知元キャラへ自動切替。
  - 第一声取得を **カレント characterId に紐付け**（`first-word?characterId=<id>`）。キャラ切替で再取得し、前キャラの knowledgeId をクリア。
  - 自前起動で**カレント以外**に未消化があれば「○○から連絡が来てるよ」と控えめに提示（consume しない）。切替えれば first-word effect が走り第一声表示＋consume（= 切替えるまで他キャラ通知が消えない＝ C3 解消）。
  - **クロス汚染防止（C2）**: 通知元キャラ ID を保持し、`カレント == 通知元` のときのみ knowledgeId を chat に渡す。第一声が常にカレント由来になる構造と二重で担保。
  - `useSearchParams` の prerender 要件のため、ページ本体を `Suspense` 境界でラップ。

## 関連 Issue

#3491（作業ブランチ → スタックのため `Closes` は付けない）

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（機能完成後に `docs/` へまとめて反映予定）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `first-word.test.ts`（新規・8件）: characterId フィルタ、未消化なし→204、characterId をレスポンスに含む。
- `pending.test.ts`（新規・7件）: キャラごとに最新未消化 1 件へ集約、未消化なし→空配列。
- `page.test.tsx`（追従＋追加）: `?character=ageha` 起動でカレント切替＆第一声、自前起動で他キャラ提示（consume しない）、カレント未消化で第一声＋consume＋knowledgeId 連携、クロス汚染ガード。
- オーケストレーター客観検証: **web 54 suites / 467 tests PASS**、カバレッジ 80% 維持（branches 91.8% / functions 82.8%）、prettier clean。`useSearchParams` の build 失敗を先回りで Suspense ラップにより回避。

## レビューポイント

- 「起動経路で出し分け」の体験（push クリック=自動切替 / 自前起動=提示）の妥当性。
- pending 提示の UI（控えめなテキスト提示。凝った一覧・バッジは深さ(3)の宿題）。
- クロス汚染ガード（characterId 一致時のみ knowledgeId 連携）の二重防御。

## スクリーンショット（該当する場合）

UI 変更（pending 提示テキスト）あり。dev 反映後に実機確認予定。

## 補足事項

これで #3491 深さ(2) の生成〜配信〜消化が揃う。設計ドキュメントは `tasks/notification-multichar/`。dev 検証（アゲハ通知の生成・配信、push クリックでアゲハ起動、他キャラ通知の提示、クロス汚染なし）は integration 反映後に実施。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAXiTTe9n6Lxc5tAB5eRco)_