### PR TITLE
リブトーク: 早瀬アゲハを一枚絵（still）レンダラで表示する

### DIFF
--- a/services/livetalk/web/src/components/CharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/CharacterCanvas.tsx
@@ -5,6 +5,7 @@ import { CircularProgress, Box, Typography } from '@mui/material';
 import type { LifecycleState } from '@nagiyu/livetalk-core';
 import { getCharacterRenderProfile } from '@/lib/characters/client-profiles';
 import PlaceholderCanvas from '@/components/PlaceholderCanvas';
+import StillImageCanvas from '@/components/StillImageCanvas';
 
 /**
  * CharacterCanvas のプロパティ。
@@ -82,6 +83,7 @@ function Live2DCanvasFallback({ statusText }: { statusText?: string }) {
  *
  * getCharacterRenderProfile で renderer 種別を判定し、
  * - 'live2d': PixiJS + pixi-live2d-display による Live2D 描画（ssr:false 動的 import）
+ * - 'still': 完成した一枚絵（静止画）の描画（SSR 可・静的 import）
  * - 'placeholder': シルエット + 名前ラベル + 音声連動口パクによるプレースホルダー描画
  *
  * page.tsx はこのコンポーネントに同じ props を渡すだけでよく、
@@ -92,6 +94,11 @@ export default function CharacterCanvas(props: CharacterCanvasProps) {
 
   if (renderProfile.renderer === 'live2d') {
     return <Live2DCanvas {...props} />;
+  }
+
+  if (renderProfile.renderer === 'still') {
+    // img + Web Audio のみで SSR 可。PlaceholderCanvas と同様に静的 import を使う。
+    return <StillImageCanvas {...props} />;
   }
 
   // 'placeholder': PlaceholderCanvas を描画する

--- a/services/livetalk/web/src/components/StillImageCanvas.tsx
+++ b/services/livetalk/web/src/components/StillImageCanvas.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Image from 'next/image';
+import { Box, Typography } from '@mui/material';
+import type { LifecycleState } from '@nagiyu/livetalk-core';
+import {
+  getCharacterDisplay,
+  getCharacterRenderProfile,
+} from '@/lib/characters/client-profiles';
+
+/**
+ * StillImageCanvas のプロパティ。
+ * PlaceholderCanvas と同じ再生コントラクトに合わせる。
+ */
+export interface StillImageCanvasProps {
+  /**
+   * 表示するキャラクターの ID。省略時はレジストリの既定キャラクターを使用する。
+   * 画像パスと alt テキストの取得に使用する。
+   */
+  characterId?: string;
+  /**
+   * 再生対象の AudioBuffer。null または undefined のときは再生しない（待機表示）。
+   *
+   * iOS Safari の HTMLAudioElement autoplay 制約回避のため、HTMLAudio は使わず
+   * Web Audio API の AudioBufferSourceNode を直接使う。
+   */
+  audioBuffer?: AudioBuffer | null;
+  /**
+   * 再生に使う AudioContext。親側で user gesture 中に resume 済みである前提。
+   * audioBuffer が指定されているのに audioContext が null の場合は再生しない。
+   */
+  audioContext?: AudioContext | null;
+  /** 「考え中 / 話している / 待機中」の状態テキスト */
+  statusText?: string;
+  /** 生活サイクル状態（現在は参照のみ・将来の拡張用） */
+  lifecycleState?: LifecycleState;
+  /** 音声再生完了時のコールバック */
+  onPlaybackEnd?: () => void;
+  /** 音声再生エラー時のコールバック */
+  onPlaybackError?: (error: Error) => void;
+}
+
+/**
+ * 完成した一枚絵（静止画）を表示するコンポーネント。
+ *
+ * renderer:'still' キャラクター向けに、CloudFront/S3 から配信される一枚絵画像を表示する。
+ * 瞬き・口パクなどのアニメーションは一切行わない（将来は別レンダラで対応予定）。
+ *
+ * 音声再生は Web Audio API（AudioBufferSourceNode）で行い、
+ * 画像へのアニメーション連動はしない（source → destination の直結のみ）。
+ *
+ * iOS Safari 対策として HTMLAudio は使わず Web Audio のみ。
+ * AudioContext は親が resume 済みの前提（PlaceholderCanvas / Live2DCanvas と同じ）。
+ */
+export default function StillImageCanvas({
+  characterId,
+  audioBuffer,
+  audioContext,
+  statusText,
+  // lifecycleState は将来の拡張用。現時点では参照しない（静止画に sleeping 表現なし）
+  lifecycleState: _lifecycleStateUnused, // eslint-disable-line @typescript-eslint/no-unused-vars
+  onPlaybackEnd,
+  onPlaybackError,
+}: StillImageCanvasProps) {
+  // コールバックを ref 経由で参照することで、再生の useEffect が
+  // 親側のコールバック識別子変更で再走するのを避ける
+  const onPlaybackEndRef = useRef(onPlaybackEnd);
+  const onPlaybackErrorRef = useRef(onPlaybackError);
+  useEffect(() => {
+    onPlaybackEndRef.current = onPlaybackEnd;
+    onPlaybackErrorRef.current = onPlaybackError;
+  }, [onPlaybackEnd, onPlaybackError]);
+
+  // audioBuffer + audioContext を受け取ったら Web Audio で再生する。
+  // 口パク・拡大発光などのアニメーションは行わない（source → destination の直結のみ）。
+  useEffect(() => {
+    if (!audioBuffer || !audioContext) return;
+
+    let cancelled = false;
+    let source: AudioBufferSourceNode | null = null;
+
+    try {
+      source = audioContext.createBufferSource();
+      source.buffer = audioBuffer;
+
+      source.connect(audioContext.destination);
+
+      source.onended = () => {
+        if (cancelled) return;
+        onPlaybackEndRef.current?.();
+      };
+
+      source.start(0);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      onPlaybackErrorRef.current?.(error);
+    }
+
+    return () => {
+      cancelled = true;
+      try {
+        source?.stop();
+      } catch {
+        // 既に停止済み・未開始など。無視。
+      }
+      source?.disconnect();
+    };
+  }, [audioBuffer, audioContext]);
+
+  // 画像パスと alt テキストを取得する（取得失敗時はフォールバック）
+  let imagePath: string | null = null;
+  let altText = '';
+  try {
+    const renderProfile = getCharacterRenderProfile(characterId);
+    if (renderProfile.renderer === 'still') {
+      imagePath = renderProfile.imagePath;
+    }
+  } catch {
+    // 未登録 ID や renderer 不一致の場合は画像を出さず、フォールバック表示にする
+  }
+  try {
+    altText = getCharacterDisplay(characterId).displayName;
+  } catch {
+    // 未登録 ID などの場合は空文字列のまま表示する
+  }
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'background.default',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+      data-testid="still-image-container"
+    >
+      {/* 一枚絵画像（CloudFront/S3 配信のため unoptimized 必須） */}
+      {imagePath && (
+        <Image
+          src={imagePath}
+          alt={altText}
+          fill
+          unoptimized
+          style={{ objectFit: 'contain' }}
+          sizes="(max-width: 600px) 100vw, 360px"
+          data-testid="still-image"
+        />
+      )}
+
+      {/* ステータステキスト（PlaceholderCanvas / Live2DCanvas と同様に下部に表示） */}
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          position: 'absolute',
+          bottom: 4,
+          left: 0,
+          right: 0,
+          textAlign: 'center',
+        }}
+      >
+        {statusText ?? '待機中'}
+      </Typography>
+    </Box>
+  );
+}

--- a/services/livetalk/web/src/components/StillImageCanvas.tsx
+++ b/services/livetalk/web/src/components/StillImageCanvas.tsx
@@ -4,10 +4,7 @@ import { useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { Box, Typography } from '@mui/material';
 import type { LifecycleState } from '@nagiyu/livetalk-core';
-import {
-  getCharacterDisplay,
-  getCharacterRenderProfile,
-} from '@/lib/characters/client-profiles';
+import { getCharacterDisplay, getCharacterRenderProfile } from '@/lib/characters/client-profiles';
 
 /**
  * StillImageCanvas のプロパティ。

--- a/services/livetalk/web/src/lib/characters/client-profiles.ts
+++ b/services/livetalk/web/src/lib/characters/client-profiles.ts
@@ -66,12 +66,13 @@ const PROFILES: Record<string, CharacterClientProfile> = {
       shortName: 'アゲハ',
     },
     render: {
-      renderer: 'placeholder',
+      renderer: 'still',
+      imagePath: '/assets/characters/ageha/still.png',
     },
     licenseText: AGEHA_LICENSE_TEXT,
     description:
       'テンション高めで背中を押してくれる相棒ギャル。落ち込んでも隣でアゲてくれる、ノリのいい女の子。',
-    model: { engine: 'プレースホルダー', name: '仮アバター（シルエット）' },
+    model: { engine: '一枚絵', name: '早瀬アゲハ' },
     voice: { engine: 'OpenAI TTS', name: 'shimmer' },
   },
 };

--- a/services/livetalk/web/src/lib/characters/types.ts
+++ b/services/livetalk/web/src/lib/characters/types.ts
@@ -7,6 +7,7 @@
  * renderer フィールドで描画方式を区別する discriminated union。
  * - 'live2d': PixiJS + pixi-live2d-display を使った Live2D モデル描画
  * - 'placeholder': Live2D モデル未用意のキャラ向けプレースホルダー描画（シルエット + 名前ラベル）
+ * - 'still': 完成した一枚絵（静止画 1 枚）の描画。アニメーションなし。将来の瞬き＋口パクは別レンダラ。
  */
 export type CharacterRenderProfile =
   | {
@@ -27,6 +28,12 @@ export type CharacterRenderProfile =
   | {
       /** Live2D モデル未用意のキャラ向けプレースホルダー描画（シルエット + 名前ラベル、音声連動の口パク） */
       renderer: 'placeholder';
+    }
+  | {
+      /** 完成した一枚絵（静止画 1 枚）の描画。アニメーションなし。将来の瞬き＋口パクは別レンダラ。 */
+      renderer: 'still';
+      /** 一枚絵画像のパス（public/CloudFront 配下の絶対パス。例: /assets/characters/ageha/still.png） */
+      imagePath: string;
     };
 
 /**

--- a/services/livetalk/web/tests/unit/components/CharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/CharacterCanvas.test.tsx
@@ -35,6 +35,14 @@ jest.mock('@/components/PlaceholderCanvas', () => ({
   )),
 }));
 
+// StillImageCanvas: next/image + Web Audio 依存を排除するためモック化する
+jest.mock('@/components/StillImageCanvas', () => ({
+  __esModule: true,
+  default: jest.fn(({ characterId }: { characterId?: string }) => (
+    <div data-testid="still-image-canvas" data-character-id={characterId ?? ''} />
+  )),
+}));
+
 // getCharacterRenderProfile をモック化して renderer 種別を制御する
 jest.mock('@/lib/characters/client-profiles', () => ({
   ...jest.requireActual('@/lib/characters/client-profiles'),
@@ -79,6 +87,58 @@ describe('CharacterCanvas', () => {
     it('characterId が Live2DCanvas に渡される', () => {
       render(<CharacterCanvas characterId="hiyori" />);
       expect(screen.getByTestId('live2d-canvas')).toHaveAttribute('data-character-id', 'hiyori');
+    });
+  });
+
+  describe('renderer: still のとき', () => {
+    beforeEach(() => {
+      mockGetCharacterRenderProfile.mockReturnValue({
+        renderer: 'still',
+        imagePath: '/assets/characters/ageha/still.png',
+      });
+    });
+
+    it('StillImageCanvas がマウントされる', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('still-image-canvas')).toBeInTheDocument();
+    });
+
+    it('Live2DCanvas がマウントされない', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.queryByTestId('live2d-canvas')).toBeNull();
+    });
+
+    it('PlaceholderCanvas がマウントされない', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.queryByTestId('placeholder-canvas')).toBeNull();
+    });
+
+    it('characterId が StillImageCanvas に渡される', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('still-image-canvas')).toHaveAttribute(
+        'data-character-id',
+        'ageha'
+      );
+    });
+
+    it('statusText などの props が StillImageCanvas に透過される', () => {
+      const mockPlaybackEnd = jest.fn();
+      const { default: MockStillImageCanvas } = jest.requireMock('@/components/StillImageCanvas');
+
+      render(
+        <CharacterCanvas
+          characterId="ageha"
+          statusText="話している"
+          onPlaybackEnd={mockPlaybackEnd}
+        />
+      );
+      expect(MockStillImageCanvas).toHaveBeenCalled();
+      const [receivedProps] = (MockStillImageCanvas as jest.Mock).mock.calls[0];
+      expect(receivedProps).toMatchObject({
+        characterId: 'ageha',
+        statusText: '話している',
+        onPlaybackEnd: mockPlaybackEnd,
+      });
     });
   });
 
@@ -182,6 +242,16 @@ describe('CharacterCanvas', () => {
 
       render(<CharacterCanvas />);
       expect(screen.getByTestId('placeholder-canvas')).toBeInTheDocument();
+    });
+
+    it('renderer: still の場合 StillImageCanvas がマウントされる', () => {
+      mockGetCharacterRenderProfile.mockReturnValue({
+        renderer: 'still',
+        imagePath: '/assets/characters/ageha/still.png',
+      });
+
+      render(<CharacterCanvas />);
+      expect(screen.getByTestId('still-image-canvas')).toBeInTheDocument();
     });
   });
 });

--- a/services/livetalk/web/tests/unit/components/StillImageCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/StillImageCanvas.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import StillImageCanvas from '@/components/StillImageCanvas';
+
+// getCharacterRenderProfile / getCharacterDisplay をモック化して表示内容を制御する
+jest.mock('@/lib/characters/client-profiles', () => ({
+  ...jest.requireActual('@/lib/characters/client-profiles'),
+  getCharacterRenderProfile: jest.fn((id?: string) => {
+    if (id === 'ageha' || id === undefined) {
+      return { renderer: 'still', imagePath: '/assets/characters/ageha/still.png' };
+    }
+    // renderer 不一致のキャラ（フォールバック確認用）
+    if (id === 'hiyori') {
+      return {
+        renderer: 'live2d',
+        modelPath: '/assets/characters/hiyori/runtime/hiyori_free_t08.model3.json',
+        cubismParams: {
+          mouthOpenY: 'ParamMouthOpenY',
+          eyeLOpen: 'ParamEyeLOpen',
+          eyeROpen: 'ParamEyeROpen',
+        },
+      };
+    }
+    throw new Error('指定されたキャラクターのプロファイルが見つかりません。');
+  }),
+  getCharacterDisplay: jest.fn((id?: string) => {
+    if (id === 'ageha' || id === undefined) {
+      return { displayName: '早瀬アゲハ', shortName: 'アゲハ' };
+    }
+    if (id === 'hiyori') {
+      return { displayName: '桃瀬ひより', shortName: 'ひより' };
+    }
+    throw new Error('指定されたキャラクターのプロファイルが見つかりません。');
+  }),
+}));
+
+// next/image: テスト環境で動作可能だが、fill モードの検証を確実にするため
+// data-testid が通るシンプルな img を返すモックを使う
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: jest.fn(
+    ({ src, alt, 'data-testid': testId }: { src: string; alt: string; 'data-testid'?: string }) => (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={src} alt={alt} data-testid={testId} />
+    )
+  ),
+}));
+
+describe('StillImageCanvas', () => {
+  describe('画像表示', () => {
+    it('still-image-container が描画される', () => {
+      render(<StillImageCanvas characterId="ageha" />);
+      expect(screen.getByTestId('still-image-container')).toBeInTheDocument();
+    });
+
+    it('still-image が描画され alt に displayName が設定される', () => {
+      render(<StillImageCanvas characterId="ageha" />);
+      const img = screen.getByTestId('still-image');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('alt', '早瀬アゲハ');
+    });
+
+    it('still-image の src が imagePath と一致する', () => {
+      render(<StillImageCanvas characterId="ageha" />);
+      const img = screen.getByTestId('still-image');
+      expect(img).toHaveAttribute('src', '/assets/characters/ageha/still.png');
+    });
+  });
+
+  describe('statusText の表示', () => {
+    it('statusText が指定されていない場合「待機中」が表示される', () => {
+      render(<StillImageCanvas characterId="ageha" />);
+      expect(screen.getByText('待機中')).toBeInTheDocument();
+    });
+
+    it('statusText が指定された場合その内容が表示される', () => {
+      render(<StillImageCanvas characterId="ageha" statusText="考え中" />);
+      expect(screen.getByText('考え中')).toBeInTheDocument();
+    });
+
+    it('statusText を変えても表示が切り替わる', () => {
+      const { rerender } = render(<StillImageCanvas characterId="ageha" statusText="待機中" />);
+      expect(screen.getByText('待機中')).toBeInTheDocument();
+
+      rerender(<StillImageCanvas characterId="ageha" statusText="話している" />);
+      expect(screen.getByText('話している')).toBeInTheDocument();
+    });
+  });
+
+  describe('audioBuffer / audioContext 未指定時', () => {
+    it('audioBuffer が null のときクラッシュしない（待機表示）', () => {
+      expect(() => {
+        render(<StillImageCanvas characterId="ageha" audioBuffer={null} />);
+      }).not.toThrow();
+    });
+
+    it('audioContext が null のときクラッシュしない（待機表示）', () => {
+      expect(() => {
+        render(<StillImageCanvas characterId="ageha" audioBuffer={null} audioContext={null} />);
+      }).not.toThrow();
+    });
+
+    it('両方 undefined のときクラッシュしない', () => {
+      expect(() => {
+        render(<StillImageCanvas characterId="ageha" />);
+      }).not.toThrow();
+    });
+
+    it('audioBuffer / audioContext 未指定でも still-image-container が表示される', () => {
+      render(<StillImageCanvas />);
+      expect(screen.getByTestId('still-image-container')).toBeInTheDocument();
+    });
+  });
+
+  describe('renderer 不一致時のフォールバック', () => {
+    it('renderer が still でないキャラ（live2d）は画像を出さずクラッシュしない', () => {
+      expect(() => {
+        render(<StillImageCanvas characterId="hiyori" />);
+      }).not.toThrow();
+      // still-image は表示されない
+      expect(screen.queryByTestId('still-image')).toBeNull();
+      // コンテナと statusText は表示される
+      expect(screen.getByTestId('still-image-container')).toBeInTheDocument();
+      expect(screen.getByText('待機中')).toBeInTheDocument();
+    });
+
+    it('getCharacterRenderProfile がスローしても画像を出さずクラッシュしない', () => {
+      expect(() => {
+        render(<StillImageCanvas characterId="unknown-id" />);
+      }).not.toThrow();
+      expect(screen.queryByTestId('still-image')).toBeNull();
+      expect(screen.getByTestId('still-image-container')).toBeInTheDocument();
+    });
+
+    it('getCharacterDisplay がスローしても alt が空文字列でクラッシュしない', () => {
+      // getCharacterDisplay のモックを一時的にスローさせる
+      const { getCharacterDisplay } = jest.requireMock('@/lib/characters/client-profiles');
+      (getCharacterDisplay as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('未登録');
+      });
+
+      expect(() => {
+        render(<StillImageCanvas characterId="ageha" />);
+      }).not.toThrow();
+      // still-image は imagePath が取れているので表示される（alt が空文字列）
+      const img = screen.queryByTestId('still-image');
+      if (img) {
+        expect(img).toHaveAttribute('alt', '');
+      }
+    });
+  });
+
+  describe('characterId 省略時', () => {
+    it('characterId を省略しても still-image-container が描画される', () => {
+      render(<StillImageCanvas />);
+      expect(screen.getByTestId('still-image-container')).toBeInTheDocument();
+    });
+
+    it('characterId を省略しても still-image が描画される', () => {
+      render(<StillImageCanvas />);
+      expect(screen.getByTestId('still-image')).toBeInTheDocument();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
@@ -174,14 +174,26 @@ describe('早瀬アゲハ クライアントプロファイル', () => {
     expect(profile.display.shortName).toBe('アゲハ');
   });
 
-  it('render.renderer が "placeholder" である（Live2D モデル未用意）', () => {
+  it('render.renderer が "still" である（一枚絵静止画）', () => {
     const profile = getCharacterClientProfile('ageha');
-    expect(profile.render.renderer).toBe('placeholder');
+    expect(profile.render.renderer).toBe('still');
   });
 
-  it('getCharacterRenderProfile("ageha") も placeholder を返す', () => {
+  it('render.imagePath が "/assets/characters/ageha/still.png" である', () => {
+    const profile = getCharacterClientProfile('ageha');
+    // renderer で narrowing してから imagePath を参照する
+    expect(profile.render.renderer).toBe('still');
+    if (profile.render.renderer === 'still') {
+      expect(profile.render.imagePath).toBe('/assets/characters/ageha/still.png');
+    }
+  });
+
+  it('getCharacterRenderProfile("ageha") も still を返す', () => {
     const render = getCharacterRenderProfile('ageha');
-    expect(render.renderer).toBe('placeholder');
+    expect(render.renderer).toBe('still');
+    if (render.renderer === 'still') {
+      expect(render.imagePath).toBe('/assets/characters/ageha/still.png');
+    }
   });
 
   it('licenseText に AI 生成音声の明示が含まれる（OpenAI 利用規約上必須）', () => {
@@ -195,9 +207,14 @@ describe('早瀬アゲハ クライアントプロファイル', () => {
     expect(profile.description.length).toBeGreaterThan(0);
   });
 
-  it('model.engine が "プレースホルダー" である', () => {
+  it('model.engine が "一枚絵" である', () => {
     const profile = getCharacterClientProfile('ageha');
-    expect(profile.model.engine).toBe('プレースホルダー');
+    expect(profile.model.engine).toBe('一枚絵');
+  });
+
+  it('model.name が "早瀬アゲハ" である', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.model.name).toBe('早瀬アゲハ');
   });
 
   it('voice.engine が "OpenAI TTS" である', () => {

--- a/services/livetalk/web/tests/unit/lib/characters/registry.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/registry.test.ts
@@ -49,8 +49,8 @@ describe('キャラクターレジストリ', () => {
       const entry = getCharacterEntry('ageha');
       expect(entry.definition.id).toBe('ageha');
       expect(entry.definition.displayName).toBe('早瀬アゲハ');
-      // ageha は placeholder renderer を使用する
-      expect(entry.render.renderer).toBe('placeholder');
+      // ageha は still renderer（一枚絵）を使用する
+      expect(entry.render.renderer).toBe('still');
     });
 
     it('未登録の characterId を指定すると日本語定数メッセージで Error をスローする', () => {


### PR DESCRIPTION
## 変更の概要

早瀬アゲハの表示を、プレースホルダー（シルエット円＋名前ラベル）から **完成した一枚絵（静止画）** に切り替える。

- キャラクター描画の抽象化（`CharacterRenderProfile`）に **新レンダラ種別 `still`**（一枚絵・静止画 1 枚、アニメーションなし）を追加。
- アゲハのプロファイルを `renderer: 'still'` + `imagePath: '/assets/characters/ageha/still.png'` に変更。モデル属性表記も「一枚絵「早瀬アゲハ」」に更新。
- 一枚絵を表示する `StillImageCanvas` を新規追加。`next/image`（`fill` + `unoptimized`）で表示し、音声再生（Web Audio）は維持、口パク・瞬きなどのアニメーションは行わない。
- 既存の `placeholder` レンダラは他キャラ向けに温存。

瞬き・口パクは本 PR のスコープ外（将来 `still` とは別レンダラとして追加予定）。

## 関連 Issue

参照: #3497
<!-- 作業ブランチ → integration の PR のため Closes は付けない。Issue クローズは integration → develop の PR で行う。 -->

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（※下記「補足事項」参照）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリではないため不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `StillImageCanvas.test.tsx`（新規）: 画像要素・コンテナ描画、`alt` テキスト、`statusText` 表示、`audioBuffer`/`audioContext` 未指定時のクラッシュ耐性、imagePath 取得失敗時のフォールバックなどを検証。
- `CharacterCanvas.test.tsx`（更新）: `renderer: 'still'` 時に `StillImageCanvas` がマウントされ、live2d/placeholder がマウントされないこと、props 透過を検証。
- `client-profiles.test.ts` / `registry.test.ts`（更新）: アゲハの `renderer` 期待値を `'still'` に、`imagePath`・`model` 属性を検証。
- 実行結果: `@nagiyu/livetalk-web` で **53 スイート / 467 テスト 全パス**、カバレッジ全体 90.71%（閾値 80% 達成）、`lint` exit 0。

## レビューポイント

- 新レンダラ種別の命名を `still`（一枚絵・静止画 1 枚）とした点。将来の「瞬き＋口パク」は描画戦略が異なるため、`still` とは別レンダラ（例 `sprite`）として追加する想定（`image` のような広い名前を避けた）。
- `StillImageCanvas` で `next/image` に `unoptimized` を指定している点。`/assets/*` は CloudFront→S3 配信であり、Next.js 画像最適化に通すと standalone で 500 になるため。
- 音声再生は `AudioBufferSourceNode` を `destination` に直結するのみ（AnalyserNode・rAF なし）。

## スクリーンショット（該当する場合）

一枚絵画像（S3）の配置後に dev 環境で確認予定。

## 補足事項

- **dev 環境で実際に一枚絵を表示するには、画像ファイルを S3 バケット `nagiyu-livetalk-assets-{env}` のキー `characters/ageha/still.png` にアップロードする必要があります**（コードはパス参照のみ。ひより の Live2D アセットと同じ配信経路）。S3 アップロードは人手で実施してください。ファイル名を変える場合は `client-profiles.ts` の `imagePath` を合わせて変更します。
- 関連ドキュメント（`docs/services/livetalk/` の architecture / external-design 等）への `still` レンダラ追記は、必要であれば別途対応します。


---
_Generated by [Claude Code](https://claude.ai/code/session_01CUwMihM3vPxtj9CwhGHnf4)_