### PR TITLE
リブトーク: admin 限定のテスト通知送信（dev 検証用、#3491）

### DIFF
--- a/services/livetalk/web/jest.config.ts
+++ b/services/livetalk/web/jest.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
     '^@nagiyu/ui$': '<rootDir>/../../../libs/ui/src/index.ts',
     '^@nagiyu/browser$': '<rootDir>/../../../libs/browser/src/index.ts',
     '^@nagiyu/common$': '<rootDir>/../../../libs/common/src/index.ts',
+    '^@nagiyu/common/push$': '<rootDir>/../../../libs/common/src/push/index.ts',
     '^@nagiyu/nextjs$': '<rootDir>/../../../libs/nextjs/src/index.ts',
     '^@nagiyu/livetalk-core$': '<rootDir>/../core/src/index.ts',
     '^@nagiyu/aws$': '<rootDir>/../../../libs/aws/src/index.ts',

--- a/services/livetalk/web/src/app/(protected)/status/page.tsx
+++ b/services/livetalk/web/src/app/(protected)/status/page.tsx
@@ -33,8 +33,13 @@ import {
   getStudyTopicRepository,
   getMessageRepository,
 } from '@/lib/server/repositories';
-import { hasCharacter } from '@/lib/characters/registry';
+import {
+  hasCharacter,
+  getRegisteredCharacterIds,
+  getCharacterDisplay,
+} from '@/lib/characters/registry';
 import StatusCharacterSwitcher from '@/components/StatusCharacterSwitcher';
+import StatusTestPush from '@/components/StatusTestPush';
 
 const JST = 'Asia/Tokyo';
 
@@ -126,6 +131,12 @@ export default async function StatusPage({ searchParams }: StatusPageProps) {
   }
 
   const recentNotifications = notificationEvents.slice(0, 5);
+
+  // テスト通知送信用: 登録キャラクターの表示名マップを構築する
+  const registeredCharacterIds = getRegisteredCharacterIds();
+  const characterDisplayNames = Object.fromEntries(
+    registeredCharacterIds.map((id) => [id, getCharacterDisplay(id).displayName])
+  );
 
   return (
     <Container maxWidth="sm" sx={{ py: 2 }}>
@@ -239,6 +250,17 @@ export default async function StatusPage({ searchParams }: StatusPageProps) {
       </Typography>
       <Typography variant="body2">KNOWLEDGE: {knowledge.length} 件</Typography>
       <Typography variant="body2">STUDY_TOPIC (pending): {studyPending.length} 件</Typography>
+
+      <Divider sx={{ my: 1.5 }} />
+
+      {/* テスト通知送信（admin デバッグ用 — Issue #3491） */}
+      <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+        テスト通知送信
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1, fontSize: '0.75rem' }}>
+        decision ゲートを介さず即時送信します。dev 検証専用。
+      </Typography>
+      <StatusTestPush characterIds={registeredCharacterIds} displayNames={characterDisplayNames} />
     </Container>
   );
 }

--- a/services/livetalk/web/src/app/api/push/test/route.ts
+++ b/services/livetalk/web/src/app/api/push/test/route.ts
@@ -1,0 +1,165 @@
+/**
+ * POST /api/push/test
+ *
+ * livetalk:admin 権限保持者向けの「テスト通知送信」API（Issue #3491）。
+ *
+ * dev 環境での通知結合検証用：
+ *   - 任意のキャラクターへの通知を decision ゲートを一切介さずに即時送信できる。
+ *   - 「両キャラから通知が届く／タップで各キャラが開く／第一声が出る」の検証に使用する。
+ *
+ * このエンドポイントは恒久的な admin デバッグツールとして維持する。
+ */
+
+import { NextResponse } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import { logger, toErrorMessage } from '@nagiyu/common';
+import { sendWebPushNotification, getVapidConfig } from '@nagiyu/common/push';
+import { defaultUlidFactory, NOTIFICATION_EVENT_TTL_SECONDS } from '@nagiyu/livetalk-core';
+import { getSession } from '@/lib/server/session';
+import {
+  getPushSubscriptionRepository,
+  getNotificationEventRepository,
+} from '@/lib/server/repositories';
+import { hasCharacter, getCharacterDefinition } from '@/lib/characters/registry';
+
+/**
+ * このエンドポイント固有のエラーメッセージ定数。
+ */
+export const TEST_PUSH_ERROR_MESSAGES = {
+  INVALID_REQUEST_BODY: 'リクエストボディが不正です',
+  MISSING_CHARACTER_ID: 'characterId が必要です',
+  UNKNOWN_CHARACTER: '指定されたキャラクターが見つかりません',
+  SEND_FAILED: 'テスト通知の送信に失敗しました',
+} as const;
+
+export const POST = withAuth(getSession, 'livetalk:admin', async (session, request: Request) => {
+  const userId = session.user.googleId;
+
+  // リクエストボディを解析する
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'INVALID_REQUEST', message: TEST_PUSH_ERROR_MESSAGES.INVALID_REQUEST_BODY },
+      { status: 400 }
+    );
+  }
+
+  // characterId バリデーション
+  if (!body || typeof body !== 'object' || !('characterId' in body)) {
+    return NextResponse.json(
+      { error: 'INVALID_REQUEST', message: TEST_PUSH_ERROR_MESSAGES.MISSING_CHARACTER_ID },
+      { status: 400 }
+    );
+  }
+
+  const { characterId } = body as { characterId: unknown };
+
+  if (typeof characterId !== 'string' || characterId.trim() === '') {
+    return NextResponse.json(
+      { error: 'INVALID_REQUEST', message: TEST_PUSH_ERROR_MESSAGES.MISSING_CHARACTER_ID },
+      { status: 400 }
+    );
+  }
+
+  if (!hasCharacter(characterId)) {
+    return NextResponse.json(
+      { error: 'UNKNOWN_CHARACTER', message: TEST_PUSH_ERROR_MESSAGES.UNKNOWN_CHARACTER },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // キャラクター定義からテスト通知の文面を生成する（テストと明確に分かる内容にする）
+    const def = getCharacterDefinition(characterId);
+    const title = `${def.notificationName}より`;
+    const body_text = `【テスト送信】${def.displayName}からのテスト通知です`;
+
+    // プッシュサブスクリプションを取得する
+    const subscriptions = await getPushSubscriptionRepository().listByUser(userId);
+
+    // サブスクリプションが 0 件の場合は送信せずに返す
+    if (subscriptions.length === 0) {
+      logger.info('[POST /api/push/test] 購読なし（送信スキップ）', { userId, characterId });
+      return NextResponse.json({ sent: 0, characterId }, { status: 200 });
+    }
+
+    // VAPID 設定を取得する
+    const vapidConfig = getVapidConfig();
+
+    // payload: notify.usecase.ts と同様の形式
+    const payload = {
+      title,
+      body: body_text,
+      data: { url: `/?character=${characterId}`, characterId },
+    };
+
+    // 各サブスクリプションへ送信する（失敗はログのみで継続・無効サブスクは削除）
+    const pushSubscriptionRepo = getPushSubscriptionRepository();
+    let sentCount = 0;
+
+    for (const sub of subscriptions) {
+      try {
+        const sent = await sendWebPushNotification(
+          { endpoint: sub.Endpoint, keys: { p256dh: sub.P256dhKey, auth: sub.AuthKey } },
+          payload,
+          vapidConfig
+        );
+        if (sent) {
+          sentCount++;
+        } else {
+          // 無効なサブスクリプション（404/410）を削除する
+          await pushSubscriptionRepo.delete({
+            userId,
+            subscriptionId: sub.SubscriptionID,
+          });
+        }
+      } catch (error) {
+        logger.warn('[POST /api/push/test] Push 送信失敗（継続）', {
+          userId,
+          characterId,
+          subscriptionId: sub.SubscriptionID,
+          error: toErrorMessage(error),
+        });
+      }
+    }
+
+    // 1 件以上送信成功した場合、NotificationEvent を記録する（first-word/pending 検証のため）
+    if (sentCount > 0) {
+      const ttl = Math.floor(Date.now() / 1000) + NOTIFICATION_EVENT_TTL_SECONDS;
+      await getNotificationEventRepository().put({
+        UserID: userId,
+        NotifID: defaultUlidFactory(),
+        CharacterID: characterId,
+        Kind: 'normal',
+        Title: title,
+        Body: body_text,
+        Ttl: ttl,
+      });
+
+      logger.info('[POST /api/push/test] テスト通知送信完了', {
+        userId,
+        characterId,
+        sentCount,
+      });
+    } else {
+      logger.info('[POST /api/push/test] 有効サブスクリプションなし（送信 0 件）', {
+        userId,
+        characterId,
+      });
+    }
+
+    return NextResponse.json({ sent: sentCount, characterId }, { status: 200 });
+  } catch (error) {
+    logger.error('[POST /api/push/test] テスト通知送信に失敗しました', {
+      userId,
+      characterId,
+      error: toErrorMessage(error),
+    });
+    return NextResponse.json(
+      { error: 'SEND_FAILED', message: TEST_PUSH_ERROR_MESSAGES.SEND_FAILED },
+      { status: 500 }
+    );
+  }
+});

--- a/services/livetalk/web/src/app/api/push/test/route.ts
+++ b/services/livetalk/web/src/app/api/push/test/route.ts
@@ -24,8 +24,11 @@ import { hasCharacter, getCharacterDefinition } from '@/lib/characters/registry'
 
 /**
  * このエンドポイント固有のエラーメッセージ定数。
+ *
+ * Next.js の Route ファイルは HTTP メソッド等の規定エクスポートしか許可しないため、
+ * この定数は export せずローカルに閉じる（export すると build の型検査で弾かれる）。
  */
-export const TEST_PUSH_ERROR_MESSAGES = {
+const TEST_PUSH_ERROR_MESSAGES = {
   INVALID_REQUEST_BODY: 'リクエストボディが不正です',
   MISSING_CHARACTER_ID: 'characterId が必要です',
   UNKNOWN_CHARACTER: '指定されたキャラクターが見つかりません',

--- a/services/livetalk/web/src/app/api/push/test/route.ts
+++ b/services/livetalk/web/src/app/api/push/test/route.ts
@@ -74,7 +74,7 @@ export const POST = withAuth(getSession, 'livetalk:admin', async (session, reque
     // キャラクター定義からテスト通知の文面を生成する（テストと明確に分かる内容にする）
     const def = getCharacterDefinition(characterId);
     const title = `${def.notificationName}より`;
-    const body_text = `【テスト送信】${def.displayName}からのテスト通知です`;
+    const bodyText = `【テスト送信】${def.displayName}からのテスト通知です`;
 
     // プッシュサブスクリプションを取得する
     const subscriptions = await getPushSubscriptionRepository().listByUser(userId);
@@ -91,7 +91,7 @@ export const POST = withAuth(getSession, 'livetalk:admin', async (session, reque
     // payload: notify.usecase.ts と同様の形式
     const payload = {
       title,
-      body: body_text,
+      body: bodyText,
       data: { url: `/?character=${characterId}`, characterId },
     };
 
@@ -134,7 +134,7 @@ export const POST = withAuth(getSession, 'livetalk:admin', async (session, reque
         CharacterID: characterId,
         Kind: 'normal',
         Title: title,
-        Body: body_text,
+        Body: bodyText,
         Ttl: ttl,
       });
 

--- a/services/livetalk/web/src/components/StatusTestPush.tsx
+++ b/services/livetalk/web/src/components/StatusTestPush.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+/**
+ * StatusTestPush — admin デバッグ用「テスト通知送信」コンポーネント（Issue #3491）。
+ *
+ * ステータスページに埋め込み、各キャラクターへのテスト push を
+ * decision ゲートを介さず即時送信できる。
+ *
+ * dev 環境での以下の検証に使用する:
+ *   - 両キャラから通知が届く
+ *   - タップで各キャラが開く
+ *   - 第一声が出る
+ *
+ * このコンポーネントは恒久的な admin デバッグツールとして維持する。
+ */
+
+import { useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+
+/**
+ * テスト通知送信の結果状態。
+ */
+interface SendResult {
+  characterId: string;
+  /** 送信成功件数。0 の場合は購読なし。 */
+  sent: number;
+  /** エラー発生時のメッセージ。 */
+  error?: string;
+}
+
+/**
+ * コンポーネントの Props。
+ */
+export interface StatusTestPushProps {
+  /** 送信ボタンを表示するキャラクター ID の一覧。 */
+  characterIds: string[];
+  /**
+   * キャラクター ID → 表示名のマップ。
+   * ボタンラベルに使用する（例: 「桃瀬ひより にテスト通知」）。
+   */
+  displayNames: Record<string, string>;
+}
+
+/**
+ * POST /api/push/test を呼び出してテスト通知を送信する。
+ *
+ * UI ロジックとフェッチロジックを分離するため、この関数はコンポーネント外に定義する。
+ */
+async function sendTestPush(characterId: string): Promise<SendResult> {
+  const response = await fetch('/api/push/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ characterId }),
+  });
+
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    try {
+      const json = (await response.json()) as { message?: string };
+      if (json.message) {
+        message = json.message;
+      }
+    } catch {
+      // JSON 解析失敗時はステータスコードのみ使用
+    }
+    return { characterId, sent: 0, error: message };
+  }
+
+  const json = (await response.json()) as { sent: number; characterId: string };
+  return { characterId, sent: json.sent };
+}
+
+/**
+ * ステータスページ用のテスト通知送信セクション。
+ */
+export default function StatusTestPush({ characterIds, displayNames }: StatusTestPushProps) {
+  // characterId ごとの送信中フラグ
+  const [sending, setSending] = useState<Record<string, boolean>>({});
+  // characterId ごとの直近送信結果
+  const [results, setResults] = useState<Record<string, SendResult>>({});
+
+  const handleSend = async (characterId: string) => {
+    setSending((prev) => ({ ...prev, [characterId]: true }));
+    try {
+      const result = await sendTestPush(characterId);
+      setResults((prev) => ({ ...prev, [characterId]: result }));
+    } finally {
+      setSending((prev) => ({ ...prev, [characterId]: false }));
+    }
+  };
+
+  /**
+   * 送信結果のメッセージを生成する。
+   */
+  const getResultMessage = (result: SendResult): string => {
+    if (result.error) {
+      return `エラー: ${result.error}`;
+    }
+    if (result.sent === 0) {
+      return '購読なし（送信されませんでした）';
+    }
+    return `送信完了（${result.sent} 件）`;
+  };
+
+  /**
+   * 送信結果の色を返す（エラー: error、購読なし: text.secondary、成功: success.main）。
+   */
+  const getResultColor = (result: SendResult): string => {
+    if (result.error) return 'error.main';
+    if (result.sent === 0) return 'text.secondary';
+    return 'success.main';
+  };
+
+  return (
+    <Box>
+      {characterIds.map((characterId) => {
+        const displayName = displayNames[characterId] ?? characterId;
+        const isSending = sending[characterId] ?? false;
+        const result = results[characterId];
+
+        return (
+          <Box key={characterId} sx={{ mb: 1.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+              <Button
+                variant="outlined"
+                size="small"
+                disabled={isSending}
+                onClick={() => handleSend(characterId)}
+                sx={{ fontSize: '0.75rem', py: 0.5 }}
+              >
+                {isSending ? '送信中…' : `${displayName} にテスト通知`}
+              </Button>
+              {result && (
+                <Typography
+                  variant="body2"
+                  sx={{ fontSize: '0.75rem', color: getResultColor(result) }}
+                >
+                  {getResultMessage(result)}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/services/livetalk/web/src/components/StatusTestPush.tsx
+++ b/services/livetalk/web/src/components/StatusTestPush.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useState } from 'react';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import { Button } from '@nagiyu/ui';
 
 /**
  * テスト通知送信の結果状態。
@@ -122,11 +123,10 @@ export default function StatusTestPush({ characterIds, displayNames }: StatusTes
           <Box key={characterId} sx={{ mb: 1.5 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
               <Button
-                variant="outlined"
-                size="small"
+                variant="outline"
+                size="sm"
                 disabled={isSending}
                 onClick={() => handleSend(characterId)}
-                sx={{ fontSize: '0.75rem', py: 0.5 }}
               >
                 {isSending ? '送信中…' : `${displayName} にテスト通知`}
               </Button>

--- a/services/livetalk/web/tests/unit/app/api/push/test.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/push/test.test.ts
@@ -1,0 +1,405 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * POST /api/push/test のユニットテスト（Issue #3491）。
+ *
+ * テスト観点:
+ *   - 非 admin（未認証・livetalk:admin 権限なし）は withAuth で弾かれる
+ *   - 不正 / 欠落 characterId → 400
+ *   - 購読 0 件 → 200 `{ sent: 0 }`、push 未送信・NotificationEvent 未記録
+ *   - 正常系 → 各サブスクへ送信、payload に data.characterId / data.url が入る、
+ *     成功時 NotificationEvent が CharacterID 付きで記録、`{ sent }` を返す
+ *   - 無効サブスク（false 戻り）→ delete される
+ */
+import { POST } from '@/app/api/push/test/route';
+import { getSession } from '@/lib/server/session';
+import {
+  getPushSubscriptionRepository,
+  getNotificationEventRepository,
+} from '@/lib/server/repositories';
+import { sendWebPushNotification } from '@nagiyu/common/push';
+import { hasCharacter, getCharacterDefinition } from '@/lib/characters/registry';
+import type {
+  PushSubscriptionRepository,
+  NotificationEventRepository,
+  PushSubscriptionEntity,
+} from '@nagiyu/livetalk-core';
+
+// ---- モック設定 -------------------------------------------------------
+
+jest.mock('@/lib/server/session', () => ({
+  getSession: jest.fn(),
+}));
+
+jest.mock('@/lib/server/repositories', () => ({
+  getPushSubscriptionRepository: jest.fn(),
+  getNotificationEventRepository: jest.fn(),
+}));
+
+jest.mock('@nagiyu/common/push', () => ({
+  sendWebPushNotification: jest.fn(),
+  getVapidConfig: jest.fn(() => ({
+    publicKey: 'test-public-key',
+    privateKey: 'test-private-key',
+    subject: 'mailto:test@example.com',
+  })),
+}));
+
+jest.mock('@/lib/characters/registry', () => ({
+  hasCharacter: jest.fn(),
+  getCharacterDefinition: jest.fn(),
+}));
+
+// livetalk-core の defaultUlidFactory と NOTIFICATION_EVENT_TTL_SECONDS をモック化する
+jest.mock('@nagiyu/livetalk-core', () => ({
+  defaultUlidFactory: jest.fn(() => 'test-ulid'),
+  NOTIFICATION_EVENT_TTL_SECONDS: 2592000,
+}));
+
+// ---- 型付きモック変数 ---------------------------------------------------
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetPushSubscriptionRepo = getPushSubscriptionRepository as jest.MockedFunction<
+  typeof getPushSubscriptionRepository
+>;
+const mockGetNotifEventRepo = getNotificationEventRepository as jest.MockedFunction<
+  typeof getNotificationEventRepository
+>;
+const mockSendWebPushNotification = sendWebPushNotification as jest.MockedFunction<
+  typeof sendWebPushNotification
+>;
+const mockHasCharacter = hasCharacter as jest.MockedFunction<typeof hasCharacter>;
+const mockGetCharacterDefinition = getCharacterDefinition as jest.MockedFunction<
+  typeof getCharacterDefinition
+>;
+
+// ---- テスト用定数 -------------------------------------------------------
+
+/** 非 admin セッション（livetalk:admin 権限なし） */
+const livetalkUserSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'user@example.com',
+    name: 'User',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+/** admin セッション */
+const adminSession = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'admin@example.com',
+    name: 'Admin',
+    roles: ['livetalk-admin'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60 * 1000).toISOString(),
+};
+
+/** サブスクリプションエンティティのファクトリ */
+function makeSubscription(overrides: Partial<PushSubscriptionEntity> = {}): PushSubscriptionEntity {
+  return {
+    UserID: 'g1',
+    SubscriptionID: 'sub-1',
+    Endpoint: 'https://push.example.com/sub-1',
+    P256dhKey: 'p256dh-key',
+    AuthKey: 'auth-key',
+    CreatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+/** PushSubscriptionRepository モックのファクトリ */
+function makePushRepo(subscriptions: PushSubscriptionEntity[]): PushSubscriptionRepository {
+  return {
+    listByUser: jest.fn(async () => subscriptions),
+    put: jest.fn(),
+    get: jest.fn(),
+    delete: jest.fn(),
+  } as unknown as PushSubscriptionRepository;
+}
+
+/** NotificationEventRepository モックのファクトリ */
+function makeNotifEventRepo(): NotificationEventRepository {
+  return {
+    put: jest.fn(),
+    get: jest.fn(),
+    listByUser: jest.fn(),
+    markConsumed: jest.fn(),
+  } as unknown as NotificationEventRepository;
+}
+
+/** POST リクエストを組み立てるヘルパー */
+function buildPostRequest(body: unknown): Request {
+  return new Request('http://localhost/api/push/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** hiyori のキャラクター定義モック */
+const hiyoriDefinition = {
+  id: 'hiyori',
+  displayName: '桃瀬ひより',
+  notificationName: 'ひより',
+} as ReturnType<typeof getCharacterDefinition>;
+
+// ---- テスト -------------------------------------------------------
+
+describe('POST /api/push/test', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルトでは hiyori が有効なキャラクターとして設定する
+    mockHasCharacter.mockImplementation((id) => id === 'hiyori' || id === 'ageha');
+    mockGetCharacterDefinition.mockReturnValue(hiyoriDefinition);
+  });
+
+  describe('認証・認可チェック', () => {
+    it('未認証は 401 を返す', async () => {
+      mockGetSession.mockResolvedValueOnce(null);
+      const res = await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(res.status).toBe(401);
+    });
+
+    it('livetalk:admin 権限なし（livetalk-user のみ）は 403 を返す', async () => {
+      mockGetSession.mockResolvedValueOnce(livetalkUserSession);
+      const res = await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('バリデーション（admin セッション前提）', () => {
+    it('リクエストボディが不正な JSON → 400', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      const req = new Request('http://localhost/api/push/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'invalid-json',
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('INVALID_REQUEST');
+    });
+
+    it('characterId が欠落 → 400', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      const res = await POST(buildPostRequest({}));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('INVALID_REQUEST');
+      expect(json.message).toContain('characterId');
+    });
+
+    it('characterId が空文字列 → 400', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      const res = await POST(buildPostRequest({ characterId: '' }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('INVALID_REQUEST');
+    });
+
+    it('未登録の characterId → 400', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      mockHasCharacter.mockReturnValue(false);
+      const res = await POST(buildPostRequest({ characterId: 'unknown-char' }));
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('UNKNOWN_CHARACTER');
+    });
+  });
+
+  describe('購読 0 件の場合', () => {
+    it('送信せずに 200 で { sent: 0, characterId } を返す', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      const pushRepo = makePushRepo([]);
+      mockGetPushSubscriptionRepo.mockReturnValue(pushRepo);
+
+      const res = await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.sent).toBe(0);
+      expect(json.characterId).toBe('hiyori');
+    });
+
+    it('購読 0 件のとき sendWebPushNotification は呼ばれない', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([]));
+
+      await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(mockSendWebPushNotification).not.toHaveBeenCalled();
+    });
+
+    it('購読 0 件のとき NotificationEvent は記録されない', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([]));
+      const notifRepo = makeNotifEventRepo();
+      mockGetNotifEventRepo.mockReturnValue(notifRepo);
+
+      await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(notifRepo.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('正常系（送信成功）', () => {
+    it('各サブスクリプションへ sendWebPushNotification を呼ぶ', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      const sub1 = makeSubscription({ SubscriptionID: 'sub-1' });
+      const sub2 = makeSubscription({
+        SubscriptionID: 'sub-2',
+        Endpoint: 'https://push.example.com/sub-2',
+      });
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([sub1, sub2]));
+      mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
+      mockSendWebPushNotification.mockResolvedValue(true);
+
+      await POST(buildPostRequest({ characterId: 'hiyori' }));
+
+      expect(mockSendWebPushNotification).toHaveBeenCalledTimes(2);
+    });
+
+    it('payload の data に characterId と url=/?character=<id> が含まれる', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([makeSubscription()]));
+      mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
+      mockSendWebPushNotification.mockResolvedValue(true);
+
+      await POST(buildPostRequest({ characterId: 'hiyori' }));
+
+      const callArgs = mockSendWebPushNotification.mock.calls[0];
+      const payload = callArgs[1];
+      expect(payload.data).toMatchObject({
+        characterId: 'hiyori',
+        url: '/?character=hiyori',
+      });
+    });
+
+    it('送信成功時に { sent: <成功数>, characterId } を返す', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      const sub1 = makeSubscription({ SubscriptionID: 'sub-1' });
+      const sub2 = makeSubscription({
+        SubscriptionID: 'sub-2',
+        Endpoint: 'https://push.example.com/sub-2',
+      });
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([sub1, sub2]));
+      mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
+      mockSendWebPushNotification.mockResolvedValue(true);
+
+      const res = await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.sent).toBe(2);
+      expect(json.characterId).toBe('hiyori');
+    });
+
+    it('成功時に NotificationEvent が CharacterID 付きで記録される', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([makeSubscription()]));
+      const notifRepo = makeNotifEventRepo();
+      mockGetNotifEventRepo.mockReturnValue(notifRepo);
+      mockSendWebPushNotification.mockResolvedValue(true);
+
+      await POST(buildPostRequest({ characterId: 'hiyori' }));
+
+      expect(notifRepo.put).toHaveBeenCalledTimes(1);
+      const putArg = (notifRepo.put as jest.Mock).mock.calls[0][0];
+      expect(putArg.CharacterID).toBe('hiyori');
+      expect(putArg.UserID).toBe('g1');
+      expect(putArg.Kind).toBe('normal');
+    });
+
+    it('テストと分かる文面（title/body）で送信される', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([makeSubscription()]));
+      mockGetNotifEventRepo.mockReturnValue(makeNotifEventRepo());
+      mockSendWebPushNotification.mockResolvedValue(true);
+
+      await POST(buildPostRequest({ characterId: 'hiyori' }));
+
+      const callArgs = mockSendWebPushNotification.mock.calls[0];
+      const payload = callArgs[1];
+      // notificationName を使ったタイトル
+      expect(payload.title).toBe('ひよりより');
+      // テスト送信であることが明確に分かる body
+      expect(payload.body).toContain('テスト送信');
+      expect(payload.body).toContain('桃瀬ひより');
+    });
+  });
+
+  describe('無効サブスクリプションの処理', () => {
+    it('false を返すサブスクリプションは delete される', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      const validSub = makeSubscription({ SubscriptionID: 'sub-valid' });
+      const invalidSub = makeSubscription({
+        SubscriptionID: 'sub-invalid',
+        Endpoint: 'https://push.example.com/sub-invalid',
+      });
+      const pushRepo = makePushRepo([validSub, invalidSub]);
+      mockGetPushSubscriptionRepo.mockReturnValue(pushRepo);
+      const notifRepo = makeNotifEventRepo();
+      mockGetNotifEventRepo.mockReturnValue(notifRepo);
+
+      // 最初のサブスク(valid)は成功、2番目(invalid)は false（無効）を返す
+      mockSendWebPushNotification.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+      const res = await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      // 有効なサブスクリプション 1 件のみ成功
+      expect(json.sent).toBe(1);
+
+      // 無効サブスクが delete される
+      expect(pushRepo.delete).toHaveBeenCalledWith({
+        userId: 'g1',
+        subscriptionId: 'sub-invalid',
+      });
+    });
+
+    it('全サブスク無効（sent=0）のとき NotificationEvent は記録されない', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([makeSubscription()]));
+      const notifRepo = makeNotifEventRepo();
+      mockGetNotifEventRepo.mockReturnValue(notifRepo);
+      mockSendWebPushNotification.mockResolvedValue(false);
+
+      const res = await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.sent).toBe(0);
+      expect(notifRepo.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('送信例外の処理', () => {
+    it('一部サブスクで例外が発生しても他を送信し続ける', async () => {
+      mockGetSession.mockResolvedValue(adminSession);
+      const sub1 = makeSubscription({ SubscriptionID: 'sub-1' });
+      const sub2 = makeSubscription({
+        SubscriptionID: 'sub-2',
+        Endpoint: 'https://push.example.com/sub-2',
+      });
+      mockGetPushSubscriptionRepo.mockReturnValue(makePushRepo([sub1, sub2]));
+      const notifRepo = makeNotifEventRepo();
+      mockGetNotifEventRepo.mockReturnValue(notifRepo);
+
+      // sub-1 で例外、sub-2 は成功
+      mockSendWebPushNotification
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce(true);
+
+      const res = await POST(buildPostRequest({ characterId: 'hiyori' }));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.sent).toBe(1);
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/components/StatusTestPush.test.tsx
+++ b/services/livetalk/web/tests/unit/components/StatusTestPush.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * StatusTestPush コンポーネントのユニットテスト（Issue #3491）。
+ *
+ * テスト観点:
+ *   - 登録キャラクター分のボタンが表示される
+ *   - クリックで /api/push/test が呼ばれる（fetch モック）
+ *   - 成功 / 購読なし / エラー の各結果メッセージが表示される
+ *   - 送信中は disabled になる
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import StatusTestPush from '@/components/StatusTestPush';
+
+// ---- fetch のモック設定 -----------------------------------------------
+
+// グローバル fetch をモック化する
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// ---- テスト用定数 -------------------------------------------------------
+
+const characterIds = ['hiyori', 'ageha'];
+const displayNames: Record<string, string> = {
+  hiyori: '桃瀬ひより',
+  ageha: '早瀬アゲハ',
+};
+
+// ---- ヘルパー -----------------------------------------------------------
+
+/** 成功レスポンスのモック（sent > 0）を返す */
+function mockFetchSuccess(sent: number, characterId: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ sent, characterId }),
+  });
+}
+
+/** sent=0 レスポンス（購読なし）のモックを返す */
+function mockFetchNoSubscription(characterId: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ sent: 0, characterId }),
+  });
+}
+
+/** エラーレスポンスのモックを返す */
+function mockFetchError(status: number, message: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: async () => ({ message }),
+  });
+}
+
+// ---- テスト -------------------------------------------------------
+
+describe('StatusTestPush', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('描画', () => {
+    it('登録キャラクター分のボタンが表示される', () => {
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+      expect(screen.getByRole('button', { name: '桃瀬ひより にテスト通知' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '早瀬アゲハ にテスト通知' })).toBeInTheDocument();
+    });
+
+    it('空の characterIds の場合はボタンが表示されない', () => {
+      render(<StatusTestPush characterIds={[]} displayNames={{}} />);
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('初期状態では結果メッセージが表示されない', () => {
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+      expect(screen.queryByText(/送信完了/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/購読なし/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/エラー/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('クリックで /api/push/test を呼ぶ', () => {
+    it('hiyori のボタンをクリックすると fetch が正しい引数で呼ばれる', async () => {
+      mockFetchSuccess(1, 'hiyori');
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+
+      const button = screen.getByRole('button', { name: '桃瀬ひより にテスト通知' });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/api/push/test',
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ characterId: 'hiyori' }),
+          })
+        );
+      });
+    });
+
+    it('ageha のボタンをクリックすると characterId=ageha で fetch が呼ばれる', async () => {
+      mockFetchSuccess(1, 'ageha');
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+
+      const button = screen.getByRole('button', { name: '早瀬アゲハ にテスト通知' });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/api/push/test',
+          expect.objectContaining({
+            body: JSON.stringify({ characterId: 'ageha' }),
+          })
+        );
+      });
+    });
+  });
+
+  describe('送信結果の表示', () => {
+    it('送信成功（sent > 0）のとき「送信完了（N 件）」が表示される', async () => {
+      mockFetchSuccess(2, 'hiyori');
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '桃瀬ひより にテスト通知' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('送信完了（2 件）')).toBeInTheDocument();
+      });
+    });
+
+    it('purchased 0 件（sent=0）のとき「購読なし」メッセージが表示される', async () => {
+      mockFetchNoSubscription('hiyori');
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '桃瀬ひより にテスト通知' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('購読なし（送信されませんでした）')).toBeInTheDocument();
+      });
+    });
+
+    it('エラーレスポンスのとき「エラー:」メッセージが表示される', async () => {
+      mockFetchError(500, 'テスト通知の送信に失敗しました');
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '桃瀬ひより にテスト通知' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('エラー: テスト通知の送信に失敗しました')).toBeInTheDocument();
+      });
+    });
+
+    it('各キャラの結果は独立して表示される（hiyori の結果が ageha に影響しない）', async () => {
+      mockFetchSuccess(1, 'hiyori');
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '桃瀬ひより にテスト通知' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('送信完了（1 件）')).toBeInTheDocument();
+      });
+
+      // ageha の結果は表示されていない
+      // ボタンが 2 個あることを確認（ageha には結果がない）
+      const buttons = screen.getAllByRole('button');
+      expect(buttons).toHaveLength(2);
+    });
+  });
+
+  describe('送信中の状態', () => {
+    it('送信中はボタンが disabled になり「送信中…」ラベルに変わる', async () => {
+      // fetch が即時に解決しないようにする
+      let resolveFetch!: (value: unknown) => void;
+      mockFetch.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+      );
+
+      render(<StatusTestPush characterIds={characterIds} displayNames={displayNames} />);
+      const button = screen.getByRole('button', { name: '桃瀬ひより にテスト通知' });
+
+      fireEvent.click(button);
+
+      // 送信中: ボタンが disabled かつラベルが変わる
+      await waitFor(() => {
+        expect(screen.getByText('送信中…')).toBeInTheDocument();
+      });
+
+      // fetch を解決する
+      resolveFetch({
+        ok: true,
+        json: async () => ({ sent: 1, characterId: 'hiyori' }),
+      });
+
+      // 送信完了後はボタンが復活する
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '桃瀬ひより にテスト通知' })).not.toBeDisabled();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

リブトーク（#3491）の **dev 検証用に、admin 限定の「テスト通知送信」機能**を追加する。
通知の自然発火は decision ゲート（間隔・活動時間帯・1日上限）と生成の素材条件（lifecycle/knowledge）に縛られ、検証が安定しない（ひよりは直近通知済みで interval not due、アゲハは追加直後で条件未達の可能性）。これをバイパスして任意キャラの通知をオンデマンドで送れるようにする。

- **`POST /api/push/test`（`livetalk:admin` 限定）**: `{ characterId }` を受け、decision/生成条件を一切介さず、そのキャラの文面（テストと明確に分かる本文）で端末の購読へ**実 push 送信**。payload は本番同様 `{ title, body, data: { url: '/?character=<id>', characterId } }`。送信成功時に `NotificationEvent`（CharacterID 付き）も記録し、first-word/pending（第一声・他キャラ提示・クロス汚染防止）まで一気通貫で検証できる。購読 0 件は `{ sent: 0 }`、無効サブスクは削除、例外は warn 継続（notify バッチと同パターン）。
- **`/status`（admin 専用画面）に「テスト通知送信」セクション**: 登録キャラごとの送信ボタン（`StatusTestPush` コンポーネント）。クリックで上記 API を呼び、結果（送信件数 / 購読なし / エラー）を表示。端末上で完結して検証できる。
- 恒久的な admin デバッグツールとして維持する想定。

## 関連 Issue

#3491（作業ブランチ → integration のため `Closes` は付けない）

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（機能完成後にまとめて反映）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `test.test.ts`（route・17件）: admin 認可、characterId バリデーション、購読0件→sent:0、正常系（payload に `data.characterId`/`url`、成功時 NotificationEvent 記録）、無効サブスク削除、例外。
- `StatusTestPush.test.tsx`（10件）: 登録キャラ分のボタン描画、クリックで `/api/push/test` 呼び出し、結果表示、送信中状態。
- `jest.config.ts` に `@nagiyu/common/push` サブパスの moduleNameMapper を追加（既存パターン踏襲）。
- オーケストレーター客観検証: **web 56 suites / 494 tests PASS**、カバレッジ 80% 維持、prettier clean。

## レビューポイント

- admin 限定のテスト送信を**恒久ツール**として残す方針の是非（dev 検証で合意済み）。
- payload・NotificationEvent 記録が本番経路と一致していること（検証の妥当性）。

## スクリーンショット（該当する場合）

/status に送信ボタンを追加（admin のみ表示）。dev 反映後に実機確認。

## 補足事項

dev 検証の段取り: 端末で通知有効化 → /status で「ひより/アゲハ にテスト通知」→ 2 件受信 → タップで各キャラが開き第一声、を確認。カレント≠通知元での「○○から連絡」提示・クロス汚染なしも同手順で確認可能。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAXiTTe9n6Lxc5tAB5eRco)_