### PR TITLE
リブトーク: 早瀬アゲハの権利表記にイラストの AI 生成開示を追記

### DIFF
--- a/services/livetalk/web/src/lib/characters/client-profiles.ts
+++ b/services/livetalk/web/src/lib/characters/client-profiles.ts
@@ -25,9 +25,12 @@ export const DEFAULT_CLIENT_CHARACTER_ID = 'hiyori';
 
 /**
  * 早瀬アゲハ のライセンス・クレジット文字列。
- * OpenAI TTS を使用するため AI 生成音声であることの明示は OpenAI 利用規約上必須。
+ * 音声は OpenAI TTS を使用するため、AI 生成音声であることの明示が OpenAI 利用規約上必須。
+ * イラストは OpenAI gpt-image による AI 生成。規約上の必須表記ではないが、AI 生成物を
+ * 人間作と誤認させない（OpenAI 利用ポリシー）ため、音声開示と足並みを揃えて明示する。
  */
-export const AGEHA_LICENSE_TEXT = '音声：OpenAI TTS による AI 生成音声（人間の音声ではありません）';
+export const AGEHA_LICENSE_TEXT =
+  'イラスト：OpenAI gpt-image による AI 生成 / 音声：OpenAI TTS による AI 生成音声（人間の音声ではありません）';
 
 /**
  * クライアントプロファイルのエラーメッセージ定数。

--- a/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
@@ -201,6 +201,12 @@ describe('早瀬アゲハ クライアントプロファイル', () => {
     expect(profile.licenseText).toContain('AI 生成音声');
   });
 
+  it('licenseText にイラストが AI 生成である明示が含まれる', () => {
+    const profile = getCharacterClientProfile('ageha');
+    expect(profile.licenseText).toContain('イラスト');
+    expect(profile.licenseText).toContain('AI 生成');
+  });
+
   it('description が設定されている', () => {
     const profile = getCharacterClientProfile('ageha');
     expect(typeof profile.description).toBe('string');


### PR DESCRIPTION
## 変更の概要

早瀬アゲハの権利・クレジット表記（`AGEHA_LICENSE_TEXT`）に、**イラストが OpenAI gpt-image による AI 生成である旨**を追記する。

既存の音声開示（`音声：OpenAI TTS による AI 生成音声…`）に、`イラスト：OpenAI gpt-image による AI 生成 /` を前置した単一行表記（hiyori の ` / ` 区切り慣例に準拠）。

### 背景

アゲハの一枚絵は OpenAI gpt-image で生成したもの。OpenAI 規約上、生成物の権利は利用者に帰属し、画像のクレジット表記は必須ではない。ただし「AI 生成物を人間作と誤認させない」という OpenAI 利用ポリシーの趣旨に沿い、また既存の音声開示と足並みを揃えるため、フッターのクレジット行に AI 生成イラストである旨を明示する。

## 関連 Issue

参照: #3497
<!-- 作業ブランチ → integration の PR のため Closes は付けない。Issue クローズは integration → develop の PR で行う。 -->

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新（ユーザー向けクレジット表記の更新）
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（クレジット文言のみのため不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `client-profiles.test.ts`: `licenseText` にイラストの AI 生成明示（`イラスト` / `AI 生成`）が含まれることを検証するケースを追加。既存の音声開示の検証はそのまま維持。
- 実行結果: `@nagiyu/livetalk-web` で **53 スイート / 468 テスト 全パス**、`lint` / `prettier --check` clean。

## レビューポイント

- クレジット文言（`イラスト：OpenAI gpt-image による AI 生成`）。モデル版（gpt-image-2 等）まで明記するか、プロダクト名どまりにするかは方針次第。本 PR では版に依存しない `gpt-image` 表記にしている。
- 表示はフッターのクレジット行（`CharacterLicenseText` → `Footer.licenseText`）に単一行で出る。

## スクリーンショット（該当する場合）

文言変更のみ（フッターのクレジット行）。

## 補足事項

- OpenAI 生成画像には C2PA メタデータ + SynthID 透かしが自動付与される（2026-05-19 以降）。本 PR は表示文言のみで、来歴情報の操作は行わない。


---
_Generated by [Claude Code](https://claude.ai/code/session_01CUwMihM3vPxtj9CwhGHnf4)_