### PR TITLE
アゲハの瞬き・口パクを二値スナップに再調整

### DIFF
--- a/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
@@ -44,12 +44,12 @@ export interface SpriteCharacterCanvasProps {
  * renderer:'sprite' キャラクター向けに、5 枚の透過 PNG（ベース・開いた目・閉じた目・
  * 開いた口・閉じた口）を絶対配置で重ね合わせて描画する。
  *
- * 瞬き: ランダム間隔（3000〜6000ms）で約 140ms かけて eyeClosed レイヤーの opacity を
- * 0 → 1 → 0 と変化させる三角波アニメーション。発話有無に関わらず常時駆動。
+ * 瞬き: ランダム間隔（3000〜6000ms）で約 100ms だけ eyeClosed レイヤーを opacity 1（閉じ）
+ * にする二値スナップ。パッと閉じてパッと開く。発話有無に関わらず常時駆動。
  *
  * 口パク: audioBuffer + audioContext が揃ったら Web Audio API（AudioBufferSourceNode +
- * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して
- * mouthOpen レイヤーの opacity を毎フレーム駆動する。
+ * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して、
+ * しきい値（ヒステリシス付き）で mouthOpen レイヤーを開閉二値（opacity 0/1）で駆動する。
  *
  * iOS Safari 対策として HTMLAudio は使わず Web Audio のみ。
  * AudioContext は親が resume 済みの前提（PlaceholderCanvas / Live2DCanvas と同じ）。
@@ -83,10 +83,10 @@ export default function SpriteCharacterCanvas({
   }, [onPlaybackEnd, onPlaybackError]);
 
   // 瞬きアニメーション（常時駆動）。
-  // Live2DCanvas の computeEyeOpen と同じ三角波ロジックを使用する。
+  // ぬるっとした三角波フェードではなく、パッと閉じてパッと開く二値（0/1）スナップにする。
   useEffect(() => {
-    // 瞬きの設定値（Live2DCanvas と同じ値）
-    const BLINK_DURATION_MS = 140;
+    // 瞬きの設定値。BLINK_CLOSED_MS の間だけ目を完全に閉じる（dev 実機で調整可）。
+    const BLINK_CLOSED_MS = 100;
     const BLINK_INTERVAL_MIN_MS = 3000;
     const BLINK_INTERVAL_RANGE_MS = 3000;
 
@@ -95,28 +95,23 @@ export default function SpriteCharacterCanvas({
       performance.now() + BLINK_INTERVAL_MIN_MS + Math.random() * BLINK_INTERVAL_RANGE_MS;
 
     /**
-     * 三角波で瞬きの閉じ具合（0〜1）を計算する。
-     * 瞬き窓外は 0（開いた状態）、窓内の half で最も閉じる（1）。
+     * 瞬きの閉じ状態（0=開き / 1=閉じ）を二値で計算する。
+     * nextBlinkAt に達したら瞬きを開始し、BLINK_CLOSED_MS の間だけ 1（閉じ）を返す。
      */
-    const computeCloseRatio = (now: number): number => {
-      if (now >= nextBlinkAt && now > blinkStart + BLINK_DURATION_MS) {
+    const computeClosed = (now: number): number => {
+      if (now >= nextBlinkAt && now > blinkStart + BLINK_CLOSED_MS) {
         blinkStart = now;
         nextBlinkAt = now + BLINK_INTERVAL_MIN_MS + Math.random() * BLINK_INTERVAL_RANGE_MS;
       }
       const t = now - blinkStart;
-      if (t >= 0 && t < BLINK_DURATION_MS) {
-        const half = BLINK_DURATION_MS / 2;
-        // 0 → 1 → 0（閉じ具合）。half で最も閉じる
-        return t < half ? t / half : 1 - (t - half) / half;
-      }
-      return 0;
+      return t >= 0 && t < BLINK_CLOSED_MS ? 1 : 0;
     };
 
     const animate = () => {
       blinkRafIdRef.current = requestAnimationFrame(animate);
-      const closeRatio = computeCloseRatio(performance.now());
+      const closed = computeClosed(performance.now());
       if (eyeClosedRef.current) {
-        eyeClosedRef.current.style.opacity = String(closeRatio);
+        eyeClosedRef.current.style.opacity = String(closed);
       }
     };
     animate();
@@ -152,8 +147,13 @@ export default function SpriteCharacterCanvas({
       source.connect(analyser);
       analyser.connect(audioContext.destination);
 
-      // requestAnimationFrame ループで音量レベルを算出して mouthOpen の opacity を駆動する
+      // requestAnimationFrame ループで音量レベルを算出して mouthOpen を二値（開/閉）で駆動する。
+      // ぬるっとした連続フェードをやめ、しきい値で口をパッと開閉する。
+      // 開く閾値 > 閉じる閾値のヒステリシスで、境界付近のチラつき（パカパカ）を抑える（dev で調整可）。
+      const MOUTH_OPEN_THRESHOLD = 0.1;
+      const MOUTH_CLOSE_THRESHOLD = 0.05;
       const dataArray = new Uint8Array(analyser.frequencyBinCount);
+      let mouthIsOpen = false;
       const animateLipsync = () => {
         if (cancelled || !analyser) return;
         lipsyncRafIdRef.current = requestAnimationFrame(animateLipsync);
@@ -165,11 +165,16 @@ export default function SpriteCharacterCanvas({
           sum += dataArray[i];
         }
         const avg = sum / dataArray.length / 255;
-        // 視認できるよう増幅し 0〜1 にクランプする
-        const opacity = Math.min(1, avg * 2.2);
+
+        // ヒステリシス付きで開閉状態を更新する
+        if (!mouthIsOpen && avg >= MOUTH_OPEN_THRESHOLD) {
+          mouthIsOpen = true;
+        } else if (mouthIsOpen && avg < MOUTH_CLOSE_THRESHOLD) {
+          mouthIsOpen = false;
+        }
 
         if (mouthOpenRef.current) {
-          mouthOpenRef.current.style.opacity = String(opacity);
+          mouthOpenRef.current.style.opacity = mouthIsOpen ? '1' : '0';
         }
       };
       animateLipsync();

--- a/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
@@ -347,6 +347,36 @@ describe('SpriteCharacterCanvas', () => {
       expect(onPlaybackEnd).toHaveBeenCalledTimes(1);
     });
 
+    it('音量がしきい値を跨ぐと mouthOpen が開閉する（二値・ヒステリシス）', () => {
+      mockAnalyser.frequencyBinCount = 4;
+      // まず大音量（開く閾値超え）
+      mockGetByteFrequencyData.mockImplementation((arr: Uint8Array) => {
+        arr.fill(200);
+      });
+
+      render(
+        <SpriteCharacterCanvas
+          characterId="ageha"
+          audioBuffer={mockAudioBuffer}
+          audioContext={mockAudioContext}
+        />
+      );
+
+      // mouthOpen の Image をラップする div（ref 対象）の inline opacity を確認する
+      const mouthOpenWrapper = screen.getByTestId('sprite-mouth-open').parentElement as HTMLElement;
+
+      // 大音量の rAF 一巡で口が開く（opacity 1）
+      flushRaf(0);
+      expect(mouthOpenWrapper.style.opacity).toBe('1');
+
+      // 無音（閉じる閾値未満）の rAF 一巡で口が閉じる（opacity 0）
+      mockGetByteFrequencyData.mockImplementation((arr: Uint8Array) => {
+        arr.fill(0);
+      });
+      flushRaf(0);
+      expect(mouthOpenWrapper.style.opacity).toBe('0');
+    });
+
     it('onPlaybackError が指定されている場合、例外時に呼ばれる', () => {
       const onPlaybackError = jest.fn();
       const error = new Error('テスト再生エラー');


### PR DESCRIPTION
## 変更の概要

早瀬アゲハの瞬き・口パクが「もっさり」して見える問題に対する再調整。連続値の opacity 駆動をやめ、**二値（0/1）スナップ**でキビキビした動きにする。

- **瞬き**：約 140ms の三角波フェード → **約 100ms だけ完全に閉じる二値スナップ**（パッと閉じてパッと開く）。ランダム間隔（3000〜6000ms）は維持。
- **口パク**：音量連動の連続 opacity（`Math.min(1, avg * 2.2)`）→ **しきい値での開閉 2 状態**（`avg >= 閾値 ? 開 : 閉`）。境界付近のチラつき（パカパカ）を抑えるため、開く閾値（0.1）＞閉じる閾値（0.05）の**ヒステリシス**を入れる。

いずれも dev 実機での見え方に応じて調整できるよう定数化済み。

## 関連 Issue

#3502（本 PR は integration ブランチ宛のため `Closes` は付けない）

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング（既存機能の挙動調整）
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `SpriteCharacterCanvas.test.tsx`：音量がしきい値を跨いだとき mouthOpen の opacity が `1`（開）↔ `0`（閉）で切り替わる二値・ヒステリシス挙動の検証を追加。
- 既存の瞬き・再生・フォールバック等のテストはそのまま通過。
- 結果：54 スイート / 508 件 pass、カバレッジ閾値 80% クリア。ESLint エラーなし・Prettier 適合。

## レビューポイント

- 瞬きの閉じ時間（`BLINK_CLOSED_MS = 100`）、口の開閉しきい値（開 `0.1` / 閉 `0.05`）は dev 実機で要・最終調整。
- 二値化により「パカパカ」寄りの動きになる（依頼どおりの方向）。ヒステリシス幅で滑らかさを微調整可能。

## スクリーンショット（該当する場合）

dev 環境で実機確認予定。

## 補足事項

- マージ済み #3503 の続きの調整。同じ integration ブランチ `integration/3502-ageha-blink-lipsync` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_0185GTqyGSws2SZj2MnTZqB3)_