### PR TITLE
さくっとクリップ: 各クリップに文字起こしテキストを表示する

### DIFF
--- a/services/quick-clip/core/src/libs/quick-clip-batch-runner.ts
+++ b/services/quick-clip/core/src/libs/quick-clip-batch-runner.ts
@@ -49,6 +49,7 @@ const VIDEO_INPUT_PATH = (jobId: string): string => `/tmp/quick-clip/${jobId}/in
 const SOURCE_VIDEO_KEY = (jobId: string): string => `uploads/${jobId}/input.mp4`;
 const CLIP_OUTPUT_KEY = (jobId: string, highlightId: string): string =>
   `outputs/${jobId}/clips/${highlightId}.mp4`;
+const TRANSCRIPT_OUTPUT_KEY = (jobId: string): string => `outputs/${jobId}/transcript.json`;
 const CLIP_OUTPUT_PATH = (jobId: string, highlightId: string): string =>
   `/tmp/quick-clip/${jobId}/clips/${highlightId}.mp4`;
 const DOWNLOAD_RETRY_INTERVAL_MS = 3000;
@@ -208,6 +209,11 @@ const generateClips = async (
   console.info(`[generateClips] 完了: jobId=${jobId}`);
 };
 
+type BuildHighlightsResult = {
+  highlights: Highlight[];
+  segments: TranscriptSegment[];
+};
+
 const buildHighlights = async (
   jobId: string,
   localPath: string,
@@ -215,7 +221,7 @@ const buildHighlights = async (
   awsRegion: string,
   openAiApiKey?: string,
   emotionFilter?: EmotionFilter
-): Promise<Highlight[]> => {
+): Promise<BuildHighlightsResult> => {
   const { size: videoFileSizeBytes } = await stat(localPath);
   console.info(`[buildHighlights] 開始: jobId=${jobId} videoFileSize=${videoFileSizeBytes}bytes`);
 
@@ -330,7 +336,7 @@ const buildHighlights = async (
       ? aggregationService.aggregate(motionScores, volumeScores, duration, emotionScores)
       : aggregationService.aggregate(motionScores, volumeScores, duration);
   const sortedByStartSec = extracted.slice().sort((a, b) => a.startSec - b.startSec);
-  return sortedByStartSec.map((item, index) => ({
+  const highlights = sortedByStartSec.map((item, index) => ({
     highlightId: randomUUID(),
     jobId,
     order: index + 1,
@@ -339,9 +345,10 @@ const buildHighlights = async (
     source: item.source,
     dominantEmotion: item.dominantEmotion,
     expiresAt: 0, // persistHighlights で上書きされる
-    status: 'unconfirmed',
-    clipStatus: 'PENDING',
+    status: 'unconfirmed' as const,
+    clipStatus: 'PENDING' as const,
   }));
+  return { highlights, segments };
 };
 
 const updateBatchStage = async (
@@ -404,7 +411,7 @@ const runExtract = async (env: QuickClipBatchRunInput): Promise<void> => {
 
   console.info(`[runExtract] analyzing ステージ開始: jobId=${env.jobId}`);
   await updateBatchStage(env.jobId, 'analyzing', env.tableName, env.awsRegion);
-  const highlights = await buildHighlights(
+  const { highlights, segments } = await buildHighlights(
     env.jobId,
     localVideoPath,
     env.tableName,
@@ -422,6 +429,29 @@ const runExtract = async (env: QuickClipBatchRunInput): Promise<void> => {
   const expiresAt = await getJobExpiresAt(env.jobId, env.tableName, env.awsRegion);
   await persistHighlights(env.jobId, highlights, expiresAt, env.tableName, env.awsRegion);
   console.info(`[runExtract] ハイライト保存完了: jobId=${env.jobId} count=${highlights.length}`);
+
+  if (segments.length > 0) {
+    try {
+      const s3Client = getS3Client(env.awsRegion);
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket: env.bucketName,
+          Key: TRANSCRIPT_OUTPUT_KEY(env.jobId),
+          Body: JSON.stringify(segments),
+          ContentType: 'application/json',
+        })
+      );
+      console.info(
+        `[runExtract] 文字起こし保存完了: jobId=${env.jobId} segments=${segments.length}`
+      );
+    } catch (error) {
+      console.warn('[runExtract] 文字起こしの保存に失敗しました（処理は継続します）:', error);
+    }
+  } else {
+    console.info(
+      `[runExtract] 文字起こしセグメントが0件のため transcript.json を保存しません: jobId=${env.jobId}`
+    );
+  }
 };
 
 export const runQuickClipBatch = async (env: QuickClipBatchRunInput): Promise<void> => {

--- a/services/quick-clip/core/tests/unit/libs/quick-clip-batch-runner.test.ts
+++ b/services/quick-clip/core/tests/unit/libs/quick-clip-batch-runner.test.ts
@@ -469,4 +469,72 @@ describe('runQuickClipBatch', () => {
     );
     expect(failCall).toBeDefined();
   });
+
+  it('transcript 保存: segments が1件以上の場合、transcript.json を S3 に PutObject する', async () => {
+    mockS3Send.mockResolvedValue({ Body: { pipe: jest.fn() } });
+    const segments = [{ start: 0.0, end: 3.5, text: 'やばい！' }];
+    mockTranscribe.mockResolvedValue(segments);
+
+    const inputWithKey: QuickClipBatchRunInput = { ...input, openAiApiKey: 'sk-test-key' };
+    await expect(runQuickClipBatch(inputWithKey)).resolves.toBeUndefined();
+
+    // PutObjectCommand がクリップ用と transcript 用で呼ばれていること
+    const transcriptCall = (mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>).find(
+      ([args]) => typeof args.Key === 'string' && args.Key === `outputs/job-1/transcript.json`
+    );
+    expect(transcriptCall).toBeDefined();
+    expect(transcriptCall?.[0]).toMatchObject({
+      Bucket: 'bucket',
+      Key: 'outputs/job-1/transcript.json',
+      Body: JSON.stringify(segments),
+      ContentType: 'application/json',
+    });
+  });
+
+  it('transcript 保存: segments が 0 件の場合、transcript.json を S3 に保存しない', async () => {
+    mockS3Send.mockResolvedValue({ Body: { pipe: jest.fn() } });
+    mockTranscribe.mockResolvedValue([]);
+
+    const inputWithKey: QuickClipBatchRunInput = { ...input, openAiApiKey: 'sk-test-key' };
+    await expect(runQuickClipBatch(inputWithKey)).resolves.toBeUndefined();
+
+    const transcriptCall = (mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>).find(
+      ([args]) => typeof args.Key === 'string' && args.Key === `outputs/job-1/transcript.json`
+    );
+    expect(transcriptCall).toBeUndefined();
+  });
+
+  it('transcript 保存: openAiApiKey が未指定の場合、transcript.json を保存しない', async () => {
+    mockS3Send.mockResolvedValue({ Body: { pipe: jest.fn() } });
+
+    await expect(runQuickClipBatch(input)).resolves.toBeUndefined();
+
+    const transcriptCall = (mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>).find(
+      ([args]) => typeof args.Key === 'string' && args.Key === `outputs/job-1/transcript.json`
+    );
+    expect(transcriptCall).toBeUndefined();
+  });
+
+  it('transcript 保存: S3 保存が失敗しても抽出処理全体は成功する', async () => {
+    // ダウンロード成功、クリップ S3 PUT 成功、transcript PUT だけ失敗させる
+    // PutObjectCommand は mockPutObjectCommand でモックしており、引数を返す
+    // sendに渡るのはそのモックの戻り値（inputそのもの）なので Key で判定可能
+    mockS3Send.mockImplementation(async (cmd: unknown) => {
+      const command = cmd as Record<string, unknown>;
+      const key = command.Key as string | undefined;
+      if (key !== undefined && key.endsWith('transcript.json')) {
+        throw new Error('S3 保存失敗');
+      }
+      // ダウンロード用（Body付き）またはクリップ PUT 用
+      return { Body: { pipe: jest.fn() } };
+    });
+    const segments = [{ start: 0.0, end: 3.5, text: 'テスト' }];
+    mockTranscribe.mockResolvedValue(segments);
+
+    const inputWithKey: QuickClipBatchRunInput = { ...input, openAiApiKey: 'sk-test-key' };
+    // transcript 保存失敗でも全体は resolve する
+    await expect(runQuickClipBatch(inputWithKey)).resolves.toBeUndefined();
+    // エラーメッセージは記録されない
+    expect(mockUpdateErrorMessage).not.toHaveBeenCalled();
+  });
 });

--- a/services/quick-clip/core/tests/unit/libs/quick-clip-batch-runner.test.ts
+++ b/services/quick-clip/core/tests/unit/libs/quick-clip-batch-runner.test.ts
@@ -479,7 +479,9 @@ describe('runQuickClipBatch', () => {
     await expect(runQuickClipBatch(inputWithKey)).resolves.toBeUndefined();
 
     // PutObjectCommand がクリップ用と transcript 用で呼ばれていること
-    const transcriptCall = (mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>).find(
+    const transcriptCall = (
+      mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>
+    ).find(
       ([args]) => typeof args.Key === 'string' && args.Key === `outputs/job-1/transcript.json`
     );
     expect(transcriptCall).toBeDefined();
@@ -498,7 +500,9 @@ describe('runQuickClipBatch', () => {
     const inputWithKey: QuickClipBatchRunInput = { ...input, openAiApiKey: 'sk-test-key' };
     await expect(runQuickClipBatch(inputWithKey)).resolves.toBeUndefined();
 
-    const transcriptCall = (mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>).find(
+    const transcriptCall = (
+      mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>
+    ).find(
       ([args]) => typeof args.Key === 'string' && args.Key === `outputs/job-1/transcript.json`
     );
     expect(transcriptCall).toBeUndefined();
@@ -509,7 +513,9 @@ describe('runQuickClipBatch', () => {
 
     await expect(runQuickClipBatch(input)).resolves.toBeUndefined();
 
-    const transcriptCall = (mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>).find(
+    const transcriptCall = (
+      mockPutObjectCommand.mock.calls as Array<[Record<string, unknown>]>
+    ).find(
       ([args]) => typeof args.Key === 'string' && args.Key === `outputs/job-1/transcript.json`
     );
     expect(transcriptCall).toBeUndefined();

--- a/services/quick-clip/web/src/app/api/jobs/[jobId]/transcript/route.ts
+++ b/services/quick-clip/web/src/app/api/jobs/[jobId]/transcript/route.ts
@@ -1,0 +1,86 @@
+import { DynamoDBJobRepository } from '@nagiyu/quick-clip-core';
+import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
+import { NextResponse } from 'next/server';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getBucketName, getDynamoDBDocumentClient, getS3Client, getTableName } from '@/lib/server/aws';
+import { JobDomainService } from '@/lib/server/domain-services';
+import type { TranscriptSegment } from '@/types/quick-clip';
+
+const ERROR_MESSAGES = {
+  JOB_NOT_FOUND: COMMON_ERROR_MESSAGES.JOB_NOT_FOUND,
+  INTERNAL_SERVER_ERROR: '文字起こし情報の取得に失敗しました',
+} as const;
+
+type S3Error = {
+  name?: string;
+  Code?: string;
+};
+
+const isNoSuchKeyError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const s3Error = error as S3Error;
+  return s3Error.name === 'NoSuchKey' || s3Error.Code === 'NoSuchKey';
+};
+
+const buildTranscriptKey = (jobId: string): string => `outputs/${jobId}/transcript.json`;
+
+type RouteParams = {
+  params: Promise<{
+    jobId: string;
+  }>;
+};
+
+export async function GET(_request: Request, { params }: RouteParams): Promise<NextResponse> {
+  try {
+    const { jobId } = await params;
+    const jobService = new JobDomainService(
+      new DynamoDBJobRepository(getDynamoDBDocumentClient(), getTableName())
+    );
+    const job = await jobService.getJob(jobId);
+    if (!job) {
+      return NextResponse.json(
+        {
+          error: 'JOB_NOT_FOUND',
+          message: ERROR_MESSAGES.JOB_NOT_FOUND,
+        },
+        { status: 404 }
+      );
+    }
+
+    const s3Client = getS3Client();
+    const bucketName = getBucketName();
+
+    try {
+      const response = await s3Client.send(
+        new GetObjectCommand({
+          Bucket: bucketName,
+          Key: buildTranscriptKey(jobId),
+        })
+      );
+
+      if (!response.Body) {
+        return NextResponse.json({ segments: [] });
+      }
+
+      const rawText = await response.Body.transformToString();
+      const segments = JSON.parse(rawText) as TranscriptSegment[];
+      return NextResponse.json({ segments });
+    } catch (error) {
+      if (isNoSuchKeyError(error)) {
+        // transcript.json が存在しない場合はオプショナル扱いで空配列を返す
+        return NextResponse.json({ segments: [] });
+      }
+      throw error;
+    }
+  } catch {
+    return NextResponse.json(
+      {
+        error: 'INTERNAL_SERVER_ERROR',
+        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/services/quick-clip/web/src/app/api/jobs/[jobId]/transcript/route.ts
+++ b/services/quick-clip/web/src/app/api/jobs/[jobId]/transcript/route.ts
@@ -2,7 +2,12 @@ import { DynamoDBJobRepository } from '@nagiyu/quick-clip-core';
 import { COMMON_ERROR_MESSAGES } from '@nagiyu/common';
 import { NextResponse } from 'next/server';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
-import { getBucketName, getDynamoDBDocumentClient, getS3Client, getTableName } from '@/lib/server/aws';
+import {
+  getBucketName,
+  getDynamoDBDocumentClient,
+  getS3Client,
+  getTableName,
+} from '@/lib/server/aws';
 import { JobDomainService } from '@/lib/server/domain-services';
 import type { TranscriptSegment } from '@/types/quick-clip';
 

--- a/services/quick-clip/web/src/app/jobs/[jobId]/highlights/page.tsx
+++ b/services/quick-clip/web/src/app/jobs/[jobId]/highlights/page.tsx
@@ -538,8 +538,7 @@ export default function HighlightsPage({ params }: HighlightsPageProps) {
                   {(() => {
                     const filteredSegments = transcriptSegments.filter(
                       (seg) =>
-                        seg.start < selectedHighlight.endSec &&
-                        seg.end > selectedHighlight.startSec
+                        seg.start < selectedHighlight.endSec && seg.end > selectedHighlight.startSec
                     );
                     if (filteredSegments.length === 0) return null;
                     return (

--- a/services/quick-clip/web/src/app/jobs/[jobId]/highlights/page.tsx
+++ b/services/quick-clip/web/src/app/jobs/[jobId]/highlights/page.tsx
@@ -22,7 +22,7 @@ import {
 import { Button, Chip, ErrorAlert, TextField } from '@nagiyu/ui';
 import ReplayIcon from '@mui/icons-material/Replay';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutlined';
-import type { Highlight } from '@/types/quick-clip';
+import type { Highlight, TranscriptSegment } from '@/types/quick-clip';
 import { ColumnVisibilityButton } from '@/components/highlights/ColumnVisibilityButton';
 import { HIGHLIGHT_TABLE_COLUMNS } from '@/constants/highlightTableColumns';
 import { useColumnVisibility } from '@/hooks/useColumnVisibility';
@@ -65,6 +65,10 @@ type HighlightsPageProps = {
 
 type HighlightsResponse = {
   highlights: Array<Highlight & { clipUrl?: string }>;
+};
+
+type TranscriptResponse = {
+  segments: TranscriptSegment[];
 };
 
 type DownloadResponse = {
@@ -127,6 +131,7 @@ export default function HighlightsPage({ params }: HighlightsPageProps) {
   const [isDownloading, setIsDownloading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const [transcriptSegments, setTranscriptSegments] = useState<TranscriptSegment[]>([]);
   const isFetchingRef = useRef(false);
   const { visibilityMap, toggleColumn } = useColumnVisibility(COLUMN_DEFINITIONS);
 
@@ -216,6 +221,22 @@ export default function HighlightsPage({ params }: HighlightsPageProps) {
       }
     };
     void fetchExpiresAt();
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const fetchTranscript = async () => {
+      try {
+        const res = await fetch(`/api/jobs/${jobId}/transcript`);
+        if (!res.ok) return;
+        const data = (await res.json()) as TranscriptResponse;
+        setTranscriptSegments(data.segments ?? []);
+      } catch (error) {
+        // 文字起こし取得失敗は非致命的
+        console.warn('文字起こしの取得に失敗しました', error);
+      }
+    };
+    void fetchTranscript();
   }, [jobId]);
 
   const selectedHighlight = useMemo(() => {
@@ -512,6 +533,40 @@ export default function HighlightsPage({ params }: HighlightsPageProps) {
                       {HIGHLIGHT_SOURCE_LABELS[selectedHighlight.source]}
                     </Typography>
                   </Box>
+
+                  {/* 文字起こしセクション */}
+                  {(() => {
+                    const filteredSegments = transcriptSegments.filter(
+                      (seg) =>
+                        seg.start < selectedHighlight.endSec &&
+                        seg.end > selectedHighlight.startSec
+                    );
+                    if (filteredSegments.length === 0) return null;
+                    return (
+                      <Box>
+                        <Typography variant="body2" sx={{ mb: 0.5 }}>
+                          文字起こし:
+                        </Typography>
+                        <Box
+                          sx={{
+                            p: 1,
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            borderRadius: 1,
+                            bgcolor: 'grey.50',
+                            maxHeight: 160,
+                            overflowY: 'auto',
+                          }}
+                        >
+                          {filteredSegments.map((seg, index) => (
+                            <Typography key={index} variant="body2" sx={{ lineHeight: 1.6 }}>
+                              {seg.text}
+                            </Typography>
+                          ))}
+                        </Box>
+                      </Box>
+                    );
+                  })()}
 
                   {/* 採否ステータス */}
                   <Box>

--- a/services/quick-clip/web/src/types/quick-clip.ts
+++ b/services/quick-clip/web/src/types/quick-clip.ts
@@ -34,3 +34,13 @@ export type UpdateHighlightInput = {
   status?: HighlightStatus;
   clipStatus?: ClipStatus;
 };
+
+/** Whisper 文字起こしの1セグメント。 */
+export type TranscriptSegment = {
+  /** セグメント開始時刻（秒）。 */
+  start: number;
+  /** セグメント終了時刻（秒）。 */
+  end: number;
+  /** 書き起こしテキスト。 */
+  text: string;
+};

--- a/services/quick-clip/web/tests/unit/app/api/jobs/[jobId]/transcript/route.test.ts
+++ b/services/quick-clip/web/tests/unit/app/api/jobs/[jobId]/transcript/route.test.ts
@@ -1,0 +1,162 @@
+import { GET } from '@/app/api/jobs/[jobId]/transcript/route';
+import type { JobRepository } from '@nagiyu/quick-clip-core';
+import { getDynamoDBDocumentClient, getS3Client } from '@/lib/server/aws';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+jest.mock('@/lib/server/aws', () => ({
+  getDynamoDBDocumentClient: jest.fn(() => ({})),
+  getS3Client: jest.fn(() => ({})),
+  getBucketName: jest.fn(() => 'test-bucket'),
+  getTableName: jest.fn(() => 'test-table'),
+}));
+
+const mockS3Send = jest.fn();
+jest.mock('@aws-sdk/client-s3', () => ({
+  GetObjectCommand: jest.fn().mockImplementation((input: unknown) => input),
+}));
+
+const mockGetJob = jest.fn();
+jest.mock('@nagiyu/quick-clip-core', () => ({
+  ...jest.requireActual('@nagiyu/quick-clip-core'),
+  DynamoDBJobRepository: jest.fn().mockImplementation(
+    () =>
+      ({
+        create: jest.fn(),
+        getById: mockGetJob,
+        updateBatchJobId: jest.fn(),
+      }) as unknown as JobRepository
+  ),
+}));
+
+describe('GET /api/jobs/[jobId]/transcript', () => {
+  const mockedGetDynamoDBDocumentClient = getDynamoDBDocumentClient as jest.MockedFunction<
+    typeof getDynamoDBDocumentClient
+  >;
+  const mockedGetS3Client = getS3Client as jest.MockedFunction<typeof getS3Client>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetDynamoDBDocumentClient.mockReturnValue(
+      {} as ReturnType<typeof getDynamoDBDocumentClient>
+    );
+    mockedGetS3Client.mockReturnValue({
+      send: mockS3Send,
+    } as unknown as ReturnType<typeof getS3Client>);
+  });
+
+  const mockRequest = {} as Request;
+
+  it('正常系: transcript.json が存在する場合は segments を返す', async () => {
+    const segments = [
+      { start: 0.0, end: 3.5, text: 'こんにちは' },
+      { start: 3.5, end: 7.0, text: 'テストです' },
+    ];
+    mockGetJob.mockResolvedValue({
+      jobId: 'job-1',
+      status: 'COMPLETED',
+      originalFileName: 'movie.mp4',
+      fileSize: 100,
+      createdAt: 1,
+      expiresAt: 2,
+    });
+    mockS3Send.mockResolvedValue({
+      Body: {
+        transformToString: jest.fn().mockResolvedValue(JSON.stringify(segments)),
+      },
+    });
+
+    const response = await GET(mockRequest, {
+      params: Promise.resolve({ jobId: 'job-1' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ segments });
+  });
+
+  it('正常系: Body が null の場合は空配列を返す', async () => {
+    mockGetJob.mockResolvedValue({
+      jobId: 'job-1',
+      status: 'COMPLETED',
+      originalFileName: 'movie.mp4',
+      fileSize: 100,
+      createdAt: 1,
+      expiresAt: 2,
+    });
+    mockS3Send.mockResolvedValue({ Body: null });
+
+    const response = await GET(mockRequest, {
+      params: Promise.resolve({ jobId: 'job-1' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ segments: [] });
+  });
+
+  it('正常系: NoSuchKey の場合は 200 で空配列を返す（オプショナル扱い）', async () => {
+    mockGetJob.mockResolvedValue({
+      jobId: 'job-1',
+      status: 'COMPLETED',
+      originalFileName: 'movie.mp4',
+      fileSize: 100,
+      createdAt: 1,
+      expiresAt: 2,
+    });
+    mockS3Send.mockRejectedValue({ name: 'NoSuchKey', Code: 'NoSuchKey' });
+
+    const response = await GET(mockRequest, {
+      params: Promise.resolve({ jobId: 'job-1' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ segments: [] });
+  });
+
+  it('異常系: ジョブが存在しない場合は 404 を返す', async () => {
+    mockGetJob.mockResolvedValue(null);
+
+    const response = await GET(mockRequest, {
+      params: Promise.resolve({ jobId: 'missing' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({
+      error: 'JOB_NOT_FOUND',
+      message: expect.any(String),
+    });
+  });
+
+  it('異常系: S3 で予期しないエラーが発生した場合は 500 を返す', async () => {
+    mockGetJob.mockResolvedValue({
+      jobId: 'job-1',
+      status: 'COMPLETED',
+      originalFileName: 'movie.mp4',
+      fileSize: 100,
+      createdAt: 1,
+      expiresAt: 2,
+    });
+    mockS3Send.mockRejectedValue(new Error('S3 接続エラー'));
+
+    const response = await GET(mockRequest, {
+      params: Promise.resolve({ jobId: 'job-1' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      error: 'INTERNAL_SERVER_ERROR',
+      message: '文字起こし情報の取得に失敗しました',
+    });
+  });
+});

--- a/services/quick-clip/web/tests/unit/app/jobs/highlights-page.test.tsx
+++ b/services/quick-clip/web/tests/unit/app/jobs/highlights-page.test.tsx
@@ -7,6 +7,13 @@ describe('HighlightsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
+    // transcript エンドポイントのデフォルトモック（オーバーライドがない場合のフォールバック）
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/transcript')) {
+        return { ok: true, json: async () => ({ segments: [] }) };
+      }
+      return { ok: false };
+    }) as jest.Mock;
   });
 
   it('初期状態は右パネルの一覧を表示し、左パネルはプレースホルダーを表示する', async () => {
@@ -215,8 +222,7 @@ describe('HighlightsPage', () => {
     fireEvent.click(retryButton);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenNthCalledWith(
-        3,
+      expect(global.fetch).toHaveBeenCalledWith(
         '/api/jobs/job-1/highlights/h-1/regenerate',
         expect.objectContaining({ method: 'POST' })
       );
@@ -351,8 +357,7 @@ describe('HighlightsPage', () => {
     fireEvent.click(acceptedRadio);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenNthCalledWith(
-        3,
+      expect(global.fetch).toHaveBeenCalledWith(
         '/api/jobs/job-1/highlights/h-1',
         expect.objectContaining({
           method: 'PATCH',
@@ -404,14 +409,15 @@ describe('HighlightsPage', () => {
 
     render(<HighlightsPage params={Promise.resolve({ jobId: 'job-1' })} />);
 
+    // highlights + expiresAt + transcript の 3 回
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
     });
 
     jest.advanceTimersByTime(3000);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(global.fetch).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -457,14 +463,15 @@ describe('HighlightsPage', () => {
 
     render(<HighlightsPage params={Promise.resolve({ jobId: 'job-1' })} />);
 
+    // highlights + expiresAt + transcript の 3 回
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
     });
 
     jest.advanceTimersByTime(3000);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(global.fetch).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -492,14 +499,15 @@ describe('HighlightsPage', () => {
 
     render(<HighlightsPage params={Promise.resolve({ jobId: 'job-1' })} />);
 
+    // highlights + expiresAt + transcript の 3 回
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
     });
 
     jest.advanceTimersByTime(6000);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -548,14 +556,14 @@ describe('HighlightsPage', () => {
     const startInputs = await screen.findAllByRole('spinbutton');
     fireEvent.change(startInputs[0], { target: { value: '11' } });
 
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    // highlights + expiresAt + transcript の 3 回（blur 前はPATCHしない）
+    expect(global.fetch).toHaveBeenCalledTimes(3);
 
     fireEvent.blur(startInputs[0]);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(3);
-      expect(global.fetch).toHaveBeenNthCalledWith(
-        3,
+      expect(global.fetch).toHaveBeenCalledTimes(4);
+      expect(global.fetch).toHaveBeenCalledWith(
         '/api/jobs/job-1/highlights/h-1',
         expect.objectContaining({ method: 'PATCH' })
       );
@@ -598,7 +606,8 @@ describe('HighlightsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('開始時刻は終了時刻より小さくしてください')).toBeInTheDocument();
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      // highlights + expiresAt + transcript の 3 回（PATCHなし）
+      expect(global.fetch).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -642,7 +651,8 @@ describe('HighlightsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('見どころの更新に失敗しました')).toBeInTheDocument();
       expect(startInputs[0]).toHaveValue(10);
-      expect(global.fetch).toHaveBeenCalledTimes(3);
+      // highlights + expiresAt + transcript + PATCH の 4 回
+      expect(global.fetch).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -782,7 +792,8 @@ describe('HighlightsPage', () => {
     });
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(3);
+      // highlights + expiresAt + transcript + ポーリング1回 = 4 回
+      expect(global.fetch).toHaveBeenCalledTimes(4);
       expect(screen.getByLabelText('見どころ動画プレビュー')).toHaveAttribute(
         'src',
         'https://example.com/h-1-url-1.mp4'
@@ -793,63 +804,82 @@ describe('HighlightsPage', () => {
   it('時刻調整後にポーリングで即 GENERATED が返った場合、新しいクリップ URL を video src に反映する', async () => {
     jest.useFakeTimers();
 
-    global.fetch = jest
-      .fn()
-      // Initial load: h-1 is GENERATED with old URL
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          highlights: [
-            {
-              highlightId: 'h-1',
-              jobId: 'job-1',
-              order: 1,
-              startSec: 10,
-              endSec: 20,
-              source: 'motion',
-              status: 'accepted',
-              clipStatus: 'GENERATED',
-              clipUrl: 'https://example.com/h-1-old.mp4',
-            },
-          ],
-        }),
-      })
-      // expiresAt fetch
-      .mockResolvedValueOnce({ ok: false })
-      // PATCH: time range update → returns GENERATING
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          highlightId: 'h-1',
-          jobId: 'job-1',
-          order: 1,
-          startSec: 11,
-          endSec: 20,
-          source: 'motion',
-          status: 'unconfirmed',
-          clipStatus: 'GENERATING',
-        }),
-      })
-      // Poll: regeneration finished quickly, returns GENERATED with new URL
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          highlights: [
-            {
-              highlightId: 'h-1',
-              jobId: 'job-1',
-              order: 1,
-              startSec: 11,
-              endSec: 20,
-              source: 'motion',
-              status: 'unconfirmed',
-              clipStatus: 'GENERATED',
-              clipUrl: 'https://example.com/h-1-new.mp4',
-            },
-          ],
-        }),
-      })
-      .mockResolvedValue({ ok: false }) as jest.Mock;
+    // URL ベースでレスポンスを振り分ける（呼び出し順序に依存しない方式）
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/transcript')) {
+        return { ok: true, json: async () => ({ segments: [] }) };
+      }
+      return { ok: false };
+    }) as jest.Mock;
+
+    // highlights（初回）のみ成功レスポンスを返し、PATCH や poll のために上書き
+    let highlightsFetchCount = 0;
+    let patchDone = false;
+    (global.fetch as jest.Mock).mockImplementation(async (url: string, options?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/transcript')) {
+        return { ok: true, json: async () => ({ segments: [] }) };
+      }
+      if (typeof url === 'string' && url.includes('/api/jobs/job-1/highlights/h-1') && options?.method === 'PATCH') {
+        patchDone = true;
+        return {
+          ok: true,
+          json: async () => ({
+            highlightId: 'h-1',
+            jobId: 'job-1',
+            order: 1,
+            startSec: 11,
+            endSec: 20,
+            source: 'motion',
+            status: 'unconfirmed',
+            clipStatus: 'GENERATING',
+          }),
+        };
+      }
+      if (typeof url === 'string' && url.includes('/api/jobs/job-1/highlights') && !url.includes('/h-1')) {
+        highlightsFetchCount++;
+        if (highlightsFetchCount === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              highlights: [
+                {
+                  highlightId: 'h-1',
+                  jobId: 'job-1',
+                  order: 1,
+                  startSec: 10,
+                  endSec: 20,
+                  source: 'motion',
+                  status: 'accepted',
+                  clipStatus: 'GENERATED',
+                  clipUrl: 'https://example.com/h-1-old.mp4',
+                },
+              ],
+            }),
+          };
+        }
+        if (patchDone) {
+          return {
+            ok: true,
+            json: async () => ({
+              highlights: [
+                {
+                  highlightId: 'h-1',
+                  jobId: 'job-1',
+                  order: 1,
+                  startSec: 11,
+                  endSec: 20,
+                  source: 'motion',
+                  status: 'unconfirmed',
+                  clipStatus: 'GENERATED',
+                  clipUrl: 'https://example.com/h-1-new.mp4',
+                },
+              ],
+            }),
+          };
+        }
+      }
+      return { ok: false };
+    });
 
     render(<HighlightsPage params={Promise.resolve({ jobId: 'job-1' })} />);
 
@@ -873,7 +903,6 @@ describe('HighlightsPage', () => {
 
     // After PATCH returns GENERATING, spinner is shown and video is hidden
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(3);
       expect(screen.getByText('クリップ生成中...')).toBeInTheDocument();
       expect(screen.queryByLabelText('見どころ動画プレビュー')).not.toBeInTheDocument();
     });
@@ -885,7 +914,6 @@ describe('HighlightsPage', () => {
 
     // After polling returns GENERATED with new URL, video should show new URL
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(4);
       expect(screen.getByLabelText('見どころ動画プレビュー')).toHaveAttribute(
         'src',
         'https://example.com/h-1-new.mp4'
@@ -896,68 +924,76 @@ describe('HighlightsPage', () => {
   it('GENERATING から GENERATED に遷移したクリップの clipUrl を選択時の video src に反映する', async () => {
     jest.useFakeTimers();
 
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          highlights: [
-            {
-              highlightId: 'h-1',
-              jobId: 'job-1',
-              order: 1,
-              startSec: 10,
-              endSec: 20,
-              source: 'motion',
-              status: 'accepted',
-              clipStatus: 'GENERATED',
-              clipUrl: 'https://example.com/h-1.mp4',
-            },
-            {
-              highlightId: 'h-2',
-              jobId: 'job-1',
-              order: 2,
-              startSec: 30,
-              endSec: 40,
-              source: 'volume',
-              status: 'accepted',
-              clipStatus: 'GENERATING',
-            },
-          ],
-        }),
-      })
-      // expiresAt fetch
-      .mockResolvedValueOnce({ ok: false })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          highlights: [
-            {
-              highlightId: 'h-1',
-              jobId: 'job-1',
-              order: 1,
-              startSec: 10,
-              endSec: 20,
-              source: 'motion',
-              status: 'accepted',
-              clipStatus: 'GENERATED',
-              clipUrl: 'https://example.com/h-1.mp4',
-            },
-            {
-              highlightId: 'h-2',
-              jobId: 'job-1',
-              order: 2,
-              startSec: 30,
-              endSec: 40,
-              source: 'volume',
-              status: 'accepted',
-              clipStatus: 'GENERATED',
-              clipUrl: 'https://example.com/h-2.mp4',
-            },
-          ],
-        }),
-      })
-      .mockResolvedValue({ ok: false }) as jest.Mock;
+    // URL ベースでレスポンスを振り分ける（呼び出し順序に依存しない方式）
+    let highlightsFetchCount = 0;
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/transcript')) {
+        return { ok: true, json: async () => ({ segments: [] }) };
+      }
+      if (typeof url === 'string' && url.includes('/api/jobs/job-1/highlights') && !url.includes('/h-')) {
+        highlightsFetchCount++;
+        if (highlightsFetchCount === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              highlights: [
+                {
+                  highlightId: 'h-1',
+                  jobId: 'job-1',
+                  order: 1,
+                  startSec: 10,
+                  endSec: 20,
+                  source: 'motion',
+                  status: 'accepted',
+                  clipStatus: 'GENERATED',
+                  clipUrl: 'https://example.com/h-1.mp4',
+                },
+                {
+                  highlightId: 'h-2',
+                  jobId: 'job-1',
+                  order: 2,
+                  startSec: 30,
+                  endSec: 40,
+                  source: 'volume',
+                  status: 'accepted',
+                  clipStatus: 'GENERATING',
+                },
+              ],
+            }),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            highlights: [
+              {
+                highlightId: 'h-1',
+                jobId: 'job-1',
+                order: 1,
+                startSec: 10,
+                endSec: 20,
+                source: 'motion',
+                status: 'accepted',
+                clipStatus: 'GENERATED',
+                clipUrl: 'https://example.com/h-1.mp4',
+              },
+              {
+                highlightId: 'h-2',
+                jobId: 'job-1',
+                order: 2,
+                startSec: 30,
+                endSec: 40,
+                source: 'volume',
+                status: 'accepted',
+                clipStatus: 'GENERATED',
+                clipUrl: 'https://example.com/h-2.mp4',
+              },
+            ],
+          }),
+        };
+      }
+      return { ok: false };
+    }) as jest.Mock;
 
     render(<HighlightsPage params={Promise.resolve({ jobId: 'job-1' })} />);
 
@@ -979,7 +1015,8 @@ describe('HighlightsPage', () => {
     });
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(3);
+      // highlights + expiresAt + transcript + ポーリング1回 = 4 回
+      expect(global.fetch).toHaveBeenCalledTimes(4);
     });
 
     fireEvent.click(screen.getByText('#2'));
@@ -1197,9 +1234,22 @@ describe('HighlightsPage', () => {
   });
 
   it('有効期限がフェッチされて表示される', async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
+    // URL ベースでレスポンスを振り分ける（呼び出し順序に依存しない方式）
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/transcript')) {
+        return { ok: true, json: async () => ({ segments: [] }) };
+      }
+      if (typeof url === 'string' && url.endsWith('/api/jobs/job-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            jobId: 'job-1',
+            status: 'COMPLETED',
+            expiresAt: 1700000000,
+          }),
+        };
+      }
+      return {
         ok: true,
         json: async () => ({
           highlights: [
@@ -1215,15 +1265,8 @@ describe('HighlightsPage', () => {
             },
           ],
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          jobId: 'job-1',
-          status: 'COMPLETED',
-          expiresAt: 1700000000,
-        }),
-      }) as jest.Mock;
+      };
+    }) as jest.Mock;
 
     render(<HighlightsPage params={Promise.resolve({ jobId: 'job-1' })} />);
 

--- a/services/quick-clip/web/tests/unit/app/jobs/highlights-page.test.tsx
+++ b/services/quick-clip/web/tests/unit/app/jobs/highlights-page.test.tsx
@@ -819,7 +819,11 @@ describe('HighlightsPage', () => {
       if (typeof url === 'string' && url.includes('/transcript')) {
         return { ok: true, json: async () => ({ segments: [] }) };
       }
-      if (typeof url === 'string' && url.includes('/api/jobs/job-1/highlights/h-1') && options?.method === 'PATCH') {
+      if (
+        typeof url === 'string' &&
+        url.includes('/api/jobs/job-1/highlights/h-1') &&
+        options?.method === 'PATCH'
+      ) {
         patchDone = true;
         return {
           ok: true,
@@ -835,7 +839,11 @@ describe('HighlightsPage', () => {
           }),
         };
       }
-      if (typeof url === 'string' && url.includes('/api/jobs/job-1/highlights') && !url.includes('/h-1')) {
+      if (
+        typeof url === 'string' &&
+        url.includes('/api/jobs/job-1/highlights') &&
+        !url.includes('/h-1')
+      ) {
         highlightsFetchCount++;
         if (highlightsFetchCount === 1) {
           return {
@@ -930,7 +938,11 @@ describe('HighlightsPage', () => {
       if (typeof url === 'string' && url.includes('/transcript')) {
         return { ok: true, json: async () => ({ segments: [] }) };
       }
-      if (typeof url === 'string' && url.includes('/api/jobs/job-1/highlights') && !url.includes('/h-')) {
+      if (
+        typeof url === 'string' &&
+        url.includes('/api/jobs/job-1/highlights') &&
+        !url.includes('/h-')
+      ) {
         highlightsFetchCount++;
         if (highlightsFetchCount === 1) {
           return {


### PR DESCRIPTION
## 変更の概要

さくっとクリップで取得済みの文字起こし（Whisper のタイムスタンプ付きセグメント）を活用し、各クリップの時間範囲に対応するテキストをハイライト画面に表示できるようにした。これまで文字起こし結果はメモリ上で感情分析に使われた後に破棄されていたため、S3 に永続化したうえで表示する。

- **永続化（batch/core）**: `buildHighlights` の戻り値を `{ highlights, segments }` に変更し、`runExtract` で `segments.length > 0` のときのみ `outputs/{jobId}/transcript.json` を S3 に保存（保存失敗は警告ログに留めバッチ全体は継続）。
- **取得（web API）**: `GET /api/jobs/[jobId]/transcript` を新規追加。transcript.json が存在しない（NoSuchKey）場合は 200 + 空配列でオプショナル扱い。
- **表示（web frontend）**: ハイライト画面で transcript を一度だけ fetch し、選択クリップの時間範囲（`seg.start < clip.endSec && seg.end > clip.startSec`）に重なるセグメントを左詳細パネルに表示。セグメント0件のジョブはセクションごと非表示。

## 関連 Issue

関連: #3509

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（永続化方針が固まり次第、docs へ反映予定）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリではないため不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- core (`@nagiyu/quick-clip-core`): 13 スイート / 142 件 すべて通過。transcript 保存ロジックのテストを追加（segments>0 で PutObject される / 0件でスキップ / openAiApiKey なしでスキップ / S3保存失敗でもバッチ成功）。
- web (`@nagiyu/quick-clip-web`): 16 スイート / 158 件 すべて通過（coverageThreshold 付き）。transcript route のテストを追加（正常取得 / NoSuchKey で空配列 / ジョブ不在 404）。既存の highlights ページテストを transcript fetch 追加に合わせて修正。

## レビューポイント

- 文字起こしはオプショナルな付加機能であり、文字起こしを実施しなかった/失敗したジョブ（セグメント0件）は transcript.json を作らず、フロントでも非表示にする割り切り。
- transcript.json の S3 オブジェクトには個別 TTL を設定していない（既存クリップ出力と同様、バケットのライフサイクルで管理される前提）。
- セグメントとクリップの重なり判定はクライアント側で都度フィルタしているため、クリップ時間の編集にも追従する。

## スクリーンショット（該当する場合）

dev 環境で実際に動画を流し、transcript.json 生成とハイライト画面での表示を確認する想定（integration ブランチ上で検証）。

## 補足事項

- 本 PR は `integration/3509-clip-transcript` をターゲットとする。dev 検証後に develop へ取り込む。
- 文字起こしの常時実行化（API コスト増）は本 PR のスコープ外。文字起こしが走ったジョブのみ表示する。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ht4jSEshH3J4SuVbszrozu)_