### PR TITLE
アゲハの瞬きを長め・口の開閉を排他切替に再調整

### DIFF
--- a/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
@@ -44,12 +44,13 @@ export interface SpriteCharacterCanvasProps {
  * renderer:'sprite' キャラクター向けに、5 枚の透過 PNG（ベース・開いた目・閉じた目・
  * 開いた口・閉じた口）を絶対配置で重ね合わせて描画する。
  *
- * 瞬き: ランダム間隔（3000〜6000ms）で約 100ms だけ eyeClosed レイヤーを opacity 1（閉じ）
+ * 瞬き: ランダム間隔（3000〜6000ms）で約 180ms だけ eyeClosed レイヤーを opacity 1（閉じ）
  * にする二値スナップ。パッと閉じてパッと開く。発話有無に関わらず常時駆動。
  *
  * 口パク: audioBuffer + audioContext が揃ったら Web Audio API（AudioBufferSourceNode +
  * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して、
- * しきい値（ヒステリシス付き）で mouthOpen レイヤーを開閉二値（opacity 0/1）で駆動する。
+ * しきい値（ヒステリシス付き）で mouthOpen / mouthClosed レイヤーを排他で開閉二値
+ * （opacity 0/1）切替する。開いている間は閉じた口を隠し、下から透けないようにする。
  *
  * iOS Safari 対策として HTMLAudio は使わず Web Audio のみ。
  * AudioContext は親が resume 済みの前提（PlaceholderCanvas / Live2DCanvas と同じ）。
@@ -66,8 +67,9 @@ export default function SpriteCharacterCanvas({
 }: SpriteCharacterCanvasProps) {
   // eyeClosed レイヤーの div（opacity を直接操作する）
   const eyeClosedRef = useRef<HTMLDivElement | null>(null);
-  // mouthOpen レイヤーの div（opacity を直接操作する）
+  // mouthOpen / mouthClosed レイヤーの div（opacity を直接操作し、開/閉を排他切替する）
   const mouthOpenRef = useRef<HTMLDivElement | null>(null);
+  const mouthClosedRef = useRef<HTMLDivElement | null>(null);
   // 瞬き用 rAF キャンセル ID
   const blinkRafIdRef = useRef<number | null>(null);
   // 口パク用 rAF キャンセル ID
@@ -86,7 +88,8 @@ export default function SpriteCharacterCanvas({
   // ぬるっとした三角波フェードではなく、パッと閉じてパッと開く二値（0/1）スナップにする。
   useEffect(() => {
     // 瞬きの設定値。BLINK_CLOSED_MS の間だけ目を完全に閉じる（dev 実機で調整可）。
-    const BLINK_CLOSED_MS = 100;
+    // 一瞬すぎて分かりにくかったため、閉じている時間をやや長め（180ms）にする。
+    const BLINK_CLOSED_MS = 180;
     const BLINK_INTERVAL_MIN_MS = 3000;
     const BLINK_INTERVAL_RANGE_MS = 3000;
 
@@ -138,11 +141,12 @@ export default function SpriteCharacterCanvas({
       source.buffer = audioBuffer;
 
       analyser = audioContext.createAnalyser();
-      // fftSize・各種 dB 設定は PlaceholderCanvas / Live2DCanvas と合わせる
+      // fftSize・dB 範囲は PlaceholderCanvas / Live2DCanvas と合わせる。
+      // smoothingTimeConstant は開閉の追従を素早くするため低め（0.5）にする。
       analyser.fftSize = 256;
       analyser.minDecibels = -90;
       analyser.maxDecibels = -10;
-      analyser.smoothingTimeConstant = 0.85;
+      analyser.smoothingTimeConstant = 0.5;
 
       source.connect(analyser);
       analyser.connect(audioContext.destination);
@@ -173,21 +177,28 @@ export default function SpriteCharacterCanvas({
           mouthIsOpen = false;
         }
 
+        // 開/閉を排他で切り替える（開いている間は閉じた口を隠して下から透けないようにする）
         if (mouthOpenRef.current) {
           mouthOpenRef.current.style.opacity = mouthIsOpen ? '1' : '0';
+        }
+        if (mouthClosedRef.current) {
+          mouthClosedRef.current.style.opacity = mouthIsOpen ? '0' : '1';
         }
       };
       animateLipsync();
 
       source.onended = () => {
         if (cancelled) return;
-        // rAF を止めて口を閉じた状態に戻す
+        // rAF を止めて口を閉じた状態に戻す（開いた口を隠し、閉じた口を表示する）
         if (lipsyncRafIdRef.current !== null) {
           cancelAnimationFrame(lipsyncRafIdRef.current);
           lipsyncRafIdRef.current = null;
         }
         if (mouthOpenRef.current) {
           mouthOpenRef.current.style.opacity = '0';
+        }
+        if (mouthClosedRef.current) {
+          mouthClosedRef.current.style.opacity = '1';
         }
         onPlaybackEndRef.current?.();
       };
@@ -285,17 +296,19 @@ export default function SpriteCharacterCanvas({
             />
           </Box>
 
-          {/* 閉じた口: 常時表示（opacity 固定 1）のベース口 */}
-          <Image
-            src={spritePaths.mouthClosed}
-            alt=""
-            fill
-            unoptimized
-            style={{ objectFit: 'contain' }}
-            data-testid="sprite-mouth-closed"
-          />
+          {/* 閉じた口: 待機時に表示。発話で口が開いている間は opacity 0 にして下から透けないようにする */}
+          <Box ref={mouthClosedRef} sx={{ position: 'absolute', inset: 0, opacity: 1 }}>
+            <Image
+              src={spritePaths.mouthClosed}
+              alt=""
+              fill
+              unoptimized
+              style={{ objectFit: 'contain' }}
+              data-testid="sprite-mouth-closed"
+            />
+          </Box>
 
-          {/* 開いた口: 発話時に音量連動で opacity を上げる。div でラップして ref を持たせる */}
+          {/* 開いた口: 発話時に表示。閉じた口と排他で切り替える。div でラップして ref を持たせる */}
           <Box ref={mouthOpenRef} sx={{ position: 'absolute', inset: 0, opacity: 0 }}>
             <Image
               src={spritePaths.mouthOpen}

--- a/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
@@ -306,7 +306,7 @@ describe('SpriteCharacterCanvas', () => {
       expect(mockAnalyser.fftSize).toBe(256);
       expect(mockAnalyser.minDecibels).toBe(-90);
       expect(mockAnalyser.maxDecibels).toBe(-10);
-      expect(mockAnalyser.smoothingTimeConstant).toBe(0.85);
+      expect(mockAnalyser.smoothingTimeConstant).toBe(0.5);
     });
 
     it('rAF 一巡で getByteFrequencyData が呼ばれ mouthOpen の opacity が更新される', () => {
@@ -362,19 +362,23 @@ describe('SpriteCharacterCanvas', () => {
         />
       );
 
-      // mouthOpen の Image をラップする div（ref 対象）の inline opacity を確認する
+      // 開いた口 / 閉じた口の Image をラップする div（ref 対象）の inline opacity を確認する
       const mouthOpenWrapper = screen.getByTestId('sprite-mouth-open').parentElement as HTMLElement;
+      const mouthClosedWrapper = screen.getByTestId('sprite-mouth-closed')
+        .parentElement as HTMLElement;
 
-      // 大音量の rAF 一巡で口が開く（opacity 1）
+      // 大音量の rAF 一巡で口が開く（開=1 / 閉=0 の排他）
       flushRaf(0);
       expect(mouthOpenWrapper.style.opacity).toBe('1');
+      expect(mouthClosedWrapper.style.opacity).toBe('0');
 
-      // 無音（閉じる閾値未満）の rAF 一巡で口が閉じる（opacity 0）
+      // 無音（閉じる閾値未満）の rAF 一巡で口が閉じる（開=0 / 閉=1 の排他）
       mockGetByteFrequencyData.mockImplementation((arr: Uint8Array) => {
         arr.fill(0);
       });
       flushRaf(0);
       expect(mouthOpenWrapper.style.opacity).toBe('0');
+      expect(mouthClosedWrapper.style.opacity).toBe('1');
     });
 
     it('onPlaybackError が指定されている場合、例外時に呼ばれる', () => {


### PR DESCRIPTION
## 変更の概要

アゲハの瞬き・口パクの見え方に関する追加調整。

- **瞬きが一瞬すぎる** → 閉じている時間を `100ms` → `180ms` に延長（瞬きを視認しやすくする。長めでも不自然ではない範囲）。
- **発話中に閉じた口が透けて見える** → 重ね順の問題（閉じた口を常時表示し開いた口を上に重ねていたため、開いた口の絵で覆いきれない部分から下の閉じた口が透けていた）。**開いた口 / 閉じた口を排他切替**（常にどちらか一方だけを opacity 1 にする）に変更して解消。
- あわせて開閉の追従を素早くするため `AnalyserNode.smoothingTimeConstant` を `0.85` → `0.5` に変更。

各値は引き続き定数化済みで dev 実機で微調整可能。

## 関連 Issue

#3502（本 PR は integration ブランチ宛のため `Closes` は付けない）

## 変更種別

- [ ] 新規機能
- [x] バグ修正（発話中に閉じた口が透ける表示不具合）
- [x] リファクタリング（挙動調整）
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `SpriteCharacterCanvas.test.tsx`：口の開閉時に mouthOpen / mouthClosed が**排他**（開=1/閉=0、閉=1/開=0）で切り替わることを検証するアサーションを追加。`smoothingTimeConstant` の期待値を `0.5` に更新。
- 結果：54 スイート / 508 件 pass、カバレッジ閾値 80% クリア。ESLint エラーなし・Prettier 適合。

## レビューポイント

- 瞬きの閉じ時間（`BLINK_CLOSED_MS = 180`）、口の開閉しきい値（開 `0.1` / 閉 `0.05`）、`smoothingTimeConstant`（`0.5`）は dev 実機で最終調整。
- 排他切替により、発話中は「開いた口」のみが表示される（閉じた口は隠れる）。

## スクリーンショット（該当する場合）

dev 環境で実機確認予定。

## 補足事項

- マージ済み #3503・#3507 に続く調整。同じ integration ブランチ `integration/3502-ageha-blink-lipsync` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_0185GTqyGSws2SZj2MnTZqB3)_