### PR TITLE
アゲハの瞬きで目が二重に見える問題を修正（開/閉の排他切替）

### DIFF
--- a/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
@@ -44,8 +44,9 @@ export interface SpriteCharacterCanvasProps {
  * renderer:'sprite' キャラクター向けに、5 枚の透過 PNG（ベース・開いた目・閉じた目・
  * 開いた口・閉じた口）を絶対配置で重ね合わせて描画する。
  *
- * 瞬き: ランダム間隔（3000〜6000ms）で約 180ms だけ eyeClosed レイヤーを opacity 1（閉じ）
- * にする二値スナップ。パッと閉じてパッと開く。発話有無に関わらず常時駆動。
+ * 瞬き: ランダム間隔（3000〜6000ms）で約 180ms だけ目を閉じる二値スナップ。eyeOpen /
+ * eyeClosed レイヤーを排他で切り替える（閉じている間は開いた目を隠して二重表示を防ぐ）。
+ * パッと閉じてパッと開く。発話有無に関わらず常時駆動。
  *
  * 口パク: audioBuffer + audioContext が揃ったら Web Audio API（AudioBufferSourceNode +
  * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して、
@@ -65,7 +66,8 @@ export default function SpriteCharacterCanvas({
   onPlaybackEnd,
   onPlaybackError,
 }: SpriteCharacterCanvasProps) {
-  // eyeClosed レイヤーの div（opacity を直接操作する）
+  // eyeOpen / eyeClosed レイヤーの div（opacity を直接操作し、開/閉を排他切替する）
+  const eyeOpenRef = useRef<HTMLDivElement | null>(null);
   const eyeClosedRef = useRef<HTMLDivElement | null>(null);
   // mouthOpen / mouthClosed レイヤーの div（opacity を直接操作し、開/閉を排他切替する）
   const mouthOpenRef = useRef<HTMLDivElement | null>(null);
@@ -113,8 +115,12 @@ export default function SpriteCharacterCanvas({
     const animate = () => {
       blinkRafIdRef.current = requestAnimationFrame(animate);
       const closed = computeClosed(performance.now());
+      // 開/閉を排他で切り替える（閉じている間は開いた目を隠して二重に見えないようにする）
       if (eyeClosedRef.current) {
-        eyeClosedRef.current.style.opacity = String(closed);
+        eyeClosedRef.current.style.opacity = closed ? '1' : '0';
+      }
+      if (eyeOpenRef.current) {
+        eyeOpenRef.current.style.opacity = closed ? '0' : '1';
       }
     };
     animate();
@@ -274,17 +280,19 @@ export default function SpriteCharacterCanvas({
             data-testid="sprite-base"
           />
 
-          {/* 開いた目: 常時表示（opacity 固定 1） */}
-          <Image
-            src={spritePaths.eyeOpen}
-            alt=""
-            fill
-            unoptimized
-            style={{ objectFit: 'contain' }}
-            data-testid="sprite-eye-open"
-          />
+          {/* 開いた目: 待機時に表示。瞬きで目を閉じている間は opacity 0 にして二重表示を防ぐ */}
+          <Box ref={eyeOpenRef} sx={{ position: 'absolute', inset: 0, opacity: 1 }}>
+            <Image
+              src={spritePaths.eyeOpen}
+              alt=""
+              fill
+              unoptimized
+              style={{ objectFit: 'contain' }}
+              data-testid="sprite-eye-open"
+            />
+          </Box>
 
-          {/* 閉じた目: 瞬き時に opacity を上げる。div でラップして ref を持たせる */}
+          {/* 閉じた目: 瞬き時に表示。開いた目と排他で切り替える。div でラップして ref を持たせる */}
           <Box ref={eyeClosedRef} sx={{ position: 'absolute', inset: 0, opacity: 0 }}>
             <Image
               src={spritePaths.eyeClosed}

--- a/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
@@ -408,30 +408,29 @@ describe('SpriteCharacterCanvas', () => {
       expect(requestAnimationFrame).toHaveBeenCalled();
     });
 
-    it('瞬き窓内で eyeClosed の div の opacity が更新される', () => {
-      // performance.now をスパイして瞬き窓内（blinkStart 直後の 50ms）に入れる
-      const mockNow = jest.spyOn(performance, 'now');
-      // 初回呼び出し（nextBlinkAt 設定）は大きな値を返し、2 回目以降でターゲット時刻を返す
-      // まず初期の nextBlinkAt を計算させる
-      let callCount = 0;
-      const BASE_TIME = 0;
-      const NEXT_BLINK = BASE_TIME + 3000; // 最小インターバル
+    it('瞬き窓内では開いた目を隠し閉じた目を表示する（排他）', () => {
+      // Math.random を 0 に固定して nextBlinkAt を決定的（= now + 3000）にする
+      const mockRandom = jest.spyOn(Math, 'random').mockReturnValue(0);
+      // performance.now は可変の currentTime を返す（呼び出し回数に依存しない堅牢な制御）
+      let currentTime = 0;
+      const mockNow = jest.spyOn(performance, 'now').mockImplementation(() => currentTime);
 
-      mockNow.mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) {
-          // nextBlinkAt の計算時（random * 3000 が加算される想定）
-          return BASE_TIME;
-        }
-        // 瞬き窓内（nextBlinkAt の 50ms 後＝三角波の前半）
-        return NEXT_BLINK + 50;
-      });
-
+      // currentTime=0 でマウント: nextBlinkAt=3000、初回 animate は窓外（開いた目を表示）
       render(<SpriteCharacterCanvas characterId="ageha" />);
-      flushRaf(NEXT_BLINK + 50);
+      const eyeOpenWrapper = screen.getByTestId('sprite-eye-open').parentElement as HTMLElement;
+      const eyeClosedWrapper = screen.getByTestId('sprite-eye-closed').parentElement as HTMLElement;
+
+      expect(eyeOpenWrapper.style.opacity).toBe('1');
+      expect(eyeClosedWrapper.style.opacity).toBe('0');
+
+      // 瞬き窓（nextBlinkAt 到達）へ進めて rAF 一巡 → 排他反転（開=0 / 閉=1）
+      currentTime = 3000;
+      flushRaf(3000);
+      expect(eyeOpenWrapper.style.opacity).toBe('0');
+      expect(eyeClosedWrapper.style.opacity).toBe('1');
 
       mockNow.mockRestore();
-      // クラッシュせずに完了することを確認（opacity の値は乱数に依存するため数値チェックは省略）
+      mockRandom.mockRestore();
     });
   });
 


### PR DESCRIPTION
## 変更の概要

瞬きの度に目が二重に見える表示不具合の修正。

- **原因**：「開いた目」を常時 opacity 1 で表示したまま、瞬き時に「閉じた目」を上に重ねていたため、閉眼時に下の開いた目が透けて二重に見えていた（先に口で直した重ね順問題と同じ構図）。
- **修正**：口と同様に**開いた目 / 閉じた目を排他切替**（常にどちらか一方だけ opacity 1）に変更。瞬きの間は「開いた目」を opacity 0 にして二重表示を解消。

## 関連 Issue

#3502（本 PR は integration ブランチ宛のため `Closes` は付けない）

## 変更種別

- [ ] 新規機能
- [x] バグ修正（瞬き時の目の二重表示）
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `SpriteCharacterCanvas.test.tsx`：既存の瞬きテストを、`Math.random` と `performance.now` を決定的に固定して **瞬き窓内で開いた目=0 / 閉じた目=1、窓外で開いた目=1 / 閉じた目=0 の排他切替**を検証する形に更新。
- 結果：54 スイート / 508 件 pass、カバレッジ閾値 80% クリア。ESLint エラーなし・Prettier 適合。

## レビューポイント

- 開いた目 / 閉じた目を排他にしたことで、瞬きの瞬間は「閉じた目」だけが表示される（二重表示なし）。
- 瞬きの閉じ時間（`BLINK_CLOSED_MS = 180`）は引き続き dev 実機で微調整可能。

## スクリーンショット（該当する場合）

dev 環境で実機確認予定。

## 補足事項

- マージ済み #3503・#3507・#3512 に続く調整。同じ integration ブランチ `integration/3502-ageha-blink-lipsync` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_0185GTqyGSws2SZj2MnTZqB3)_