### PR TITLE
早瀬アゲハに瞬き＋口パクを追加（新レンダラ sprite）

### DIFF
--- a/services/livetalk/web/src/components/CharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/CharacterCanvas.tsx
@@ -6,6 +6,7 @@ import type { LifecycleState } from '@nagiyu/livetalk-core';
 import { getCharacterRenderProfile } from '@/lib/characters/client-profiles';
 import PlaceholderCanvas from '@/components/PlaceholderCanvas';
 import StillImageCanvas from '@/components/StillImageCanvas';
+import SpriteCharacterCanvas from '@/components/SpriteCharacterCanvas';
 
 /**
  * CharacterCanvas のプロパティ。
@@ -84,6 +85,7 @@ function Live2DCanvasFallback({ statusText }: { statusText?: string }) {
  * getCharacterRenderProfile で renderer 種別を判定し、
  * - 'live2d': PixiJS + pixi-live2d-display による Live2D 描画（ssr:false 動的 import）
  * - 'still': 完成した一枚絵（静止画）の描画（SSR 可・静的 import）
+ * - 'sprite': 透過 PNG パーツ重ね合わせによる瞬き＋口パク描画（SSR 可・静的 import）
  * - 'placeholder': シルエット + 名前ラベル + 音声連動口パクによるプレースホルダー描画
  *
  * page.tsx はこのコンポーネントに同じ props を渡すだけでよく、
@@ -99,6 +101,11 @@ export default function CharacterCanvas(props: CharacterCanvasProps) {
   if (renderProfile.renderer === 'still') {
     // img + Web Audio のみで SSR 可。PlaceholderCanvas と同様に静的 import を使う。
     return <StillImageCanvas {...props} />;
+  }
+
+  if (renderProfile.renderer === 'sprite') {
+    // 透過 PNG 重ね合わせ + Web Audio のみで SSR 可。静的 import を使う。
+    return <SpriteCharacterCanvas {...props} />;
   }
 
   // 'placeholder': PlaceholderCanvas を描画する

--- a/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
@@ -44,12 +44,12 @@ export interface SpriteCharacterCanvasProps {
  * renderer:'sprite' キャラクター向けに、5 枚の透過 PNG（ベース・開いた目・閉じた目・
  * 開いた口・閉じた口）を絶対配置で重ね合わせて描画する。
  *
- * 瞬き: ランダム間隔（3000〜6000ms）で約 140ms かけて eyeClosed レイヤーの opacity を
- * 0 → 1 → 0 と変化させる三角波アニメーション。発話有無に関わらず常時駆動。
+ * 瞬き: ランダム間隔（3000〜6000ms）で約 100ms だけ eyeClosed レイヤーを opacity 1（閉じ）
+ * にする二値スナップ。パッと閉じてパッと開く。発話有無に関わらず常時駆動。
  *
  * 口パク: audioBuffer + audioContext が揃ったら Web Audio API（AudioBufferSourceNode +
- * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して
- * mouthOpen レイヤーの opacity を毎フレーム駆動する。
+ * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して、
+ * しきい値（ヒステリシス付き）で mouthOpen レイヤーを開閉二値（opacity 0/1）で駆動する。
  *
  * iOS Safari 対策として HTMLAudio は使わず Web Audio のみ。
  * AudioContext は親が resume 済みの前提（PlaceholderCanvas / Live2DCanvas と同じ）。
@@ -83,10 +83,10 @@ export default function SpriteCharacterCanvas({
   }, [onPlaybackEnd, onPlaybackError]);
 
   // 瞬きアニメーション（常時駆動）。
-  // Live2DCanvas の computeEyeOpen と同じ三角波ロジックを使用する。
+  // ぬるっとした三角波フェードではなく、パッと閉じてパッと開く二値（0/1）スナップにする。
   useEffect(() => {
-    // 瞬きの設定値（Live2DCanvas と同じ値）
-    const BLINK_DURATION_MS = 140;
+    // 瞬きの設定値。BLINK_CLOSED_MS の間だけ目を完全に閉じる（dev 実機で調整可）。
+    const BLINK_CLOSED_MS = 100;
     const BLINK_INTERVAL_MIN_MS = 3000;
     const BLINK_INTERVAL_RANGE_MS = 3000;
 
@@ -95,28 +95,23 @@ export default function SpriteCharacterCanvas({
       performance.now() + BLINK_INTERVAL_MIN_MS + Math.random() * BLINK_INTERVAL_RANGE_MS;
 
     /**
-     * 三角波で瞬きの閉じ具合（0〜1）を計算する。
-     * 瞬き窓外は 0（開いた状態）、窓内の half で最も閉じる（1）。
+     * 瞬きの閉じ状態（0=開き / 1=閉じ）を二値で計算する。
+     * nextBlinkAt に達したら瞬きを開始し、BLINK_CLOSED_MS の間だけ 1（閉じ）を返す。
      */
-    const computeCloseRatio = (now: number): number => {
-      if (now >= nextBlinkAt && now > blinkStart + BLINK_DURATION_MS) {
+    const computeClosed = (now: number): number => {
+      if (now >= nextBlinkAt && now > blinkStart + BLINK_CLOSED_MS) {
         blinkStart = now;
         nextBlinkAt = now + BLINK_INTERVAL_MIN_MS + Math.random() * BLINK_INTERVAL_RANGE_MS;
       }
       const t = now - blinkStart;
-      if (t >= 0 && t < BLINK_DURATION_MS) {
-        const half = BLINK_DURATION_MS / 2;
-        // 0 → 1 → 0（閉じ具合）。half で最も閉じる
-        return t < half ? t / half : 1 - (t - half) / half;
-      }
-      return 0;
+      return t >= 0 && t < BLINK_CLOSED_MS ? 1 : 0;
     };
 
     const animate = () => {
       blinkRafIdRef.current = requestAnimationFrame(animate);
-      const closeRatio = computeCloseRatio(performance.now());
+      const closed = computeClosed(performance.now());
       if (eyeClosedRef.current) {
-        eyeClosedRef.current.style.opacity = String(closeRatio);
+        eyeClosedRef.current.style.opacity = String(closed);
       }
     };
     animate();
@@ -152,8 +147,13 @@ export default function SpriteCharacterCanvas({
       source.connect(analyser);
       analyser.connect(audioContext.destination);
 
-      // requestAnimationFrame ループで音量レベルを算出して mouthOpen の opacity を駆動する
+      // requestAnimationFrame ループで音量レベルを算出して mouthOpen を二値（開/閉）で駆動する。
+      // ぬるっとした連続フェードをやめ、しきい値で口をパッと開閉する。
+      // 開く閾値 > 閉じる閾値のヒステリシスで、境界付近のチラつき（パカパカ）を抑える（dev で調整可）。
+      const MOUTH_OPEN_THRESHOLD = 0.1;
+      const MOUTH_CLOSE_THRESHOLD = 0.05;
       const dataArray = new Uint8Array(analyser.frequencyBinCount);
+      let mouthIsOpen = false;
       const animateLipsync = () => {
         if (cancelled || !analyser) return;
         lipsyncRafIdRef.current = requestAnimationFrame(animateLipsync);
@@ -165,11 +165,16 @@ export default function SpriteCharacterCanvas({
           sum += dataArray[i];
         }
         const avg = sum / dataArray.length / 255;
-        // 視認できるよう増幅し 0〜1 にクランプする
-        const opacity = Math.min(1, avg * 2.2);
+
+        // ヒステリシス付きで開閉状態を更新する
+        if (!mouthIsOpen && avg >= MOUTH_OPEN_THRESHOLD) {
+          mouthIsOpen = true;
+        } else if (mouthIsOpen && avg < MOUTH_CLOSE_THRESHOLD) {
+          mouthIsOpen = false;
+        }
 
         if (mouthOpenRef.current) {
-          mouthOpenRef.current.style.opacity = String(opacity);
+          mouthOpenRef.current.style.opacity = mouthIsOpen ? '1' : '0';
         }
       };
       animateLipsync();

--- a/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
@@ -44,12 +44,13 @@ export interface SpriteCharacterCanvasProps {
  * renderer:'sprite' キャラクター向けに、5 枚の透過 PNG（ベース・開いた目・閉じた目・
  * 開いた口・閉じた口）を絶対配置で重ね合わせて描画する。
  *
- * 瞬き: ランダム間隔（3000〜6000ms）で約 100ms だけ eyeClosed レイヤーを opacity 1（閉じ）
+ * 瞬き: ランダム間隔（3000〜6000ms）で約 180ms だけ eyeClosed レイヤーを opacity 1（閉じ）
  * にする二値スナップ。パッと閉じてパッと開く。発話有無に関わらず常時駆動。
  *
  * 口パク: audioBuffer + audioContext が揃ったら Web Audio API（AudioBufferSourceNode +
  * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して、
- * しきい値（ヒステリシス付き）で mouthOpen レイヤーを開閉二値（opacity 0/1）で駆動する。
+ * しきい値（ヒステリシス付き）で mouthOpen / mouthClosed レイヤーを排他で開閉二値
+ * （opacity 0/1）切替する。開いている間は閉じた口を隠し、下から透けないようにする。
  *
  * iOS Safari 対策として HTMLAudio は使わず Web Audio のみ。
  * AudioContext は親が resume 済みの前提（PlaceholderCanvas / Live2DCanvas と同じ）。
@@ -66,8 +67,9 @@ export default function SpriteCharacterCanvas({
 }: SpriteCharacterCanvasProps) {
   // eyeClosed レイヤーの div（opacity を直接操作する）
   const eyeClosedRef = useRef<HTMLDivElement | null>(null);
-  // mouthOpen レイヤーの div（opacity を直接操作する）
+  // mouthOpen / mouthClosed レイヤーの div（opacity を直接操作し、開/閉を排他切替する）
   const mouthOpenRef = useRef<HTMLDivElement | null>(null);
+  const mouthClosedRef = useRef<HTMLDivElement | null>(null);
   // 瞬き用 rAF キャンセル ID
   const blinkRafIdRef = useRef<number | null>(null);
   // 口パク用 rAF キャンセル ID
@@ -86,7 +88,8 @@ export default function SpriteCharacterCanvas({
   // ぬるっとした三角波フェードではなく、パッと閉じてパッと開く二値（0/1）スナップにする。
   useEffect(() => {
     // 瞬きの設定値。BLINK_CLOSED_MS の間だけ目を完全に閉じる（dev 実機で調整可）。
-    const BLINK_CLOSED_MS = 100;
+    // 一瞬すぎて分かりにくかったため、閉じている時間をやや長め（180ms）にする。
+    const BLINK_CLOSED_MS = 180;
     const BLINK_INTERVAL_MIN_MS = 3000;
     const BLINK_INTERVAL_RANGE_MS = 3000;
 
@@ -138,11 +141,12 @@ export default function SpriteCharacterCanvas({
       source.buffer = audioBuffer;
 
       analyser = audioContext.createAnalyser();
-      // fftSize・各種 dB 設定は PlaceholderCanvas / Live2DCanvas と合わせる
+      // fftSize・dB 範囲は PlaceholderCanvas / Live2DCanvas と合わせる。
+      // smoothingTimeConstant は開閉の追従を素早くするため低め（0.5）にする。
       analyser.fftSize = 256;
       analyser.minDecibels = -90;
       analyser.maxDecibels = -10;
-      analyser.smoothingTimeConstant = 0.85;
+      analyser.smoothingTimeConstant = 0.5;
 
       source.connect(analyser);
       analyser.connect(audioContext.destination);
@@ -173,21 +177,28 @@ export default function SpriteCharacterCanvas({
           mouthIsOpen = false;
         }
 
+        // 開/閉を排他で切り替える（開いている間は閉じた口を隠して下から透けないようにする）
         if (mouthOpenRef.current) {
           mouthOpenRef.current.style.opacity = mouthIsOpen ? '1' : '0';
+        }
+        if (mouthClosedRef.current) {
+          mouthClosedRef.current.style.opacity = mouthIsOpen ? '0' : '1';
         }
       };
       animateLipsync();
 
       source.onended = () => {
         if (cancelled) return;
-        // rAF を止めて口を閉じた状態に戻す
+        // rAF を止めて口を閉じた状態に戻す（開いた口を隠し、閉じた口を表示する）
         if (lipsyncRafIdRef.current !== null) {
           cancelAnimationFrame(lipsyncRafIdRef.current);
           lipsyncRafIdRef.current = null;
         }
         if (mouthOpenRef.current) {
           mouthOpenRef.current.style.opacity = '0';
+        }
+        if (mouthClosedRef.current) {
+          mouthClosedRef.current.style.opacity = '1';
         }
         onPlaybackEndRef.current?.();
       };
@@ -285,17 +296,19 @@ export default function SpriteCharacterCanvas({
             />
           </Box>
 
-          {/* 閉じた口: 常時表示（opacity 固定 1）のベース口 */}
-          <Image
-            src={spritePaths.mouthClosed}
-            alt=""
-            fill
-            unoptimized
-            style={{ objectFit: 'contain' }}
-            data-testid="sprite-mouth-closed"
-          />
+          {/* 閉じた口: 待機時に表示。発話で口が開いている間は opacity 0 にして下から透けないようにする */}
+          <Box ref={mouthClosedRef} sx={{ position: 'absolute', inset: 0, opacity: 1 }}>
+            <Image
+              src={spritePaths.mouthClosed}
+              alt=""
+              fill
+              unoptimized
+              style={{ objectFit: 'contain' }}
+              data-testid="sprite-mouth-closed"
+            />
+          </Box>
 
-          {/* 開いた口: 発話時に音量連動で opacity を上げる。div でラップして ref を持たせる */}
+          {/* 開いた口: 発話時に表示。閉じた口と排他で切り替える。div でラップして ref を持たせる */}
           <Box ref={mouthOpenRef} sx={{ position: 'absolute', inset: 0, opacity: 0 }}>
             <Image
               src={spritePaths.mouthOpen}

--- a/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Image from 'next/image';
+import { Box, Typography } from '@mui/material';
+import type { LifecycleState } from '@nagiyu/livetalk-core';
+import { getCharacterDisplay, getCharacterRenderProfile } from '@/lib/characters/client-profiles';
+
+/**
+ * SpriteCharacterCanvas のプロパティ。
+ * StillImageCanvas と同じ再生コントラクト。
+ */
+export interface SpriteCharacterCanvasProps {
+  /**
+   * 表示するキャラクターの ID。省略時はレジストリの既定キャラクターを使用する。
+   * 画像パスと alt テキストの取得に使用する。
+   */
+  characterId?: string;
+  /**
+   * 再生対象の AudioBuffer。null または undefined のときは再生しない（待機表示）。
+   *
+   * iOS Safari の HTMLAudioElement autoplay 制約回避のため、HTMLAudio は使わず
+   * Web Audio API の AudioBufferSourceNode を直接使う。
+   */
+  audioBuffer?: AudioBuffer | null;
+  /**
+   * 再生に使う AudioContext。親側で user gesture 中に resume 済みである前提。
+   * audioBuffer が指定されているのに audioContext が null の場合は再生しない。
+   */
+  audioContext?: AudioContext | null;
+  /** 「考え中 / 話している / 待機中」の状態テキスト */
+  statusText?: string;
+  /** 生活サイクル状態（現在は参照のみ・将来の拡張用） */
+  lifecycleState?: LifecycleState;
+  /** 音声再生完了時のコールバック */
+  onPlaybackEnd?: () => void;
+  /** 音声再生エラー時のコールバック */
+  onPlaybackError?: (error: Error) => void;
+}
+
+/**
+ * 透過 PNG パーツを重ね合わせて瞬き＋音声連動口パクを行うコンポーネント。
+ *
+ * renderer:'sprite' キャラクター向けに、5 枚の透過 PNG（ベース・開いた目・閉じた目・
+ * 開いた口・閉じた口）を絶対配置で重ね合わせて描画する。
+ *
+ * 瞬き: ランダム間隔（3000〜6000ms）で約 140ms かけて eyeClosed レイヤーの opacity を
+ * 0 → 1 → 0 と変化させる三角波アニメーション。発話有無に関わらず常時駆動。
+ *
+ * 口パク: audioBuffer + audioContext が揃ったら Web Audio API（AudioBufferSourceNode +
+ * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して
+ * mouthOpen レイヤーの opacity を毎フレーム駆動する。
+ *
+ * iOS Safari 対策として HTMLAudio は使わず Web Audio のみ。
+ * AudioContext は親が resume 済みの前提（PlaceholderCanvas / Live2DCanvas と同じ）。
+ */
+export default function SpriteCharacterCanvas({
+  characterId,
+  audioBuffer,
+  audioContext,
+  statusText,
+  // lifecycleState は将来の拡張用。現時点では参照しない（sprite は sleeping 表現なし）
+  lifecycleState: _lifecycleStateUnused, // eslint-disable-line @typescript-eslint/no-unused-vars
+  onPlaybackEnd,
+  onPlaybackError,
+}: SpriteCharacterCanvasProps) {
+  // eyeClosed レイヤーの div（opacity を直接操作する）
+  const eyeClosedRef = useRef<HTMLDivElement | null>(null);
+  // mouthOpen レイヤーの div（opacity を直接操作する）
+  const mouthOpenRef = useRef<HTMLDivElement | null>(null);
+  // 瞬き用 rAF キャンセル ID
+  const blinkRafIdRef = useRef<number | null>(null);
+  // 口パク用 rAF キャンセル ID
+  const lipsyncRafIdRef = useRef<number | null>(null);
+
+  // コールバックを ref 経由で参照することで、再生の useEffect が
+  // 親側のコールバック識別子変更で再走するのを避ける
+  const onPlaybackEndRef = useRef(onPlaybackEnd);
+  const onPlaybackErrorRef = useRef(onPlaybackError);
+  useEffect(() => {
+    onPlaybackEndRef.current = onPlaybackEnd;
+    onPlaybackErrorRef.current = onPlaybackError;
+  }, [onPlaybackEnd, onPlaybackError]);
+
+  // 瞬きアニメーション（常時駆動）。
+  // Live2DCanvas の computeEyeOpen と同じ三角波ロジックを使用する。
+  useEffect(() => {
+    // 瞬きの設定値（Live2DCanvas と同じ値）
+    const BLINK_DURATION_MS = 140;
+    const BLINK_INTERVAL_MIN_MS = 3000;
+    const BLINK_INTERVAL_RANGE_MS = 3000;
+
+    let blinkStart = -Infinity;
+    let nextBlinkAt =
+      performance.now() + BLINK_INTERVAL_MIN_MS + Math.random() * BLINK_INTERVAL_RANGE_MS;
+
+    /**
+     * 三角波で瞬きの閉じ具合（0〜1）を計算する。
+     * 瞬き窓外は 0（開いた状態）、窓内の half で最も閉じる（1）。
+     */
+    const computeCloseRatio = (now: number): number => {
+      if (now >= nextBlinkAt && now > blinkStart + BLINK_DURATION_MS) {
+        blinkStart = now;
+        nextBlinkAt = now + BLINK_INTERVAL_MIN_MS + Math.random() * BLINK_INTERVAL_RANGE_MS;
+      }
+      const t = now - blinkStart;
+      if (t >= 0 && t < BLINK_DURATION_MS) {
+        const half = BLINK_DURATION_MS / 2;
+        // 0 → 1 → 0（閉じ具合）。half で最も閉じる
+        return t < half ? t / half : 1 - (t - half) / half;
+      }
+      return 0;
+    };
+
+    const animate = () => {
+      blinkRafIdRef.current = requestAnimationFrame(animate);
+      const closeRatio = computeCloseRatio(performance.now());
+      if (eyeClosedRef.current) {
+        eyeClosedRef.current.style.opacity = String(closeRatio);
+      }
+    };
+    animate();
+
+    return () => {
+      if (blinkRafIdRef.current !== null) {
+        cancelAnimationFrame(blinkRafIdRef.current);
+        blinkRafIdRef.current = null;
+      }
+    };
+  }, []);
+
+  // 口パク（audioBuffer + audioContext が揃ったら Web Audio で再生して音量連動）。
+  // PlaceholderCanvas と同じ AnalyserNode 設定・算出方法を踏襲する。
+  useEffect(() => {
+    if (!audioBuffer || !audioContext) return;
+
+    let cancelled = false;
+    let source: AudioBufferSourceNode | null = null;
+    let analyser: AnalyserNode | null = null;
+
+    try {
+      source = audioContext.createBufferSource();
+      source.buffer = audioBuffer;
+
+      analyser = audioContext.createAnalyser();
+      // fftSize・各種 dB 設定は PlaceholderCanvas / Live2DCanvas と合わせる
+      analyser.fftSize = 256;
+      analyser.minDecibels = -90;
+      analyser.maxDecibels = -10;
+      analyser.smoothingTimeConstant = 0.85;
+
+      source.connect(analyser);
+      analyser.connect(audioContext.destination);
+
+      // requestAnimationFrame ループで音量レベルを算出して mouthOpen の opacity を駆動する
+      const dataArray = new Uint8Array(analyser.frequencyBinCount);
+      const animateLipsync = () => {
+        if (cancelled || !analyser) return;
+        lipsyncRafIdRef.current = requestAnimationFrame(animateLipsync);
+
+        analyser.getByteFrequencyData(dataArray);
+        // 全周波数ビンの平均を 0〜255 → 0〜1 に正規化する（PlaceholderCanvas と同じ算出）
+        let sum = 0;
+        for (let i = 0; i < dataArray.length; i++) {
+          sum += dataArray[i];
+        }
+        const avg = sum / dataArray.length / 255;
+        // 視認できるよう増幅し 0〜1 にクランプする
+        const opacity = Math.min(1, avg * 2.2);
+
+        if (mouthOpenRef.current) {
+          mouthOpenRef.current.style.opacity = String(opacity);
+        }
+      };
+      animateLipsync();
+
+      source.onended = () => {
+        if (cancelled) return;
+        // rAF を止めて口を閉じた状態に戻す
+        if (lipsyncRafIdRef.current !== null) {
+          cancelAnimationFrame(lipsyncRafIdRef.current);
+          lipsyncRafIdRef.current = null;
+        }
+        if (mouthOpenRef.current) {
+          mouthOpenRef.current.style.opacity = '0';
+        }
+        onPlaybackEndRef.current?.();
+      };
+
+      source.start(0);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      onPlaybackErrorRef.current?.(error);
+    }
+
+    return () => {
+      cancelled = true;
+      if (lipsyncRafIdRef.current !== null) {
+        cancelAnimationFrame(lipsyncRafIdRef.current);
+        lipsyncRafIdRef.current = null;
+      }
+      try {
+        source?.stop();
+      } catch {
+        // 既に停止済み・未開始など。無視。
+      }
+      source?.disconnect();
+      analyser?.disconnect();
+    };
+  }, [audioBuffer, audioContext]);
+
+  // 画像パスと alt テキストを取得する（取得失敗時はフォールバック）
+  let spritePaths: {
+    base: string;
+    eyeOpen: string;
+    eyeClosed: string;
+    mouthOpen: string;
+    mouthClosed: string;
+  } | null = null;
+  let altText = '';
+  try {
+    const renderProfile = getCharacterRenderProfile(characterId);
+    if (renderProfile.renderer === 'sprite') {
+      spritePaths = renderProfile.sprite;
+    }
+  } catch {
+    // 未登録 ID や renderer 不一致の場合は画像を出さず、フォールバック表示にする
+  }
+  try {
+    altText = getCharacterDisplay(characterId).displayName;
+  } catch {
+    // 未登録 ID などの場合は空文字列のまま表示する
+  }
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'background.default',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+      data-testid="sprite-canvas-container"
+    >
+      {spritePaths && (
+        <>
+          {/* ベース画像（目・口なし顔）: z 順の最下層 */}
+          <Image
+            src={spritePaths.base}
+            alt={altText}
+            fill
+            unoptimized
+            style={{ objectFit: 'contain' }}
+            data-testid="sprite-base"
+          />
+
+          {/* 開いた目: 常時表示（opacity 固定 1） */}
+          <Image
+            src={spritePaths.eyeOpen}
+            alt=""
+            fill
+            unoptimized
+            style={{ objectFit: 'contain' }}
+            data-testid="sprite-eye-open"
+          />
+
+          {/* 閉じた目: 瞬き時に opacity を上げる。div でラップして ref を持たせる */}
+          <Box ref={eyeClosedRef} sx={{ position: 'absolute', inset: 0, opacity: 0 }}>
+            <Image
+              src={spritePaths.eyeClosed}
+              alt=""
+              fill
+              unoptimized
+              style={{ objectFit: 'contain' }}
+              data-testid="sprite-eye-closed"
+            />
+          </Box>
+
+          {/* 閉じた口: 常時表示（opacity 固定 1）のベース口 */}
+          <Image
+            src={spritePaths.mouthClosed}
+            alt=""
+            fill
+            unoptimized
+            style={{ objectFit: 'contain' }}
+            data-testid="sprite-mouth-closed"
+          />
+
+          {/* 開いた口: 発話時に音量連動で opacity を上げる。div でラップして ref を持たせる */}
+          <Box ref={mouthOpenRef} sx={{ position: 'absolute', inset: 0, opacity: 0 }}>
+            <Image
+              src={spritePaths.mouthOpen}
+              alt=""
+              fill
+              unoptimized
+              style={{ objectFit: 'contain' }}
+              data-testid="sprite-mouth-open"
+            />
+          </Box>
+        </>
+      )}
+
+      {/* ステータステキスト（PlaceholderCanvas / Live2DCanvas と同様に下部に表示） */}
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          position: 'absolute',
+          bottom: 4,
+          left: 0,
+          right: 0,
+          textAlign: 'center',
+        }}
+      >
+        {statusText ?? '待機中'}
+      </Typography>
+    </Box>
+  );
+}

--- a/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
+++ b/services/livetalk/web/src/components/SpriteCharacterCanvas.tsx
@@ -44,8 +44,9 @@ export interface SpriteCharacterCanvasProps {
  * renderer:'sprite' キャラクター向けに、5 枚の透過 PNG（ベース・開いた目・閉じた目・
  * 開いた口・閉じた口）を絶対配置で重ね合わせて描画する。
  *
- * 瞬き: ランダム間隔（3000〜6000ms）で約 180ms だけ eyeClosed レイヤーを opacity 1（閉じ）
- * にする二値スナップ。パッと閉じてパッと開く。発話有無に関わらず常時駆動。
+ * 瞬き: ランダム間隔（3000〜6000ms）で約 180ms だけ目を閉じる二値スナップ。eyeOpen /
+ * eyeClosed レイヤーを排他で切り替える（閉じている間は開いた目を隠して二重表示を防ぐ）。
+ * パッと閉じてパッと開く。発話有無に関わらず常時駆動。
  *
  * 口パク: audioBuffer + audioContext が揃ったら Web Audio API（AudioBufferSourceNode +
  * AnalyserNode）で再生し、AnalyserNode の全周波数ビン平均を 0〜1 に正規化して、
@@ -65,7 +66,8 @@ export default function SpriteCharacterCanvas({
   onPlaybackEnd,
   onPlaybackError,
 }: SpriteCharacterCanvasProps) {
-  // eyeClosed レイヤーの div（opacity を直接操作する）
+  // eyeOpen / eyeClosed レイヤーの div（opacity を直接操作し、開/閉を排他切替する）
+  const eyeOpenRef = useRef<HTMLDivElement | null>(null);
   const eyeClosedRef = useRef<HTMLDivElement | null>(null);
   // mouthOpen / mouthClosed レイヤーの div（opacity を直接操作し、開/閉を排他切替する）
   const mouthOpenRef = useRef<HTMLDivElement | null>(null);
@@ -113,8 +115,12 @@ export default function SpriteCharacterCanvas({
     const animate = () => {
       blinkRafIdRef.current = requestAnimationFrame(animate);
       const closed = computeClosed(performance.now());
+      // 開/閉を排他で切り替える（閉じている間は開いた目を隠して二重に見えないようにする）
       if (eyeClosedRef.current) {
-        eyeClosedRef.current.style.opacity = String(closed);
+        eyeClosedRef.current.style.opacity = closed ? '1' : '0';
+      }
+      if (eyeOpenRef.current) {
+        eyeOpenRef.current.style.opacity = closed ? '0' : '1';
       }
     };
     animate();
@@ -274,17 +280,19 @@ export default function SpriteCharacterCanvas({
             data-testid="sprite-base"
           />
 
-          {/* 開いた目: 常時表示（opacity 固定 1） */}
-          <Image
-            src={spritePaths.eyeOpen}
-            alt=""
-            fill
-            unoptimized
-            style={{ objectFit: 'contain' }}
-            data-testid="sprite-eye-open"
-          />
+          {/* 開いた目: 待機時に表示。瞬きで目を閉じている間は opacity 0 にして二重表示を防ぐ */}
+          <Box ref={eyeOpenRef} sx={{ position: 'absolute', inset: 0, opacity: 1 }}>
+            <Image
+              src={spritePaths.eyeOpen}
+              alt=""
+              fill
+              unoptimized
+              style={{ objectFit: 'contain' }}
+              data-testid="sprite-eye-open"
+            />
+          </Box>
 
-          {/* 閉じた目: 瞬き時に opacity を上げる。div でラップして ref を持たせる */}
+          {/* 閉じた目: 瞬き時に表示。開いた目と排他で切り替える。div でラップして ref を持たせる */}
           <Box ref={eyeClosedRef} sx={{ position: 'absolute', inset: 0, opacity: 0 }}>
             <Image
               src={spritePaths.eyeClosed}

--- a/services/livetalk/web/src/lib/characters/client-profiles.ts
+++ b/services/livetalk/web/src/lib/characters/client-profiles.ts
@@ -69,8 +69,14 @@ const PROFILES: Record<string, CharacterClientProfile> = {
       shortName: 'アゲハ',
     },
     render: {
-      renderer: 'still',
-      imagePath: '/assets/characters/ageha/still.png',
+      renderer: 'sprite',
+      sprite: {
+        base: '/assets/characters/ageha/sprite/base.png',
+        eyeOpen: '/assets/characters/ageha/sprite/eye-open.png',
+        eyeClosed: '/assets/characters/ageha/sprite/eye-closed.png',
+        mouthOpen: '/assets/characters/ageha/sprite/mouth-open.png',
+        mouthClosed: '/assets/characters/ageha/sprite/mouth-closed.png',
+      },
     },
     licenseText: AGEHA_LICENSE_TEXT,
     description:

--- a/services/livetalk/web/src/lib/characters/types.ts
+++ b/services/livetalk/web/src/lib/characters/types.ts
@@ -7,7 +7,8 @@
  * renderer フィールドで描画方式を区別する discriminated union。
  * - 'live2d': PixiJS + pixi-live2d-display を使った Live2D モデル描画
  * - 'placeholder': Live2D モデル未用意のキャラ向けプレースホルダー描画（シルエット + 名前ラベル）
- * - 'still': 完成した一枚絵（静止画 1 枚）の描画。アニメーションなし。将来の瞬き＋口パクは別レンダラ。
+ * - 'still': 完成した一枚絵（静止画 1 枚）の描画。アニメーションなし。
+ * - 'sprite': 一枚絵のパーツを重ね合わせて瞬き＋音声連動口パクを行う描画。
  */
 export type CharacterRenderProfile =
   | {
@@ -30,10 +31,27 @@ export type CharacterRenderProfile =
       renderer: 'placeholder';
     }
   | {
-      /** 完成した一枚絵（静止画 1 枚）の描画。アニメーションなし。将来の瞬き＋口パクは別レンダラ。 */
+      /** 完成した一枚絵（静止画 1 枚）の描画。アニメーションなし。 */
       renderer: 'still';
       /** 一枚絵画像のパス（public/CloudFront 配下の絶対パス。例: /assets/characters/ageha/still.png） */
       imagePath: string;
+    }
+  | {
+      /** 一枚絵のパーツを重ね合わせて瞬き＋音声連動口パクを行う描画。 */
+      renderer: 'sprite';
+      /** パーツ画像のパス群（public/CloudFront 配下の絶対パス） */
+      sprite: {
+        /** 目・口を含まないベース画像 */
+        base: string;
+        /** 開いた目 */
+        eyeOpen: string;
+        /** 閉じた目（瞬き時に重ねる） */
+        eyeClosed: string;
+        /** 開いた口（発話時に音量連動で不透明度を上げる） */
+        mouthOpen: string;
+        /** 閉じた口（常時表示のベース口） */
+        mouthClosed: string;
+      };
     };
 
 /**

--- a/services/livetalk/web/tests/unit/components/CharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/CharacterCanvas.test.tsx
@@ -43,6 +43,14 @@ jest.mock('@/components/StillImageCanvas', () => ({
   )),
 }));
 
+// SpriteCharacterCanvas: next/image + Web Audio + rAF 依存を排除するためモック化する
+jest.mock('@/components/SpriteCharacterCanvas', () => ({
+  __esModule: true,
+  default: jest.fn(({ characterId }: { characterId?: string }) => (
+    <div data-testid="sprite-character-canvas" data-character-id={characterId ?? ''} />
+  )),
+}));
+
 // getCharacterRenderProfile をモック化して renderer 種別を制御する
 jest.mock('@/lib/characters/client-profiles', () => ({
   ...jest.requireActual('@/lib/characters/client-profiles'),
@@ -51,6 +59,7 @@ jest.mock('@/lib/characters/client-profiles', () => ({
 
 import { getCharacterRenderProfile } from '@/lib/characters/client-profiles';
 import CharacterCanvas from '@/components/CharacterCanvas';
+import type { SpriteCharacterCanvasProps } from '@/components/SpriteCharacterCanvas';
 
 const mockGetCharacterRenderProfile = getCharacterRenderProfile as jest.MockedFunction<
   typeof getCharacterRenderProfile
@@ -134,6 +143,75 @@ describe('CharacterCanvas', () => {
       );
       expect(MockStillImageCanvas).toHaveBeenCalled();
       const [receivedProps] = (MockStillImageCanvas as jest.Mock).mock.calls[0];
+      expect(receivedProps).toMatchObject({
+        characterId: 'ageha',
+        statusText: '話している',
+        onPlaybackEnd: mockPlaybackEnd,
+      });
+    });
+  });
+
+  describe('renderer: sprite のとき', () => {
+    beforeEach(() => {
+      mockGetCharacterRenderProfile.mockReturnValue({
+        renderer: 'sprite',
+        sprite: {
+          base: '/assets/characters/ageha/sprite/base.png',
+          eyeOpen: '/assets/characters/ageha/sprite/eye-open.png',
+          eyeClosed: '/assets/characters/ageha/sprite/eye-closed.png',
+          mouthOpen: '/assets/characters/ageha/sprite/mouth-open.png',
+          mouthClosed: '/assets/characters/ageha/sprite/mouth-closed.png',
+        },
+      });
+    });
+
+    it('SpriteCharacterCanvas がマウントされる', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-character-canvas')).toBeInTheDocument();
+    });
+
+    it('Live2DCanvas がマウントされない', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.queryByTestId('live2d-canvas')).toBeNull();
+    });
+
+    it('StillImageCanvas がマウントされない', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.queryByTestId('still-image-canvas')).toBeNull();
+    });
+
+    it('PlaceholderCanvas がマウントされない', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.queryByTestId('placeholder-canvas')).toBeNull();
+    });
+
+    it('characterId が SpriteCharacterCanvas に渡される', () => {
+      render(<CharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-character-canvas')).toHaveAttribute(
+        'data-character-id',
+        'ageha'
+      );
+    });
+
+    it('statusText などの props が SpriteCharacterCanvas に透過される', () => {
+      const mockPlaybackEnd = jest.fn();
+      const { default: MockSpriteCharacterCanvas } = jest.requireMock(
+        '@/components/SpriteCharacterCanvas'
+      );
+
+      render(
+        <CharacterCanvas
+          characterId="ageha"
+          statusText="話している"
+          onPlaybackEnd={mockPlaybackEnd}
+        />
+      );
+      expect(MockSpriteCharacterCanvas).toHaveBeenCalled();
+      const [receivedProps] = (
+        MockSpriteCharacterCanvas as jest.MockedFunction<
+          (props: SpriteCharacterCanvasProps) => React.ReactElement
+        >
+      ).mock.calls[0];
       expect(receivedProps).toMatchObject({
         characterId: 'ageha',
         statusText: '話している',
@@ -252,6 +330,22 @@ describe('CharacterCanvas', () => {
 
       render(<CharacterCanvas />);
       expect(screen.getByTestId('still-image-canvas')).toBeInTheDocument();
+    });
+
+    it('renderer: sprite の場合 SpriteCharacterCanvas がマウントされる', () => {
+      mockGetCharacterRenderProfile.mockReturnValue({
+        renderer: 'sprite',
+        sprite: {
+          base: '/assets/characters/ageha/sprite/base.png',
+          eyeOpen: '/assets/characters/ageha/sprite/eye-open.png',
+          eyeClosed: '/assets/characters/ageha/sprite/eye-closed.png',
+          mouthOpen: '/assets/characters/ageha/sprite/mouth-open.png',
+          mouthClosed: '/assets/characters/ageha/sprite/mouth-closed.png',
+        },
+      });
+
+      render(<CharacterCanvas />);
+      expect(screen.getByTestId('sprite-character-canvas')).toBeInTheDocument();
     });
   });
 });

--- a/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
@@ -306,7 +306,7 @@ describe('SpriteCharacterCanvas', () => {
       expect(mockAnalyser.fftSize).toBe(256);
       expect(mockAnalyser.minDecibels).toBe(-90);
       expect(mockAnalyser.maxDecibels).toBe(-10);
-      expect(mockAnalyser.smoothingTimeConstant).toBe(0.85);
+      expect(mockAnalyser.smoothingTimeConstant).toBe(0.5);
     });
 
     it('rAF 一巡で getByteFrequencyData が呼ばれ mouthOpen の opacity が更新される', () => {
@@ -362,19 +362,23 @@ describe('SpriteCharacterCanvas', () => {
         />
       );
 
-      // mouthOpen の Image をラップする div（ref 対象）の inline opacity を確認する
+      // 開いた口 / 閉じた口の Image をラップする div（ref 対象）の inline opacity を確認する
       const mouthOpenWrapper = screen.getByTestId('sprite-mouth-open').parentElement as HTMLElement;
+      const mouthClosedWrapper = screen.getByTestId('sprite-mouth-closed')
+        .parentElement as HTMLElement;
 
-      // 大音量の rAF 一巡で口が開く（opacity 1）
+      // 大音量の rAF 一巡で口が開く（開=1 / 閉=0 の排他）
       flushRaf(0);
       expect(mouthOpenWrapper.style.opacity).toBe('1');
+      expect(mouthClosedWrapper.style.opacity).toBe('0');
 
-      // 無音（閉じる閾値未満）の rAF 一巡で口が閉じる（opacity 0）
+      // 無音（閉じる閾値未満）の rAF 一巡で口が閉じる（開=0 / 閉=1 の排他）
       mockGetByteFrequencyData.mockImplementation((arr: Uint8Array) => {
         arr.fill(0);
       });
       flushRaf(0);
       expect(mouthOpenWrapper.style.opacity).toBe('0');
+      expect(mouthClosedWrapper.style.opacity).toBe('1');
     });
 
     it('onPlaybackError が指定されている場合、例外時に呼ばれる', () => {

--- a/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
@@ -408,30 +408,29 @@ describe('SpriteCharacterCanvas', () => {
       expect(requestAnimationFrame).toHaveBeenCalled();
     });
 
-    it('瞬き窓内で eyeClosed の div の opacity が更新される', () => {
-      // performance.now をスパイして瞬き窓内（blinkStart 直後の 50ms）に入れる
-      const mockNow = jest.spyOn(performance, 'now');
-      // 初回呼び出し（nextBlinkAt 設定）は大きな値を返し、2 回目以降でターゲット時刻を返す
-      // まず初期の nextBlinkAt を計算させる
-      let callCount = 0;
-      const BASE_TIME = 0;
-      const NEXT_BLINK = BASE_TIME + 3000; // 最小インターバル
+    it('瞬き窓内では開いた目を隠し閉じた目を表示する（排他）', () => {
+      // Math.random を 0 に固定して nextBlinkAt を決定的（= now + 3000）にする
+      const mockRandom = jest.spyOn(Math, 'random').mockReturnValue(0);
+      // performance.now は可変の currentTime を返す（呼び出し回数に依存しない堅牢な制御）
+      let currentTime = 0;
+      const mockNow = jest.spyOn(performance, 'now').mockImplementation(() => currentTime);
 
-      mockNow.mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) {
-          // nextBlinkAt の計算時（random * 3000 が加算される想定）
-          return BASE_TIME;
-        }
-        // 瞬き窓内（nextBlinkAt の 50ms 後＝三角波の前半）
-        return NEXT_BLINK + 50;
-      });
-
+      // currentTime=0 でマウント: nextBlinkAt=3000、初回 animate は窓外（開いた目を表示）
       render(<SpriteCharacterCanvas characterId="ageha" />);
-      flushRaf(NEXT_BLINK + 50);
+      const eyeOpenWrapper = screen.getByTestId('sprite-eye-open').parentElement as HTMLElement;
+      const eyeClosedWrapper = screen.getByTestId('sprite-eye-closed').parentElement as HTMLElement;
+
+      expect(eyeOpenWrapper.style.opacity).toBe('1');
+      expect(eyeClosedWrapper.style.opacity).toBe('0');
+
+      // 瞬き窓（nextBlinkAt 到達）へ進めて rAF 一巡 → 排他反転（開=0 / 閉=1）
+      currentTime = 3000;
+      flushRaf(3000);
+      expect(eyeOpenWrapper.style.opacity).toBe('0');
+      expect(eyeClosedWrapper.style.opacity).toBe('1');
 
       mockNow.mockRestore();
-      // クラッシュせずに完了することを確認（opacity の値は乱数に依存するため数値チェックは省略）
+      mockRandom.mockRestore();
     });
   });
 

--- a/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
@@ -347,6 +347,36 @@ describe('SpriteCharacterCanvas', () => {
       expect(onPlaybackEnd).toHaveBeenCalledTimes(1);
     });
 
+    it('音量がしきい値を跨ぐと mouthOpen が開閉する（二値・ヒステリシス）', () => {
+      mockAnalyser.frequencyBinCount = 4;
+      // まず大音量（開く閾値超え）
+      mockGetByteFrequencyData.mockImplementation((arr: Uint8Array) => {
+        arr.fill(200);
+      });
+
+      render(
+        <SpriteCharacterCanvas
+          characterId="ageha"
+          audioBuffer={mockAudioBuffer}
+          audioContext={mockAudioContext}
+        />
+      );
+
+      // mouthOpen の Image をラップする div（ref 対象）の inline opacity を確認する
+      const mouthOpenWrapper = screen.getByTestId('sprite-mouth-open').parentElement as HTMLElement;
+
+      // 大音量の rAF 一巡で口が開く（opacity 1）
+      flushRaf(0);
+      expect(mouthOpenWrapper.style.opacity).toBe('1');
+
+      // 無音（閉じる閾値未満）の rAF 一巡で口が閉じる（opacity 0）
+      mockGetByteFrequencyData.mockImplementation((arr: Uint8Array) => {
+        arr.fill(0);
+      });
+      flushRaf(0);
+      expect(mouthOpenWrapper.style.opacity).toBe('0');
+    });
+
     it('onPlaybackError が指定されている場合、例外時に呼ばれる', () => {
       const onPlaybackError = jest.fn();
       const error = new Error('テスト再生エラー');

--- a/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
+++ b/services/livetalk/web/tests/unit/components/SpriteCharacterCanvas.test.tsx
@@ -1,0 +1,448 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SpriteCharacterCanvas from '@/components/SpriteCharacterCanvas';
+
+// getCharacterRenderProfile / getCharacterDisplay をモック化して表示内容を制御する
+jest.mock('@/lib/characters/client-profiles', () => ({
+  ...jest.requireActual('@/lib/characters/client-profiles'),
+  getCharacterRenderProfile: jest.fn((id?: string) => {
+    if (id === 'ageha' || id === undefined) {
+      return {
+        renderer: 'sprite',
+        sprite: {
+          base: '/assets/characters/ageha/sprite/base.png',
+          eyeOpen: '/assets/characters/ageha/sprite/eye-open.png',
+          eyeClosed: '/assets/characters/ageha/sprite/eye-closed.png',
+          mouthOpen: '/assets/characters/ageha/sprite/mouth-open.png',
+          mouthClosed: '/assets/characters/ageha/sprite/mouth-closed.png',
+        },
+      };
+    }
+    // renderer 不一致（live2d）のキャラ（フォールバック確認用）
+    if (id === 'hiyori') {
+      return {
+        renderer: 'live2d',
+        modelPath: '/assets/characters/hiyori/runtime/hiyori_free_t08.model3.json',
+        cubismParams: {
+          mouthOpenY: 'ParamMouthOpenY',
+          eyeLOpen: 'ParamEyeLOpen',
+          eyeROpen: 'ParamEyeROpen',
+        },
+      };
+    }
+    throw new Error('指定されたキャラクターのプロファイルが見つかりません。');
+  }),
+  getCharacterDisplay: jest.fn((id?: string) => {
+    if (id === 'ageha' || id === undefined) {
+      return { displayName: '早瀬アゲハ', shortName: 'アゲハ' };
+    }
+    if (id === 'hiyori') {
+      return { displayName: '桃瀬ひより', shortName: 'ひより' };
+    }
+    throw new Error('指定されたキャラクターのプロファイルが見つかりません。');
+  }),
+}));
+
+// next/image: テスト環境で動作可能だが、fill モードの検証を確実にするため
+// data-testid が通るシンプルな img を返すモックを使う
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: jest.fn(
+    ({ src, alt, 'data-testid': testId }: { src: string; alt: string; 'data-testid'?: string }) => (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={src} alt={alt} data-testid={testId} />
+    )
+  ),
+}));
+
+// Web Audio API のスタブ（PlaceholderCanvas.test.tsx と同じパターン）
+const mockGetByteFrequencyData = jest.fn();
+const mockAnalyserConnect = jest.fn();
+const mockAnalyserDisconnect = jest.fn();
+const mockSourceConnect = jest.fn();
+const mockSourceDisconnect = jest.fn();
+const mockSourceStop = jest.fn();
+const mockSourceStart = jest.fn();
+
+const mockAnalyser = {
+  fftSize: 0,
+  minDecibels: 0,
+  maxDecibels: 0,
+  smoothingTimeConstant: 0,
+  frequencyBinCount: 4,
+  getByteFrequencyData: mockGetByteFrequencyData,
+  connect: mockAnalyserConnect,
+  disconnect: mockAnalyserDisconnect,
+};
+
+let mockOnEnded: (() => void) | null = null;
+const mockSource = {
+  buffer: null as AudioBuffer | null,
+  connect: mockSourceConnect,
+  disconnect: mockSourceDisconnect,
+  stop: mockSourceStop,
+  start: mockSourceStart,
+  set onended(fn: (() => void) | null) {
+    mockOnEnded = fn;
+  },
+  get onended() {
+    return mockOnEnded;
+  },
+};
+
+const mockCreateBufferSource = jest.fn(() => mockSource);
+const mockCreateAnalyser = jest.fn(() => mockAnalyser);
+const mockDestination = {};
+
+const mockAudioContext = {
+  createBufferSource: mockCreateBufferSource,
+  createAnalyser: mockCreateAnalyser,
+  destination: mockDestination,
+} as unknown as AudioContext;
+
+const mockAudioBuffer = {} as AudioBuffer;
+
+// requestAnimationFrame / cancelAnimationFrame のスタブ
+let rafCallbacks: Map<number, FrameRequestCallback> = new Map();
+let rafIdCounter = 0;
+
+const originalRaf = global.requestAnimationFrame;
+const originalCaf = global.cancelAnimationFrame;
+
+beforeEach(() => {
+  rafCallbacks = new Map();
+  rafIdCounter = 0;
+  mockOnEnded = null;
+
+  global.requestAnimationFrame = jest.fn((cb: FrameRequestCallback) => {
+    const id = ++rafIdCounter;
+    rafCallbacks.set(id, cb);
+    return id;
+  });
+
+  global.cancelAnimationFrame = jest.fn((id: number) => {
+    rafCallbacks.delete(id);
+  });
+
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  global.requestAnimationFrame = originalRaf;
+  global.cancelAnimationFrame = originalCaf;
+});
+
+/**
+ * 登録済みのすべての rAF コールバックを一巡させる。
+ */
+function flushRaf(timestamp = 0): void {
+  const currentCallbacks = new Map(rafCallbacks);
+  for (const [id, cb] of currentCallbacks) {
+    rafCallbacks.delete(id);
+    cb(timestamp);
+  }
+}
+
+describe('SpriteCharacterCanvas', () => {
+  describe('レイヤー画像の描画', () => {
+    it('sprite-canvas-container が描画される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-canvas-container')).toBeInTheDocument();
+    });
+
+    it('sprite-base が描画される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-base')).toBeInTheDocument();
+    });
+
+    it('sprite-base の alt に displayName が設定される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      const img = screen.getByTestId('sprite-base');
+      expect(img).toHaveAttribute('alt', '早瀬アゲハ');
+    });
+
+    it('sprite-base の src がベース画像パスと一致する', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-base')).toHaveAttribute(
+        'src',
+        '/assets/characters/ageha/sprite/base.png'
+      );
+    });
+
+    it('sprite-eye-open が描画される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-eye-open')).toBeInTheDocument();
+    });
+
+    it('sprite-eye-open の alt が空文字列（装飾画像）', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-eye-open')).toHaveAttribute('alt', '');
+    });
+
+    it('sprite-eye-closed が描画される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-eye-closed')).toBeInTheDocument();
+    });
+
+    it('sprite-eye-closed の alt が空文字列（装飾画像）', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-eye-closed')).toHaveAttribute('alt', '');
+    });
+
+    it('sprite-mouth-open が描画される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-mouth-open')).toBeInTheDocument();
+    });
+
+    it('sprite-mouth-open の alt が空文字列（装飾画像）', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-mouth-open')).toHaveAttribute('alt', '');
+    });
+
+    it('sprite-mouth-closed が描画される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-mouth-closed')).toBeInTheDocument();
+    });
+
+    it('sprite-mouth-closed の alt が空文字列（装飾画像）', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-mouth-closed')).toHaveAttribute('alt', '');
+    });
+
+    it('すべての sprite src が設定されている', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByTestId('sprite-eye-open')).toHaveAttribute(
+        'src',
+        '/assets/characters/ageha/sprite/eye-open.png'
+      );
+      expect(screen.getByTestId('sprite-eye-closed')).toHaveAttribute(
+        'src',
+        '/assets/characters/ageha/sprite/eye-closed.png'
+      );
+      expect(screen.getByTestId('sprite-mouth-open')).toHaveAttribute(
+        'src',
+        '/assets/characters/ageha/sprite/mouth-open.png'
+      );
+      expect(screen.getByTestId('sprite-mouth-closed')).toHaveAttribute(
+        'src',
+        '/assets/characters/ageha/sprite/mouth-closed.png'
+      );
+    });
+  });
+
+  describe('statusText の表示', () => {
+    it('statusText が指定されていない場合「待機中」が表示される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      expect(screen.getByText('待機中')).toBeInTheDocument();
+    });
+
+    it('statusText が指定された場合その内容が表示される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" statusText="考え中" />);
+      expect(screen.getByText('考え中')).toBeInTheDocument();
+    });
+
+    it('statusText を変えても表示が切り替わる', () => {
+      const { rerender } = render(
+        <SpriteCharacterCanvas characterId="ageha" statusText="待機中" />
+      );
+      expect(screen.getByText('待機中')).toBeInTheDocument();
+
+      rerender(<SpriteCharacterCanvas characterId="ageha" statusText="話している" />);
+      expect(screen.getByText('話している')).toBeInTheDocument();
+    });
+  });
+
+  describe('audioBuffer / audioContext 未指定時', () => {
+    it('audioBuffer が null のときクラッシュしない（待機表示）', () => {
+      expect(() => {
+        render(<SpriteCharacterCanvas characterId="ageha" audioBuffer={null} />);
+      }).not.toThrow();
+    });
+
+    it('audioContext が null のときクラッシュしない（待機表示）', () => {
+      expect(() => {
+        render(
+          <SpriteCharacterCanvas characterId="ageha" audioBuffer={null} audioContext={null} />
+        );
+      }).not.toThrow();
+    });
+
+    it('両方 undefined のときクラッシュしない', () => {
+      expect(() => {
+        render(<SpriteCharacterCanvas characterId="ageha" />);
+      }).not.toThrow();
+    });
+
+    it('audioBuffer / audioContext 未指定でも sprite-canvas-container が表示される', () => {
+      render(<SpriteCharacterCanvas />);
+      expect(screen.getByTestId('sprite-canvas-container')).toBeInTheDocument();
+    });
+  });
+
+  describe('音声再生と口パク', () => {
+    it('audioBuffer + audioContext を指定すると再生がセットアップされる', () => {
+      render(
+        <SpriteCharacterCanvas
+          characterId="ageha"
+          audioBuffer={mockAudioBuffer}
+          audioContext={mockAudioContext}
+        />
+      );
+      expect(mockCreateBufferSource).toHaveBeenCalled();
+      expect(mockCreateAnalyser).toHaveBeenCalled();
+      expect(mockSourceConnect).toHaveBeenCalledWith(mockAnalyser);
+      expect(mockAnalyserConnect).toHaveBeenCalledWith(mockDestination);
+      expect(mockSourceStart).toHaveBeenCalledWith(0);
+    });
+
+    it('AnalyserNode の設定値が正しい', () => {
+      render(
+        <SpriteCharacterCanvas
+          characterId="ageha"
+          audioBuffer={mockAudioBuffer}
+          audioContext={mockAudioContext}
+        />
+      );
+      expect(mockAnalyser.fftSize).toBe(256);
+      expect(mockAnalyser.minDecibels).toBe(-90);
+      expect(mockAnalyser.maxDecibels).toBe(-10);
+      expect(mockAnalyser.smoothingTimeConstant).toBe(0.85);
+    });
+
+    it('rAF 一巡で getByteFrequencyData が呼ばれ mouthOpen の opacity が更新される', () => {
+      // 音量を返す mock（全ビン 128 = 0.5 × 255）
+      mockGetByteFrequencyData.mockImplementation((arr: Uint8Array) => {
+        arr.fill(128);
+      });
+      mockAnalyser.frequencyBinCount = 4;
+
+      render(
+        <SpriteCharacterCanvas
+          characterId="ageha"
+          audioBuffer={mockAudioBuffer}
+          audioContext={mockAudioContext}
+        />
+      );
+
+      // 口パク用の rAF を一巡させる
+      flushRaf(0);
+
+      expect(mockGetByteFrequencyData).toHaveBeenCalled();
+    });
+
+    it('source.onended で onPlaybackEnd が呼ばれ mouthOpen の opacity がリセットされる', () => {
+      const onPlaybackEnd = jest.fn();
+      render(
+        <SpriteCharacterCanvas
+          characterId="ageha"
+          audioBuffer={mockAudioBuffer}
+          audioContext={mockAudioContext}
+          onPlaybackEnd={onPlaybackEnd}
+        />
+      );
+
+      expect(mockOnEnded).not.toBeNull();
+      mockOnEnded!();
+
+      expect(onPlaybackEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('onPlaybackError が指定されている場合、例外時に呼ばれる', () => {
+      const onPlaybackError = jest.fn();
+      const error = new Error('テスト再生エラー');
+      mockCreateBufferSource.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      render(
+        <SpriteCharacterCanvas
+          characterId="ageha"
+          audioBuffer={mockAudioBuffer}
+          audioContext={mockAudioContext}
+          onPlaybackError={onPlaybackError}
+        />
+      );
+
+      expect(onPlaybackError).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('瞬きアニメーション', () => {
+    it('マウント時に瞬き用 rAF が開始される', () => {
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      // requestAnimationFrame が少なくとも 1 回呼ばれていること
+      expect(requestAnimationFrame).toHaveBeenCalled();
+    });
+
+    it('瞬き窓内で eyeClosed の div の opacity が更新される', () => {
+      // performance.now をスパイして瞬き窓内（blinkStart 直後の 50ms）に入れる
+      const mockNow = jest.spyOn(performance, 'now');
+      // 初回呼び出し（nextBlinkAt 設定）は大きな値を返し、2 回目以降でターゲット時刻を返す
+      // まず初期の nextBlinkAt を計算させる
+      let callCount = 0;
+      const BASE_TIME = 0;
+      const NEXT_BLINK = BASE_TIME + 3000; // 最小インターバル
+
+      mockNow.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // nextBlinkAt の計算時（random * 3000 が加算される想定）
+          return BASE_TIME;
+        }
+        // 瞬き窓内（nextBlinkAt の 50ms 後＝三角波の前半）
+        return NEXT_BLINK + 50;
+      });
+
+      render(<SpriteCharacterCanvas characterId="ageha" />);
+      flushRaf(NEXT_BLINK + 50);
+
+      mockNow.mockRestore();
+      // クラッシュせずに完了することを確認（opacity の値は乱数に依存するため数値チェックは省略）
+    });
+  });
+
+  describe('renderer 不一致時のフォールバック', () => {
+    it('renderer が sprite でないキャラ（live2d）は画像を出さずクラッシュしない', () => {
+      expect(() => {
+        render(<SpriteCharacterCanvas characterId="hiyori" />);
+      }).not.toThrow();
+      // sprite レイヤーは表示されない
+      expect(screen.queryByTestId('sprite-base')).toBeNull();
+      expect(screen.queryByTestId('sprite-eye-open')).toBeNull();
+      // コンテナと statusText は表示される
+      expect(screen.getByTestId('sprite-canvas-container')).toBeInTheDocument();
+      expect(screen.getByText('待機中')).toBeInTheDocument();
+    });
+
+    it('getCharacterRenderProfile がスローしても画像を出さずクラッシュしない', () => {
+      expect(() => {
+        render(<SpriteCharacterCanvas characterId="unknown-id" />);
+      }).not.toThrow();
+      expect(screen.queryByTestId('sprite-base')).toBeNull();
+      expect(screen.getByTestId('sprite-canvas-container')).toBeInTheDocument();
+    });
+
+    it('getCharacterDisplay がスローしても alt が空文字列でクラッシュしない', () => {
+      const { getCharacterDisplay } = jest.requireMock('@/lib/characters/client-profiles');
+      (getCharacterDisplay as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('未登録');
+      });
+
+      expect(() => {
+        render(<SpriteCharacterCanvas characterId="ageha" />);
+      }).not.toThrow();
+    });
+  });
+
+  describe('characterId 省略時', () => {
+    it('characterId を省略しても sprite-canvas-container が描画される', () => {
+      render(<SpriteCharacterCanvas />);
+      expect(screen.getByTestId('sprite-canvas-container')).toBeInTheDocument();
+    });
+
+    it('characterId を省略しても sprite-base が描画される', () => {
+      render(<SpriteCharacterCanvas />);
+      expect(screen.getByTestId('sprite-base')).toBeInTheDocument();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/client-profiles.test.ts
@@ -174,25 +174,39 @@ describe('早瀬アゲハ クライアントプロファイル', () => {
     expect(profile.display.shortName).toBe('アゲハ');
   });
 
-  it('render.renderer が "still" である（一枚絵静止画）', () => {
+  it('render.renderer が "sprite" である（瞬き＋口パク対応パーツ描画）', () => {
     const profile = getCharacterClientProfile('ageha');
-    expect(profile.render.renderer).toBe('still');
+    expect(profile.render.renderer).toBe('sprite');
   });
 
-  it('render.imagePath が "/assets/characters/ageha/still.png" である', () => {
+  it('render.sprite に 5 枚のパーツパスが含まれる', () => {
     const profile = getCharacterClientProfile('ageha');
-    // renderer で narrowing してから imagePath を参照する
-    expect(profile.render.renderer).toBe('still');
-    if (profile.render.renderer === 'still') {
-      expect(profile.render.imagePath).toBe('/assets/characters/ageha/still.png');
+    // renderer で narrowing してから sprite を参照する
+    expect(profile.render.renderer).toBe('sprite');
+    if (profile.render.renderer === 'sprite') {
+      expect(profile.render.sprite.base).toBe('/assets/characters/ageha/sprite/base.png');
+      expect(profile.render.sprite.eyeOpen).toBe('/assets/characters/ageha/sprite/eye-open.png');
+      expect(profile.render.sprite.eyeClosed).toBe(
+        '/assets/characters/ageha/sprite/eye-closed.png'
+      );
+      expect(profile.render.sprite.mouthOpen).toBe(
+        '/assets/characters/ageha/sprite/mouth-open.png'
+      );
+      expect(profile.render.sprite.mouthClosed).toBe(
+        '/assets/characters/ageha/sprite/mouth-closed.png'
+      );
     }
   });
 
-  it('getCharacterRenderProfile("ageha") も still を返す', () => {
+  it('getCharacterRenderProfile("ageha") も sprite を返す', () => {
     const render = getCharacterRenderProfile('ageha');
-    expect(render.renderer).toBe('still');
-    if (render.renderer === 'still') {
-      expect(render.imagePath).toBe('/assets/characters/ageha/still.png');
+    expect(render.renderer).toBe('sprite');
+    if (render.renderer === 'sprite') {
+      expect(render.sprite.base).toBe('/assets/characters/ageha/sprite/base.png');
+      expect(render.sprite.eyeOpen).toBe('/assets/characters/ageha/sprite/eye-open.png');
+      expect(render.sprite.eyeClosed).toBe('/assets/characters/ageha/sprite/eye-closed.png');
+      expect(render.sprite.mouthOpen).toBe('/assets/characters/ageha/sprite/mouth-open.png');
+      expect(render.sprite.mouthClosed).toBe('/assets/characters/ageha/sprite/mouth-closed.png');
     }
   });
 

--- a/services/livetalk/web/tests/unit/lib/characters/registry.test.ts
+++ b/services/livetalk/web/tests/unit/lib/characters/registry.test.ts
@@ -49,8 +49,8 @@ describe('キャラクターレジストリ', () => {
       const entry = getCharacterEntry('ageha');
       expect(entry.definition.id).toBe('ageha');
       expect(entry.definition.displayName).toBe('早瀬アゲハ');
-      // ageha は still renderer（一枚絵）を使用する
-      expect(entry.render.renderer).toBe('still');
+      // ageha は sprite renderer（瞬き＋口パク対応パーツ描画）を使用する
+      expect(entry.render.renderer).toBe('sprite');
     });
 
     it('未登録の characterId を指定すると日本語定数メッセージで Error をスローする', () => {


### PR DESCRIPTION
## 変更の概要

早瀬アゲハに瞬き＋口パクを追加する一連の対応を develop に取り込む。新レンダラ種別 `'sprite'` を導入し、透過 PNG パーツ（ベース／開いた目／閉じた目／開いた口／閉じた口）の重ね合わせ合成で、ランダム瞬きと音声連動の口パクを実現する。アゲハは `'still'`（一枚絵静止画）から `'sprite'` へ完全切替。

integration ブランチ `integration/3502-ageha-blink-lipsync` で以下を段階的に組み立て・dev 検証済み。

1. 新レンダラ `'sprite'` と `SpriteCharacterCanvas` の実装（#3503）
2. もっさり感解消のため、瞬き・口パクを連続 opacity から**二値（0/1）スナップ**に再調整（#3507）
3. 瞬きの閉じ時間を長め化、口の開閉を排他切替に、追従を速く（`smoothingTimeConstant` 0.5）（#3512）
4. 瞬き時に目が二重に見える表示不具合の修正（開いた目／閉じた目の排他切替）（#3514）

### 主な仕様
- **瞬き**：ランダム間隔（3000〜6000ms）で約 180ms だけ目を閉じる二値スナップ。開いた目／閉じた目は排他表示。
- **口パク**：`AnalyserNode`（fftSize 256）の音量平均をしきい値（開 0.1 / 閉 0.05・ヒステリシス付き）で判定し、開いた口／閉じた口を排他で開閉。
- iOS Safari 対策で HTMLAudio は使わず Web Audio のみ。`'still'` レンダラ・`StillImageCanvas` は汎用レンダラとして温存。

### 素材ホスティング（リポジトリ管理外・S3 配信）
新素材は S3 バケット `nagiyu-livetalk-assets-{env}` に配置（CloudFront `/assets/*` 経由）。`'sprite'` へ完全切替したため、**本番リリース前に prod バケットへの配置が必須**（未配置だと prod 表示が崩れる）。dev は配置・検証済み。

| URL | S3 キー |
|---|---|
| `/assets/characters/ageha/sprite/base.png` | `characters/ageha/sprite/base.png` |
| `/assets/characters/ageha/sprite/eye-open.png` | `characters/ageha/sprite/eye-open.png` |
| `/assets/characters/ageha/sprite/eye-closed.png` | `characters/ageha/sprite/eye-closed.png` |
| `/assets/characters/ageha/sprite/mouth-open.png` | `characters/ageha/sprite/mouth-open.png` |
| `/assets/characters/ageha/sprite/mouth-closed.png` | `characters/ageha/sprite/mouth-closed.png` |

## 関連 Issue

Closes #3502

## 変更種別

- [x] 新規機能
- [x] バグ修正（発話中・瞬き時の重ね順による透け表示）
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] コーディング規約・べからず集 を確認した
- [x] アーキテクチャガイドライン を確認した
- [x] 開発方針 を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（描画レンダラの永続ドキュメント反映は別途）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `SpriteCharacterCanvas.test.tsx`（新規）：レイヤー描画・src/alt、待機/statusText 表示、Web Audio 再生セットアップ、口の開閉排他（開=1/閉=0 ↔ 開=0/閉=1）、瞬きの開閉排他（決定的検証）、`onPlaybackEnd`/`onPlaybackError`、フォールバック、characterId 省略時。
- `CharacterCanvas.test.tsx`：`renderer: 'sprite'` のディスパッチ・props 透過。
- `client-profiles.test.ts` / `registry.test.ts`：アゲハの renderer を `'sprite'` に更新。
- 結果（最新）：54 スイート / 508 件 pass、カバレッジ閾値 80% クリア。各 integration 取り込み時の Fast CI（Lint / Format / Build / Unit / E2E chromium-mobile）はいずれも success。

## レビューポイント

- アゲハを `'sprite'` へ完全切替（`'still'` フォールバックなし）。**prod 素材配置がリリースの前提**。
- 瞬きの閉じ時間（180ms）・口のしきい値（0.1 / 0.05）・`smoothingTimeConstant`（0.5）は定数化済みで調整可能。

## スクリーンショット（該当する場合）

dev 環境で瞬き・口パクの動作を確認済み。

## 補足事項

- 取り込み済み PR：#3503 / #3507 / #3512 / #3514（いずれも integration ブランチ宛）。
- マージは人手で実施（Ready 化・マージは Claude では行わない）。prod 素材配置のタイミングにご注意ください。

---
_Generated by [Claude Code](https://claude.ai/code/session_0185GTqyGSws2SZj2MnTZqB3)_