### PR TITLE
さくっとクリップ: zip ダウンロードに文字起こしテキストを同梱する（#3509 Phase 2）

### DIFF
--- a/services/quick-clip/lambda/zip/src/handler.ts
+++ b/services/quick-clip/lambda/zip/src/handler.ts
@@ -11,16 +11,48 @@ const ERROR_MESSAGES = {
 
 const CLIP_KEY = (jobId: string, highlightId: string): string =>
   `outputs/${jobId}/clips/${highlightId}.mp4`;
+const TRANSCRIPT_KEY = (jobId: string): string => `outputs/${jobId}/transcript.json`;
 const ZIP_KEY = (jobId: string): string => `outputs/${jobId}/clips.zip`;
+
+/** ZIP イベント内の1クリップ情報。 */
+export type ClipInput = {
+  highlightId: string;
+  order: number;
+  startSec: number;
+  endSec: number;
+};
 
 export type ZipGeneratorEvent = {
   jobId: string;
-  highlightIds: string[];
+  clips: ClipInput[];
 };
 
 export type ZipGeneratorResult = {
   downloadUrl: string;
 };
+
+/** 文字起こしの1セグメント。 */
+type TranscriptSegment = {
+  start: number;
+  end: number;
+  text: string;
+};
+
+type S3Error = {
+  name?: string;
+  Code?: string;
+};
+
+const isNoSuchKeyError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const s3Error = error as S3Error;
+  return s3Error.name === 'NoSuchKey' || s3Error.Code === 'NoSuchKey';
+};
+
+/** order を2桁ゼロ埋めに変換する。例: 1 → "01" */
+const padOrder = (order: number): string => String(order).padStart(2, '0');
 
 const validateEnvironment = (): { bucketName: string; awsRegion: string } => {
   const env = requireEnv(['S3_BUCKET', 'AWS_REGION']);
@@ -28,7 +60,7 @@ const validateEnvironment = (): { bucketName: string; awsRegion: string } => {
 };
 
 const validateEvent = (event: ZipGeneratorEvent): void => {
-  if (!event.jobId || !Array.isArray(event.highlightIds) || event.highlightIds.length === 0) {
+  if (!event.jobId || !Array.isArray(event.clips) || event.clips.length === 0) {
     throw new Error(ERROR_MESSAGES.INVALID_INPUT);
   }
 };
@@ -51,24 +83,83 @@ const getClipBuffer = async (
   return response.Body.transformToByteArray();
 };
 
+/**
+ * transcript.json を S3 から取得して JSON パースする。
+ * ファイルが存在しない場合は null を返す（オプショナル扱い）。
+ */
+const fetchTranscriptSegments = async (
+  s3Client: S3Client,
+  bucketName: string,
+  jobId: string
+): Promise<TranscriptSegment[] | null> => {
+  try {
+    const response = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: bucketName,
+        Key: TRANSCRIPT_KEY(jobId),
+      })
+    );
+    if (!response.Body) {
+      return null;
+    }
+    const rawText = await response.Body.transformToString();
+    return JSON.parse(rawText) as TranscriptSegment[];
+  } catch (error) {
+    if (isNoSuchKeyError(error)) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+/**
+ * クリップ時間範囲に重なるセグメントのテキストを改行で連結する。
+ * 重なる条件: seg.start < endSec && seg.end > startSec
+ */
+const buildClipText = (segments: TranscriptSegment[], startSec: number, endSec: number): string => {
+  return segments
+    .filter((seg) => seg.start < endSec && seg.end > startSec)
+    .map((seg) => seg.text)
+    .join('\n');
+};
+
 const buildZipBuffer = async (
   s3Client: S3Client,
   bucketName: string,
   event: ZipGeneratorEvent
 ): Promise<Buffer> => {
   const zip = new JSZip();
-  const clips = await Promise.all(
-    event.highlightIds.map(async (highlightId) => {
-      const bytes = await getClipBuffer(s3Client, bucketName, event.jobId, highlightId);
+
+  // 文字起こしデータを1回だけ取得する（NoSuchKey の場合は null）
+  const segments = await fetchTranscriptSegments(s3Client, bucketName, event.jobId);
+
+  const clipEntries = await Promise.all(
+    event.clips.map(async (clip) => {
+      const bytes = await getClipBuffer(s3Client, bucketName, event.jobId, clip.highlightId);
       return {
-        fileName: `${highlightId}.mp4`,
+        order: clip.order,
+        startSec: clip.startSec,
+        endSec: clip.endSec,
         bytes,
       };
     })
   );
-  for (const clip of clips) {
-    zip.file(clip.fileName, clip.bytes);
+
+  for (const entry of clipEntries) {
+    const pad = padOrder(entry.order);
+
+    // 動画ファイルを追加
+    zip.file(`clip-${pad}.mp4`, entry.bytes);
+
+    // テキストファイルを追加（セグメントあり、かつ非空の場合のみ）
+    if (segments !== null) {
+      const text = buildClipText(segments, entry.startSec, entry.endSec);
+      if (text.length > 0) {
+        zip.file(`clip-${pad}.txt`, text);
+      }
+    }
   }
+
   return zip.generateAsync({
     type: 'nodebuffer',
     compression: 'DEFLATE',
@@ -117,7 +208,7 @@ export const handler = async (event: ZipGeneratorEvent): Promise<ZipGeneratorRes
       title: 'QuickClip ZIP 生成に失敗しました',
       context: {
         jobId: event.jobId,
-        highlightIds: event.highlightIds,
+        clips: event.clips,
         s3Key: ZIP_KEY(event.jobId),
       },
     },

--- a/services/quick-clip/lambda/zip/tests/unit/handler.test.ts
+++ b/services/quick-clip/lambda/zip/tests/unit/handler.test.ts
@@ -36,29 +36,67 @@ jest.mock('@nagiyu/common', () => ({
   })),
 }));
 
+/** JSZip のバッファを展開してエントリ名の一覧を返すヘルパー。 */
+async function listZipEntries(buffer: Buffer): Promise<string[]> {
+  const JSZip = (await import('jszip')).default;
+  const zip = await JSZip.loadAsync(buffer);
+  return Object.keys(zip.files);
+}
+
+/** JSZip のバッファから特定エントリのテキストを取り出すヘルパー。 */
+async function readZipEntry(buffer: Buffer, name: string): Promise<string> {
+  const JSZip = (await import('jszip')).default;
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file(name);
+  if (!file) throw new Error(`エントリが見つかりません: ${name}`);
+  return file.async('text');
+}
+
+/** 動画バイト列のモックを作成するヘルパー。 */
+const makeVideoBody = () => ({
+  transformToByteArray: async () => new Uint8Array([1, 2, 3]),
+});
+
+/** transcript.json のモックレスポンスボディを作成するヘルパー。 */
+const makeTranscriptBody = (segments: Array<{ start: number; end: number; text: string }>) => ({
+  transformToByteArray: async () => new Uint8Array(Buffer.from(JSON.stringify(segments))),
+  transformToString: async () => JSON.stringify(segments),
+});
+
 describe('zip lambda handler', () => {
   beforeEach(() => {
     process.env.S3_BUCKET = 'bucket';
     process.env.AWS_REGION = 'ap-northeast-1';
     jest.clearAllMocks();
+    jest.resetModules();
     mockGetSignedUrl.mockResolvedValue('https://example.com/clips.zip');
-    mockSend.mockImplementation((command: { constructor: { name: string } }) => {
-      if (command.constructor.name === 'GetObjectCommand') {
-        return Promise.resolve({
-          Body: {
-            transformToByteArray: async () => new Uint8Array([1, 2, 3]),
-          },
-        });
-      }
-      return Promise.resolve({});
-    });
   });
 
+  // -------------------------------------------------------------------------
+  // 基本動作
+  // -------------------------------------------------------------------------
+
   it('クリップをZIP化して署名URLを返す', async () => {
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.resolve({ Body: makeTranscriptBody([]) });
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
     const { handler } = await import('../../src/handler.js');
     const result = await handler({
       jobId: 'job-1',
-      highlightIds: ['h1', 'h2'],
+      clips: [
+        { highlightId: 'h1', order: 1, startSec: 0, endSec: 10 },
+        { highlightId: 'h2', order: 2, startSec: 10, endSec: 20 },
+      ],
     });
     expect(result).toEqual({ downloadUrl: 'https://example.com/clips.zip' });
     expect(mockSend).toHaveBeenCalled();
@@ -66,10 +104,23 @@ describe('zip lambda handler', () => {
   });
 
   it('PutObjectCommand に ContentLength が設定される', async () => {
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.resolve({ Body: makeTranscriptBody([]) });
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
     const { handler } = await import('../../src/handler.js');
     await handler({
       jobId: 'job-1',
-      highlightIds: ['h1'],
+      clips: [{ highlightId: 'h1', order: 1, startSec: 0, endSec: 10 }],
     });
     const putCall = mockSend.mock.calls.find(
       (call: unknown[]) =>
@@ -81,30 +132,365 @@ describe('zip lambda handler', () => {
     expect(putCommand.input.ContentLength).toBe(putCommand.input.Body.length);
   });
 
-  it('highlightIds が空の場合はエラー', async () => {
+  // -------------------------------------------------------------------------
+  // validateEvent 異常系
+  // -------------------------------------------------------------------------
+
+  it('jobId が空の場合はエラー', async () => {
     const { handler } = await import('../../src/handler.js');
     await expect(
       handler({
-        jobId: 'job-1',
-        highlightIds: [],
+        jobId: '',
+        clips: [{ highlightId: 'h1', order: 1, startSec: 0, endSec: 10 }],
       })
     ).rejects.toThrow('入力値が不正です');
   });
 
+  it('clips が空配列の場合はエラー', async () => {
+    const { handler } = await import('../../src/handler.js');
+    await expect(
+      handler({
+        jobId: 'job-1',
+        clips: [],
+      })
+    ).rejects.toThrow('入力値が不正です');
+  });
+
+  it('clips が配列でない場合はエラー', async () => {
+    const { handler } = await import('../../src/handler.js');
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler({ jobId: 'job-1', clips: 'invalid' as any })
+    ).rejects.toThrow('入力値が不正です');
+  });
+
+  // -------------------------------------------------------------------------
+  // クリップ取得失敗
+  // -------------------------------------------------------------------------
+
   it('クリップ取得に失敗した場合は例外を再スローする', async () => {
-    mockSend.mockImplementation((command: { constructor: { name: string } }) => {
-      if (command.constructor.name === 'GetObjectCommand') {
-        return Promise.reject(new Error('S3 get failed'));
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            const err = Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' });
+            return Promise.reject(err);
+          }
+          return Promise.reject(new Error('S3 get failed'));
+        }
+        return Promise.resolve({});
       }
-      return Promise.resolve({});
-    });
+    );
 
     const { handler } = await import('../../src/handler.js');
     await expect(
       handler({
         jobId: 'job-1',
-        highlightIds: ['h1'],
+        clips: [{ highlightId: 'h1', order: 1, startSec: 0, endSec: 10 }],
       })
     ).rejects.toThrow('S3 get failed');
+  });
+
+  // -------------------------------------------------------------------------
+  // order ベースのファイル命名
+  // -------------------------------------------------------------------------
+
+  it('zip 内の動画ファイル名が order ベースのゼロ埋め2桁になる（order=1 → clip-01）', async () => {
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.resolve({ Body: makeTranscriptBody([]) });
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    await handler({
+      jobId: 'job-1',
+      clips: [{ highlightId: 'h1', order: 1, startSec: 0, endSec: 10 }],
+    });
+
+    // PutObjectCommand の Body から zip エントリを取得して検証
+    const putCall = mockSend.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { constructor: { name: string } }).constructor.name === 'PutObjectCommand'
+    );
+    const zipBuffer = (putCall![0] as { input: { Body: Buffer } }).input.Body;
+    const entries = await listZipEntries(zipBuffer);
+    expect(entries).toContain('clip-01.mp4');
+  });
+
+  it('order=10 の場合は clip-10 になる', async () => {
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.resolve({ Body: makeTranscriptBody([]) });
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    await handler({
+      jobId: 'job-1',
+      clips: [{ highlightId: 'h1', order: 10, startSec: 0, endSec: 10 }],
+    });
+
+    const putCall = mockSend.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { constructor: { name: string } }).constructor.name === 'PutObjectCommand'
+    );
+    const zipBuffer = (putCall![0] as { input: { Body: Buffer } }).input.Body;
+    const entries = await listZipEntries(zipBuffer);
+    expect(entries).toContain('clip-10.mp4');
+  });
+
+  // -------------------------------------------------------------------------
+  // transcript.json ありのケース
+  // -------------------------------------------------------------------------
+
+  it('transcript.json あり: テキストに重なるセグメントがある場合は .txt も同梱される', async () => {
+    const segments = [
+      { start: 5, end: 15, text: 'こんにちは' },
+      { start: 12, end: 18, text: '世界' },
+    ];
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.resolve({ Body: makeTranscriptBody(segments) });
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    await handler({
+      jobId: 'job-1',
+      clips: [{ highlightId: 'h1', order: 1, startSec: 10, endSec: 20 }],
+    });
+
+    const putCall = mockSend.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { constructor: { name: string } }).constructor.name === 'PutObjectCommand'
+    );
+    const zipBuffer = (putCall![0] as { input: { Body: Buffer } }).input.Body;
+    const entries = await listZipEntries(zipBuffer);
+    expect(entries).toContain('clip-01.mp4');
+    expect(entries).toContain('clip-01.txt');
+  });
+
+  it('transcript.json あり: テキスト内容は改行で連結される', async () => {
+    const segments = [
+      { start: 0, end: 12, text: '1行目' },
+      { start: 8, end: 20, text: '2行目' },
+    ];
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.resolve({ Body: makeTranscriptBody(segments) });
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    await handler({
+      jobId: 'job-1',
+      clips: [{ highlightId: 'h1', order: 3, startSec: 5, endSec: 15 }],
+    });
+
+    const putCall = mockSend.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { constructor: { name: string } }).constructor.name === 'PutObjectCommand'
+    );
+    const zipBuffer = (putCall![0] as { input: { Body: Buffer } }).input.Body;
+    const text = await readZipEntry(zipBuffer, 'clip-03.txt');
+    expect(text).toBe('1行目\n2行目');
+  });
+
+  it('transcript.json あり: テキストが空のクリップには .txt を含めない', async () => {
+    // クリップ範囲 (50, 60) にはセグメントが重ならない
+    const segments = [{ start: 0, end: 10, text: 'テキスト' }];
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.resolve({ Body: makeTranscriptBody(segments) });
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    await handler({
+      jobId: 'job-1',
+      clips: [{ highlightId: 'h1', order: 2, startSec: 50, endSec: 60 }],
+    });
+
+    const putCall = mockSend.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { constructor: { name: string } }).constructor.name === 'PutObjectCommand'
+    );
+    const zipBuffer = (putCall![0] as { input: { Body: Buffer } }).input.Body;
+    const entries = await listZipEntries(zipBuffer);
+    expect(entries).toContain('clip-02.mp4');
+    expect(entries).not.toContain('clip-02.txt');
+  });
+
+  it('transcript.json あり: 複数クリップで .txt の有無が正しく分岐する', async () => {
+    const segments = [
+      { start: 0, end: 15, text: 'テキストA' },
+      // clip-02 (30-40) には重ならない
+    ];
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.resolve({ Body: makeTranscriptBody(segments) });
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    await handler({
+      jobId: 'job-1',
+      clips: [
+        { highlightId: 'h1', order: 1, startSec: 5, endSec: 20 },
+        { highlightId: 'h2', order: 2, startSec: 30, endSec: 40 },
+      ],
+    });
+
+    const putCall = mockSend.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { constructor: { name: string } }).constructor.name === 'PutObjectCommand'
+    );
+    const zipBuffer = (putCall![0] as { input: { Body: Buffer } }).input.Body;
+    const entries = await listZipEntries(zipBuffer);
+    // clip-01 はセグメントあり → .txt 同梱
+    expect(entries).toContain('clip-01.mp4');
+    expect(entries).toContain('clip-01.txt');
+    // clip-02 はセグメントなし → .txt なし
+    expect(entries).toContain('clip-02.mp4');
+    expect(entries).not.toContain('clip-02.txt');
+  });
+
+  // -------------------------------------------------------------------------
+  // transcript.json なし（NoSuchKey）のケース
+  // -------------------------------------------------------------------------
+
+  it('transcript.json が存在しない場合は .mp4 のみで .txt を一切含めない', async () => {
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            const err = Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' });
+            return Promise.reject(err);
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    await handler({
+      jobId: 'job-1',
+      clips: [
+        { highlightId: 'h1', order: 1, startSec: 0, endSec: 10 },
+        { highlightId: 'h2', order: 2, startSec: 10, endSec: 20 },
+      ],
+    });
+
+    const putCall = mockSend.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { constructor: { name: string } }).constructor.name === 'PutObjectCommand'
+    );
+    const zipBuffer = (putCall![0] as { input: { Body: Buffer } }).input.Body;
+    const entries = await listZipEntries(zipBuffer);
+    expect(entries).toContain('clip-01.mp4');
+    expect(entries).toContain('clip-02.mp4');
+    // .txt は一切含まない
+    expect(entries.filter((e) => e.endsWith('.txt'))).toHaveLength(0);
+  });
+
+  it('transcript.json の Code: NoSuchKey でも .mp4 のみで処理が続行する', async () => {
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            const err = Object.assign(new Error('NoSuchKey'), { Code: 'NoSuchKey' });
+            return Promise.reject(err);
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    const result = await handler({
+      jobId: 'job-1',
+      clips: [{ highlightId: 'h1', order: 5, startSec: 0, endSec: 10 }],
+    });
+    expect(result).toEqual({ downloadUrl: 'https://example.com/clips.zip' });
+
+    const putCall = mockSend.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { constructor: { name: string } }).constructor.name === 'PutObjectCommand'
+    );
+    const zipBuffer = (putCall![0] as { input: { Body: Buffer } }).input.Body;
+    const entries = await listZipEntries(zipBuffer);
+    expect(entries).toContain('clip-05.mp4');
+    expect(entries.filter((e) => e.endsWith('.txt'))).toHaveLength(0);
+  });
+
+  it('transcript.json の取得で想定外エラーが起きた場合は例外を再スローする', async () => {
+    mockSend.mockImplementation(
+      (command: { constructor: { name: string }; input: { Key?: string } }) => {
+        const key = (command.input as { Key?: string }).Key ?? '';
+        if (command.constructor.name === 'GetObjectCommand') {
+          if (key.endsWith('transcript.json')) {
+            return Promise.reject(new Error('AccessDenied'));
+          }
+          return Promise.resolve({ Body: makeVideoBody() });
+        }
+        return Promise.resolve({});
+      }
+    );
+
+    const { handler } = await import('../../src/handler.js');
+    await expect(
+      handler({
+        jobId: 'job-1',
+        clips: [{ highlightId: 'h1', order: 1, startSec: 0, endSec: 10 }],
+      })
+    ).rejects.toThrow('AccessDenied');
   });
 });

--- a/services/quick-clip/web/src/app/api/jobs/[jobId]/download/route.ts
+++ b/services/quick-clip/web/src/app/api/jobs/[jobId]/download/route.ts
@@ -141,7 +141,12 @@ export async function POST(_request: Request, { params }: RouteParams): Promise<
         Payload: Buffer.from(
           JSON.stringify({
             jobId,
-            highlightIds: acceptedHighlights.map((highlight) => highlight.highlightId),
+            clips: acceptedHighlights.map((highlight) => ({
+              highlightId: highlight.highlightId,
+              order: highlight.order,
+              startSec: highlight.startSec,
+              endSec: highlight.endSec,
+            })),
           })
         ),
       })

--- a/services/quick-clip/web/tests/unit/app/api/jobs/[jobId]/download/route.test.ts
+++ b/services/quick-clip/web/tests/unit/app/api/jobs/[jobId]/download/route.test.ts
@@ -153,6 +153,46 @@ describe('POST /api/jobs/[jobId]/download', () => {
     expect(lambdaSend).toHaveBeenCalledTimes(1);
   });
 
+  it('正常系: Lambda 呼び出し payload が { jobId, clips: [{ highlightId, order, startSec, endSec }] } 形式になる', async () => {
+    mockGetByJobId.mockResolvedValue([
+      {
+        highlightId: 'h1',
+        jobId: 'job-1',
+        order: 1,
+        startSec: 10,
+        endSec: 20,
+        status: 'accepted',
+        clipStatus: 'GENERATED',
+      },
+      {
+        highlightId: 'h2',
+        jobId: 'job-1',
+        order: 2,
+        startSec: 30,
+        endSec: 40,
+        status: 'accepted',
+        clipStatus: 'FAILED',
+      },
+    ]);
+
+    await POST(mockRequest, {
+      params: Promise.resolve({ jobId: 'job-1' }),
+    });
+
+    expect(lambdaSend).toHaveBeenCalledTimes(1);
+    const invokeCommand = lambdaSend.mock.calls[0][0] as {
+      input: { Payload: Buffer };
+    };
+    const payload = JSON.parse(invokeCommand.input.Payload.toString()) as unknown;
+    expect(payload).toEqual({
+      jobId: 'job-1',
+      clips: [
+        { highlightId: 'h1', order: 1, startSec: 10, endSec: 20 },
+        { highlightId: 'h2', order: 2, startSec: 30, endSec: 40 },
+      ],
+    });
+  });
+
   it('正常系: Lambda 呼び出し前に旧 ZIP を S3 から削除する', async () => {
     mockGetByJobId.mockResolvedValue([
       {


### PR DESCRIPTION
## 変更の概要

クリップを zip でダウンロードする際、各クリップ動画に加えて、対応する文字起こしテキストを `.txt` として同梱できるようにした（#3509 Phase 2）。主用途は切り抜き作成で、動画とテキストがセットで手に入ると後工程が楽になる。

- **zip 内ファイル名を UI の No（`Highlight.order`）連動に変更**：動画 `clip-NN.mp4` / テキスト `clip-NN.txt`（ゼロ埋め2桁）。同じベース名で突合しやすい。従来の `${highlightId}.mp4`（UUID）から変更。
- **テキスト内容**：クリップの時間範囲（`startSec`〜`endSec`）に重なるセグメント（`seg.start < endSec && seg.end > startSec`）の `text` を改行連結した素のテキスト。
- **空クリップは .txt を出力しない**。`transcript.json` が無いジョブも .txt を同梱しない（動画のみ。オプショナル扱い）。
- web `POST /api/jobs/[jobId]/download` が zip Lambda へ渡す payload を `{ jobId, clips: [{ highlightId, order, startSec, endSec }] }` に拡張。

## 関連 Issue

関連: #3509（Phase 2）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（永続化方針が固まり次第、docs へ反映予定）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリではないため不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- zip Lambda (`@nagiyu/quick-clip-lambda-zip`): 15 件通過（カバレッジ Stmts 95.89%）。order ベース命名のゼロ埋め、transcript あり時の .txt 同梱／空クリップ skip／複数クリップ混在、transcript なし（NoSuchKey）時の .mp4 のみ、`validateEvent` 異常系（clips 空・非配列）を追加。
- web (`@nagiyu/quick-clip-web`): 16 スイート / 159 件 通過（coverageThreshold 付き）。download route の Lambda payload が `{ jobId, clips: [...] }` 形状になることを検証するテストを追加。
- 両パッケージとも `format:check` 通過。

## レビューポイント

- zip 内ファイル名を UUID から order ベース（`clip-NN`）へ変更している点（UI の No と突合できることを優先）。S3 上の動画キーは従来どおり highlightId ベースのまま（変えたのは zip 内の表示名のみ）。
- 文字起こしはオプショナル：`transcript.json` 不在・空テキストは .txt を出さない割り切り。
- 本 PR は #3511 のバッチ保存（transcript.json 生成）に依存するため、`integration/3509-clip-transcript` をターゲットとし、Phase 1 と合わせて dev 検証後に develop へ取り込む。

## スクリーンショット（該当する場合）

UI 変更なし（zip 同梱物の変更のみ）。dev で実際にダウンロードし、`clip-NN.mp4` / `clip-NN.txt` の同梱と内容を確認する想定。

## 補足事項

- 全文文字起こしの同梱は今回スコープ外。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ht4jSEshH3J4SuVbszrozu)_