### PR TITLE
リブトーク: バッチ処理のマルチキャラクター対応（integration → develop）

### DIFF
--- a/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
+++ b/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
@@ -7,10 +7,7 @@ import {
   type CompressConversationParams,
 } from '@nagiyu/livetalk-core';
 
-export type CompressAllConversationsParams = Omit<
-  CompressConversationParams,
-  'characterName'
-> & {
+export type CompressAllConversationsParams = Omit<CompressConversationParams, 'characterName'> & {
   docClient: DynamoDBDocumentClient;
   tableName: string;
 };

--- a/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
+++ b/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
@@ -1,19 +1,19 @@
 import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
-  DEFAULT_CHARACTER_ID,
+  getAllCharacterIds,
+  getCharacterDefinitionById,
   compressConversation,
   type CompressConversationParams,
 } from '@nagiyu/livetalk-core';
 
-export interface CompressAllConversationsParams extends Omit<
+export type CompressAllConversationsParams = Omit<
   CompressConversationParams,
   'characterName'
-> {
+> & {
   docClient: DynamoDBDocumentClient;
   tableName: string;
-  characterName?: string;
-}
+};
 
 export interface CompressAllConversationsResult {
   processedUsers: number;
@@ -23,10 +23,11 @@ export interface CompressAllConversationsResult {
 }
 
 /**
- * 全アクティブユーザーの会話を圧縮要約する。
+ * 全アクティブユーザーの全キャラクター会話を圧縮要約する。
  *
  * DynamoDB を Scan して Type='Profile' のアイテムを列挙し、
- * 各ユーザーについて DEFAULT_CHARACTER_ID（hiyori）の会話を圧縮する。
+ * 各ユーザーについて全キャラクターの会話を圧縮する。
+ * キャラクターごとに処理し、あるキャラクターで失敗しても他キャラクターの処理を継続する。
  */
 export async function compressAllConversations(
   params: CompressAllConversationsParams
@@ -38,7 +39,6 @@ export async function compressAllConversations(
     summaryRepo,
     messageRepo,
     memoryRepo,
-    characterName = '桃瀬ひより',
     now,
     interestRepo,
     characterStateRepo,
@@ -58,22 +58,49 @@ export async function compressAllConversations(
     failedUserIds: [],
   };
 
+  const allCharacterIds = getAllCharacterIds();
+
   for (const userId of userIds) {
+    let hasCharacterError = false;
+
     try {
-      const before = { ...result };
-      await compressConversation(userId, DEFAULT_CHARACTER_ID, {
-        summaryRepo,
-        messageRepo,
-        memoryRepo,
-        llmClient,
-        characterName,
-        now,
-        interestRepo,
-        characterStateRepo,
-        embeddingClient,
-      });
-      void before;
-      result.processedUsers++;
+      for (const characterId of allCharacterIds) {
+        const characterDef = getCharacterDefinitionById(characterId);
+        if (!characterDef) {
+          logger.warn('[compressAllConversations] キャラクター定義が見つかりません（スキップ）', {
+            characterId,
+          });
+          continue;
+        }
+
+        try {
+          await compressConversation(userId, characterId, {
+            summaryRepo,
+            messageRepo,
+            memoryRepo,
+            llmClient,
+            characterName: characterDef.displayName,
+            now,
+            interestRepo,
+            characterStateRepo,
+            embeddingClient,
+          });
+        } catch (error) {
+          logger.warn('[compressAllConversations] キャラクター処理失敗（他キャラは継続）', {
+            userId,
+            characterId,
+            error: toErrorMessage(error),
+          });
+          hasCharacterError = true;
+        }
+      }
+
+      if (hasCharacterError) {
+        result.failedUsers++;
+        result.failedUserIds.push(userId);
+      } else {
+        result.processedUsers++;
+      }
     } catch (error) {
       logger.error('[compressAllConversations] ユーザー処理失敗', {
         userId,

--- a/services/livetalk/batch/src/usecases/learn-user-activity.usecase.ts
+++ b/services/livetalk/batch/src/usecases/learn-user-activity.usecase.ts
@@ -1,7 +1,8 @@
 import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
-  DEFAULT_CHARACTER_ID,
+  getAllCharacterIds,
+  getCharacterDefinitionById,
   learnUserActivity,
   type LifecycleRepository,
   type MessageRepository,
@@ -27,7 +28,8 @@ export interface LearnAllUserActivitiesResult {
  * 全アクティブユーザーの活動時間を学習する。
  *
  * DynamoDB を Scan して Type='Profile' のアイテムを列挙し、
- * 各ユーザーについて DEFAULT_CHARACTER_ID（hiyori）の発話履歴を学習する。
+ * 各ユーザーについて全キャラクターの発話履歴を学習する。
+ * あるキャラクターで失敗しても他キャラクターの処理は継続する。
  */
 export async function learnAllUserActivities(
   params: LearnAllUserActivitiesParams
@@ -47,17 +49,49 @@ export async function learnAllUserActivities(
     failedUserIds: [],
   };
 
+  const allCharacterIds = getAllCharacterIds();
+
   for (const userId of userIds) {
+    let hasCharacterError = false;
+    let hasLearned = false;
+
     try {
-      const outcome = await learnUserActivity(userId, DEFAULT_CHARACTER_ID, {
-        messageRepo,
-        lifecycleRepo,
-        ...(now !== undefined && { now }),
-      });
-      if (outcome === 'skipped') {
-        result.skippedUsers++;
-      } else {
+      for (const characterId of allCharacterIds) {
+        const characterDef = getCharacterDefinitionById(characterId);
+        if (!characterDef) {
+          logger.warn('[learnAllUserActivities] キャラクター定義が見つかりません（スキップ）', {
+            characterId,
+          });
+          continue;
+        }
+
+        try {
+          const outcome = await learnUserActivity(userId, characterId, {
+            messageRepo,
+            lifecycleRepo,
+            ...(now !== undefined && { now }),
+          });
+          if (outcome === 'learned') {
+            hasLearned = true;
+          }
+        } catch (error) {
+          logger.warn('[learnAllUserActivities] キャラクター処理失敗（他キャラは継続）', {
+            userId,
+            characterId,
+            error: toErrorMessage(error),
+          });
+          hasCharacterError = true;
+        }
+      }
+
+      // failed 計上が最優先。次に learned/skipped を判定する。
+      if (hasCharacterError) {
+        result.failedUsers++;
+        result.failedUserIds.push(userId);
+      } else if (hasLearned) {
         result.processedUsers++;
+      } else {
+        result.skippedUsers++;
       }
     } catch (error) {
       logger.error('[learnAllUserActivities] ユーザー処理失敗', {

--- a/services/livetalk/batch/src/usecases/study.usecase.ts
+++ b/services/livetalk/batch/src/usecases/study.usecase.ts
@@ -1,9 +1,9 @@
 import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
-  DEFAULT_CHARACTER_ID,
+  getAllCharacterIds,
+  getCharacterDefinitionById,
   generateNotesForUser,
-  hiyori,
   studyForUser,
   type InterestRepository,
   type KnowledgeRepository,
@@ -43,8 +43,9 @@ export interface StudyAllUsersResult {
 /**
  * 全アクティブユーザーに対して勉強バッチを実行する。
  *
- * 各ユーザーについて shouldStudyNow 判定を行い、該当ユーザーのみ
- * Web リサーチ → 知識ベース保存を実行する（空振りコスト最小化）。
+ * 各ユーザーについて全キャラクターを走査し、shouldStudyNow 判定を行い、
+ * 該当するキャラクターのみ Web リサーチ → 知識ベース保存を実行する。
+ * あるキャラクターで失敗しても他キャラクターの処理は継続する。
  */
 export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyAllUsersResult> {
   const {
@@ -72,51 +73,80 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
     generatedNotes: 0,
   };
 
-  for (const userId of userIds) {
-    try {
-      const lifecycle = await lifecycleRepo.get({
-        userId,
-        characterId: DEFAULT_CHARACTER_ID,
-      });
+  const allCharacterIds = getAllCharacterIds();
 
-      if (!lifecycle) {
-        result.skippedUsers++;
-        continue;
+  for (const userId of userIds) {
+    let hasCharacterError = false;
+    let hasStudied = false;
+
+    try {
+      for (const characterId of allCharacterIds) {
+        const characterDef = getCharacterDefinitionById(characterId);
+        if (!characterDef) {
+          logger.warn('[studyAllUsers] キャラクター定義が見つかりません（スキップ）', {
+            characterId,
+          });
+          continue;
+        }
+
+        try {
+          const lifecycle = await lifecycleRepo.get({ userId, characterId });
+          if (!lifecycle) {
+            // lifecycle 未登録のキャラクターはスキップ（計上しない）
+            continue;
+          }
+
+          const outcome = await studyForUser(userId, characterId, {
+            knowledgeRepo,
+            interestRepo,
+            studyTopicRepo,
+            researchClient,
+            character: characterDef,
+            lifecycle,
+            ulidFactory,
+            now,
+          });
+
+          if (outcome.outcome === 'studied') {
+            hasStudied = true;
+
+            // KNOWLEDGE → NOTE 昇格（Phase 5c）。
+            // fail-warn: ノート生成の失敗は勉強バッチ全体を止めない。
+            if (noteRepo) {
+              try {
+                const noteResult = await generateNotesForUser(userId, characterId, {
+                  knowledgeRepo,
+                  noteRepo,
+                  ulidFactory,
+                });
+                result.generatedNotes += noteResult.generatedCount;
+              } catch (error) {
+                logger.warn('[studyAllUsers] ノート生成失敗（スキップして継続）', {
+                  userId,
+                  characterId,
+                  error: toErrorMessage(error),
+                });
+              }
+            }
+          }
+        } catch (error) {
+          logger.warn('[studyAllUsers] キャラクター処理失敗（他キャラは継続）', {
+            userId,
+            characterId,
+            error: toErrorMessage(error),
+          });
+          hasCharacterError = true;
+        }
       }
 
-      const outcome = await studyForUser(userId, DEFAULT_CHARACTER_ID, {
-        knowledgeRepo,
-        interestRepo,
-        studyTopicRepo,
-        researchClient,
-        character: hiyori,
-        lifecycle,
-        ulidFactory,
-        now,
-      });
-
-      if (outcome.outcome === 'skipped') {
-        result.skippedUsers++;
-      } else {
+      // failed 計上が最優先。次に studied/skipped を判定する。
+      if (hasCharacterError) {
+        result.failedUsers++;
+        result.failedUserIds.push(userId);
+      } else if (hasStudied) {
         result.studiedUsers++;
-
-        // KNOWLEDGE → NOTE 昇格（Phase 5c）。
-        // fail-warn: ノート生成の失敗は勉強バッチ全体を止めない。
-        if (noteRepo) {
-          try {
-            const noteResult = await generateNotesForUser(userId, DEFAULT_CHARACTER_ID, {
-              knowledgeRepo,
-              noteRepo,
-              ulidFactory,
-            });
-            result.generatedNotes += noteResult.generatedCount;
-          } catch (error) {
-            logger.warn('[studyAllUsers] ノート生成失敗（スキップして継続）', {
-              userId,
-              error: toErrorMessage(error),
-            });
-          }
-        }
+      } else {
+        result.skippedUsers++;
       }
     } catch (error) {
       logger.error('[studyAllUsers] ユーザー処理失敗', {

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -84,7 +84,7 @@ describe('compressAllConversations', () => {
     expect(result.processedUsers).toBe(2);
   });
 
-  it('メッセージのあるユーザー分だけ LLM を呼ぶ', async () => {
+  it('hiyori にメッセージのあるユーザー分だけ LLM を呼ぶ', async () => {
     const llmClient = makeLLMClient();
     const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
     tick = fixedNow;
@@ -176,5 +176,129 @@ describe('compressAllConversations', () => {
 
     const result = await compressAllConversations(makeParams({ llmClient, docClient }));
     expect(result.processedUsers).toBe(1);
+  });
+
+  it('複数キャラ（hiyori と ageha）両方のメッセージで LLM が 2 回呼ばれる', async () => {
+    const llmClient = makeLLMClient();
+    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hiyori msg' });
+    tick++;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'ageha msg' });
+
+    const docClient = makeDocClientMock(['u1']);
+    const result = await compressAllConversations({
+      docClient,
+      tableName: 'test',
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    // hiyori と ageha の両方で summarize が呼ばれる
+    expect(llmClient.summarizeCalls).toBe(2);
+    expect(result.processedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('一方のキャラのみメッセージがある場合はそのキャラのみ LLM を呼ぶ', async () => {
+    const llmClient = makeLLMClient();
+    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    // ageha のみメッセージあり
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'ageha only' });
+
+    const docClient = makeDocClientMock(['u1']);
+    const result = await compressAllConversations({
+      docClient,
+      tableName: 'test',
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    expect(llmClient.summarizeCalls).toBe(1);
+    expect(result.processedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('あるキャラクター処理がエラーでも他キャラは処理され、ユーザーは failed に計上される', async () => {
+    let callCount = 0;
+    const partialErrorClient: ILLMClient = {
+      async *chatStream() {
+        yield '';
+      },
+      async chatComplete() {
+        return '';
+      },
+      async summarize() {
+        callCount++;
+        // hiyori（1 回目）は成功、ageha（2 回目）は失敗
+        if (callCount === 2) throw new Error('ageha LLM 失敗');
+        return { mergedSummary: '要約', newMemoryCandidates: [] };
+      },
+    };
+
+    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hi' });
+    tick++;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'hi2' });
+
+    const docClient = makeDocClientMock(['u1']);
+    const result = await compressAllConversations({
+      docClient,
+      tableName: 'test',
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient: partialErrorClient,
+    });
+
+    // 両キャラ試行されること（callCount は 2）
+    expect(callCount).toBe(2);
+    // キャラエラーがあるのでユーザーは failed
+    expect(result.failedUsers).toBe(1);
+    expect(result.failedUserIds).toContain('u1');
+    expect(result.processedUsers).toBe(0);
+  });
+
+  it('characterName が各キャラの displayName で渡されること（hiyori は 桃瀬ひより）', async () => {
+    const summarizeCalls: Array<string | undefined> = [];
+    const spyClient: ILLMClient = {
+      async *chatStream() {
+        yield '';
+      },
+      async chatComplete() {
+        return '';
+      },
+      async summarize(input) {
+        summarizeCalls.push(input.characterName);
+        return { mergedSummary: '要約', newMemoryCandidates: [] };
+      },
+    };
+
+    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
+    tick++;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'hey' });
+
+    const docClient = makeDocClientMock(['u1']);
+    await compressAllConversations({
+      docClient,
+      tableName: 'test',
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient: spyClient,
+    });
+
+    // hiyori の displayName は '桃瀬ひより'
+    expect(summarizeCalls).toContain('桃瀬ひより');
+    // ageha の displayName が含まれること（'早瀬アゲハ'）
+    expect(summarizeCalls.some((name) => name !== '桃瀬ひより' && name !== undefined)).toBe(true);
   });
 });

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -182,9 +182,19 @@ describe('compressAllConversations', () => {
     const llmClient = makeLLMClient();
     const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
     tick = fixedNow;
-    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hiyori msg' });
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'user',
+      Text: 'hiyori msg',
+    });
     tick++;
-    await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'ageha msg' });
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'ageha',
+      Role: 'user',
+      Text: 'ageha msg',
+    });
 
     const docClient = makeDocClientMock(['u1']);
     const result = await compressAllConversations({
@@ -207,7 +217,12 @@ describe('compressAllConversations', () => {
     const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
     tick = fixedNow;
     // ageha のみメッセージあり
-    await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'ageha only' });
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'ageha',
+      Role: 'user',
+      Text: 'ageha only',
+    });
 
     const docClient = makeDocClientMock(['u1']);
     const result = await compressAllConversations({

--- a/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -49,7 +49,7 @@ describe('learnAllUserActivities', () => {
     expect(result.failedUsers).toBe(0);
   });
 
-  it('メッセージのないユーザーは skipped にカウントされる', async () => {
+  it('メッセージのないユーザーは全キャラ skipped にカウントされる', async () => {
     const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await learnAllUserActivities(makeParams({ docClient }));
     expect(result.skippedUsers).toBe(2);
@@ -57,7 +57,7 @@ describe('learnAllUserActivities', () => {
     expect(result.failedUsers).toBe(0);
   });
 
-  it('メッセージが 5 件以上のユーザーは processedUsers にカウントされる', async () => {
+  it('hiyori に 5 件以上メッセージのあるユーザーは processedUsers にカウントされる', async () => {
     const store = new InMemorySingleTableStore();
     tick = fixedNow;
     const nowMs = () => tick;
@@ -89,6 +89,82 @@ describe('learnAllUserActivities', () => {
 
     expect(result.processedUsers).toBe(1);
     expect(result.skippedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('ageha に 5 件以上メッセージのあるユーザーは processedUsers にカウントされる', async () => {
+    const store = new InMemorySingleTableStore();
+    tick = fixedNow;
+    const nowMs = () => tick;
+    const ulidFactory = () => `ULID-${tick++}`;
+    const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
+    const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+
+    const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
+    for (let i = 0; i < 5; i++) {
+      tick = recentBase + i * 3600 * 1000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'ageha',
+        Role: 'user',
+        Text: `ageha msg ${i}`,
+      });
+    }
+
+    const docClient = makeDocClientMock(['u1']);
+    const result = await learnAllUserActivities({
+      docClient,
+      tableName: 'test',
+      messageRepo,
+      lifecycleRepo,
+      now: () => new Date(fixedNow),
+    });
+
+    expect(result.processedUsers).toBe(1);
+    expect(result.skippedUsers).toBe(0);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('hiyori と ageha 両方に 5 件以上メッセージがある場合は processedUsers に 1 回だけカウントされる', async () => {
+    const store = new InMemorySingleTableStore();
+    tick = fixedNow;
+    const nowMs = () => tick;
+    const ulidFactory = () => `ULID-${tick++}`;
+    const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
+    const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+
+    const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
+    for (let i = 0; i < 5; i++) {
+      tick = recentBase + i * 3600 * 1000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Role: 'user',
+        Text: `hiyori msg ${i}`,
+      });
+    }
+    for (let i = 0; i < 5; i++) {
+      tick = recentBase + (i + 5) * 3600 * 1000;
+      await messageRepo.create({
+        UserID: 'u1',
+        CharacterID: 'ageha',
+        Role: 'user',
+        Text: `ageha msg ${i}`,
+      });
+    }
+
+    const docClient = makeDocClientMock(['u1']);
+    const result = await learnAllUserActivities({
+      docClient,
+      tableName: 'test',
+      messageRepo,
+      lifecycleRepo,
+      now: () => new Date(fixedNow),
+    });
+
+    // 1 ユーザーが両キャラで learned されても processedUsers は 1
+    expect(result.processedUsers).toBe(1);
+    expect(result.skippedUsers).toBe(0);
     expect(result.failedUsers).toBe(0);
   });
 
@@ -152,5 +228,50 @@ describe('learnAllUserActivities', () => {
 
     expect(result.skippedUsers).toBe(2);
     expect(callCount).toBe(2);
+  });
+
+  it('あるキャラクター処理がエラーでも他キャラは処理され、ユーザーは failed に計上される', async () => {
+    const { lifecycleRepo } = makeRepos();
+    let callCount = 0;
+    const failingLifecycleRepo = {
+      ...lifecycleRepo,
+      updateUserActivityProfile: jest.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) throw new Error('hiyori の学習エラー');
+        // 2 回目（ageha）は成功
+      }),
+    };
+
+    const store = new InMemorySingleTableStore();
+    tick = fixedNow;
+    const ulidFactory = () => `ULID-${tick++}`;
+    const messageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+
+    // u1 の hiyori と ageha に 5 件ずつメッセージを作成
+    const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
+    for (const characterId of ['hiyori', 'ageha']) {
+      for (let i = 0; i < 5; i++) {
+        tick = recentBase + i * 3600 * 1000;
+        await messageRepo.create({
+          UserID: 'u1',
+          CharacterID: characterId,
+          Role: 'user',
+          Text: `msg ${i}`,
+        });
+      }
+    }
+
+    const docClient = makeDocClientMock(['u1']);
+    const result = await learnAllUserActivities({
+      docClient,
+      tableName: 'test',
+      messageRepo,
+      lifecycleRepo: failingLifecycleRepo as never,
+      now: () => new Date(fixedNow),
+    });
+
+    // u1 はキャラエラーがあるので failed に計上
+    expect(result.failedUsers).toBe(1);
+    expect(result.failedUserIds).toContain('u1');
   });
 });

--- a/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
@@ -25,7 +25,12 @@ jest.mock('@nagiyu/livetalk-core', () => ({
           speechStyle: '活発な口調',
           preferences: { likes: [], dislikes: [] },
         },
-        voiceConfig: { provider: 'openai-tts' as const, model: 'gpt-4o-mini-tts', voice: 'nova', instructions: '' },
+        voiceConfig: {
+          provider: 'openai-tts' as const,
+          model: 'gpt-4o-mini-tts',
+          voice: 'nova',
+          instructions: '',
+        },
         license: { displayText: '', creditName: '' },
       };
     }
@@ -35,8 +40,10 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   generateNotesForUser: jest.fn(),
 }));
 
-const mockGetAllCharacterIds = jest.requireMock('@nagiyu/livetalk-core').getAllCharacterIds as jest.Mock;
-const mockGetCharacterDefinitionById = jest.requireMock('@nagiyu/livetalk-core').getCharacterDefinitionById as jest.Mock;
+const mockGetAllCharacterIds = jest.requireMock('@nagiyu/livetalk-core')
+  .getAllCharacterIds as jest.Mock;
+const mockGetCharacterDefinitionById = jest.requireMock('@nagiyu/livetalk-core')
+  .getCharacterDefinitionById as jest.Mock;
 const mockStudyForUser = jest.requireMock('@nagiyu/livetalk-core').studyForUser as jest.Mock;
 const mockGenerateNotesForUser = jest.requireMock('@nagiyu/livetalk-core')
   .generateNotesForUser as jest.Mock;
@@ -47,18 +54,20 @@ describe('studyAllUsers', () => {
   };
 
   const makeLifecycleRepo = (overrides: Record<string, object | null> = {}) => ({
-    get: jest.fn().mockImplementation(({ userId, characterId }: { userId: string; characterId: string }) => {
-      const key = `${userId}:${characterId}`;
-      if (key in overrides) return Promise.resolve(overrides[key]);
-      return Promise.resolve({
-        Bedtime: '01:30',
-        WakeUpTime: '09:30',
-        UserID: userId,
-        CharacterID: characterId,
-        CreatedAt: 0,
-        UpdatedAt: 0,
-      });
-    }),
+    get: jest
+      .fn()
+      .mockImplementation(({ userId, characterId }: { userId: string; characterId: string }) => {
+        const key = `${userId}:${characterId}`;
+        if (key in overrides) return Promise.resolve(overrides[key]);
+        return Promise.resolve({
+          Bedtime: '01:30',
+          WakeUpTime: '09:30',
+          UserID: userId,
+          CharacterID: characterId,
+          CreatedAt: 0,
+          UpdatedAt: 0,
+        });
+      }),
   });
 
   const makeParams = (overrides = {}) => ({
@@ -137,7 +146,11 @@ describe('studyAllUsers', () => {
     // hiyori のみ処理（u1, u2 各 1 回 = 2 回）
     expect(mockStudyForUser).toHaveBeenCalledTimes(2);
     expect(mockStudyForUser).toHaveBeenCalledWith('u1', 'hiyori', expect.anything());
-    expect(mockStudyForUser).not.toHaveBeenCalledWith(expect.anything(), 'ageha', expect.anything());
+    expect(mockStudyForUser).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'ageha',
+      expect.anything()
+    );
     expect(result.studiedUsers).toBe(2);
   });
 
@@ -246,17 +259,19 @@ describe('studyAllUsers', () => {
   it('全キャラ lifecycle なし（skipped）より failed が優先される', async () => {
     // u1: hiyori はエラー、ageha は lifecycle なし
     const lifecycleRepo = {
-      get: jest.fn().mockImplementation(({ userId, characterId }: { userId: string; characterId: string }) => {
-        if (userId === 'u1' && characterId === 'ageha') return Promise.resolve(null);
-        return Promise.resolve({
-          Bedtime: '01:30',
-          WakeUpTime: '09:30',
-          UserID: userId,
-          CharacterID: characterId,
-          CreatedAt: 0,
-          UpdatedAt: 0,
-        });
-      }),
+      get: jest
+        .fn()
+        .mockImplementation(({ userId, characterId }: { userId: string; characterId: string }) => {
+          if (userId === 'u1' && characterId === 'ageha') return Promise.resolve(null);
+          return Promise.resolve({
+            Bedtime: '01:30',
+            WakeUpTime: '09:30',
+            UserID: userId,
+            CharacterID: characterId,
+            CreatedAt: 0,
+            UpdatedAt: 0,
+          });
+        }),
     };
     mockStudyForUser
       .mockRejectedValueOnce(new Error('hiyori エラー')) // u1 hiyori
@@ -278,7 +293,11 @@ describe('studyAllUsers', () => {
           id: 'hiyori',
           displayName: '桃瀬ひより',
           notificationName: 'ひより',
-          personality: { basePrompt: '', speechStyle: '', preferences: { likes: [], dislikes: [] } },
+          personality: {
+            basePrompt: '',
+            speechStyle: '',
+            preferences: { likes: [], dislikes: [] },
+          },
           voiceConfig: { provider: 'voicevox' as const, speakerId: 14 },
           license: { displayText: '', creditName: '' },
         };

--- a/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
@@ -1,20 +1,42 @@
 jest.mock('@nagiyu/livetalk-core', () => ({
-  DEFAULT_CHARACTER_ID: 'hiyori',
-  hiyori: {
-    id: 'hiyori',
-    displayName: '桃瀬ひより',
-    personality: {
-      basePrompt: '',
-      speechStyle: '優しい口調',
-      preferences: { likes: [], dislikes: [] },
-    },
-    voiceConfig: { provider: 'voicevox' as const, speakerId: 14 },
-    license: { displayText: '', creditName: '' },
-  },
+  getAllCharacterIds: jest.fn(() => ['hiyori', 'ageha']),
+  getCharacterDefinitionById: jest.fn((id: string) => {
+    if (id === 'hiyori') {
+      return {
+        id: 'hiyori',
+        displayName: '桃瀬ひより',
+        notificationName: 'ひより',
+        personality: {
+          basePrompt: '',
+          speechStyle: '優しい口調',
+          preferences: { likes: [], dislikes: [] },
+        },
+        voiceConfig: { provider: 'voicevox' as const, speakerId: 14 },
+        license: { displayText: '', creditName: '' },
+      };
+    }
+    if (id === 'ageha') {
+      return {
+        id: 'ageha',
+        displayName: '早瀬アゲハ',
+        notificationName: 'アゲハ',
+        personality: {
+          basePrompt: '',
+          speechStyle: '活発な口調',
+          preferences: { likes: [], dislikes: [] },
+        },
+        voiceConfig: { provider: 'openai-tts' as const, model: 'gpt-4o-mini-tts', voice: 'nova', instructions: '' },
+        license: { displayText: '', creditName: '' },
+      };
+    }
+    return undefined;
+  }),
   studyForUser: jest.fn(),
   generateNotesForUser: jest.fn(),
 }));
 
+const mockGetAllCharacterIds = jest.requireMock('@nagiyu/livetalk-core').getAllCharacterIds as jest.Mock;
+const mockGetCharacterDefinitionById = jest.requireMock('@nagiyu/livetalk-core').getCharacterDefinitionById as jest.Mock;
 const mockStudyForUser = jest.requireMock('@nagiyu/livetalk-core').studyForUser as jest.Mock;
 const mockGenerateNotesForUser = jest.requireMock('@nagiyu/livetalk-core')
   .generateNotesForUser as jest.Mock;
@@ -24,19 +46,25 @@ describe('studyAllUsers', () => {
     send: jest.fn(),
   };
 
+  const makeLifecycleRepo = (overrides: Record<string, object | null> = {}) => ({
+    get: jest.fn().mockImplementation(({ userId, characterId }: { userId: string; characterId: string }) => {
+      const key = `${userId}:${characterId}`;
+      if (key in overrides) return Promise.resolve(overrides[key]);
+      return Promise.resolve({
+        Bedtime: '01:30',
+        WakeUpTime: '09:30',
+        UserID: userId,
+        CharacterID: characterId,
+        CreatedAt: 0,
+        UpdatedAt: 0,
+      });
+    }),
+  });
+
   const makeParams = (overrides = {}) => ({
     docClient: mockDocClient as never,
     tableName: 'test-table',
-    lifecycleRepo: {
-      get: jest.fn().mockResolvedValue({
-        Bedtime: '01:30',
-        WakeUpTime: '09:30',
-        UserID: 'u1',
-        CharacterID: 'hiyori',
-        CreatedAt: 0,
-        UpdatedAt: 0,
-      }),
-    } as never,
+    lifecycleRepo: makeLifecycleRepo() as never,
     interestRepo: {} as never,
     knowledgeRepo: {} as never,
     researchClient: {} as never,
@@ -45,56 +73,91 @@ describe('studyAllUsers', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetAllCharacterIds.mockReturnValue(['hiyori', 'ageha']);
     mockDocClient.send.mockResolvedValue({
       Items: [{ UserID: 'u1' }, { UserID: 'u2' }],
     });
     mockGenerateNotesForUser.mockResolvedValue({ generatedCount: 0 });
   });
 
-  it('全ユーザーをループして studyForUser を呼ぶ', async () => {
+  it('全ユーザー全キャラをループして studyForUser を呼ぶ', async () => {
     mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
 
     const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
     const result = await studyAllUsers(makeParams());
 
+    // u1, u2 × hiyori, ageha = 4 回
+    expect(mockStudyForUser).toHaveBeenCalledTimes(4);
     expect(result.studiedUsers).toBe(2);
     expect(result.skippedUsers).toBe(0);
     expect(result.failedUsers).toBe(0);
-    expect(mockStudyForUser).toHaveBeenCalledTimes(2);
   });
 
-  it('studyForUser がスキップを返したユーザーをカウント', async () => {
+  it('studyForUser がスキップを返したキャラはユーザー単位の studied に加算しない', async () => {
     mockStudyForUser
-      .mockResolvedValueOnce({ outcome: 'studied', savedCount: 1 })
-      .mockResolvedValueOnce({ outcome: 'skipped', skipReason: 'テスト' });
+      .mockResolvedValueOnce({ outcome: 'studied', savedCount: 1 }) // u1 hiyori
+      .mockResolvedValueOnce({ outcome: 'skipped', skipReason: 'テスト' }) // u1 ageha
+      .mockResolvedValueOnce({ outcome: 'skipped', skipReason: 'テスト' }) // u2 hiyori
+      .mockResolvedValueOnce({ outcome: 'skipped', skipReason: 'テスト' }); // u2 ageha
 
     const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
     const result = await studyAllUsers(makeParams());
 
+    // u1 は 1 キャラ studied, u2 は全スキップ
     expect(result.studiedUsers).toBe(1);
     expect(result.skippedUsers).toBe(1);
   });
 
-  it('lifecycle が null のユーザーはスキップ', async () => {
-    const lifecycleRepo = {
-      get: jest.fn().mockResolvedValue(null),
-    };
+  it('lifecycle が null のキャラクターはスキップ（計上しない）', async () => {
+    const lifecycleRepo = makeLifecycleRepo({
+      'u1:hiyori': null,
+      'u1:ageha': null,
+      'u2:hiyori': null,
+      'u2:ageha': null,
+    });
 
     const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
     const result = await studyAllUsers(makeParams({ lifecycleRepo: lifecycleRepo as never }));
 
+    // 全キャラ lifecycle なし → skippedUsers
     expect(result.skippedUsers).toBe(2);
     expect(mockStudyForUser).not.toHaveBeenCalled();
   });
 
-  it('studyForUser が throw したユーザーは failedUsers にカウント', async () => {
-    mockStudyForUser.mockRejectedValue(new Error('DynamoDB エラー'));
+  it('一部キャラのみ lifecycle 登録（hiyori あり、ageha なし）の場合、hiyori のみ処理', async () => {
+    const lifecycleRepo = makeLifecycleRepo({
+      'u1:ageha': null,
+      'u2:ageha': null,
+    });
+    mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams({ lifecycleRepo: lifecycleRepo as never }));
+
+    // hiyori のみ処理（u1, u2 各 1 回 = 2 回）
+    expect(mockStudyForUser).toHaveBeenCalledTimes(2);
+    expect(mockStudyForUser).toHaveBeenCalledWith('u1', 'hiyori', expect.anything());
+    expect(mockStudyForUser).not.toHaveBeenCalledWith(expect.anything(), 'ageha', expect.anything());
+    expect(result.studiedUsers).toBe(2);
+  });
+
+  it('studyForUser が throw したキャラクターは failedUsers にカウント、他キャラは継続', async () => {
+    mockStudyForUser
+      .mockRejectedValueOnce(new Error('hiyori エラー')) // u1 hiyori
+      .mockResolvedValueOnce({ outcome: 'studied', savedCount: 1 }) // u1 ageha
+      .mockResolvedValueOnce({ outcome: 'studied', savedCount: 1 }) // u2 hiyori
+      .mockResolvedValueOnce({ outcome: 'studied', savedCount: 1 }); // u2 ageha
 
     const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
     const result = await studyAllUsers(makeParams());
 
-    expect(result.failedUsers).toBe(2);
-    expect(result.failedUserIds).toEqual(['u1', 'u2']);
+    // u1 はキャラエラーがあるので failed
+    expect(result.failedUsers).toBe(1);
+    expect(result.failedUserIds).toContain('u1');
+    // u2 は studied
+    expect(result.studiedUsers).toBe(1);
+    // 全 4 回呼ばれること（エラーしても他キャラ継続）
+    expect(mockStudyForUser).toHaveBeenCalledTimes(4);
   });
 
   it('studyTopicRepo を studyForUser に受け渡す（Phase 5b 配線）', async () => {
@@ -111,7 +174,29 @@ describe('studyAllUsers', () => {
     );
   });
 
-  it('noteRepo 指定時、勉強したユーザーに対しノート生成を行い件数を集計する（Phase 5c）', async () => {
+  it('studyForUser に character として getCharacterDefinitionById の結果が渡される', async () => {
+    mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    await studyAllUsers(makeParams());
+
+    expect(mockStudyForUser).toHaveBeenCalledWith(
+      'u1',
+      'hiyori',
+      expect.objectContaining({
+        character: expect.objectContaining({ id: 'hiyori', displayName: '桃瀬ひより' }),
+      })
+    );
+    expect(mockStudyForUser).toHaveBeenCalledWith(
+      'u1',
+      'ageha',
+      expect.objectContaining({
+        character: expect.objectContaining({ id: 'ageha', displayName: '早瀬アゲハ' }),
+      })
+    );
+  });
+
+  it('noteRepo 指定時、studied キャラについてノート生成を行い件数を集計する（Phase 5c）', async () => {
     mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
     mockGenerateNotesForUser.mockResolvedValue({ generatedCount: 2 });
     const noteRepo = { put: jest.fn(), list: jest.fn(), get: jest.fn(), listRecent: jest.fn() };
@@ -119,17 +204,22 @@ describe('studyAllUsers', () => {
     const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
     const result = await studyAllUsers(makeParams({ noteRepo: noteRepo as never }));
 
-    // u1 / u2 各 2 件 = 4 件
-    expect(result.generatedNotes).toBe(4);
-    expect(mockGenerateNotesForUser).toHaveBeenCalledTimes(2);
+    // u1 hiyori, u1 ageha, u2 hiyori, u2 ageha の 4 キャラ × 2 件 = 8 件
+    expect(result.generatedNotes).toBe(8);
+    expect(mockGenerateNotesForUser).toHaveBeenCalledTimes(4);
     expect(mockGenerateNotesForUser).toHaveBeenCalledWith(
       'u1',
       'hiyori',
       expect.objectContaining({ noteRepo })
     );
+    expect(mockGenerateNotesForUser).toHaveBeenCalledWith(
+      'u1',
+      'ageha',
+      expect.objectContaining({ noteRepo })
+    );
   });
 
-  it('スキップしたユーザーにはノート生成を行わない（Phase 5c）', async () => {
+  it('スキップしたキャラにはノート生成を行わない（Phase 5c）', async () => {
     mockStudyForUser.mockResolvedValue({ outcome: 'skipped', skipReason: 'テスト' });
     const noteRepo = { put: jest.fn(), list: jest.fn(), get: jest.fn(), listRecent: jest.fn() };
 
@@ -151,5 +241,61 @@ describe('studyAllUsers', () => {
     expect(result.studiedUsers).toBe(2);
     expect(result.generatedNotes).toBe(0);
     expect(result.failedUsers).toBe(0);
+  });
+
+  it('全キャラ lifecycle なし（skipped）より failed が優先される', async () => {
+    // u1: hiyori はエラー、ageha は lifecycle なし
+    const lifecycleRepo = {
+      get: jest.fn().mockImplementation(({ userId, characterId }: { userId: string; characterId: string }) => {
+        if (userId === 'u1' && characterId === 'ageha') return Promise.resolve(null);
+        return Promise.resolve({
+          Bedtime: '01:30',
+          WakeUpTime: '09:30',
+          UserID: userId,
+          CharacterID: characterId,
+          CreatedAt: 0,
+          UpdatedAt: 0,
+        });
+      }),
+    };
+    mockStudyForUser
+      .mockRejectedValueOnce(new Error('hiyori エラー')) // u1 hiyori
+      .mockResolvedValue({ outcome: 'studied', savedCount: 1 }); // u2 系
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    const result = await studyAllUsers(makeParams({ lifecycleRepo: lifecycleRepo as never }));
+
+    // u1 はキャラエラーがあるので failed（lifecycle なしより優先）
+    expect(result.failedUsers).toBe(1);
+    expect(result.failedUserIds).toContain('u1');
+  });
+
+  it('getCharacterDefinitionById が undefined を返すキャラクターはスキップ', async () => {
+    mockGetAllCharacterIds.mockReturnValue(['hiyori', 'unknown-char']);
+    mockGetCharacterDefinitionById.mockImplementation((id: string) => {
+      if (id === 'hiyori') {
+        return {
+          id: 'hiyori',
+          displayName: '桃瀬ひより',
+          notificationName: 'ひより',
+          personality: { basePrompt: '', speechStyle: '', preferences: { likes: [], dislikes: [] } },
+          voiceConfig: { provider: 'voicevox' as const, speakerId: 14 },
+          license: { displayText: '', creditName: '' },
+        };
+      }
+      return undefined;
+    });
+    mockStudyForUser.mockResolvedValue({ outcome: 'studied', savedCount: 1 });
+
+    const { studyAllUsers } = await import('../../../src/usecases/study.usecase.js');
+    await studyAllUsers(makeParams());
+
+    // hiyori のみ処理（unknown-char は undefined なのでスキップ）
+    expect(mockStudyForUser).toHaveBeenCalledWith(expect.anything(), 'hiyori', expect.anything());
+    expect(mockStudyForUser).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'unknown-char',
+      expect.anything()
+    );
   });
 });


### PR DESCRIPTION
## 変更の概要

リブトークのバッチ 3 種（compress / study / learn-user-activity）を「ユーザー × キャラクター単位」処理に対応させ、非既定キャラクター（早瀬アゲハ）が既定キャラクター（ひより）固定で放置されていた仕様矛盾を解消する。`integration/3522-batch-multichar` を develop へ取り込む。

通知バッチ（`notify.usecase.ts`）の確立済みパターンに倣い、`getAllCharacterIds()` で全キャラを走査し、キャラ定義は `getCharacterDefinitionById()` から動的取得する（ハードコードの `DEFAULT_CHARACTER_ID` / `hiyori` / `'桃瀬ひより'` を全廃）。

### 各バッチの変更
- **compress-conversations**: 全キャラ走査。`characterName` は各キャラの `displayName` から導出。新着メッセージ 0 件なら内部で早期 return するため会話のないキャラに LLM コストは発生しない。
- **study**: 全キャラ走査。lifecycle 未登録キャラはスキップ。`character` に `getCharacterDefinitionById(characterId)` を渡し、studied キャラごとに NOTE 昇格。
- **learn-user-activity**: 全キャラ走査（キャラ単位処理）。ヒストグラムは「そのキャラへの発話」由来、適応先も各キャラの LIFECYCLE スケジュールのためキャラ単位が正しい。LLM 非使用のためコスト増なし。

### 失敗分離・集約セマンティクス
各キャラ処理を try/catch で囲み、あるキャラが失敗しても他キャラは継続。ユーザー単位の計上は failed 最優先（studied/skipped より優先）。result カウンタの shape は不変。

## dev 環境での検証結果

dev（`nagiyu-livetalk-dynamodb-dev`）でバッチを手動発火し、非既定キャラ ageha の発火前→後を実データで確認済み。

| 項目 | 発火前 | 発火後 |
|---|---|---|
| LIFECYCLE（learn） | 無 | 有（UserActivityProfile 学習済み） |
| MEMORY#SUMMARY（compress） | 無 | 1 |
| MEM 記憶（compress） | 0 | 5 |
| INTEREST（compress） | 0 | 5 |
| KNOWLEDGE（study） | 0 | 3 |
| NOTE（study） | 0 | 2 |

study の起床/ピーク判定（`TZ=Asia/Tokyo`）・6h 間隔ゲートも仕様通り動作することを確認した。

## 関連 Issue

サブ Issue #3522 / 親 Issue #3521。
※ サブ Issue は手動クローズ・親 Issue は全サブ Issue 完了後の手動クローズ運用のため、本 PR には `Closes #` を含めない。

## 変更種別

- [x] バグ修正
- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（ドキュメント整合性は別サブ Issue #3531 のスコープ）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `services/livetalk/batch` で `npm run test:coverage`（8 suites / 65 tests passed、branch カバレッジ 84.4%）・`npm run build`・`npm run lint` 全て green
- dev 環境での実データ前後比較（上表）
- Fast Verification（PR #3534）green 済み

## レビューポイント

- 集約セマンティクス（failed 最優先）の妥当性
- learn-user-activity をキャラ単位とした仕様判断
- 失敗分離（一部キャラ失敗で他キャラ継続）の方針

## 補足事項

- 本 PR は `integration/3522-batch-multichar → develop`。サブ実装 PR #3534 は integration へマージ済み。
- ドキュメント整合性の解消は別サブ Issue #3531 のスコープ。


---
_Generated by [Claude Code](https://claude.ai/code/session_01HRbytvDYzrBN8QSG5mPN1y)_