### PR TITLE
知識ゲートの照合品質改善を develop へ取り込み（Closes #3538）

### DIFF
--- a/services/livetalk/core/src/study/knowledge-matcher.ts
+++ b/services/livetalk/core/src/study/knowledge-matcher.ts
@@ -35,12 +35,40 @@ export function toBigrams(text: string): Set<string> {
 }
 
 /**
+ * keyphrase recall の計算対象とする最小 2-gram 数。
+ * 2-gram が 2 個以下（正規化後 3 文字以下）のキーフレーズは「飲み物」「ゲーム」等の
+ * 短い一般カテゴリ名が該当し、偶然の 1 gram 一致で閾値に達して暴発しやすいため除外する。
+ */
+const KEYPHRASE_MIN_BIGRAM_COUNT = 3;
+
+/**
+ * keyphrase recall を有効とみなす最小の絶対一致 gram 数。
+ * 割合（recall）が閾値を満たしても、共有 gram が 1 個だけの近接語（例「編み物」×「飲み物」）は
+ * 誤ヒットとみなして弾く。割合ガードと併用して適合率を確保する。
+ */
+const KEYPHRASE_MIN_OVERLAP = 2;
+
+/**
  * 文字 2-gram の重なり率でキーワード照合する既定マッチャ（外部依存なし）。
  *
  * 日本語はスペースで分かち書きされないため substring 照合だと自然文
- * （例「最近の飲み物のトレンド知ってる？」）を取りこぼす。ユーザー発話を
- * 文字 2-gram に分解し、知識テキスト（Topic + Summary）の 2-gram に
- * 含まれる割合が閾値以上なら一致とみなすことで再現率を確保する。
+ * （例「最近の飲み物のトレンド知ってる？」）を取りこぼす。2 つの指標の最大値で
+ * ヒット判定することで、フィラー付き自然文での再現率を確保しつつ後方互換を維持する。
+ *
+ * ## 指標 1: keyphrase recall（フィラー対策の本命）
+ * 知識の Topic / RelatedCategory（キーフレーズ）ごとに
+ * `overlap(grams(keyphrase) ∩ grams(user)) / grams(keyphrase).size` を計算し最大を取る。
+ * 分母がキーフレーズ側なので、ユーザー発話にフィラーが多くても薄まらない。
+ * 暴発抑制として 2-gram が {@link KEYPHRASE_MIN_BIGRAM_COUNT} 個未満の短い
+ * キーフレーズは対象外とし、さらに共有 gram が {@link KEYPHRASE_MIN_OVERLAP} 個未満の
+ * 弱い部分一致も弾く。
+ *
+ * ## 指標 2: user recall（後方互換）
+ * `overlap(grams(user) ∩ grams(target)) / grams(user).size`。
+ * target は `${Topic} ${RelatedCategory} ${Summary}`（RelatedCategory を含む）。
+ * 分母はユーザー発話側。
+ *
+ * 最終スコア = `max(keyphraseRecall, userRecall)` が `minRatio` 以上なら一致。
  */
 export class NgramKnowledgeMatcher implements KnowledgeMatcher {
   private readonly minRatio: number;
@@ -57,13 +85,60 @@ export class NgramKnowledgeMatcher implements KnowledgeMatcher {
     const userGrams = toBigrams(userText);
     if (userGrams.size === 0) return [];
 
-    return knowledge.filter(
-      (k) => this.matchRatio(userGrams, `${k.Topic} ${k.Summary}`) >= this.minRatio
-    );
+    return knowledge.filter((k) => this.matchScore(userGrams, k) >= this.minRatio);
   }
 
-  /** userGrams のうち target に含まれる割合（0〜1）。 */
-  private matchRatio(userGrams: Set<string>, target: string): number {
+  /**
+   * ユーザー発話と知識エンティティの一致スコア（0〜1）を返す。
+   * keyphrase recall と user recall の最大値。
+   */
+  private matchScore(userGrams: Set<string>, knowledge: KnowledgeEntity): number {
+    const keyphraseRecall = this.calcKeyphraseRecall(userGrams, knowledge);
+    const userRecall = this.calcUserRecall(
+      userGrams,
+      `${knowledge.Topic} ${knowledge.RelatedCategory} ${knowledge.Summary}`
+    );
+    return Math.max(keyphraseRecall, userRecall);
+  }
+
+  /**
+   * keyphrase recall: Topic / RelatedCategory ごとに
+   * `overlap(grams(field) ∩ grams(user)) / grams(field).size` を計算し最大を返す。
+   *
+   * 2-gram 数が {@link KEYPHRASE_MIN_BIGRAM_COUNT} 未満のフィールド、および共有 gram が
+   * {@link KEYPHRASE_MIN_OVERLAP} 未満の弱い部分一致は除外（暴発抑制）。
+   * RelatedCategory が空文字の場合も除外。
+   */
+  private calcKeyphraseRecall(userGrams: Set<string>, knowledge: KnowledgeEntity): number {
+    const candidates: string[] = [knowledge.Topic];
+    if (knowledge.RelatedCategory.length > 0) {
+      candidates.push(knowledge.RelatedCategory);
+    }
+
+    let maxRecall = 0;
+    for (const field of candidates) {
+      const fieldGrams = toBigrams(field);
+      // 2-gram 数が最小数未満のキーフレーズは除外（暴発抑制）
+      if (fieldGrams.size < KEYPHRASE_MIN_BIGRAM_COUNT) continue;
+
+      let overlap = 0;
+      for (const gram of fieldGrams) {
+        if (userGrams.has(gram)) overlap++;
+      }
+      // 共有 gram が少なすぎる弱い部分一致は誤ヒットとして弾く
+      if (overlap < KEYPHRASE_MIN_OVERLAP) continue;
+
+      const recall = overlap / fieldGrams.size;
+      if (recall > maxRecall) maxRecall = recall;
+    }
+    return maxRecall;
+  }
+
+  /**
+   * user recall: `overlap(grams(user) ∩ grams(target)) / grams(user).size`。
+   * target は `${Topic} ${RelatedCategory} ${Summary}` を結合した文字列。
+   */
+  private calcUserRecall(userGrams: Set<string>, target: string): number {
     const targetGrams = toBigrams(target);
     let overlap = 0;
     for (const gram of userGrams) {

--- a/services/livetalk/core/tests/unit/study/knowledge-matcher.test.ts
+++ b/services/livetalk/core/tests/unit/study/knowledge-matcher.test.ts
@@ -118,10 +118,93 @@ describe('NgramKnowledgeMatcher', () => {
   });
 
   // ── 閾値の差し替え ──
-  it('minRatio を上げると弱い一致を除外できる', async () => {
+  // 旧テスト: 「最近の飲み物のトレンド知ってる？」× drinkKnowledge（RelatedCategory='飲み物'）で
+  // keyphrase recall = 1.0 になるため、minRatio=0.99 でもヒットするようになった。
+  // 新指標の意味に合わせ「完全に無関係な語で 0 hits を確認する」ケースに書き換える。
+  it('minRatio を上げると弱い一致を除外できる（完全無関係語は 0.99 閾値でも弾かれる）', async () => {
     const strict = new NgramKnowledgeMatcher(0.99);
-    const hits = await strict.findMatches('最近の飲み物のトレンド知ってる？', [drinkKnowledge]);
-    // 0.71 程度の一致は 0.99 閾値では弾かれる
+    // 「天気予報」は drinkKnowledge と共通 2-gram を持たないため keyphrase recall/user recall ともに 0
+    const hits = await strict.findMatches('明日の天気予報教えて', [drinkKnowledge]);
+    expect(hits).toHaveLength(0);
+  });
+
+  // ── フィラー付き自然文の新規受け入れケース（dev 実測を模す）──
+  it('「麻辣担の種類について何かわかった？」が RelatedCategory「麻辣担の種類」にヒットする', async () => {
+    const k = makeKnowledge({
+      KnowledgeID: 'malatang',
+      Topic: '麻辣担（マーラー）',
+      RelatedCategory: '麻辣担の種類',
+      Summary: '麻辣担の種類と特徴についての情報。',
+    });
+    const hits = await matcher.findMatches('麻辣担の種類について何かわかった？', [k]);
+    expect(hits.map((h) => h.KnowledgeID)).toContain('malatang');
+  });
+
+  it('「リズム天国の新作について何かわかった？」が RelatedCategory「リズム天国新作」にヒットする', async () => {
+    const k = makeKnowledge({
+      KnowledgeID: 'rhythm',
+      Topic: 'リズム天国 ミラクルスターズ',
+      RelatedCategory: 'リズム天国新作',
+      Summary: 'リズム天国の新作ゲームに関する情報。',
+    });
+    const hits = await matcher.findMatches('リズム天国の新作について何かわかった？', [k]);
+    expect(hits.map((h) => h.KnowledgeID)).toContain('rhythm');
+  });
+
+  // ── keyphrase recall の誤ヒット抑制（ガード条件の確認）──
+  it('RelatedCategory が空文字のとき keyphrase 候補から除外され、Topic のみで評価される', async () => {
+    // RelatedCategory='' のため keyphrase 候補は Topic のみ
+    // Topic「トピック」= 正規化後 4 文字 = 2-gram × 3個 → ガード（>= 3）通過
+    const k = makeKnowledge({ Topic: 'トピック', RelatedCategory: '', Summary: 'サマリー内容' });
+    // 完全一致する発話 → ヒット
+    const hits = await matcher.findMatches('トピック', [k]);
+    expect(hits).toHaveLength(1);
+  });
+
+  it('Topic が 3 文字以下（2-gram 数 < 3）のとき keyphrase recall は計算されない', async () => {
+    // Topic「あいう」= 2-gram × 2個 → ガード除外（短い一般カテゴリ名の暴発対策）
+    // user recall のみで評価されるため、無関係な長文ではヒットしない
+    const k = makeKnowledge({
+      Topic: 'あいう',
+      RelatedCategory: '',
+      Summary: '全く関係ない説明文',
+    });
+    // Topic と部分一致する「あい」を含むが、keyphrase 経路は無効・user recall も低いため非ヒット
+    const hits = await matcher.findMatches('あいまいな今日の天気の話', [k]);
+    expect(hits).toHaveLength(0);
+  });
+
+  // ── 短いカテゴリ名 / 弱い部分一致での誤ヒット抑制（fresh-eyes 指摘の回帰）──
+  it('短い RelatedCategory「飲み物」と 1 gram だけ一致する近接語「編み物」は誤ヒットしない', async () => {
+    // RelatedCategory「飲み物」= 2-gram × 2個 → ガード除外。
+    // 「編み物が趣味」は「み物」のみ共有するが keyphrase 経路は無効、user recall も閾値未満。
+    const hits = await matcher.findMatches('編み物が趣味なんだ', [drinkKnowledge, sweetsKnowledge]);
+    expect(hits).toHaveLength(0);
+  });
+
+  it('keyphrase が 3 個以上の 2-gram を持っても、共有 gram が 1 個だけなら弾く（絶対一致数の下限）', async () => {
+    // RelatedCategory「あいうえ」= 2-gram × 3個（ガード通過）。発話は「あい」1 個のみ共有。
+    // 割合は 1/3 だが、絶対一致数 < 2 のため keyphrase recall は無効化される。
+    const k = makeKnowledge({
+      KnowledgeID: 'partial',
+      Topic: '無関係トピック名',
+      RelatedCategory: 'あいうえ',
+      Summary: '全く異なる内容の説明',
+    });
+    const hits = await matcher.findMatches('あいさつは大事だよね', [k]);
+    expect(hits).toHaveLength(0);
+  });
+
+  it('「ゲーム」のような短い一般カテゴリ名は文脈外の言及で誤ヒットしない', async () => {
+    // RelatedCategory「ゲーム」= 2-gram × 2個 → ガード除外。
+    const k = makeKnowledge({
+      KnowledgeID: 'game',
+      Topic: 'ゲームの最新情報',
+      RelatedCategory: 'ゲーム',
+      Summary: '新作ゲームのトレンド情報。',
+    });
+    // Topic は keyphrase 対象だが「ゲーム」しか共有せず recall は低い。user recall も閾値未満。
+    const hits = await matcher.findMatches('今日はゲームの話じゃなくて天気の話をしたい気分', [k]);
     expect(hits).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## 変更の概要

チャットの知識ゲート（`NgramKnowledgeMatcher`）が、study 済みの知識を自然文の質問で取りこぼし「勉強しておくね」と誤って返す問題（#3538）を解消する。

真因は照合指標の分母にあった。従来は `overlap / userGrams.size`（分母 = ユーザー発話の全 2-gram）で判定しており、「について」「何か」「わかった」等のフィラーが分母を膨らませ、内容語が一致しても割合が閾値 0.5 を割っていた（dev 実測: 麻辣担 0.13 / リズム天国 0.29）。

これに対し、**keyphrase recall**（分母を知識側のキーフレーズに取る指標）を追加し、従来の user recall と最大値で判定する 2 指標方式へ変更した。誤ヒット抑制の 2 段ガード（最小 2-gram 数 / 最小一致数）も併せて導入している。

詳細は実装単位の PR #3539 を参照。

## 関連 Issue

Closes #3538

## 変更種別

- [x] バグ修正

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] ローカルでテストが全て通ることを確認した（`@nagiyu/livetalk-core`: 76 suites / 1091 tests pass）
- [x] ビルドエラーがないことを確認した
- [ ] 関連ドキュメントを更新した（本変更は内部ヒューリスティクスのため docs 更新なし）

## テスト内容

`services/livetalk/core/tests/unit/study/knowledge-matcher.test.ts` を更新・追加（フィラー付き自然文の HIT、短いカテゴリ名・弱い部分一致の誤ヒット抑制、既存 positive 維持の回帰）。

### dev 環境での反映確認（ageha 実会話）

study 済みの実 KNOWLEDGE に対し、修正前は全て「勉強しておくね」だった以下が、調べた内容を踏まえた応答に変わることを dev で確認:

- 「麻辣担の種類について何かわかった？」→ 知識活用 ✅
- 「リズム天国の新作について何かわかった？」→ 知識活用 ✅
- 「OpenAIのプライバシーポリシーって何か更新あった？」→ 知識活用 ✅
- 雑談（「仕事疲れた〜」等）→ 知識の無理な持ち出しなし（誤ヒットなし）✅

## レビューポイント

- **既知の残課題（本対応のスコープ外）**: 「Nintendo Direct → リズム天国新作」のように質問文と知識テキストに文字の重なりが無い**意味的ギャップ**は文字 N-gram 照合では解けず、dev でも deferral のまま（本 PR の FAIL ではない）。embedding 照合や `classifyTopic` への知識付与で扱う領分で、必要なら別 Issue とする。今回は不問とする方針で合意済み。
- 変更は `services/livetalk/core/src/study/knowledge-matcher.ts` とそのテストに閉じる。`classifyTopic` / `chat-usecase` / embedding 照合は未変更。

## 補足事項

- 本 PR は integration/3538-knowledge-gate を develop へ取り込むもの。実装単位の Draft PR #3539 は integration へマージ済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_01LfXA7zXGQF5wa7P3F8QaeV)_