### PR TITLE
リブトーク: 圧縮要約バッチの冪等性・部分失敗ハンドリング改善

### DIFF
--- a/services/livetalk/batch/src/handlers/compress-conversations.ts
+++ b/services/livetalk/batch/src/handlers/compress-conversations.ts
@@ -38,6 +38,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     eventTime: event.time,
   });
 
+  let result;
   try {
     const docClient = getDynamoDBDocumentClient();
     const tableName = getTableName();
@@ -52,7 +53,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const interestRepo = new DynamoDBInterestRepository(docClient, tableName);
     const characterStateRepo = new DynamoDBCharacterStateRepository(docClient, tableName);
 
-    const result = await compressAllConversations({
+    result = await compressAllConversations({
       docClient,
       tableName,
       summaryRepo,
@@ -63,20 +64,8 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       characterStateRepo,
       embeddingClient,
     });
-
-    logger.info('[compress-conversations] バッチ完了', {
-      eventId: event.id,
-      ...result,
-    });
-
-    return {
-      statusCode: 200,
-      body: JSON.stringify({
-        message: '圧縮要約バッチが正常に完了しました',
-        ...result,
-      }),
-    };
   } catch (error) {
+    // 致命的エラー: 報告して rethrow（非同期 Lambda を失敗させ DLQ/リトライに乗せる）
     const errorMessage = toErrorMessage(error);
     logger.error('[compress-conversations] バッチ失敗', {
       eventId: event.id,
@@ -89,13 +78,37 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       message: errorMessage,
       context: { eventId: event.id },
     });
-
-    return {
-      statusCode: 500,
-      body: JSON.stringify({
-        message: '圧縮要約バッチでエラーが発生しました',
-        error: errorMessage,
-      }),
-    };
+    throw error;
   }
+
+  logger.info('[compress-conversations] バッチ完了', {
+    eventId: event.id,
+    ...result,
+  });
+
+  if (result.failedUsers > 0) {
+    // 部分失敗: 報告して throw（非同期 Lambda を失敗させ DLQ/リトライに乗せる）
+    const message = `圧縮要約バッチで ${result.failedUsers} 件のユーザー処理が失敗しました`;
+    logger.error('[compress-conversations] 部分失敗', {
+      eventId: event.id,
+      failedUsers: result.failedUsers,
+      failedUserIds: result.failedUserIds,
+    });
+    await reportErrorEvent({
+      serviceId: SERVICE_ID,
+      severity: 'error',
+      title: '圧縮要約バッチ: 部分失敗',
+      message,
+      context: { eventId: event.id, failedUserIds: result.failedUserIds },
+    });
+    throw new Error(message);
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: '圧縮要約バッチが正常に完了しました',
+      ...result,
+    }),
+  };
 }

--- a/services/livetalk/batch/src/handlers/compress-conversations.ts
+++ b/services/livetalk/batch/src/handlers/compress-conversations.ts
@@ -11,9 +11,30 @@ import {
   OpenAIEmbeddingClient,
   defaultUlidFactory,
 } from '@nagiyu/livetalk-core';
-import { compressAllConversations } from '../usecases/compress-conversations.usecase.js';
+import {
+  compressAllConversations,
+  type CompressAllConversationsResult,
+} from '../usecases/compress-conversations.usecase.js';
 
 const SERVICE_ID = 'livetalk';
+
+/**
+ * エラー通知は best-effort。通知自体が失敗しても、後続の throw（Lambda 失敗→DLQ/リトライ）を
+ * 握り潰さないよう warn に留める。
+ */
+async function safeReportErrorEvent(
+  params: Parameters<typeof reportErrorEvent>[0],
+  eventId: string
+): Promise<void> {
+  try {
+    await reportErrorEvent(params);
+  } catch (reportError) {
+    logger.warn('[compress-conversations] エラー通知の送信に失敗しました', {
+      eventId,
+      error: toErrorMessage(reportError),
+    });
+  }
+}
 
 export interface ScheduledEvent {
   version: string;
@@ -38,7 +59,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     eventTime: event.time,
   });
 
-  let result;
+  let result: CompressAllConversationsResult;
   try {
     const docClient = getDynamoDBDocumentClient();
     const tableName = getTableName();
@@ -71,13 +92,16 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       eventId: event.id,
       error: errorMessage,
     });
-    await reportErrorEvent({
-      serviceId: SERVICE_ID,
-      severity: 'error',
-      title: '圧縮要約バッチ: 致命的エラー',
-      message: errorMessage,
-      context: { eventId: event.id },
-    });
+    await safeReportErrorEvent(
+      {
+        serviceId: SERVICE_ID,
+        severity: 'error',
+        title: '圧縮要約バッチ: 致命的エラー',
+        message: errorMessage,
+        context: { eventId: event.id },
+      },
+      event.id
+    );
     throw error;
   }
 
@@ -94,13 +118,16 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
       failedUsers: result.failedUsers,
       failedUserIds: result.failedUserIds,
     });
-    await reportErrorEvent({
-      serviceId: SERVICE_ID,
-      severity: 'error',
-      title: '圧縮要約バッチ: 部分失敗',
-      message,
-      context: { eventId: event.id, failedUserIds: result.failedUserIds },
-    });
+    await safeReportErrorEvent(
+      {
+        serviceId: SERVICE_ID,
+        severity: 'error',
+        title: '圧縮要約バッチ: 部分失敗',
+        message,
+        context: { eventId: event.id, failedUserIds: result.failedUserIds },
+      },
+      event.id
+    );
     throw new Error(message);
   }
 

--- a/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
+++ b/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
@@ -59,6 +59,7 @@ export async function compressAllConversations(
 
   for (const userId of userIds) {
     let hasCharacterError = false;
+    let hasCompressed = false;
 
     try {
       for (const characterId of allCharacterIds) {
@@ -71,7 +72,7 @@ export async function compressAllConversations(
         }
 
         try {
-          await compressConversation(userId, characterId, {
+          const outcome = await compressConversation(userId, characterId, {
             summaryRepo,
             messageRepo,
             memoryRepo,
@@ -82,6 +83,9 @@ export async function compressAllConversations(
             characterStateRepo,
             embeddingClient,
           });
+          if (outcome === 'compressed') {
+            hasCompressed = true;
+          }
         } catch (error) {
           logger.warn('[compressAllConversations] キャラクター処理失敗（他キャラは継続）', {
             userId,
@@ -92,11 +96,14 @@ export async function compressAllConversations(
         }
       }
 
+      // failed 計上が最優先。次に compressed/skipped を判定する。
       if (hasCharacterError) {
         result.failedUsers++;
         result.failedUserIds.push(userId);
-      } else {
+      } else if (hasCompressed) {
         result.processedUsers++;
+      } else {
+        result.skippedUsers++;
       }
     } catch (error) {
       logger.error('[compressAllConversations] ユーザー処理失敗', {

--- a/services/livetalk/batch/tests/unit/handlers/compress-conversations.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/compress-conversations.test.ts
@@ -57,15 +57,11 @@ describe('compress-conversations handler', () => {
     expect(body.processedUsers).toBe(5);
   });
 
-  it('例外発生時に 500 を返す', async () => {
+  it('例外発生時に throw する', async () => {
     mockCompressAll.mockRejectedValue(new Error('DynamoDB 接続エラー'));
 
     const { handler } = await import('../../../src/handlers/compress-conversations.js');
-    const response = await handler(makeEvent());
-
-    expect(response.statusCode).toBe(500);
-    const body = JSON.parse(response.body);
-    expect(body.error).toContain('DynamoDB 接続エラー');
+    await expect(handler(makeEvent())).rejects.toThrow('DynamoDB 接続エラー');
   });
 
   it('例外発生時に reportErrorEvent を呼ぶ', async () => {
@@ -73,12 +69,34 @@ describe('compress-conversations handler', () => {
     mockCompressAll.mockRejectedValue(new Error('fatal'));
 
     const { handler } = await import('../../../src/handlers/compress-conversations.js');
-    await handler(makeEvent({ id: 'ev-999' }));
+    await expect(handler(makeEvent({ id: 'ev-999' }))).rejects.toThrow();
 
     expect(reportErrorEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         serviceId: 'livetalk',
         severity: 'error',
+        title: '圧縮要約バッチ: 致命的エラー',
+      })
+    );
+  });
+
+  it('部分失敗（failedUsers > 0）時に throw し reportErrorEvent を呼ぶ', async () => {
+    const { reportErrorEvent } = await import('@nagiyu/aws');
+    mockCompressAll.mockResolvedValue({
+      processedUsers: 1,
+      skippedUsers: 0,
+      failedUsers: 1,
+      failedUserIds: ['u1'],
+    });
+
+    const { handler } = await import('../../../src/handlers/compress-conversations.js');
+    await expect(handler(makeEvent())).rejects.toThrow();
+
+    expect(reportErrorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: 'livetalk',
+        severity: 'error',
+        title: '圧縮要約バッチ: 部分失敗',
       })
     );
   });

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -81,7 +81,8 @@ describe('compressAllConversations', () => {
     const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await compressAllConversations(makeParams({ llmClient, docClient }));
     expect(llmClient.summarizeCalls).toBe(0);
-    expect(result.processedUsers).toBe(2);
+    expect(result.processedUsers).toBe(0);
+    expect(result.skippedUsers).toBe(2);
   });
 
   it('hiyori にメッセージのあるユーザー分だけ LLM を呼ぶ', async () => {
@@ -101,7 +102,9 @@ describe('compressAllConversations', () => {
     });
 
     expect(llmClient.summarizeCalls).toBe(1);
-    expect(result.processedUsers).toBe(2);
+    // u1 はメッセージあり（processed）、u2 はメッセージなし（skipped）
+    expect(result.processedUsers).toBe(1);
+    expect(result.skippedUsers).toBe(1);
     expect(result.failedUsers).toBe(0);
   });
 
@@ -162,7 +165,8 @@ describe('compressAllConversations', () => {
       makeParams({ llmClient, docClient: pagedDocClient })
     );
 
-    expect(result.processedUsers).toBe(2);
+    expect(result.processedUsers).toBe(0);
+    expect(result.skippedUsers).toBe(2);
     expect(pageCount).toBe(2);
   });
 
@@ -175,7 +179,8 @@ describe('compressAllConversations', () => {
     } as unknown as DynamoDBDocumentClient;
 
     const result = await compressAllConversations(makeParams({ llmClient, docClient }));
-    expect(result.processedUsers).toBe(1);
+    expect(result.processedUsers).toBe(0);
+    expect(result.skippedUsers).toBe(1);
   });
 
   it('複数キャラ（hiyori と ageha）両方のメッセージで LLM が 2 回呼ばれる', async () => {
@@ -315,5 +320,27 @@ describe('compressAllConversations', () => {
     expect(summarizeCalls).toContain('桃瀬ひより');
     // ageha の displayName が含まれること（'早瀬アゲハ'）
     expect(summarizeCalls.some((name) => name !== '桃瀬ひより' && name !== undefined)).toBe(true);
+  });
+
+  it('メッセージのあるユーザーは processedUsers、ないユーザーは skippedUsers に計上される（混在ケース）', async () => {
+    const llmClient = makeLLMClient();
+    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    // u1 のみメッセージあり（processed）、u2 はメッセージなし（skipped）
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
+
+    const docClient = makeDocClientMock(['u1', 'u2']);
+    const result = await compressAllConversations({
+      docClient,
+      tableName: 'test',
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    expect(result.processedUsers).toBe(1);
+    expect(result.skippedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
   });
 });

--- a/services/livetalk/core/src/usecases/compress-conversation.usecase.ts
+++ b/services/livetalk/core/src/usecases/compress-conversation.usecase.ts
@@ -36,16 +36,23 @@ export interface CompressConversationParams {
  * 処理フロー：
  * 1. MEMORY#SUMMARY の最終圧縮時刻を取得
  * 2. lastCompressedAt 以降のメッセージを listSince で取得
- * 3. メッセージが 0 件なら何もしない（return）
+ * 3. メッセージが 0 件なら 'skipped' を返す
  * 4. LLM で要約 + 新規記憶候補抽出
- * 5. MEMORY#SUMMARY を更新（既存 + 新規をマージした要約）
- * 6. 新規記憶候補を Tier C として保存（embedding・TTL はリポジトリ任せ）
+ * 5. 新規記憶候補を Tier C として保存（embedding・TTL はリポジトリ任せ）
+ * 6. MEMORY#SUMMARY を更新（既存 + 新規をマージした要約・LastCompressedAt を前進）
+ *
+ * 書き込み順序の意図：
+ * memoryRepo.put を summaryRepo.put より先に実行することで冪等性を保証する。
+ * もし memoryRepo.put が途中失敗しても LastCompressedAt は前進しないため、
+ * 次回実行で同じメッセージが再処理されて永久欠落を防ぐ。
+ *
+ * @returns 'compressed' | 'skipped'
  */
 export async function compressConversation(
   userId: string,
   characterId: string,
   params: CompressConversationParams
-): Promise<void> {
+): Promise<'compressed' | 'skipped'> {
   const {
     summaryRepo,
     messageRepo,
@@ -67,7 +74,7 @@ export async function compressConversation(
 
   if (messages.length === 0) {
     logger.info('[compressConversation] スキップ（新着メッセージなし）', { userId, characterId });
-    return;
+    return 'skipped';
   }
 
   // listSince 直後にスナップショットを取ることで、summarize 実行中に届いたメッセージが
@@ -104,6 +111,21 @@ export async function compressConversation(
     existingInterestCategories,
   });
 
+  // 新規記憶候補を先に保存する（冪等性保証）
+  // summaryRepo.put（LastCompressedAt の前進）より前に実行することで、
+  // put が途中失敗しても次回実行で同じメッセージが再処理される（永久欠落防止）
+  for (const candidate of result.newMemoryCandidates) {
+    await memoryRepo.put({
+      UserID: userId,
+      CharacterID: characterId,
+      Tier: 'C',
+      Category: candidate.category,
+      Content: candidate.content,
+      Confidence: MEMORY_DEFAULT_CONFIDENCE.C,
+      ReferencedCount: 0,
+    });
+  }
+
   await summaryRepo.put({
     UserID: userId,
     CharacterID: characterId,
@@ -128,18 +150,6 @@ export async function compressConversation(
     emitBatchMetricsEMF(batchMetrics);
   } catch (err) {
     logger.warn('[compressConversation] バッチ計測の emit に失敗しました', { err });
-  }
-
-  for (const candidate of result.newMemoryCandidates) {
-    await memoryRepo.put({
-      UserID: userId,
-      CharacterID: characterId,
-      Tier: 'C',
-      Category: candidate.category,
-      Content: candidate.content,
-      Confidence: MEMORY_DEFAULT_CONFIDENCE.C,
-      ReferencedCount: 0,
-    });
   }
 
   // 興味カテゴリ抽出・保存（fail-warn: エラー時はスキップして継続）
@@ -185,4 +195,6 @@ export async function compressConversation(
     interestCount: result.interestCategories?.length ?? 0,
     bidirectionalityScore: result.bidirectionalityScore,
   });
+
+  return 'compressed';
 }

--- a/services/livetalk/core/src/usecases/compress-conversation.usecase.ts
+++ b/services/livetalk/core/src/usecases/compress-conversation.usecase.ts
@@ -41,10 +41,16 @@ export interface CompressConversationParams {
  * 5. 新規記憶候補を Tier C として保存（embedding・TTL はリポジトリ任せ）
  * 6. MEMORY#SUMMARY を更新（既存 + 新規をマージした要約・LastCompressedAt を前進）
  *
- * 書き込み順序の意図：
- * memoryRepo.put を summaryRepo.put より先に実行することで冪等性を保証する。
+ * 書き込み順序の意図（at-least-once 保証）：
+ * memoryRepo.put を summaryRepo.put（LastCompressedAt の前進）より先に実行する。
  * もし memoryRepo.put が途中失敗しても LastCompressedAt は前進しないため、
- * 次回実行で同じメッセージが再処理されて永久欠落を防ぐ。
+ * 次回実行（DLQ/リトライ含む）で同じメッセージが再処理され、記憶の永久欠落を防ぐ。
+ *
+ * 注意：保証されるのは「欠落しない（at-least-once）」方向のみ。
+ * summaryRepo.put 失敗後にリトライした場合、同一メッセージが再要約され、
+ * Tier C 記憶が別 ID で重複保存され得る。不可逆な欠落を避けることを優先し、
+ * （回復可能な）重複は許容する設計判断である。完全成功後の再実行は
+ * LastCompressedAt 前進により no-op となり重複しない。
  *
  * @returns 'compressed' | 'skipped'
  */
@@ -111,9 +117,9 @@ export async function compressConversation(
     existingInterestCategories,
   });
 
-  // 新規記憶候補を先に保存する（冪等性保証）
+  // 新規記憶候補を先に保存する（at-least-once 保証）
   // summaryRepo.put（LastCompressedAt の前進）より前に実行することで、
-  // put が途中失敗しても次回実行で同じメッセージが再処理される（永久欠落防止）
+  // put が途中失敗しても LastCompressedAt が進まず、次回実行で再処理される（永久欠落防止）
   for (const candidate of result.newMemoryCandidates) {
     await memoryRepo.put({
       UserID: userId,

--- a/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
@@ -521,12 +521,13 @@ describe('compressConversation', () => {
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'テスト' });
 
     // memoryRepo.put が必ず throw するラッパーを作成
+    // （put 失敗後は他メソッドが呼ばれないため、型はアサーションで補う）
     const failingMemoryRepo = {
       ...realMemoryRepo,
       put: async () => {
         throw new Error('memoryRepo.put 失敗');
       },
-    };
+    } as unknown as typeof realMemoryRepo;
 
     // compressConversation は reject するはず
     await expect(

--- a/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
@@ -74,6 +74,29 @@ describe('compressConversation', () => {
     expect(llmClient.summarizeCalls).toBe(0);
   });
 
+  it('メッセージが 0 件のとき "skipped" を返す', async () => {
+    const params = makeParams();
+    const outcome = await compressConversation('u1', 'hiyori', params);
+    expect(outcome).toBe('skipped');
+  });
+
+  it('メッセージがあるとき "compressed" を返す', async () => {
+    const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'テスト' });
+
+    const outcome = await compressConversation('u1', 'hiyori', {
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient: makeLLMClient(),
+      characterName: 'ひより',
+      now: () => fixedNow,
+    });
+
+    expect(outcome).toBe('compressed');
+  });
+
   it('メッセージがあれば LLM を 1 回呼ぶ', async () => {
     const llmClient = makeLLMClient();
     const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
@@ -450,6 +473,76 @@ describe('compressConversation', () => {
     expect(saved?.LastCompressedAt).not.toBe(fixedNow + 10_000);
     // now() はスナップショット取得で 1 回だけ呼ばれる
     expect(paramNowCallCount).toBe(1);
+  });
+
+  it('2 回目実行時は同じメッセージを重複処理しない（冪等性）', async () => {
+    const candidates = [{ category: 'food', content: 'ケーキが好き' }];
+    const llmClient = makeLLMClient({ mergedSummary: '要約', newMemoryCandidates: candidates });
+    const { messageRepo, summaryRepo, memoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'テスト' });
+
+    // 1 回目実行
+    const outcome1 = await compressConversation('u1', 'hiyori', {
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+      characterName: 'ひより',
+      now: () => fixedNow,
+    });
+    expect(outcome1).toBe('compressed');
+
+    const { items: after1st } = await memoryRepo.listByTier('u1', 'hiyori', 'C');
+    expect(after1st).toHaveLength(1);
+
+    // 2 回目実行（同じ user/char）: LastCompressedAt が前進しているのでスキップされる
+    const llmClient2 = makeLLMClient({ mergedSummary: '要約2', newMemoryCandidates: candidates });
+    const outcome2 = await compressConversation('u1', 'hiyori', {
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient: llmClient2,
+      characterName: 'ひより',
+      now: () => fixedNow,
+    });
+    expect(outcome2).toBe('skipped');
+
+    // メモリは重複せず 1 件のまま
+    const { items: after2nd } = await memoryRepo.listByTier('u1', 'hiyori', 'C');
+    expect(after2nd).toHaveLength(1);
+  });
+
+  it('memoryRepo.put が失敗したとき summaryRepo の LastCompressedAt が前進しない（永久欠落防止）', async () => {
+    const candidates = [{ category: 'food', content: 'ケーキが好き' }];
+    const llmClient = makeLLMClient({ mergedSummary: '要約', newMemoryCandidates: candidates });
+    const { messageRepo, summaryRepo, memoryRepo: realMemoryRepo } = makeRepos();
+    tick = fixedNow;
+    await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'テスト' });
+
+    // memoryRepo.put が必ず throw するラッパーを作成
+    const failingMemoryRepo = {
+      ...realMemoryRepo,
+      put: async () => {
+        throw new Error('memoryRepo.put 失敗');
+      },
+    };
+
+    // compressConversation は reject するはず
+    await expect(
+      compressConversation('u1', 'hiyori', {
+        summaryRepo,
+        messageRepo,
+        memoryRepo: failingMemoryRepo,
+        llmClient,
+        characterName: 'ひより',
+        now: () => fixedNow,
+      })
+    ).rejects.toThrow('memoryRepo.put 失敗');
+
+    // LastCompressedAt が前進していないこと（0 のまま）
+    const summary = await summaryRepo.get('u1', 'hiyori');
+    expect(summary?.LastCompressedAt ?? 0).toBe(0);
   });
 
   it('bidirectionalityScore が 0 のときは AffectionLevel を更新しない', async () => {

--- a/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/compress-conversation.usecase.test.ts
@@ -475,7 +475,7 @@ describe('compressConversation', () => {
     expect(paramNowCallCount).toBe(1);
   });
 
-  it('2 回目実行時は同じメッセージを重複処理しない（冪等性）', async () => {
+  it('完全成功後の再実行は LastCompressedAt 前進により no-op となり記憶を重複させない', async () => {
     const candidates = [{ category: 'food', content: 'ケーキが好き' }];
     const llmClient = makeLLMClient({ mergedSummary: '要約', newMemoryCandidates: candidates });
     const { messageRepo, summaryRepo, memoryRepo } = makeRepos();


### PR DESCRIPTION
## 変更の概要

リブトーク圧縮要約バッチの「冪等性・部分失敗ハンドリング」を改善する（Issue #3523 / 親 #3521）。

1. **書き込み順序の是正（永久欠落の根治）**: `compressConversation`（core）で `memoryRepo.put`（Tier C 記憶）を `summaryRepo.put`（`LastCompressedAt` の前進）より**前**に実行するよう順序を入れ替えた。途中失敗時に checkpoint が前進しないため、次回実行（日次／DLQ リトライ）で同じメッセージが再処理され、記憶の**不可逆な永久欠落を防ぐ**（at-least-once 保証）。
   - 設計判断: 失敗リトライ時に Tier C 記憶が別 ID で重複保存され得るが、回復可能な重複を許容し不可逆な欠落の回避を優先する（完全成功後の再実行は `LastCompressedAt` 前進により no-op となり重複しない）。コメントにその旨を明記。
2. **部分失敗を失敗として扱う（DLQ/リトライの実効化）**: handler が `failedUsers > 0`／致命的エラー時に **throw** するよう変更。compress Lambda は EventBridge 非同期＋DLQ（`retryAttempts:1`）構成のため、従来の `return 500` ではリトライ／DLQ が起動しなかった。throw により非同期 Lambda 失敗→リトライ／DLQ に乗る。エラー通知（`reportErrorEvent`）は best-effort 化し、通知失敗が throw を握り潰さないようにした。
3. **`skippedUsers` カウンタの是正**: `compressConversation` の戻り値を `'compressed' | 'skipped'` 化し、batch usecase で `learn-user-activity` と同じ流儀で集計。メッセージなしユーザーが `processedUsers` に誤計上されていた問題を解消。

なお Issue 記載のデッドコード（`const before = {...result}; void before;`）は、既存リファクタ（バッチのユーザー×キャラ単位処理対応）で既に解消済みのため対象外。

## 関連 Issue

Issue #3523（サブ Issue のため自動クローズはせず、dev 反映確認後に手動クローズ）

## 変更種別

- [x] バグ修正
- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（永続ドキュメントの更新は不要と判断）
- [ ] CI/CD 設定を追加・更新した（該当なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（tsc クリーン）

## テスト内容

- core（`compress-conversation.usecase.test.ts`）:
  - 戻り値 `'compressed' | 'skipped'` の検証
  - 冪等性: 完全成功後の再実行が `LastCompressedAt` 前進により no-op となり記憶を重複させないこと
  - **永久欠落防止**: `memoryRepo.put` 失敗時に `summaryRepo` の `LastCompressedAt` が前進しないこと（reject 検証）
- batch usecase（`compress-conversations.usecase.test.ts`）:
  - メッセージなしユーザーが `skippedUsers` に計上されること（従来 `processedUsers` 誤計上を修正）
  - `processedUsers` / `skippedUsers` 混在ケース
- batch handler（`compress-conversations.test.ts`）:
  - 致命的エラー時に throw すること（従来「500 を返す」から変更）
  - 部分失敗（`failedUsers > 0`）時に throw し `reportErrorEvent` を呼ぶこと
- テスト結果: livetalk-core 全 1095 件パス / livetalk-batch 全 67 件パス、カバレッジ閾値（80%）超過。tsc クリーン。

## レビューポイント

- **書き込み順序の入れ替え**（`compress-conversation.usecase.ts`）が意図どおり「memory put 群 → summary put」になっているか。best-effort 処理（メトリクス・興味カテゴリ・親密度）は `summaryRepo.put` 後のままで、fail-warn のため checkpoint 前進を妨げない。
- **handler の throw セマンティクス**: EventBridge 非同期＋DLQ 前提。DLQ 実機での配送確認は本 PR の範囲外（AWS 非同期挙動＋既存 CDK 配線で担保）。マージ後に dev 環境で別途オペ確認予定。
- 重複許容のトレードオフ（at-least-once）に同意いただけるか。完全な exactly-once（決定的 MemoryID）は必要なら別 Issue。

## 補足事項

fresh-eyes レビュー（Opus）の指摘を反映済み（通知失敗のマスキング解消・冪等性コメントの正確化・`result` 型明示）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ2e28RQZrtBY5dZsbeDpM)_