### PR TITLE
リブトーク: LLM 呼び出しのリトライ戦略を共有モジュールで統一する

### DIFF
--- a/services/livetalk/core/src/lib/llm-retry.ts
+++ b/services/livetalk/core/src/lib/llm-retry.ts
@@ -1,0 +1,114 @@
+import OpenAI from 'openai';
+import { withRetry } from '@nagiyu/common';
+
+/**
+ * LLM 呼び出し共通のリトライ設定。
+ *
+ * 最大 3 回リトライし、初回待機 1 秒から指数バックオフ（倍率 2）で増加する。
+ */
+export const LLM_RETRY_OPTIONS = {
+  maxRetries: 3,
+  initialDelayMs: 1000,
+  backoffMultiplier: 2,
+} as const;
+
+/**
+ * LLM リトライモジュール内のエラーメッセージ定数。
+ */
+export const LLM_RETRY_ERROR_MESSAGES = {
+  TIMEOUT: 'LLM API 呼び出しがタイムアウトしました',
+} as const;
+
+/**
+ * 自前タイムアウトを一過性エラーとして識別するためのエラークラス。
+ *
+ * `isRetryableLLMError` はこのクラスのインスタンスをリトライ対象と判定する。
+ */
+export class LLMTimeoutError extends Error {
+  /** エラー種別の識別子（`'LLMTimeoutError'`）。 */
+  public override readonly name = 'LLMTimeoutError';
+
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * 一過性エラーかどうかを判定する。
+ *
+ * OpenAI SDK の既定リトライ意味論に準拠し、以下を一過性（リトライ可能）と判定する：
+ * - `LLMTimeoutError`（自前タイムアウト）
+ * - `OpenAI.APIConnectionError`（接続エラー・接続タイムアウト。`APIConnectionTimeoutError` を含む）
+ * - `OpenAI.APIError` で `status` が `408 | 409 | 429 | 500+`
+ *
+ * それ以外（`400 | 401 | 403 | 404`、自前バリデーションエラー等）は恒久的エラーとして false を返す。
+ */
+export function isRetryableLLMError(error: Error): boolean {
+  // 自前タイムアウトは一過性
+  if (error instanceof LLMTimeoutError) {
+    return true;
+  }
+
+  // 接続エラー（APIConnectionTimeoutError も含む）は一過性
+  // APIConnectionError は status が undefined のため、APIError の前に判定する
+  if (error instanceof OpenAI.APIConnectionError) {
+    return true;
+  }
+
+  // HTTP ステータスコードによる判定
+  if (error instanceof OpenAI.APIError) {
+    const { status } = error;
+    if (typeof status !== 'number') {
+      // status が undefined（APIUserAbortError 等）は対象外
+      return false;
+    }
+    return status === 408 || status === 409 || status === 429 || status >= 500;
+  }
+
+  // 上記以外（恒久的エラー・自前バリデーションエラー等）
+  return false;
+}
+
+/**
+ * 指定のタイムアウト時間内に Promise が解決しなければ `LLMTimeoutError` を throw する。
+ *
+ * `clearTimeout` は finally で確実に実行する。
+ *
+ * @param promise - 待機対象の Promise
+ * @param timeoutMs - タイムアウトまでのミリ秒
+ * @param message - タイムアウト時のエラーメッセージ（省略時は {@link LLM_RETRY_ERROR_MESSAGES.TIMEOUT}）
+ */
+export async function withLLMTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string = LLM_RETRY_ERROR_MESSAGES.TIMEOUT
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new LLMTimeoutError(message));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+/**
+ * LLM API 呼び出しを一過性エラーに対してリトライする薄いラッパー関数。
+ *
+ * `LLM_RETRY_OPTIONS` と `isRetryableLLMError` を使って `withRetry` を呼び出す。
+ * 恒久的エラー（`400`, `401`, `403`, `404` 等）は即時 throw される。
+ *
+ * @param fn - リトライ対象の非同期処理
+ */
+export function withLLMRetry<T>(fn: () => Promise<T>): Promise<T> {
+  return withRetry(fn, { ...LLM_RETRY_OPTIONS, shouldRetry: isRetryableLLMError });
+}

--- a/services/livetalk/core/src/llm-client/openai-client.ts
+++ b/services/livetalk/core/src/llm-client/openai-client.ts
@@ -18,6 +18,7 @@ import type {
   SummarizeResult,
 } from './types.js';
 import { SummarizeResultSchema } from './schemas/summarize.schema.js';
+import { withLLMRetry } from '../lib/llm-retry.js';
 
 /**
  * OpenAI 実装の用途別既定モデル（GPT-5 系）。
@@ -57,7 +58,9 @@ export interface OpenAIClientOptions {
  * - ストリーミング: `stream: true` で `response.output_text.delta` イベントから text delta を yield
  * - 一括: `response.output_text` をそのまま返す
  *
- * リトライは行わない（呼び出し側の責務）。`new OpenAI` 既定のリトライも `maxRetries: 0` で無効化する。
+ * 非ストリーミング呼び出し（`chatComplete` / `chatStructured`）は `withLLMRetry` で一過性エラー
+ * （rate limit, timeout 等）をリトライする。ストリーミング（`chatStream`）は出力重複防止のため
+ * リトライ対象外とする。SDK 自動リトライは `maxRetries: 0` で無効化し、アプリ側で一元管理する。
  */
 export class OpenAIClient implements ILLMClient {
   private readonly client: OpenAI;
@@ -97,13 +100,15 @@ export class OpenAIClient implements ILLMClient {
 
   public async chatComplete(messages: ChatMessage[], options: ChatOptions = {}): Promise<string> {
     this.assertMessages(messages);
-    const response = (await this.client.responses.create({
-      model: this.resolveModel(options),
-      stream: false,
-      input: messages.map(toEasyInputMessage),
-      temperature: options.temperature,
-      max_output_tokens: options.maxTokens,
-    })) as Response;
+    const response = (await withLLMRetry(() =>
+      this.client.responses.create({
+        model: this.resolveModel(options),
+        stream: false,
+        input: messages.map(toEasyInputMessage),
+        temperature: options.temperature,
+        max_output_tokens: options.maxTokens,
+      })
+    )) as Response;
     return response.output_text ?? '';
   }
 
@@ -113,14 +118,16 @@ export class OpenAIClient implements ILLMClient {
     options: ChatOptions = {}
   ): Promise<z.infer<T>> {
     this.assertMessages(messages);
-    const response = await this.client.responses.parse({
-      model: this.resolveModel(options),
-      stream: false,
-      input: messages.map(toEasyInputMessage),
-      temperature: options.temperature,
-      max_output_tokens: options.maxTokens,
-      text: { format: zodTextFormat(schema, 'structured_output') },
-    });
+    const response = await withLLMRetry(() =>
+      this.client.responses.parse({
+        model: this.resolveModel(options),
+        stream: false,
+        input: messages.map(toEasyInputMessage),
+        temperature: options.temperature,
+        max_output_tokens: options.maxTokens,
+        text: { format: zodTextFormat(schema, 'structured_output') },
+      })
+    );
 
     if (response.output_parsed === null || response.output_parsed === undefined) {
       throw new Error(OPENAI_ERROR_MESSAGES.REFUSAL);
@@ -327,10 +334,12 @@ export class OpenAIEmbeddingClient implements IEmbeddingClient {
     if (!trimmed) {
       throw new Error(OPENAI_EMBEDDING_ERROR_MESSAGES.EMPTY_TEXT);
     }
-    const response = await this.client.embeddings.create({
-      model: this.model,
-      input: trimmed,
-    });
+    const response = await withLLMRetry(() =>
+      this.client.embeddings.create({
+        model: this.model,
+        input: trimmed,
+      })
+    );
     return response.data[0].embedding;
   }
 }

--- a/services/livetalk/core/src/openai-voice/openai-voice-client.ts
+++ b/services/livetalk/core/src/openai-voice/openai-voice-client.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 import type { IVoiceClient, VoiceConfig } from '../voice/types.js';
 import type { OpenAIVoiceClientOptions } from './types.js';
+import { withLLMRetry } from '../lib/llm-retry.js';
 
 /**
  * OpenAI TTS クライアント周りのエラーメッセージ（日本語、定数化）。
@@ -20,7 +21,9 @@ const DEFAULT_VOICE = 'alloy';
  * - `audio.speech.create` で MP3 バイナリを取得し、ArrayBuffer として返す。
  * - `voice.provider === 'openai'` の場合のみ voice / instructions / model を解釈する。
  *   それ以外（voicevox 等）は既定値で合成する（VoicevoxClient と同じ寛容さ）。
- * - リトライは行わない（呼び出し側の責務）。maxRetries: 0 を設定する。
+ * - `synthesize` は `withLLMRetry` で一過性エラー（rate limit, timeout 等）をリトライする。
+ *   全敗した場合は `SYNTHESIS_FAILED` エラーでラップして throw する。
+ * - SDK 自動リトライは `maxRetries: 0` で無効化し、アプリ側で一元管理する。
  */
 export class OpenAIVoiceClient implements IVoiceClient {
   private readonly client: OpenAI;
@@ -67,7 +70,7 @@ export class OpenAIVoiceClient implements IVoiceClient {
         (requestParams as any).instructions = resolvedInstructions;
       }
 
-      const response = await this.client.audio.speech.create(requestParams);
+      const response = await withLLMRetry(() => this.client.audio.speech.create(requestParams));
       return response.arrayBuffer();
     } catch (error) {
       throw new Error(OPENAI_VOICE_ERROR_MESSAGES.SYNTHESIS_FAILED, { cause: error });

--- a/services/livetalk/core/src/research/openai-research-client.ts
+++ b/services/livetalk/core/src/research/openai-research-client.ts
@@ -1,12 +1,11 @@
 import OpenAI from 'openai';
 import { zodTextFormat } from 'openai/helpers/zod';
 import { z } from 'zod';
-import { withRetry } from '@nagiyu/common';
 import type { CharacterDefinition } from '../characters/types.js';
 import type { IResearchClient, ResearchResult } from './types.js';
+import { withLLMRetry, withLLMTimeout } from '../lib/llm-retry.js';
 
 const RESEARCH_MODEL = 'gpt-5-mini';
-const MAX_RETRIES = 3;
 const REQUEST_TIMEOUT_MS = 120_000;
 
 export const RESEARCH_ERROR_MESSAGES = {
@@ -45,30 +44,29 @@ export class OpenAIResearchClient implements IResearchClient {
   }
 
   public async research(query: string, character: CharacterDefinition): Promise<ResearchResult> {
-    const response = await withRetry(
-      async () =>
-        withTimeout(
-          this.client.responses.parse({
-            model: this.model,
-            stream: false,
-            tools: [{ type: 'web_search' }],
-            tool_choice: 'required',
-            text: { format: zodTextFormat(researchResultSchema, 'livetalk_research') },
-            input: [
-              {
-                role: 'user',
-                content: [
-                  {
-                    type: 'input_text',
-                    text: buildPrompt(query, character),
-                  },
-                ],
-              },
-            ],
-          }),
-          REQUEST_TIMEOUT_MS
-        ),
-      { maxRetries: MAX_RETRIES }
+    const response = await withLLMRetry(() =>
+      withLLMTimeout(
+        this.client.responses.parse({
+          model: this.model,
+          stream: false,
+          tools: [{ type: 'web_search' }],
+          tool_choice: 'required',
+          text: { format: zodTextFormat(researchResultSchema, 'livetalk_research') },
+          input: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'input_text',
+                  text: buildPrompt(query, character),
+                },
+              ],
+            },
+          ],
+        }),
+        REQUEST_TIMEOUT_MS,
+        RESEARCH_ERROR_MESSAGES.TIMEOUT
+      )
     );
 
     if (!response.output_parsed) {
@@ -94,23 +92,4 @@ function buildPrompt(query: string, character: CharacterDefinition): string {
     '- sourceUrls: 参照した URL のリスト（空の場合は空配列）',
     `- rawComment: ${character.displayName} として一言コメント（50〜100 文字、上記の口調で）`,
   ].join('\n');
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          reject(new Error(RESEARCH_ERROR_MESSAGES.TIMEOUT));
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  }
 }

--- a/services/livetalk/core/src/safety/moderation.ts
+++ b/services/livetalk/core/src/safety/moderation.ts
@@ -10,6 +10,7 @@
 
 import OpenAI from 'openai';
 import type { IModerationClient, ModerationResult } from './types.js';
+import { withLLMRetry } from '../lib/llm-retry.js';
 
 export const MODERATION_ERROR_MESSAGES = {
   EMPTY_API_KEY: 'OpenAI API キーが指定されていません',
@@ -32,6 +33,7 @@ export interface OpenAIModerationClientOptions {
 /**
  * OpenAI Moderation API を {@link IModerationClient} 形にラップする実装。
  *
+ * `check` メソッドは `withLLMRetry` で一過性エラー（rate limit, timeout 等）をリトライする。
  * API エラー・タイムアウト時は Error を throw する（呼び出し側で fail-warn ハンドリング）。
  */
 export class OpenAIModerationClient implements IModerationClient {
@@ -56,10 +58,12 @@ export class OpenAIModerationClient implements IModerationClient {
       throw new Error(MODERATION_ERROR_MESSAGES.EMPTY_TEXT);
     }
 
-    const response = await this.client.moderations.create({
-      input: trimmed,
-      model: this.model,
-    });
+    const response = await withLLMRetry(() =>
+      this.client.moderations.create({
+        input: trimmed,
+        model: this.model,
+      })
+    );
 
     const result = response.results[0];
     if (!result) {

--- a/services/livetalk/core/tests/unit/lib/llm-retry.test.ts
+++ b/services/livetalk/core/tests/unit/lib/llm-retry.test.ts
@@ -1,0 +1,254 @@
+import OpenAI from 'openai';
+import {
+  LLM_RETRY_OPTIONS,
+  LLMTimeoutError,
+  isRetryableLLMError,
+  withLLMTimeout,
+  withLLMRetry,
+} from '../../../src/lib/llm-retry.js';
+
+/** OpenAI エラー生成用ヘルパー（headers の get メソッドを持つ最低限のモック） */
+const headersLike = { get: () => null } as unknown as Headers;
+
+/** APIError を指定ステータスで生成する */
+function makeAPIError(status: number): InstanceType<typeof OpenAI.APIError> {
+  return new OpenAI.APIError(status, { message: `HTTP ${status}` }, `HTTP ${status}`, headersLike);
+}
+
+describe('LLM_RETRY_OPTIONS', () => {
+  it('maxRetries が 3 である', () => {
+    expect(LLM_RETRY_OPTIONS.maxRetries).toBe(3);
+  });
+
+  it('initialDelayMs が 1000 である', () => {
+    expect(LLM_RETRY_OPTIONS.initialDelayMs).toBe(1000);
+  });
+
+  it('backoffMultiplier が 2 である', () => {
+    expect(LLM_RETRY_OPTIONS.backoffMultiplier).toBe(2);
+  });
+});
+
+describe('LLMTimeoutError', () => {
+  it('Error のインスタンスである', () => {
+    const err = new LLMTimeoutError('タイムアウト');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('LLMTimeoutError のインスタンスである', () => {
+    const err = new LLMTimeoutError('タイムアウト');
+    expect(err).toBeInstanceOf(LLMTimeoutError);
+  });
+
+  it('name が "LLMTimeoutError" である', () => {
+    const err = new LLMTimeoutError('タイムアウト');
+    expect(err.name).toBe('LLMTimeoutError');
+  });
+
+  it('メッセージが正しく設定される', () => {
+    const err = new LLMTimeoutError('テストメッセージ');
+    expect(err.message).toBe('テストメッセージ');
+  });
+});
+
+describe('isRetryableLLMError', () => {
+  describe('リトライ可能なエラー', () => {
+    it('LLMTimeoutError は true を返す', () => {
+      expect(isRetryableLLMError(new LLMTimeoutError('timeout'))).toBe(true);
+    });
+
+    it('APIConnectionError は true を返す', () => {
+      const err = new OpenAI.APIConnectionError({
+        message: '接続エラー',
+        cause: new Error('原因'),
+      });
+      expect(isRetryableLLMError(err)).toBe(true);
+    });
+
+    it('APIConnectionTimeoutError は true を返す（APIConnectionError のサブクラス）', () => {
+      const err = new OpenAI.APIConnectionTimeoutError({ message: 'request timed out' });
+      expect(isRetryableLLMError(err)).toBe(true);
+    });
+
+    it('APIError status 408 は true を返す', () => {
+      expect(isRetryableLLMError(makeAPIError(408))).toBe(true);
+    });
+
+    it('APIError status 409 は true を返す', () => {
+      expect(isRetryableLLMError(new OpenAI.ConflictError(409, {}, '', headersLike))).toBe(true);
+    });
+
+    it('APIError status 429 は true を返す', () => {
+      expect(
+        isRetryableLLMError(new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike))
+      ).toBe(true);
+    });
+
+    it('APIError status 500 は true を返す', () => {
+      expect(
+        isRetryableLLMError(new OpenAI.InternalServerError(500, {}, 'internal', headersLike))
+      ).toBe(true);
+    });
+
+    it('APIError status 503 は true を返す', () => {
+      expect(isRetryableLLMError(makeAPIError(503))).toBe(true);
+    });
+  });
+
+  describe('リトライ不可なエラー', () => {
+    it('APIError status 400 は false を返す', () => {
+      expect(isRetryableLLMError(new OpenAI.BadRequestError(400, {}, 'bad', headersLike))).toBe(
+        false
+      );
+    });
+
+    it('APIError status 401 は false を返す', () => {
+      expect(
+        isRetryableLLMError(new OpenAI.AuthenticationError(401, {}, 'unauth', headersLike))
+      ).toBe(false);
+    });
+
+    it('APIError status 403 は false を返す', () => {
+      expect(
+        isRetryableLLMError(new OpenAI.PermissionDeniedError(403, {}, 'forbidden', headersLike))
+      ).toBe(false);
+    });
+
+    it('APIError status 404 は false を返す', () => {
+      expect(isRetryableLLMError(new OpenAI.NotFoundError(404, {}, 'not found', headersLike))).toBe(
+        false
+      );
+    });
+
+    it('APIUserAbortError（status が undefined の APIError）は false を返す', () => {
+      // APIUserAbortError は APIError のサブクラスだが status が undefined
+      const err = new OpenAI.APIUserAbortError();
+      expect(isRetryableLLMError(err)).toBe(false);
+    });
+
+    it('無関係な Error は false を返す', () => {
+      expect(isRetryableLLMError(new Error('一般的なエラー'))).toBe(false);
+    });
+  });
+});
+
+describe('withLLMTimeout', () => {
+  it('タイムアウト前に解決すれば値を返す', async () => {
+    const promise = Promise.resolve('成功');
+    const result = await withLLMTimeout(promise, 5000, 'タイムアウト');
+    expect(result).toBe('成功');
+  });
+
+  it('タイムアウトを超えると LLMTimeoutError を throw する', async () => {
+    jest.useFakeTimers();
+    try {
+      const neverResolves = new Promise<string>(() => {
+        // 永遠に解決しない
+      });
+
+      // 先に catch を登録してから timer を進める（unhandled rejection を防ぐ）
+      const resultPromise = withLLMTimeout(neverResolves, 3000, 'テストタイムアウト');
+      const caughtPromise = resultPromise.catch((err: unknown) => err);
+
+      // タイマーを全て消化してタイムアウトを発火させる
+      await jest.runAllTimersAsync();
+
+      const caughtError = await caughtPromise;
+      expect(caughtError).toBeInstanceOf(LLMTimeoutError);
+      expect((caughtError as Error).message).toBe('テストタイムアウト');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('タイムアウト時のエラーは LLMTimeoutError のインスタンスである', async () => {
+    jest.useFakeTimers();
+    try {
+      const neverResolves = new Promise<string>(() => {});
+      const resultPromise = withLLMTimeout(neverResolves, 1000, 'タイムアウト');
+      const caughtPromise = resultPromise.catch((err: unknown) => err);
+
+      await jest.runAllTimersAsync();
+
+      const caughtError = await caughtPromise;
+      expect(caughtError).toBeInstanceOf(LLMTimeoutError);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('Promise が先に reject した場合はそのエラーを伝播する', async () => {
+    const failingPromise = Promise.reject(new Error('API エラー'));
+    await expect(withLLMTimeout(failingPromise, 5000, 'タイムアウト')).rejects.toThrow(
+      'API エラー'
+    );
+  });
+});
+
+describe('withLLMRetry', () => {
+  it('最初の呼び出しで成功すれば fn が 1 回だけ呼ばれ値を返す', async () => {
+    const fn = jest.fn().mockResolvedValue('結果');
+    const result = await withLLMRetry(fn);
+    expect(result).toBe('結果');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('恒久的エラー（status 400）は即時 reject かつ fn が 1 回だけ呼ばれる', async () => {
+    const badRequestError = new OpenAI.BadRequestError(400, {}, 'bad request', headersLike);
+    const fn = jest.fn().mockRejectedValue(badRequestError);
+
+    await expect(withLLMRetry(fn)).rejects.toThrow(badRequestError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('恒久的エラー（status 401）は即時 reject かつ fn が 1 回だけ呼ばれる', async () => {
+    const authError = new OpenAI.AuthenticationError(401, {}, 'unauthorized', headersLike);
+    const fn = jest.fn().mockRejectedValue(authError);
+
+    await expect(withLLMRetry(fn)).rejects.toThrow(authError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('一過性エラー後に成功すれば最終的に値を返す（fn が複数回呼ばれる）', async () => {
+    jest.useFakeTimers();
+    try {
+      const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+      const fn = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValue('成功');
+
+      const resultPromise = withLLMRetry(fn);
+      // タイマーを全て消化して microtask も flush する
+      await jest.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toBe('成功');
+      expect(fn).toHaveBeenCalledTimes(3);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('最大リトライ回数を超えると最後のエラーで reject する', async () => {
+    jest.useFakeTimers();
+    try {
+      const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+      // maxRetries が 3 なので 4 回呼ばれる（初回 + 3 回リトライ）
+      const fn = jest.fn().mockRejectedValue(rateLimitError);
+
+      const resultPromise = withLLMRetry(fn);
+      // 先に catch を登録してから timer を進める（unhandled rejection を防ぐ）
+      const caughtPromise = resultPromise.catch((err: unknown) => err);
+      // タイマーを全て消化して全リトライを完了させる
+      await jest.runAllTimersAsync();
+
+      const caughtError = await caughtPromise;
+      expect(caughtError).toBeInstanceOf(OpenAI.RateLimitError);
+      expect(fn).toHaveBeenCalledTimes(4);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/services/livetalk/core/tests/unit/llm-client/openai-client.test.ts
+++ b/services/livetalk/core/tests/unit/llm-client/openai-client.test.ts
@@ -8,6 +8,9 @@ import {
 import type { ChatMessage, SummarizeInput } from '../../../src/llm-client/types.js';
 import { z } from 'zod';
 
+/** OpenAI エラー生成用ヘルパー */
+const headersLike = { get: () => null } as unknown as Headers;
+
 function makeStreamEvents(deltas: Array<string | null>): AsyncIterable<unknown> {
   return {
     async *[Symbol.asyncIterator]() {
@@ -166,6 +169,18 @@ describe('OpenAIClient', () => {
       const iterator = livetalk.chatStream([])[Symbol.asyncIterator]();
       await expect(iterator.next()).rejects.toThrow(OPENAI_ERROR_MESSAGES.EMPTY_MESSAGES);
     });
+
+    it('429 エラーでもリトライしない（ストリーミングはリトライ対象外）', async () => {
+      const { client, create } = makeMockOpenAI();
+      const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+      create.mockRejectedValue(rateLimitError);
+
+      const livetalk = new OpenAIClient({ client });
+      const iterator = livetalk.chatStream(messages)[Symbol.asyncIterator]();
+      await expect(iterator.next()).rejects.toThrow(rateLimitError);
+      // ストリーミングはリトライしないため 1 回だけ呼ばれる
+      expect(create).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('chatComplete', () => {
@@ -195,6 +210,39 @@ describe('OpenAIClient', () => {
       const livetalk = new OpenAIClient({ client });
 
       await expect(livetalk.chatComplete([])).rejects.toThrow(OPENAI_ERROR_MESSAGES.EMPTY_MESSAGES);
+    });
+
+    describe('リトライ動作', () => {
+      it('429 エラー後に成功すれば値を返す（一過性エラーはリトライされる）', async () => {
+        jest.useFakeTimers();
+        try {
+          const { client, create } = makeMockOpenAI();
+          const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+          create
+            .mockRejectedValueOnce(rateLimitError)
+            .mockResolvedValue({ output_text: 'リトライ成功' });
+
+          const livetalk = new OpenAIClient({ client });
+          const resultPromise = livetalk.chatComplete(messages);
+          await jest.runAllTimersAsync();
+          const result = await resultPromise;
+
+          expect(result).toBe('リトライ成功');
+          expect(create).toHaveBeenCalledTimes(2);
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it('400 エラーは即時 throw（恒久的エラーはリトライしない）', async () => {
+        const { client, create } = makeMockOpenAI();
+        const badRequestError = new OpenAI.BadRequestError(400, {}, 'bad request', headersLike);
+        create.mockRejectedValue(badRequestError);
+
+        const livetalk = new OpenAIClient({ client });
+        await expect(livetalk.chatComplete(messages)).rejects.toThrow(badRequestError);
+        expect(create).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
@@ -242,6 +290,29 @@ describe('OpenAIClient', () => {
       await expect(livetalk.chatStructured([], testSchema)).rejects.toThrow(
         OPENAI_ERROR_MESSAGES.EMPTY_MESSAGES
       );
+    });
+
+    describe('リトライ動作', () => {
+      it('429 エラー後に成功すれば output_parsed を返す（一過性エラーはリトライされる）', async () => {
+        jest.useFakeTimers();
+        try {
+          const { client, parse } = makeMockOpenAI();
+          const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+          parse
+            .mockRejectedValueOnce(rateLimitError)
+            .mockResolvedValue({ output_parsed: { value: 'リトライ成功', count: 1 } });
+
+          const livetalk = new OpenAIClient({ client });
+          const resultPromise = livetalk.chatStructured(messages, testSchema);
+          await jest.runAllTimersAsync();
+          const result = await resultPromise;
+
+          expect(result).toEqual({ value: 'リトライ成功', count: 1 });
+          expect(parse).toHaveBeenCalledTimes(2);
+        } finally {
+          jest.useRealTimers();
+        }
+      });
     });
   });
 

--- a/services/livetalk/core/tests/unit/llm-client/openai-embedding-client.test.ts
+++ b/services/livetalk/core/tests/unit/llm-client/openai-embedding-client.test.ts
@@ -5,6 +5,9 @@ import {
   OPENAI_EMBEDDING_ERROR_MESSAGES,
 } from '../../../src/llm-client/openai-client.js';
 
+/** OpenAI エラー生成用ヘルパー */
+const headersLike = { get: () => null } as unknown as Headers;
+
 function makeMockOpenAI(): { client: OpenAI; create: jest.Mock } {
   const create = jest.fn();
   const client = {
@@ -67,6 +70,30 @@ describe('OpenAIEmbeddingClient', () => {
       await cli.embed('  テスト  ');
 
       expect(create.mock.calls[0][0].input).toBe('テスト');
+    });
+
+    describe('リトライ動作', () => {
+      it('429 エラー後に成功すれば embedding を返す（一過性エラーはリトライされる）', async () => {
+        jest.useFakeTimers();
+        try {
+          const { client, create } = makeMockOpenAI();
+          const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+          const mockVec = [0.1, 0.2, 0.3];
+          create
+            .mockRejectedValueOnce(rateLimitError)
+            .mockResolvedValue({ data: [{ embedding: mockVec }] });
+
+          const cli = new OpenAIEmbeddingClient({ client });
+          const resultPromise = cli.embed('テスト');
+          await jest.runAllTimersAsync();
+          const result = await resultPromise;
+
+          expect(result).toEqual(mockVec);
+          expect(create).toHaveBeenCalledTimes(2);
+        } finally {
+          jest.useRealTimers();
+        }
+      });
     });
   });
 });

--- a/services/livetalk/core/tests/unit/openai-voice/openai-voice-client.test.ts
+++ b/services/livetalk/core/tests/unit/openai-voice/openai-voice-client.test.ts
@@ -4,6 +4,9 @@ import {
   OPENAI_VOICE_ERROR_MESSAGES,
 } from '../../../src/openai-voice/openai-voice-client.js';
 
+/** OpenAI エラー生成用ヘルパー */
+const headersLike = { get: () => null } as unknown as Headers;
+
 /**
  * OpenAI TTS クライアント用モックファクトリ。
  * audio.speech.create の呼び出しを記録し、任意の応答を返す。
@@ -236,6 +239,59 @@ describe('OpenAIVoiceClient', () => {
           expect(err).toBeInstanceOf(Error);
           expect((err as Error & { cause?: unknown }).cause).toBe(originalError);
         }
+      });
+
+      describe('リトライ動作', () => {
+        it('429 エラー後に成功すれば ArrayBuffer を返す（一過性エラーはリトライされる）', async () => {
+          jest.useFakeTimers();
+          try {
+            const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+            const expected = new ArrayBuffer(16);
+            const create = jest
+              .fn()
+              .mockRejectedValueOnce(rateLimitError)
+              .mockResolvedValue({ arrayBuffer: async () => expected });
+            const client = {
+              audio: { speech: { create } },
+            } as unknown as OpenAI;
+
+            const ttsClient = new OpenAIVoiceClient({ client });
+            const resultPromise = ttsClient.synthesize('テスト');
+            await jest.runAllTimersAsync();
+            const result = await resultPromise;
+
+            expect(result).toBe(expected);
+            expect(create).toHaveBeenCalledTimes(2);
+          } finally {
+            jest.useRealTimers();
+          }
+        });
+
+        it('全リトライ失敗後は SYNTHESIS_FAILED エラーで wrap され cause に元エラーを含む', async () => {
+          jest.useFakeTimers();
+          try {
+            const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+            const create = jest.fn().mockRejectedValue(rateLimitError);
+            const client = {
+              audio: { speech: { create } },
+            } as unknown as OpenAI;
+
+            const ttsClient = new OpenAIVoiceClient({ client });
+            const resultPromise = ttsClient.synthesize('テスト');
+            // 先に catch を登録してから timer を進める（unhandled rejection を防ぐ）
+            const caughtPromise = resultPromise.catch((err: unknown) => err);
+            // 全リトライを消化する
+            await jest.runAllTimersAsync();
+
+            const caughtErr = await caughtPromise;
+            expect((caughtErr as Error).message).toBe(OPENAI_VOICE_ERROR_MESSAGES.SYNTHESIS_FAILED);
+            expect((caughtErr as Error & { cause?: unknown }).cause).toBeInstanceOf(
+              OpenAI.RateLimitError
+            );
+          } finally {
+            jest.useRealTimers();
+          }
+        });
       });
     });
   });

--- a/services/livetalk/core/tests/unit/research/openai-research-client.test.ts
+++ b/services/livetalk/core/tests/unit/research/openai-research-client.test.ts
@@ -5,6 +5,9 @@ import {
 } from '../../../src/research/openai-research-client.js';
 import type { CharacterDefinition } from '../../../src/characters/types.js';
 
+/** OpenAI エラー生成用ヘルパー */
+const headersLike = { get: () => null } as unknown as Headers;
+
 const character: CharacterDefinition = {
   id: 'hiyori',
   displayName: '桃瀬ひより',
@@ -61,5 +64,45 @@ describe('OpenAIResearchClient', () => {
         tool_choice: 'required',
       })
     );
+  });
+
+  describe('リトライ動作', () => {
+    it('429 エラー後に成功すれば ResearchResult を返す（一過性エラーはリトライされる）', async () => {
+      jest.useFakeTimers();
+      try {
+        const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+        const expected = {
+          topic: 'コーヒー',
+          summary: 'コーヒーの説明。'.repeat(10),
+          sourceUrls: ['https://example.com'],
+          rawComment: 'コメント',
+        };
+        const mockParse = jest
+          .fn()
+          .mockRejectedValueOnce(rateLimitError)
+          .mockResolvedValue({ output_parsed: expected });
+        const mockClient = { responses: { parse: mockParse } } as unknown as OpenAI;
+
+        const researchClient = new OpenAIResearchClient({ client: mockClient });
+        const resultPromise = researchClient.research('コーヒー', character);
+        await jest.runAllTimersAsync();
+        const result = await resultPromise;
+
+        expect(result).toEqual(expected);
+        expect(mockParse).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('恒久的エラー（401）は即時 throw（リトライしない）', async () => {
+      const authError = new OpenAI.AuthenticationError(401, {}, 'unauthorized', headersLike);
+      const mockParse = jest.fn().mockRejectedValue(authError);
+      const mockClient = { responses: { parse: mockParse } } as unknown as OpenAI;
+
+      const researchClient = new OpenAIResearchClient({ client: mockClient });
+      await expect(researchClient.research('テスト', character)).rejects.toThrow(authError);
+      expect(mockParse).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/services/livetalk/core/tests/unit/safety/moderation.test.ts
+++ b/services/livetalk/core/tests/unit/safety/moderation.test.ts
@@ -5,6 +5,9 @@ import {
   MODERATION_ERROR_MESSAGES,
 } from '../../../src/safety/moderation.js';
 
+/** OpenAI エラー生成用ヘルパー */
+const headersLike = { get: () => null } as unknown as Headers;
+
 // OpenAI クライアントのモック
 function makeOpenAIClient(flagged: boolean, categories: Record<string, boolean> = {}): OpenAI {
   return {
@@ -83,6 +86,46 @@ describe('OpenAIModerationClient', () => {
       } as unknown as OpenAI;
       const mod = new OpenAIModerationClient({ client: emptyClient });
       await expect(mod.check('テスト')).rejects.toThrow(MODERATION_ERROR_MESSAGES.API_FAILED);
+    });
+
+    describe('リトライ動作', () => {
+      it('429 エラー後に成功すれば ModerationResult を返す（一過性エラーはリトライされる）', async () => {
+        jest.useFakeTimers();
+        try {
+          const rateLimitError = new OpenAI.RateLimitError(429, {}, 'rate limit', headersLike);
+          const createFn = jest
+            .fn()
+            .mockRejectedValueOnce(rateLimitError)
+            .mockResolvedValue({
+              results: [{ flagged: false, categories: {} }],
+            });
+          const client = {
+            moderations: { create: createFn },
+          } as unknown as OpenAI;
+
+          const mod = new OpenAIModerationClient({ client });
+          const resultPromise = mod.check('テスト');
+          await jest.runAllTimersAsync();
+          const result = await resultPromise;
+
+          expect(result.flagged).toBe(false);
+          expect(createFn).toHaveBeenCalledTimes(2);
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it('401 エラーは即時 throw（恒久的エラーはリトライしない）', async () => {
+        const authError = new OpenAI.AuthenticationError(401, {}, 'unauthorized', headersLike);
+        const createFn = jest.fn().mockRejectedValue(authError);
+        const client = {
+          moderations: { create: createFn },
+        } as unknown as OpenAI;
+
+        const mod = new OpenAIModerationClient({ client });
+        await expect(mod.check('テスト')).rejects.toThrow(authError);
+        expect(createFn).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });


### PR DESCRIPTION
## 変更の概要

livetalk core の OpenAI 呼び出しのリトライ責務を共有モジュールに一元化し、コードベース全体で一貫させる。

これまで `withRetry`（`@nagiyu/common`）を適用していたのは research クライアントのみで、他のクライアントは `new OpenAI({ maxRetries: 0 })` で SDK 自動リトライを切ったまま「リトライは呼び出し側の責務」とコメントしつつ責務が宙に浮いていた。結果、一過性の rate limit / timeout がそのままユーザー処理失敗になっていた（バッチでは 1 回の 429 でそのユーザーが丸ごと failedUsers 行き）。

research パターンを横展開し、リトライ責務を「各クライアントのメソッド内（非ストリーミング呼び出し）」へ統一する。

### 実装内容

- **共有モジュール新設** `services/livetalk/core/src/lib/llm-retry.ts`
  - `LLM_RETRY_OPTIONS`（maxRetries: 3 / 初回 1s / 指数バックオフ倍率 2）の定数化
  - `isRetryableLLMError`: **一過性エラーのみ**リトライ（接続エラー・自前タイムアウト・HTTP 408/409/429/5xx）。恒久的エラー（400/401/403/404・abort）と自前バリデーションエラーは即時 throw
  - `withLLMRetry` / `withLLMTimeout` / `LLMTimeoutError`
- **適用**: `chatComplete` / `chatStructured`（= summarize）/ `embed` / `moderation.check` / `synthesize`
- **リトライ対象外**: `chatStream`（途中失敗の再試行は出力重複を招くため、理由をコメント明記）
- **research クライアント**: ローカルの `withTimeout` / inline `MAX_RETRIES` を廃止し共有モジュールへ移行（タイムアウト文言は維持）。これにより research のリトライ対象が「全エラー」から「一過性エラーのみ」へ改善

## 関連 Issue

#3524（親: #3521）

※ サブ Issue のため `Closes #` は使用せず、dev 反映確認後に手動クローズする。

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（永続ドキュメントへの反映は不要と判断。挙動はコード内 JSDoc で説明）
- [ ] CI/CD 設定を追加・更新した（該当なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（変更ファイルに型エラーなし。残る tsc エラーは `@nagiyu/common` の `web-push` 型欠落・未ビルド dist による既存環境起因で本変更とは無関係）

## テスト内容

- 新規 `tests/unit/lib/llm-retry.test.ts`: `isRetryableLLMError` の網羅（LLMTimeoutError / APIConnectionError / 408・409・429・5xx → リトライ、400・401・403・404・abort → 非リトライ）、`withLLMTimeout`、`withLLMRetry`（一過性は複数回呼び出し後に成功 / 恒久エラーは 1 回で throw）。fake timers で実時間待ちを回避
- 各クライアントのテスト追補: 429 リトライ後成功・恒久エラー即時 throw、`chatStream` はリトライされないこと、`synthesize` 全敗で `SYNTHESIS_FAILED`（cause 検証）
- 結果: **77 suites / 1136 tests すべてパス**。`llm-retry.ts` は行カバレッジ 100% / 分岐 92.85%、グローバルカバレッジも閾値 80% を大きく超過

## レビューポイント

- `isRetryableLLMError` のエラー判定順序: `instanceof OpenAI.APIConnectionError`（status undefined）を `APIError` 分岐より**前**に置く必要がある点（後ろだと接続エラーが status undefined で取りこぼされる）
- ストリーミング（`chatStream`）をリトライ対象外にした切り分けの妥当性
- research クライアントのリトライ対象が「全エラー」→「一過性エラーのみ」に変わる意図的な挙動変化

## 補足事項

fresh-eyes レビュー（別コンテキスト）で SDK エラー階層の判定・タイムアウト実装・research 移行の妥当性を確認済み。クリティカル・仕様確認要の指摘はなし。


---
_Generated by [Claude Code](https://claude.ai/code/session_011xhrCh5LNjtH5M2VDiJS3e)_