### PR TITLE
livetalk の監視・アラーム整備（DLQ / ALB / バッチ失敗検知）

### DIFF
--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -93,7 +93,8 @@ const cloudFrontStack = new LiveTalkCloudFrontStack(app, `NagiyuLiveTalkCloudFro
 // EventBridge 日次トリガー + Lambda + DLQ + IAM
 const openAiApiKey = app.node.tryGetContext('openAiApiKey') || 'PLACEHOLDER_OPENAI_API_KEY';
 const vapidPublicKey = app.node.tryGetContext('vapidPublicKey') || 'PLACEHOLDER_VAPID_PUBLIC_KEY';
-const vapidPrivateKey = app.node.tryGetContext('vapidPrivateKey') || 'PLACEHOLDER_VAPID_PRIVATE_KEY';
+const vapidPrivateKey =
+  app.node.tryGetContext('vapidPrivateKey') || 'PLACEHOLDER_VAPID_PRIVATE_KEY';
 
 new LiveTalkBatchStack(app, `NagiyuLiveTalkBatch${envSuffix}`, {
   env: stackEnv,

--- a/infra/livetalk/bin/livetalk.ts
+++ b/infra/livetalk/bin/livetalk.ts
@@ -9,6 +9,7 @@ import { LiveTalkEcsServiceStack } from '../lib/ecs-service-stack';
 import { LiveTalkCloudFrontStack } from '../lib/cloudfront-stack';
 import { LiveTalkSecretsStack } from '../lib/secrets-stack';
 import { LiveTalkBatchStack } from '../lib/batch-stack';
+import { LiveTalkAlarmsStack } from '../lib/alarms-stack';
 
 const app = new cdk.App();
 
@@ -106,6 +107,15 @@ new LiveTalkBatchStack(app, `NagiyuLiveTalkBatch${envSuffix}`, {
 // Batch stack は ECR リポジトリ名を `getEcrRepositoryName('livetalk-batch', env)` で
 // 決定論的に組み立てる（DynamoDB stack と同様に SSM もクロススタック参照も介さない）。
 // このため Batch ECR stack との deploy 順依存は発生しない。
+
+// LiveTalk CloudWatch アラームスタック（Issue #3526）
+// ALB ARN / Target Group ARN を SSM から読むため、ALB stack の後にデプロイされる必要がある
+const alarmsStack = new LiveTalkAlarmsStack(app, `NagiyuLiveTalkAlarms${envSuffix}`, {
+  env: stackEnv,
+  environment,
+  description: `LiveTalk CloudWatch Alarms (${environment})`,
+});
+alarmsStack.addDependency(albStack);
 
 // SSM 経由の参照のため CDK は自動的にスタック間依存を検出できない。
 // 明示的に依存を宣言して deploy 順を保証する。

--- a/infra/livetalk/lib/alarms-stack.ts
+++ b/infra/livetalk/lib/alarms-stack.ts
@@ -208,7 +208,8 @@ export class LiveTalkAlarmsStack extends cdk.Stack {
     const dynamoTableName = getDynamoDBTableName('livetalk', environment);
     const dynamoThrottledAlarm = new cloudwatch.Alarm(this, 'DynamoDBThrottledAlarm', {
       alarmName: `livetalk-dynamodb-throttled-${environment}`,
-      alarmDescription: 'livetalk DynamoDB テーブルのスロットリングが発生している（5 分で 1 件以上）',
+      alarmDescription:
+        'livetalk DynamoDB テーブルのスロットリングが発生している（5 分で 1 件以上）',
       metric: new cloudwatch.Metric({
         namespace: 'AWS/DynamoDB',
         metricName: 'ThrottledRequests',

--- a/infra/livetalk/lib/alarms-stack.ts
+++ b/infra/livetalk/lib/alarms-stack.ts
@@ -1,0 +1,256 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as cwActions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { Environment, SSM_PARAMETERS, getDynamoDBTableName } from '@nagiyu/infra-common';
+
+export interface LiveTalkAlarmsStackProps extends cdk.StackProps {
+  environment: Environment;
+}
+
+/**
+ * LiveTalk CloudWatch アラームスタック（Issue #3526）
+ *
+ * バッチ Lambda エラー・バッチ DLQ 滞留・ALB 5xx・ターゲット異常・DynamoDB スロットリングを監視する。
+ * 通知先は admin 本流 SNS Topic（`nagiyu-admin-alarms-{env}`）。
+ */
+export class LiveTalkAlarmsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: LiveTalkAlarmsStackProps) {
+    super(scope, id, props);
+
+    const { environment } = props;
+
+    // 通知先 SNS Topic（admin 本流）
+    const topicArn = this.formatArn({
+      service: 'sns',
+      resource: `nagiyu-admin-alarms-${environment}`,
+    });
+    const topic = sns.Topic.fromTopicArn(this, 'AdminAlarmTopic', topicArn);
+    const action = new cwActions.SnsAction(topic);
+
+    // アラーム共通設定
+    const commonAlarmProps = {
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    };
+
+    // ---- (A) バッチ Lambda Errors（4本）----
+
+    const compressErrorAlarm = new cloudwatch.Alarm(this, 'CompressErrorsAlarm', {
+      alarmName: `livetalk-batch-compress-errors-${environment}`,
+      alarmDescription: '圧縮要約バッチ Lambda の例外発生（5 分間で 1 件以上）',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/Lambda',
+        metricName: 'Errors',
+        dimensionsMap: { FunctionName: `nagiyu-livetalk-batch-compress-${environment}` },
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    compressErrorAlarm.addAlarmAction(action);
+
+    const learnActivityErrorAlarm = new cloudwatch.Alarm(this, 'LearnActivityErrorsAlarm', {
+      alarmName: `livetalk-batch-learn-activity-errors-${environment}`,
+      alarmDescription: '学習バッチ Lambda の例外発生（5 分間で 1 件以上）',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/Lambda',
+        metricName: 'Errors',
+        dimensionsMap: {
+          FunctionName: `nagiyu-livetalk-batch-learn-user-activity-${environment}`,
+        },
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    learnActivityErrorAlarm.addAlarmAction(action);
+
+    const studyErrorAlarm = new cloudwatch.Alarm(this, 'StudyErrorsAlarm', {
+      alarmName: `livetalk-batch-study-errors-${environment}`,
+      alarmDescription: '勉強バッチ Lambda の例外発生（5 分間で 1 件以上）',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/Lambda',
+        metricName: 'Errors',
+        dimensionsMap: { FunctionName: `nagiyu-livetalk-batch-study-${environment}` },
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    studyErrorAlarm.addAlarmAction(action);
+
+    const notifyErrorAlarm = new cloudwatch.Alarm(this, 'NotifyErrorsAlarm', {
+      alarmName: `livetalk-batch-notify-errors-${environment}`,
+      alarmDescription: '通知バッチ Lambda の例外発生（5 分間で 1 件以上）',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/Lambda',
+        metricName: 'Errors',
+        dimensionsMap: { FunctionName: `nagiyu-livetalk-batch-notify-${environment}` },
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    notifyErrorAlarm.addAlarmAction(action);
+
+    // ---- (B) バッチ DLQ 滞留（4本）----
+
+    const compressDlqAlarm = new cloudwatch.Alarm(this, 'CompressDlqAlarm', {
+      alarmName: `livetalk-batch-compress-dlq-${environment}`,
+      alarmDescription: '圧縮要約バッチ DLQ にメッセージが滞留している',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/SQS',
+        metricName: 'ApproximateNumberOfMessagesVisible',
+        dimensionsMap: { QueueName: `nagiyu-livetalk-batch-dlq-${environment}` },
+        statistic: cloudwatch.Stats.MAXIMUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    compressDlqAlarm.addAlarmAction(action);
+
+    const learnActivityDlqAlarm = new cloudwatch.Alarm(this, 'LearnActivityDlqAlarm', {
+      alarmName: `livetalk-batch-learn-activity-dlq-${environment}`,
+      alarmDescription: '学習バッチ DLQ にメッセージが滞留している',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/SQS',
+        metricName: 'ApproximateNumberOfMessagesVisible',
+        dimensionsMap: { QueueName: `nagiyu-livetalk-learn-activity-dlq-${environment}` },
+        statistic: cloudwatch.Stats.MAXIMUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    learnActivityDlqAlarm.addAlarmAction(action);
+
+    const studyDlqAlarm = new cloudwatch.Alarm(this, 'StudyDlqAlarm', {
+      alarmName: `livetalk-batch-study-dlq-${environment}`,
+      alarmDescription: '勉強バッチ DLQ にメッセージが滞留している',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/SQS',
+        metricName: 'ApproximateNumberOfMessagesVisible',
+        dimensionsMap: { QueueName: `nagiyu-livetalk-study-dlq-${environment}` },
+        statistic: cloudwatch.Stats.MAXIMUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    studyDlqAlarm.addAlarmAction(action);
+
+    const notifyDlqAlarm = new cloudwatch.Alarm(this, 'NotifyDlqAlarm', {
+      alarmName: `livetalk-batch-notify-dlq-${environment}`,
+      alarmDescription: '通知バッチ DLQ にメッセージが滞留している',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/SQS',
+        metricName: 'ApproximateNumberOfMessagesVisible',
+        dimensionsMap: { QueueName: `nagiyu-livetalk-notify-dlq-${environment}` },
+        statistic: cloudwatch.Stats.MAXIMUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    notifyDlqAlarm.addAlarmAction(action);
+
+    // ---- (C) ALB（2本）----
+    // ALB ARN と TargetGroup ARN を SSM から読み、CloudWatch の dimension 値を導出する
+    const albArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.LIVETALK_ALB_ARN(environment)
+    );
+    const targetGroupArn = ssm.StringParameter.valueForStringParameter(
+      this,
+      SSM_PARAMETERS.LIVETALK_ALB_TARGET_GROUP_ARN(environment)
+    );
+
+    // ALB ARN: arn:aws:elasticloadbalancing:region:account:loadbalancer/app/name/hash
+    // LoadBalancer dimension = "app/name/hash"（"loadbalancer/" 以降）
+    const albDim = cdk.Fn.select(1, cdk.Fn.split('loadbalancer/', albArn));
+
+    // TG ARN: arn:aws:elasticloadbalancing:region:account:targetgroup/name/hash
+    // TargetGroup dimension = "targetgroup/name/hash"（ARN の第 6 要素、0-indexed は index 5）
+    const tgDim = cdk.Fn.select(5, cdk.Fn.split(':', targetGroupArn));
+
+    const alb5xxAlarm = new cloudwatch.Alarm(this, 'Alb5xxAlarm', {
+      alarmName: `livetalk-alb-5xx-${environment}`,
+      alarmDescription: 'ALB の 5xx エラーが発生している（5 分間で 1 件以上）',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/ApplicationELB',
+        metricName: 'HTTPCode_ELB_5XX_Count',
+        dimensionsMap: { LoadBalancer: albDim },
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    alb5xxAlarm.addAlarmAction(action);
+
+    const albUnhealthyAlarm = new cloudwatch.Alarm(this, 'AlbUnhealthyHostAlarm', {
+      alarmName: `livetalk-alb-unhealthy-host-${environment}`,
+      alarmDescription: 'ALB の UnhealthyHost が存在する（5 分間で 1 件以上）',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/ApplicationELB',
+        metricName: 'UnHealthyHostCount',
+        dimensionsMap: { LoadBalancer: albDim, TargetGroup: tgDim },
+        statistic: cloudwatch.Stats.MAXIMUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    albUnhealthyAlarm.addAlarmAction(action);
+
+    // ---- (D) DynamoDB スロットリング（1本）----
+
+    const dynamoTableName = getDynamoDBTableName('livetalk', environment);
+    const dynamoThrottledAlarm = new cloudwatch.Alarm(this, 'DynamoDBThrottledAlarm', {
+      alarmName: `livetalk-dynamodb-throttled-${environment}`,
+      alarmDescription: 'livetalk DynamoDB テーブルのスロットリングが発生している（5 分で 1 件以上）',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/DynamoDB',
+        metricName: 'ThrottledRequests',
+        dimensionsMap: { TableName: dynamoTableName },
+        statistic: cloudwatch.Stats.SUM,
+        period: cdk.Duration.minutes(5),
+      }),
+      ...commonAlarmProps,
+    });
+    dynamoThrottledAlarm.addAlarmAction(action);
+
+    // タグ付与
+    const allAlarms = [
+      compressErrorAlarm,
+      learnActivityErrorAlarm,
+      studyErrorAlarm,
+      notifyErrorAlarm,
+      compressDlqAlarm,
+      learnActivityDlqAlarm,
+      studyDlqAlarm,
+      notifyDlqAlarm,
+      alb5xxAlarm,
+      albUnhealthyAlarm,
+      dynamoThrottledAlarm,
+    ];
+    allAlarms.forEach((alarm) => {
+      cdk.Tags.of(alarm).add('Application', 'nagiyu');
+      cdk.Tags.of(alarm).add('Service', 'livetalk');
+      cdk.Tags.of(alarm).add('Component', 'monitoring');
+      cdk.Tags.of(alarm).add('Environment', environment);
+    });
+
+    // スタック全体へのタグ
+    cdk.Tags.of(this).add('Application', 'nagiyu');
+    cdk.Tags.of(this).add('Service', 'livetalk');
+    cdk.Tags.of(this).add('Environment', environment);
+    cdk.Tags.of(this).add('Component', 'livetalk-monitoring');
+
+    // CloudFormation Output
+    new cdk.CfnOutput(this, 'TotalAlarmsCount', {
+      value: allAlarms.length.toString(),
+      description: 'LiveTalk CloudWatch アラームの総数',
+    });
+  }
+}

--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -97,6 +97,7 @@ export class LiveTalkBatchStack extends cdk.Stack {
         DYNAMODB_TABLE_NAME: dynamoTableName,
         OPENAI_API_KEY: openAiApiKey,
         ERROR_EVENTS_TABLE_NAME: `nagiyu-error-events-${environment}`,
+        TZ: 'Asia/Tokyo',
       },
       deadLetterQueue: dlq,
       tracing: lambda.Tracing.ACTIVE,

--- a/infra/livetalk/tests/unit/alarms-stack.test.js
+++ b/infra/livetalk/tests/unit/alarms-stack.test.js
@@ -1,0 +1,172 @@
+const cdk = require('aws-cdk-lib');
+const { Template, Match } = require('aws-cdk-lib/assertions');
+
+require('ts-node/register/transpile-only');
+const { LiveTalkAlarmsStack } = require('../../lib/alarms-stack');
+
+const STACK_ENV = { account: '000000000000', region: 'us-east-1' };
+
+const synth = (environment = 'dev') => {
+  const app = new cdk.App();
+  const stack = new LiveTalkAlarmsStack(app, `TestLiveTalkAlarms${environment}`, {
+    environment,
+    env: STACK_ENV,
+  });
+  return { template: Template.fromStack(stack), stack };
+};
+
+describe('LiveTalkAlarmsStack', () => {
+  it('CloudWatch アラームが 11 個作成される', () => {
+    const { template } = synth();
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 11);
+  });
+
+  it('圧縮バッチ Lambda エラーアラームが存在する（Namespace/MetricName 検証）', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-compress-errors-dev',
+      Namespace: 'AWS/Lambda',
+      MetricName: 'Errors',
+    });
+  });
+
+  it('学習バッチ Lambda エラーアラームが存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-learn-activity-errors-dev',
+      Namespace: 'AWS/Lambda',
+      MetricName: 'Errors',
+    });
+  });
+
+  it('勉強バッチ Lambda エラーアラームが存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-study-errors-dev',
+      Namespace: 'AWS/Lambda',
+      MetricName: 'Errors',
+    });
+  });
+
+  it('通知バッチ Lambda エラーアラームが存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-notify-errors-dev',
+      Namespace: 'AWS/Lambda',
+      MetricName: 'Errors',
+    });
+  });
+
+  it('圧縮バッチ DLQ 滞留アラームが存在する（Namespace/MetricName 検証）', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-compress-dlq-dev',
+      Namespace: 'AWS/SQS',
+      MetricName: 'ApproximateNumberOfMessagesVisible',
+    });
+  });
+
+  it('学習バッチ DLQ 滞留アラームが存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-learn-activity-dlq-dev',
+      Namespace: 'AWS/SQS',
+      MetricName: 'ApproximateNumberOfMessagesVisible',
+    });
+  });
+
+  it('勉強バッチ DLQ 滞留アラームが存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-study-dlq-dev',
+      Namespace: 'AWS/SQS',
+      MetricName: 'ApproximateNumberOfMessagesVisible',
+    });
+  });
+
+  it('通知バッチ DLQ 滞留アラームが存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-notify-dlq-dev',
+      Namespace: 'AWS/SQS',
+      MetricName: 'ApproximateNumberOfMessagesVisible',
+    });
+  });
+
+  it('ALB 5xx アラームが存在する（Namespace/MetricName 検証）', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-alb-5xx-dev',
+      Namespace: 'AWS/ApplicationELB',
+      MetricName: 'HTTPCode_ELB_5XX_Count',
+    });
+  });
+
+  it('ALB UnhealthyHost アラームが存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-alb-unhealthy-host-dev',
+      Namespace: 'AWS/ApplicationELB',
+      MetricName: 'UnHealthyHostCount',
+    });
+  });
+
+  it('DynamoDB スロットリングアラームが存在する', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-dynamodb-throttled-dev',
+      Namespace: 'AWS/DynamoDB',
+      MetricName: 'ThrottledRequests',
+    });
+  });
+
+  it('全アラームに AlarmActions（SNS）が設定されている', () => {
+    const { template } = synth();
+    // 代表として圧縮バッチエラーアラームで AlarmActions が存在することを確認
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-compress-errors-dev',
+      AlarmActions: Match.anyValue(),
+    });
+  });
+
+  it('全アラームで threshold=1, evaluationPeriods=1 が設定されている', () => {
+    const { template } = synth();
+    // 代表として DLQ アラームで共通設定を確認
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-compress-dlq-dev',
+      Threshold: 1,
+      EvaluationPeriods: 1,
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+      TreatMissingData: 'notBreaching',
+    });
+  });
+
+  it('TotalAlarmsCount の Output が存在する', () => {
+    const { template } = synth();
+    template.hasOutput('TotalAlarmsCount', Match.anyValue());
+  });
+
+  it('TotalAlarmsCount の Output 値が 11 である', () => {
+    const { template } = synth();
+    template.hasOutput('TotalAlarmsCount', {
+      Value: '11',
+    });
+  });
+
+  it('prod 環境でも正しく synth できる', () => {
+    const { template } = synth('prod');
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 11);
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'livetalk-batch-compress-errors-prod',
+      Namespace: 'AWS/Lambda',
+      MetricName: 'Errors',
+    });
+  });
+
+  it('prod 環境の TotalAlarmsCount が 11 である', () => {
+    const { template } = synth('prod');
+    template.hasOutput('TotalAlarmsCount', {
+      Value: '11',
+    });
+  });
+});

--- a/infra/livetalk/tests/unit/batch-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-stack.test.js
@@ -83,6 +83,18 @@ describe('LiveTalkBatchStack', () => {
     });
   });
 
+  it('圧縮バッチ Lambda 環境変数に TZ=Asia/Tokyo が含まれる', () => {
+    const { template } = synth();
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: Match.stringLikeRegexp('livetalk-batch-compress'),
+      Environment: {
+        Variables: Match.objectLike({
+          TZ: 'Asia/Tokyo',
+        }),
+      },
+    });
+  });
+
   it('学習バッチ Lambda には OPENAI_API_KEY を含めない', () => {
     const { stack } = synth();
     const template = Template.fromStack(stack);


### PR DESCRIPTION
## 変更の概要

livetalk には CloudWatch アラームが無く、バッチ DLQ・ALB 5xx・DynamoDB スロットリングの検知に穴があった（Issue #3526）。admin に確立済みのアラーム定義パターンを踏襲し、livetalk 専用のアラーム stack を新設して既存の通知経路へ接続する。

- **`LiveTalkAlarmsStack` を新設**（`infra/livetalk/lib/alarms-stack.ts`）。計 11 本のアラームを定義し、admin 本流 SNS Topic `nagiyu-admin-alarms-{env}`（各サービスの CloudWatch Alarm 集約用）へ接続。
  - **(A) バッチ Lambda Errors ×4**: compress / learn-activity / study / notify
  - **(B) バッチ DLQ 滞留 ×4**: 同上（`ApproximateNumberOfMessagesVisible`）。DLQ は保持 7 日のため、滞留を即検知して証拠消失を防ぐ
  - **(C) ALB ×2**: `HTTPCode_ELB_5XX_Count`（5xx）/ `UnHealthyHostCount`（ターゲット異常）
  - **(D) DynamoDB ×1**: `ThrottledRequests`（スロットリング）
- **compress Lambda の TZ 不統一を解消**（`batch-stack.ts`）。`TZ: 'Asia/Tokyo'` を追加し、learn / study / notify と統一。

### 設計判断（livetalk 個別 vs プラットフォーム共通）

- **通知先**は admin 本流 Topic `nagiyu-admin-alarms-{env}`（同一アカウント・region us-east-1）。`alarm-ingest → error-events → stream-handler → Web Push` の既存経路に乗せる。ARN は `formatArn` で決定論的に構築（admin の self-monitoring が同パターン）。
- **アラーム定義そのものは livetalk 個別**に持つ（専用 stack 新設）。admin self-monitoring との共通化（`infra/common` 抽出）は admin 側のリファクタを伴いスコープが広がるため、今回は見送り。
- **dimension の参照方針**は livetalk の no-cross-stack 思想に合わせる。Lambda / DLQ / DynamoDB は決定論的な name ベース dimension。ALB / TargetGroup は full name の hash 部分が非決定論的なため、既存 SSM の ARN を読み `Fn.split` で dimension を導出（alb-stack の改修は不要）。

## 関連 Issue

- リブトーク監視整備: #3526
- 親 Issue（設計レビュー指摘改善）: #3521

<!-- サブ Issue のため Closes は付けない。dev 反映確認後に手動クローズする運用 -->

## 変更種別

- [x] インフラ更新

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [ ] 関連ドキュメントを更新した（後述。docs 追従要否を develop 反映後に判断）
- [x] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `infra/livetalk/tests/unit/alarms-stack.test.js`（新規）: アラーム数 11 本・各カテゴリ代表アラームの AlarmName/Namespace/MetricName・AlarmActions（SNS）・共通設定値・`TotalAlarmsCount` Output・prod synth を検証
- `infra/livetalk/tests/unit/batch-stack.test.js`: compress Lambda の `TZ=Asia/Tokyo` 検証を 1 件追加
- `npm test`: **8 suites / 114 tests 全て pass**
- `ENVIRONMENT=dev npx cdk synth NagiyuLiveTalkAlarmsDev`: 11 アラームが正しい dimension で生成されることを確認（ALB の LoadBalancer/TargetGroup dimension が SSM ARN から正しく導出されることも synth 出力で確認）

## レビューポイント

- **通知先 Topic の選択**: 本流 `nagiyu-admin-alarms-{env}`（self-monitoring ではない）で意図通りか。
- **ALB dimension の ARN 導出**: `Fn.select(1, Fn.split('loadbalancer/', albArn))` / `Fn.select(5, Fn.split(':', tgArn))` の堅牢性。
- **しきい値**: 全アラーム `>= 1 / 5分 / evaluationPeriods 1`（admin 先例に合わせた）。ALB 5xx の閾値が運用上ノイズにならないか。

## 補足事項

- dev 環境での反映確認は、develop マージ後の自動デプロイ後に CloudWatch コンソール / `describe-alarms` で実在確認可能。実発火 → Web Push の E2E は能動トリガーが必要。
- docs 追従要否は develop 反映後に判断する。

https://claude.ai/code/session_017eR9Z4KtJcvGCFvtfvLVay

---
_Generated by [Claude Code](https://claude.ai/code/session_017eR9Z4KtJcvGCFvtfvLVay)_