### PR TITLE
livetalk デプロイワークフローにアラームスタックの deploy を追加

### DIFF
--- a/.github/workflows/livetalk-deploy.yml
+++ b/.github/workflows/livetalk-deploy.yml
@@ -226,7 +226,7 @@ jobs:
           echo "Batch image pushed: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
   infrastructure-app:
-    name: Deploy DynamoDB, ALB and ECS Service Stacks
+    name: Deploy DynamoDB, ALB, ECS Service and Alarms Stacks
     runs-on: ubuntu-latest
     needs: build
 
@@ -284,17 +284,20 @@ jobs:
         run: |
           # DynamoDB Single Table（Phase 2a で追加）。ECS Service とは
           # deploy 順依存がなく、ALB / Service と同じジョブで一括 deploy する。
+          # CloudWatch アラーム（Issue #3526）は ALB の SSM パラメータを読むため
+          # ALB と同じジョブで deploy する（CDK が addDependency で ALB 先行を保証）。
           npm run cdk --workspace=@nagiyu/infra-livetalk -- deploy \
             NagiyuLiveTalkDynamoDB${STACK_SUFFIX} \
             NagiyuLiveTalkAlb${STACK_SUFFIX} \
             NagiyuLiveTalkService${STACK_SUFFIX} \
+            NagiyuLiveTalkAlarms${STACK_SUFFIX} \
             --context nextAuthSecret="$SECRET_VALUE" \
             --context openAiApiKey="$OPENAI_API_KEY" \
             --context vapidPublicKey="$VAPID_PUBLIC_KEY" \
             --context vapidPrivateKey="$VAPID_PRIVATE_KEY" \
             --require-approval never
 
-          echo "LiveTalk DynamoDB, ALB and ECS Service deployed (environment: $ENVIRONMENT)"
+          echo "LiveTalk DynamoDB, ALB, ECS Service and Alarms deployed (environment: $ENVIRONMENT)"
 
       - name: Force new ECS service deployment
         env:


### PR DESCRIPTION
## 変更の概要

PR #3545 で `LiveTalkAlarmsStack`（CloudWatch アラーム、Issue #3526）を新設したが、**デプロイワークフロー `livetalk-deploy.yml` がスタックを名前指定で個別 deploy しており、新設したアラームスタックがどのジョブのリストにも含まれていなかった**。このため develop マージ後も dev にアラームが作られていなかった（`NagiyuLiveTalkAlarmsDev` スタックが存在しないことを CLI で確認）。

`infrastructure-app` ジョブの deploy コマンドに `NagiyuLiveTalkAlarms${STACK_SUFFIX}` を追加する。

- アラームスタックは ALB の SSM パラメータ（ALB ARN / Target Group ARN）を読むため、ALB を deploy する同ジョブに同梱するのが適切。
- CDK 側で `addDependency(albStack)` 済みのため、同一 deploy コマンド内で ALB → Alarms の順序が保証される。
- アラーム定義は Lambda / DLQ / DynamoDB を決定論的な名前で参照しており、それらの実在は作成前提にならない（CloudWatch アラームは対象未作成でも作成可能）ため、batch ジョブとの順序依存はない。

## 関連 Issue

- リブトーク監視整備: #3526（#3545 の実装をデプロイ配線に反映する修正。既存 Issue の管轄内）

## 変更種別

- [x] CI/CD 更新

## テスト内容

- CLI で現状を確認:
    - `aws cloudformation describe-stacks --stack-name NagiyuLiveTalkAlarmsDev` → **存在しない**（修正前の状態を確認）
    - `NagiyuLiveTalkBatchDev` は UPDATE_COMPLETE 済み（TZ 統一は反映済み。Lambda env は readonly ロールでは参照不可）
- ワークフローの YAML 差分は deploy 対象スタックの追加のみ。CDK synth は #3545 時点で検証済み（`NagiyuLiveTalkAlarmsDev` が 11 アラームで synth 成功）。

## レビューポイント

- アラームスタックを `infrastructure-app`（ALB と同ジョブ）に同梱する配置が妥当か。別ジョブに分けるべきか。

## 補足事項

- CI/CD のみの軽量変更のため integration を切らず develop へ直接 Draft PR。
- マージ後、develop の deploy ワークフローが走れば dev に `NagiyuLiveTalkAlarmsDev` が作成される。反映後に CLI（`describe-alarms --alarm-name-prefix livetalk-`）で 11 本のアラーム実在を確認できる。

https://claude.ai/code/session_017eR9Z4KtJcvGCFvtfvLVay

---
_Generated by [Claude Code](https://claude.ai/code/session_017eR9Z4KtJcvGCFvtfvLVay)_