### PR TITLE
livetalk: バッチのユーザー列挙を全件 Scan から sparse GSI Query に置換（#3527 Phase 1）

### DIFF
--- a/infra/livetalk/lib/dynamodb-stack.ts
+++ b/infra/livetalk/lib/dynamodb-stack.ts
@@ -46,8 +46,7 @@ export class LiveTalkDynamoDbStack extends cdk.Stack {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       pointInTimeRecovery: true,
       timeToLiveAttribute: 'TTL',
-      removalPolicy:
-        environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
       encryption: dynamodb.TableEncryption.AWS_MANAGED,
     });
 

--- a/infra/livetalk/lib/dynamodb-stack.ts
+++ b/infra/livetalk/lib/dynamodb-stack.ts
@@ -11,8 +11,9 @@ export interface LiveTalkDynamoDbStackProps extends cdk.StackProps {
  * LiveTalk DynamoDB Single Table スタック
  *
  * - 命名: 共通ヘルパー `getDynamoDBTableName('livetalk', env)` で決定
- * - PK / SK の 2 キー Single Table 構成。MVP では GSI を作成しない
- *   （`docs/services/livetalk/architecture.md` §3「データモデル概要」。MVP では GSI 不要、Phase 進行で必要になれば追加）
+ * - PK / SK の 2 キー Single Table 構成。Profile 列挙のために GSI1 を追加した（#3527）。
+ *   GSI1PK='PROFILE' の sparse GSI で Profile のみ索引化する。
+ *   （`docs/services/livetalk/architecture.md` §3「データモデル概要」参照）
  * - Message は TTL（属性名 `TTL`、Unix 秒）で 90 日後に自動削除
  * - Point-in-time Recovery 有効、AWS マネージドキーで at-rest 暗号化
  * - dev は破棄、prod は保持
@@ -48,6 +49,15 @@ export class LiveTalkDynamoDbStack extends cdk.Stack {
       removalPolicy:
         environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
       encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    // GSI1: Profile のみを sparse 索引化するための GSI（#3527）
+    // GSI1PK='PROFILE' の Profile アイテムのみが対象（sparse GSI）
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'GSI1',
+      partitionKey: { name: 'GSI1PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI1SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY,
     });
 
     cdk.Tags.of(this).add('Application', 'nagiyu');

--- a/infra/livetalk/tests/unit/dynamodb-stack.test.js
+++ b/infra/livetalk/tests/unit/dynamodb-stack.test.js
@@ -23,7 +23,7 @@ describe('LiveTalkDynamoDbStack', () => {
     });
   });
 
-  it('PK / SK の 2 キー Single Table 構成（GSI なし）', () => {
+  it('PK / SK の 2 キー Single Table 構成に GSI1（Profile 列挙用 sparse GSI）を追加する', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::DynamoDB::Table', {
       KeySchema: [
@@ -33,12 +33,23 @@ describe('LiveTalkDynamoDbStack', () => {
       AttributeDefinitions: Match.arrayWith([
         { AttributeName: 'PK', AttributeType: 'S' },
         { AttributeName: 'SK', AttributeType: 'S' },
+        { AttributeName: 'GSI1PK', AttributeType: 'S' },
+        { AttributeName: 'GSI1SK', AttributeType: 'S' },
       ]),
     });
-    // MVP では GSI を作成しない
-    const tableResource = template.findResources('AWS::DynamoDB::Table');
-    const table = Object.values(tableResource)[0];
-    expect(table.Properties.GlobalSecondaryIndexes).toBeUndefined();
+    // GSI1: Profile 列挙用 sparse GSI（#3527）
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: 'GSI1',
+          KeySchema: [
+            { AttributeName: 'GSI1PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI1SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'KEYS_ONLY' },
+        },
+      ],
+    });
   });
 
   it('PAY_PER_REQUEST + PITR + TTL 属性 + AWS_MANAGED 暗号化を設定する', () => {

--- a/services/livetalk/batch/src/handlers/compress-conversations.ts
+++ b/services/livetalk/batch/src/handlers/compress-conversations.ts
@@ -6,6 +6,7 @@ import {
   DynamoDBMemorySummaryRepository,
   DynamoDBMessageRepository,
   DynamoDBMemoryRepository,
+  DynamoDBProfileRepository,
   EmbeddingMemoryRepository,
   OpenAIClient,
   OpenAIEmbeddingClient,
@@ -73,10 +74,10 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const llmClient = new OpenAIClient({ apiKey });
     const interestRepo = new DynamoDBInterestRepository(docClient, tableName);
     const characterStateRepo = new DynamoDBCharacterStateRepository(docClient, tableName);
+    const profileRepo = new DynamoDBProfileRepository(docClient, tableName);
 
     result = await compressAllConversations({
-      docClient,
-      tableName,
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,

--- a/services/livetalk/batch/src/handlers/learn-user-activity.ts
+++ b/services/livetalk/batch/src/handlers/learn-user-activity.ts
@@ -3,6 +3,7 @@ import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagi
 import {
   DynamoDBLifecycleRepository,
   DynamoDBMessageRepository,
+  DynamoDBProfileRepository,
   defaultUlidFactory,
 } from '@nagiyu/livetalk-core';
 import { learnAllUserActivities } from '../usecases/learn-user-activity.usecase.js';
@@ -38,10 +39,10 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
 
     const messageRepo = new DynamoDBMessageRepository(docClient, tableName, defaultUlidFactory);
     const lifecycleRepo = new DynamoDBLifecycleRepository(docClient, tableName);
+    const profileRepo = new DynamoDBProfileRepository(docClient, tableName);
 
     const result = await learnAllUserActivities({
-      docClient,
-      tableName,
+      profileRepo,
       messageRepo,
       lifecycleRepo,
     });

--- a/services/livetalk/batch/src/handlers/notify.ts
+++ b/services/livetalk/batch/src/handlers/notify.ts
@@ -6,6 +6,7 @@ import {
   DynamoDBLifecycleRepository,
   DynamoDBMessageRepository,
   DynamoDBNotificationEventRepository,
+  DynamoDBProfileRepository,
   DynamoDBPushSubscriptionRepository,
   OpenAIEmbeddingClient,
   createLLMClient,
@@ -43,6 +44,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const tableName = getTableName();
     const apiKey = process.env.OPENAI_API_KEY ?? '';
 
+    const profileRepo = new DynamoDBProfileRepository(docClient, tableName);
     const lifecycleRepo = new DynamoDBLifecycleRepository(docClient, tableName);
     const messageRepo = new DynamoDBMessageRepository(docClient, tableName);
     const knowledgeRepo = new DynamoDBKnowledgeRepository(docClient, tableName);
@@ -53,8 +55,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const embeddingClient = new OpenAIEmbeddingClient({ apiKey });
 
     const result = await notifyAllUsers({
-      docClient,
-      tableName,
+      profileRepo,
       lifecycleRepo,
       messageRepo,
       knowledgeRepo,

--- a/services/livetalk/batch/src/handlers/study.ts
+++ b/services/livetalk/batch/src/handlers/study.ts
@@ -5,6 +5,7 @@ import {
   DynamoDBKnowledgeRepository,
   DynamoDBLifecycleRepository,
   DynamoDBNoteRepository,
+  DynamoDBProfileRepository,
   DynamoDBStudyTopicRepository,
   OpenAIResearchClient,
   defaultUlidFactory,
@@ -46,11 +47,11 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const knowledgeRepo = new DynamoDBKnowledgeRepository(docClient, tableName);
     const studyTopicRepo = new DynamoDBStudyTopicRepository(docClient, tableName);
     const noteRepo = new DynamoDBNoteRepository(docClient, tableName);
+    const profileRepo = new DynamoDBProfileRepository(docClient, tableName);
     const researchClient = new OpenAIResearchClient({ apiKey });
 
     const result = await studyAllUsers({
-      docClient,
-      tableName,
+      profileRepo,
       lifecycleRepo,
       interestRepo,
       knowledgeRepo,

--- a/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
+++ b/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
@@ -1,15 +1,14 @@
-import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
   getAllCharacterIds,
   getCharacterDefinitionById,
   compressConversation,
   type CompressConversationParams,
+  type ProfileRepository,
 } from '@nagiyu/livetalk-core';
 
 export type CompressAllConversationsParams = Omit<CompressConversationParams, 'characterName'> & {
-  docClient: DynamoDBDocumentClient;
-  tableName: string;
+  profileRepo: ProfileRepository;
 };
 
 export interface CompressAllConversationsResult {
@@ -22,7 +21,7 @@ export interface CompressAllConversationsResult {
 /**
  * 全アクティブユーザーの全キャラクター会話を圧縮要約する。
  *
- * DynamoDB を Scan して Type='Profile' のアイテムを列挙し、
+ * ProfileRepository（GSI1）でユーザーを列挙し、
  * 各ユーザーについて全キャラクターの会話を圧縮する。
  * キャラクターごとに処理し、あるキャラクターで失敗しても他キャラクターの処理を継続する。
  */
@@ -30,8 +29,7 @@ export async function compressAllConversations(
   params: CompressAllConversationsParams
 ): Promise<CompressAllConversationsResult> {
   const {
-    docClient,
-    tableName,
+    profileRepo,
     llmClient,
     summaryRepo,
     messageRepo,
@@ -42,7 +40,7 @@ export async function compressAllConversations(
     embeddingClient,
   } = params;
 
-  const userIds = await scanAllUserIds(docClient, tableName);
+  const userIds = await profileRepo.listAllUserIds();
 
   logger.info('[compressAllConversations] ユーザー一覧取得完了', {
     userCount: userIds.length,
@@ -117,33 +115,4 @@ export async function compressAllConversations(
 
   logger.info('[compressAllConversations] 全ユーザー処理完了', { ...result });
   return result;
-}
-
-async function scanAllUserIds(
-  docClient: DynamoDBDocumentClient,
-  tableName: string
-): Promise<string[]> {
-  const userIds: string[] = [];
-  let lastEvaluatedKey: Record<string, unknown> | undefined;
-
-  do {
-    const command = new ScanCommand({
-      TableName: tableName,
-      FilterExpression: '#type = :profile',
-      ExpressionAttributeNames: { '#type': 'Type' },
-      ExpressionAttributeValues: { ':profile': 'Profile' },
-      ProjectionExpression: 'UserID',
-      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
-    });
-
-    const response = await docClient.send(command);
-    for (const item of response.Items ?? []) {
-      if (typeof item.UserID === 'string' && item.UserID) {
-        userIds.push(item.UserID);
-      }
-    }
-    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastEvaluatedKey !== undefined);
-
-  return userIds;
 }

--- a/services/livetalk/batch/src/usecases/learn-user-activity.usecase.ts
+++ b/services/livetalk/batch/src/usecases/learn-user-activity.usecase.ts
@@ -1,4 +1,3 @@
-import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
   getAllCharacterIds,
@@ -6,11 +5,11 @@ import {
   learnUserActivity,
   type LifecycleRepository,
   type MessageRepository,
+  type ProfileRepository,
 } from '@nagiyu/livetalk-core';
 
 export interface LearnAllUserActivitiesParams {
-  docClient: DynamoDBDocumentClient;
-  tableName: string;
+  profileRepo: ProfileRepository;
   messageRepo: MessageRepository;
   lifecycleRepo: LifecycleRepository;
   /** 学習基準日時（省略時は実行時刻）。テスト用差し替え可。 */
@@ -27,16 +26,16 @@ export interface LearnAllUserActivitiesResult {
 /**
  * 全アクティブユーザーの活動時間を学習する。
  *
- * DynamoDB を Scan して Type='Profile' のアイテムを列挙し、
+ * ProfileRepository（GSI1）でユーザーを列挙し、
  * 各ユーザーについて全キャラクターの発話履歴を学習する。
  * あるキャラクターで失敗しても他キャラクターの処理は継続する。
  */
 export async function learnAllUserActivities(
   params: LearnAllUserActivitiesParams
 ): Promise<LearnAllUserActivitiesResult> {
-  const { docClient, tableName, messageRepo, lifecycleRepo, now } = params;
+  const { profileRepo, messageRepo, lifecycleRepo, now } = params;
 
-  const userIds = await scanAllUserIds(docClient, tableName);
+  const userIds = await profileRepo.listAllUserIds();
 
   logger.info('[learnAllUserActivities] ユーザー一覧取得完了', {
     userCount: userIds.length,
@@ -105,33 +104,4 @@ export async function learnAllUserActivities(
 
   logger.info('[learnAllUserActivities] 全ユーザー処理完了', { ...result });
   return result;
-}
-
-async function scanAllUserIds(
-  docClient: DynamoDBDocumentClient,
-  tableName: string
-): Promise<string[]> {
-  const userIds: string[] = [];
-  let lastEvaluatedKey: Record<string, unknown> | undefined;
-
-  do {
-    const command = new ScanCommand({
-      TableName: tableName,
-      FilterExpression: '#type = :profile',
-      ExpressionAttributeNames: { '#type': 'Type' },
-      ExpressionAttributeValues: { ':profile': 'Profile' },
-      ProjectionExpression: 'UserID',
-      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
-    });
-
-    const response = await docClient.send(command);
-    for (const item of response.Items ?? []) {
-      if (typeof item.UserID === 'string' && item.UserID) {
-        userIds.push(item.UserID);
-      }
-    }
-    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastEvaluatedKey !== undefined);
-
-  return userIds;
 }

--- a/services/livetalk/batch/src/usecases/notify.usecase.ts
+++ b/services/livetalk/batch/src/usecases/notify.usecase.ts
@@ -486,4 +486,3 @@ async function computeUserDailyNormalCap(params: {
 
   return computeDailyNormalCap(maxFactor);
 }
-

--- a/services/livetalk/batch/src/usecases/notify.usecase.ts
+++ b/services/livetalk/batch/src/usecases/notify.usecase.ts
@@ -1,4 +1,3 @@
-import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import { sendWebPushNotification, getVapidConfig } from '@nagiyu/common/push';
 import {
@@ -21,6 +20,7 @@ import {
   type LifecycleRepository,
   type MessageRepository,
   type NotificationEventRepository,
+  type ProfileRepository,
   type PushSubscriptionRepository,
   type UlidFactory,
   defaultUlidFactory,
@@ -30,8 +30,7 @@ import {
 } from '@nagiyu/livetalk-core';
 
 export interface NotifyAllUsersParams {
-  docClient: DynamoDBDocumentClient;
-  tableName: string;
+  profileRepo: ProfileRepository;
   lifecycleRepo: LifecycleRepository;
   messageRepo: MessageRepository;
   knowledgeRepo: KnowledgeRepository;
@@ -51,10 +50,15 @@ export interface NotifyAllUsersResult {
   failedUserIds: string[];
 }
 
+/**
+ * 全アクティブユーザーへのプッシュ通知を送信する。
+ *
+ * ProfileRepository（GSI1）でユーザーを列挙し、
+ * 各ユーザーについて全キャラクターの通知判定を行う。
+ */
 export async function notifyAllUsers(params: NotifyAllUsersParams): Promise<NotifyAllUsersResult> {
   const {
-    docClient,
-    tableName,
+    profileRepo,
     lifecycleRepo,
     messageRepo,
     knowledgeRepo,
@@ -67,7 +71,7 @@ export async function notifyAllUsers(params: NotifyAllUsersParams): Promise<Noti
     now = () => new Date(),
   } = params;
 
-  const userIds = await scanAllUserIds(docClient, tableName);
+  const userIds = await profileRepo.listAllUserIds();
   logger.info('[notifyAllUsers] ユーザー一覧取得完了', { userCount: userIds.length });
 
   const result: NotifyAllUsersResult = {
@@ -483,31 +487,3 @@ async function computeUserDailyNormalCap(params: {
   return computeDailyNormalCap(maxFactor);
 }
 
-async function scanAllUserIds(
-  docClient: DynamoDBDocumentClient,
-  tableName: string
-): Promise<string[]> {
-  const userIds: string[] = [];
-  let lastEvaluatedKey: Record<string, unknown> | undefined;
-
-  do {
-    const command = new ScanCommand({
-      TableName: tableName,
-      FilterExpression: '#type = :profile',
-      ExpressionAttributeNames: { '#type': 'Type' },
-      ExpressionAttributeValues: { ':profile': 'Profile' },
-      ProjectionExpression: 'UserID',
-      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
-    });
-
-    const response = await docClient.send(command);
-    for (const item of response.Items ?? []) {
-      if (typeof item.UserID === 'string' && item.UserID) {
-        userIds.push(item.UserID);
-      }
-    }
-    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastEvaluatedKey !== undefined);
-
-  return userIds;
-}

--- a/services/livetalk/batch/src/usecases/study.usecase.ts
+++ b/services/livetalk/batch/src/usecases/study.usecase.ts
@@ -1,4 +1,3 @@
-import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
   getAllCharacterIds,
@@ -9,14 +8,14 @@ import {
   type KnowledgeRepository,
   type LifecycleRepository,
   type NoteRepository,
+  type ProfileRepository,
   type StudyTopicRepository,
   type UlidFactory,
 } from '@nagiyu/livetalk-core';
 import type { IResearchClient } from '@nagiyu/livetalk-core';
 
 export interface StudyAllUsersParams {
-  docClient: DynamoDBDocumentClient;
-  tableName: string;
+  profileRepo: ProfileRepository;
   lifecycleRepo: LifecycleRepository;
   interestRepo: InterestRepository;
   knowledgeRepo: KnowledgeRepository;
@@ -43,14 +42,13 @@ export interface StudyAllUsersResult {
 /**
  * 全アクティブユーザーに対して勉強バッチを実行する。
  *
- * 各ユーザーについて全キャラクターを走査し、shouldStudyNow 判定を行い、
- * 該当するキャラクターのみ Web リサーチ → 知識ベース保存を実行する。
+ * ProfileRepository（GSI1）でユーザーを列挙し、各ユーザーについて全キャラクターを走査し、
+ * shouldStudyNow 判定を行い、該当するキャラクターのみ Web リサーチ → 知識ベース保存を実行する。
  * あるキャラクターで失敗しても他キャラクターの処理は継続する。
  */
 export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyAllUsersResult> {
   const {
-    docClient,
-    tableName,
+    profileRepo,
     lifecycleRepo,
     interestRepo,
     knowledgeRepo,
@@ -61,7 +59,7 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
     now,
   } = params;
 
-  const userIds = await scanAllUserIds(docClient, tableName);
+  const userIds = await profileRepo.listAllUserIds();
 
   logger.info('[studyAllUsers] ユーザー一覧取得完了', { userCount: userIds.length });
 
@@ -160,33 +158,4 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
 
   logger.info('[studyAllUsers] 全ユーザー処理完了', { ...result });
   return result;
-}
-
-async function scanAllUserIds(
-  docClient: DynamoDBDocumentClient,
-  tableName: string
-): Promise<string[]> {
-  const userIds: string[] = [];
-  let lastEvaluatedKey: Record<string, unknown> | undefined;
-
-  do {
-    const command = new ScanCommand({
-      TableName: tableName,
-      FilterExpression: '#type = :profile',
-      ExpressionAttributeNames: { '#type': 'Type' },
-      ExpressionAttributeValues: { ':profile': 'Profile' },
-      ProjectionExpression: 'UserID',
-      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
-    });
-
-    const response = await docClient.send(command);
-    for (const item of response.Items ?? []) {
-      if (typeof item.UserID === 'string' && item.UserID) {
-        userIds.push(item.UserID);
-      }
-    }
-    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastEvaluatedKey !== undefined);
-
-  return userIds;
 }

--- a/services/livetalk/batch/tests/unit/handlers/compress-conversations.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/compress-conversations.test.ts
@@ -10,6 +10,7 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBMemorySummaryRepository: jest.fn(),
   DynamoDBMessageRepository: jest.fn(),
   DynamoDBMemoryRepository: jest.fn(),
+  DynamoDBProfileRepository: jest.fn(),
   EmbeddingMemoryRepository: jest.fn(),
   DynamoDBInterestRepository: jest.fn(),
   DynamoDBCharacterStateRepository: jest.fn(),

--- a/services/livetalk/batch/tests/unit/handlers/learn-user-activity.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/learn-user-activity.test.ts
@@ -9,6 +9,7 @@ jest.mock('@nagiyu/aws', () => ({
 jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBMessageRepository: jest.fn(),
   DynamoDBLifecycleRepository: jest.fn(),
+  DynamoDBProfileRepository: jest.fn(),
   defaultUlidFactory: jest.fn(),
 }));
 

--- a/services/livetalk/batch/tests/unit/handlers/notify.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/notify.test.ts
@@ -7,6 +7,7 @@ jest.mock('@nagiyu/aws', () => ({
 }));
 
 jest.mock('@nagiyu/livetalk-core', () => ({
+  DynamoDBProfileRepository: jest.fn(),
   DynamoDBLifecycleRepository: jest.fn(),
   DynamoDBMessageRepository: jest.fn(),
   DynamoDBKnowledgeRepository: jest.fn(),

--- a/services/livetalk/batch/tests/unit/handlers/study.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/study.test.ts
@@ -12,6 +12,7 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBKnowledgeRepository: jest.fn(),
   DynamoDBStudyTopicRepository: jest.fn(),
   DynamoDBNoteRepository: jest.fn(),
+  DynamoDBProfileRepository: jest.fn(),
   OpenAIResearchClient: jest.fn(),
   defaultUlidFactory: jest.fn(),
 }));

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -3,9 +3,9 @@ import {
   InMemoryMemorySummaryRepository,
   InMemoryMessageRepository,
   InMemoryMemoryRepository,
+  InMemoryProfileRepository,
   type ILLMClient,
 } from '@nagiyu/livetalk-core';
-import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import {
   compressAllConversations,
   type CompressAllConversationsParams,
@@ -33,32 +33,40 @@ const makeLLMClient = (): ILLMClient & { summarizeCalls: number } => {
   };
 };
 
-const makeRepos = () => {
-  const store = new InMemorySingleTableStore();
+const makeRepos = (sharedStore?: InMemorySingleTableStore) => {
+  const store = sharedStore ?? new InMemorySingleTableStore();
   tick = fixedNow;
   const nowMs = () => tick;
   const ulidFactory = () => `ULID-${tick++}`;
   return {
+    store,
     summaryRepo: new InMemoryMemorySummaryRepository(store, nowMs),
     messageRepo: new InMemoryMessageRepository(store, ulidFactory, nowMs),
     memoryRepo: new InMemoryMemoryRepository(store, ulidFactory, nowMs),
+    profileRepo: new InMemoryProfileRepository(store, nowMs),
   };
 };
 
-const makeDocClientMock = (userIds: string[]): DynamoDBDocumentClient => {
-  const items = userIds.map((id) => ({ UserID: id }));
-  return {
-    send: async () => ({ Items: items }),
-  } as unknown as DynamoDBDocumentClient;
+/**
+ * 指定した userIds を持つ InMemoryProfileRepository を作る。
+ * 別ストアを使って profile だけを登録する。
+ */
+const makeProfileRepoWithUsers = async (userIds: string[]): Promise<InMemoryProfileRepository> => {
+  const store = new InMemorySingleTableStore();
+  const nowMs = () => fixedNow;
+  const profileRepo = new InMemoryProfileRepository(store, nowMs);
+  for (const id of userIds) {
+    await profileRepo.upsert({ UserID: id });
+  }
+  return profileRepo;
 };
 
 const makeParams = (
   overrides: Partial<CompressAllConversationsParams> = {}
 ): CompressAllConversationsParams => {
-  const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+  const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos();
   return {
-    docClient: makeDocClientMock([]),
-    tableName: 'test-table',
+    profileRepo,
     summaryRepo,
     messageRepo,
     memoryRepo,
@@ -78,8 +86,8 @@ describe('compressAllConversations', () => {
 
   it('メッセージのないユーザーは処理をスキップする（LLM 呼び出しなし）', async () => {
     const llmClient = makeLLMClient();
-    const docClient = makeDocClientMock(['u1', 'u2']);
-    const result = await compressAllConversations(makeParams({ llmClient, docClient }));
+    const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2']);
+    const result = await compressAllConversations(makeParams({ llmClient, profileRepo }));
     expect(llmClient.summarizeCalls).toBe(0);
     expect(result.processedUsers).toBe(0);
     expect(result.skippedUsers).toBe(2);
@@ -87,14 +95,15 @@ describe('compressAllConversations', () => {
 
   it('hiyori にメッセージのあるユーザー分だけ LLM を呼ぶ', async () => {
     const llmClient = makeLLMClient();
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,
@@ -124,16 +133,17 @@ describe('compressAllConversations', () => {
       },
     };
 
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hi' });
     tick++;
     await messageRepo.create({ UserID: 'u2', CharacterID: 'hiyori', Role: 'user', Text: 'hi2' });
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,
@@ -145,103 +155,16 @@ describe('compressAllConversations', () => {
     expect(result.processedUsers).toBe(1);
   });
 
-  it('DynamoDB Scan が複数ページに渡るとき全ユーザーを処理する', async () => {
+  it('profileRepo が複数ユーザーを返すとき全ユーザーを処理する', async () => {
     const llmClient = makeLLMClient();
-    let pageCount = 0;
-    const pagedDocClient = {
-      send: async () => {
-        pageCount++;
-        if (pageCount === 1) {
-          return {
-            Items: [{ UserID: 'u1' }],
-            LastEvaluatedKey: { PK: 'USER#u1' },
-          };
-        }
-        return { Items: [{ UserID: 'u2' }] };
-      },
-    } as unknown as DynamoDBDocumentClient;
+    const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2']);
 
     const result = await compressAllConversations(
-      makeParams({ llmClient, docClient: pagedDocClient })
+      makeParams({ llmClient, profileRepo })
     );
 
     expect(result.processedUsers).toBe(0);
     expect(result.skippedUsers).toBe(2);
-    expect(pageCount).toBe(2);
-  });
-
-  it('UserID が空や型違いのアイテムを無視する', async () => {
-    const llmClient = makeLLMClient();
-    const docClient = {
-      send: async () => ({
-        Items: [{ UserID: '' }, { UserID: 123 }, { UserID: 'valid-user' }],
-      }),
-    } as unknown as DynamoDBDocumentClient;
-
-    const result = await compressAllConversations(makeParams({ llmClient, docClient }));
-    expect(result.processedUsers).toBe(0);
-    expect(result.skippedUsers).toBe(1);
-  });
-
-  it('複数キャラ（hiyori と ageha）両方のメッセージで LLM が 2 回呼ばれる', async () => {
-    const llmClient = makeLLMClient();
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
-    tick = fixedNow;
-    await messageRepo.create({
-      UserID: 'u1',
-      CharacterID: 'hiyori',
-      Role: 'user',
-      Text: 'hiyori msg',
-    });
-    tick++;
-    await messageRepo.create({
-      UserID: 'u1',
-      CharacterID: 'ageha',
-      Role: 'user',
-      Text: 'ageha msg',
-    });
-
-    const docClient = makeDocClientMock(['u1']);
-    const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
-      summaryRepo,
-      messageRepo,
-      memoryRepo,
-      llmClient,
-    });
-
-    // hiyori と ageha の両方で summarize が呼ばれる
-    expect(llmClient.summarizeCalls).toBe(2);
-    expect(result.processedUsers).toBe(1);
-    expect(result.failedUsers).toBe(0);
-  });
-
-  it('一方のキャラのみメッセージがある場合はそのキャラのみ LLM を呼ぶ', async () => {
-    const llmClient = makeLLMClient();
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
-    tick = fixedNow;
-    // ageha のみメッセージあり
-    await messageRepo.create({
-      UserID: 'u1',
-      CharacterID: 'ageha',
-      Role: 'user',
-      Text: 'ageha only',
-    });
-
-    const docClient = makeDocClientMock(['u1']);
-    const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
-      summaryRepo,
-      messageRepo,
-      memoryRepo,
-      llmClient,
-    });
-
-    expect(llmClient.summarizeCalls).toBe(1);
-    expect(result.processedUsers).toBe(1);
-    expect(result.failedUsers).toBe(0);
   });
 
   it('あるキャラクター処理がエラーでも他キャラは処理され、ユーザーは failed に計上される', async () => {
@@ -261,16 +184,16 @@ describe('compressAllConversations', () => {
       },
     };
 
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hi' });
     tick++;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'hi2' });
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,
@@ -283,6 +206,67 @@ describe('compressAllConversations', () => {
     expect(result.failedUsers).toBe(1);
     expect(result.failedUserIds).toContain('u1');
     expect(result.processedUsers).toBe(0);
+  });
+
+  it('複数キャラ（hiyori と ageha）両方のメッセージで LLM が 2 回呼ばれる', async () => {
+    const llmClient = makeLLMClient();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
+    tick = fixedNow;
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'user',
+      Text: 'hiyori msg',
+    });
+    tick++;
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'ageha',
+      Role: 'user',
+      Text: 'ageha msg',
+    });
+    await profileRepo.upsert({ UserID: 'u1' });
+
+    const result = await compressAllConversations({
+      profileRepo,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    // hiyori と ageha の両方で summarize が呼ばれる
+    expect(llmClient.summarizeCalls).toBe(2);
+    expect(result.processedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('一方のキャラのみメッセージがある場合はそのキャラのみ LLM を呼ぶ', async () => {
+    const llmClient = makeLLMClient();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
+    tick = fixedNow;
+    // ageha のみメッセージあり
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'ageha',
+      Role: 'user',
+      Text: 'ageha only',
+    });
+    await profileRepo.upsert({ UserID: 'u1' });
+
+    const result = await compressAllConversations({
+      profileRepo,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    expect(llmClient.summarizeCalls).toBe(1);
+    expect(result.processedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
   });
 
   it('characterName が各キャラの displayName で渡されること（hiyori は 桃瀬ひより）', async () => {
@@ -300,16 +284,16 @@ describe('compressAllConversations', () => {
       },
     };
 
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
     tick++;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'hey' });
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,
@@ -324,15 +308,16 @@ describe('compressAllConversations', () => {
 
   it('メッセージのあるユーザーは processedUsers、ないユーザーは skippedUsers に計上される（混在ケース）', async () => {
     const llmClient = makeLLMClient();
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     // u1 のみメッセージあり（processed）、u2 はメッセージなし（skipped）
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -159,9 +159,7 @@ describe('compressAllConversations', () => {
     const llmClient = makeLLMClient();
     const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2']);
 
-    const result = await compressAllConversations(
-      makeParams({ llmClient, profileRepo })
-    );
+    const result = await compressAllConversations(makeParams({ llmClient, profileRepo }));
 
     expect(result.processedUsers).toBe(0);
     expect(result.skippedUsers).toBe(2);

--- a/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -1,6 +1,9 @@
 import { InMemorySingleTableStore } from '@nagiyu/aws';
-import { InMemoryMessageRepository, InMemoryLifecycleRepository } from '@nagiyu/livetalk-core';
-import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  InMemoryMessageRepository,
+  InMemoryLifecycleRepository,
+  InMemoryProfileRepository,
+} from '@nagiyu/livetalk-core';
 import {
   learnAllUserActivities,
   type LearnAllUserActivitiesParams,
@@ -9,32 +12,38 @@ import {
 const fixedNow = 1_750_000_000_000;
 let tick = fixedNow;
 
-const makeRepos = () => {
-  const store = new InMemorySingleTableStore();
+const makeRepos = (sharedStore?: InMemorySingleTableStore) => {
+  const store = sharedStore ?? new InMemorySingleTableStore();
   tick = fixedNow;
   const nowMs = () => tick;
   const ulidFactory = () => `ULID-${tick++}`;
   return {
+    store,
     messageRepo: new InMemoryMessageRepository(store, ulidFactory, nowMs),
     lifecycleRepo: new InMemoryLifecycleRepository(store, nowMs),
-    store,
+    profileRepo: new InMemoryProfileRepository(store, nowMs),
   };
 };
 
-const makeDocClientMock = (userIds: string[]): DynamoDBDocumentClient => {
-  const items = userIds.map((id) => ({ UserID: id }));
-  return {
-    send: async () => ({ Items: items }),
-  } as unknown as DynamoDBDocumentClient;
+/**
+ * 指定した userIds を持つ InMemoryProfileRepository を作る。
+ */
+const makeProfileRepoWithUsers = async (userIds: string[]): Promise<InMemoryProfileRepository> => {
+  const store = new InMemorySingleTableStore();
+  const nowMs = () => fixedNow;
+  const profileRepo = new InMemoryProfileRepository(store, nowMs);
+  for (const id of userIds) {
+    await profileRepo.upsert({ UserID: id });
+  }
+  return profileRepo;
 };
 
 const makeParams = (
   overrides: Partial<LearnAllUserActivitiesParams> = {}
 ): LearnAllUserActivitiesParams => {
-  const { messageRepo, lifecycleRepo } = makeRepos();
+  const { messageRepo, lifecycleRepo, profileRepo } = makeRepos();
   return {
-    docClient: makeDocClientMock([]),
-    tableName: 'test-table',
+    profileRepo,
     messageRepo,
     lifecycleRepo,
     ...overrides,
@@ -50,8 +59,8 @@ describe('learnAllUserActivities', () => {
   });
 
   it('メッセージのないユーザーは全キャラ skipped にカウントされる', async () => {
-    const docClient = makeDocClientMock(['u1', 'u2']);
-    const result = await learnAllUserActivities(makeParams({ docClient }));
+    const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2']);
+    const result = await learnAllUserActivities(makeParams({ profileRepo }));
     expect(result.skippedUsers).toBe(2);
     expect(result.processedUsers).toBe(0);
     expect(result.failedUsers).toBe(0);
@@ -64,6 +73,7 @@ describe('learnAllUserActivities', () => {
     const ulidFactory = () => `ULID-${tick++}`;
     const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
     const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+    const profileRepo = new InMemoryProfileRepository(store, nowMs);
 
     // u1 に user ロールのメッセージを 5 件作成（fixedNow の 10 日前 = 30 日ウィンドウ内）
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
@@ -76,12 +86,12 @@ describe('learnAllUserActivities', () => {
         Text: `msg ${i}`,
       });
     }
-    // u2 はメッセージなし
+    // u1, u2 を Profile として登録（u2 はメッセージなし）
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo,
       now: () => new Date(fixedNow),
@@ -99,6 +109,7 @@ describe('learnAllUserActivities', () => {
     const ulidFactory = () => `ULID-${tick++}`;
     const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
     const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+    const profileRepo = new InMemoryProfileRepository(store, nowMs);
 
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
     for (let i = 0; i < 5; i++) {
@@ -110,11 +121,10 @@ describe('learnAllUserActivities', () => {
         Text: `ageha msg ${i}`,
       });
     }
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo,
       now: () => new Date(fixedNow),
@@ -132,6 +142,7 @@ describe('learnAllUserActivities', () => {
     const ulidFactory = () => `ULID-${tick++}`;
     const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
     const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+    const profileRepo = new InMemoryProfileRepository(store, nowMs);
 
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
     for (let i = 0; i < 5; i++) {
@@ -152,11 +163,10 @@ describe('learnAllUserActivities', () => {
         Text: `ageha msg ${i}`,
       });
     }
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo,
       now: () => new Date(fixedNow),
@@ -169,7 +179,7 @@ describe('learnAllUserActivities', () => {
   });
 
   it('ユーザー処理が失敗しても他のユーザーは処理継続する', async () => {
-    const { lifecycleRepo } = makeRepos();
+    const { lifecycleRepo, messageRepo } = makeRepos();
     const failingLifecycleRepo = {
       ...lifecycleRepo,
       updateUserActivityProfile: jest.fn().mockRejectedValue(new Error('DB エラー')),
@@ -180,6 +190,8 @@ describe('learnAllUserActivities', () => {
     tick = fixedNow;
     const ulidFactory = () => `ULID-${tick++}`;
     const failingMessageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+    const profileStore = new InMemorySingleTableStore();
+    const profileRepo = new InMemoryProfileRepository(profileStore, () => fixedNow);
 
     // u1 に 5 件（fixedNow の 10 日前 = 30 日ウィンドウ内）
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
@@ -192,11 +204,11 @@ describe('learnAllUserActivities', () => {
         Text: `msg ${i}`,
       });
     }
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo: failingMessageRepo,
       lifecycleRepo: failingLifecycleRepo as never,
       now: () => new Date(fixedNow),
@@ -206,28 +218,17 @@ describe('learnAllUserActivities', () => {
     expect(result.failedUserIds).toContain('u1');
   });
 
-  it('DynamoDB の Scan がページネーションする場合も全ユーザーを取得する', async () => {
+  it('profileRepo が複数ユーザーを返すとき全ユーザーを取得する（ページネーション相当）', async () => {
+    const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2', 'u3']);
     const { messageRepo, lifecycleRepo } = makeRepos();
-    let callCount = 0;
-    const paginatedDocClient = {
-      send: async () => {
-        callCount++;
-        if (callCount === 1) {
-          return { Items: [{ UserID: 'u1' }], LastEvaluatedKey: { PK: 'USER#u1' } };
-        }
-        return { Items: [{ UserID: 'u2' }] };
-      },
-    } as unknown as DynamoDBDocumentClient;
 
     const result = await learnAllUserActivities({
-      docClient: paginatedDocClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo,
     });
 
-    expect(result.skippedUsers).toBe(2);
-    expect(callCount).toBe(2);
+    expect(result.skippedUsers).toBe(3);
   });
 
   it('あるキャラクター処理がエラーでも他キャラは処理され、ユーザーは failed に計上される', async () => {
@@ -246,6 +247,8 @@ describe('learnAllUserActivities', () => {
     tick = fixedNow;
     const ulidFactory = () => `ULID-${tick++}`;
     const messageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+    const profileStore = new InMemorySingleTableStore();
+    const profileRepo = new InMemoryProfileRepository(profileStore, () => fixedNow);
 
     // u1 の hiyori と ageha に 5 件ずつメッセージを作成
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
@@ -260,11 +263,10 @@ describe('learnAllUserActivities', () => {
         });
       }
     }
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo: failingLifecycleRepo as never,
       now: () => new Date(fixedNow),

--- a/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -179,7 +179,7 @@ describe('learnAllUserActivities', () => {
   });
 
   it('ユーザー処理が失敗しても他のユーザーは処理継続する', async () => {
-    const { lifecycleRepo, messageRepo } = makeRepos();
+    const { lifecycleRepo } = makeRepos();
     const failingLifecycleRepo = {
       ...lifecycleRepo,
       updateUserActivityProfile: jest.fn().mockRejectedValue(new Error('DB エラー')),

--- a/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
@@ -46,6 +46,12 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   OpenAIEmbeddingClient: jest.fn(),
 }));
 
+function makeProfileRepo(userIds: string[] = ['u1']) {
+  return {
+    listAllUserIds: jest.fn().mockResolvedValue(userIds),
+  };
+}
+
 const mockSendWebPush = jest.requireMock('@nagiyu/common/push')
   .sendWebPushNotification as jest.Mock;
 const core = jest.requireMock('@nagiyu/livetalk-core');
@@ -53,14 +59,6 @@ const mockDetectCritical = core.detectCriticalKnowledge as jest.Mock;
 const mockShouldNotifyNow = core.shouldNotifyNow as jest.Mock;
 const mockGetAllCharacterIds = core.getAllCharacterIds as jest.Mock;
 const mockSelectNotificationsToSend = core.selectNotificationsToSend as jest.Mock;
-
-function makeDocClient() {
-  return {
-    send: jest.fn().mockResolvedValue({
-      Items: [{ UserID: 'u1' }],
-    }),
-  };
-}
 
 function makeLifecycleRepo(
   lifecycle = {
@@ -128,8 +126,7 @@ function makeEmbeddingClient() {
 
 function makeParams(overrides = {}) {
   return {
-    docClient: makeDocClient() as never,
-    tableName: 'test-table',
+    profileRepo: makeProfileRepo() as never,
     lifecycleRepo: makeLifecycleRepo() as never,
     messageRepo: makeMessageRepo() as never,
     knowledgeRepo: makeKnowledgeRepo() as never,
@@ -277,11 +274,8 @@ describe('notifyAllUsers', () => {
   });
 
   it('ユーザー処理で例外 → failedUsers にカウントしてループ継続', async () => {
-    const docClient = {
-      send: jest.fn().mockResolvedValue({
-        Items: [{ UserID: 'u1' }, { UserID: 'u2' }],
-      }),
-    };
+    // profileRepo が 2 ユーザーを返す
+    const profileRepo = makeProfileRepo(['u1', 'u2']);
     // pushSubscriptionRepo が throw → processUser 全体が例外
     const pushSubscriptionRepo = {
       listByUser: jest.fn().mockRejectedValue(new Error('DynamoDB エラー')),
@@ -291,7 +285,7 @@ describe('notifyAllUsers', () => {
     const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
     const result = await notifyAllUsers(
       makeParams({
-        docClient: docClient as never,
+        profileRepo: profileRepo as never,
         pushSubscriptionRepo: pushSubscriptionRepo as never,
       })
     );
@@ -746,18 +740,9 @@ describe('notifyAllUsers', () => {
     });
   });
 
-  it('DynamoDB scan がページネーション → 全ユーザーを収集する', async () => {
-    const docClient = {
-      send: jest
-        .fn()
-        .mockResolvedValueOnce({
-          Items: [{ UserID: 'u1' }],
-          LastEvaluatedKey: { pk: 'USER#u1' },
-        })
-        .mockResolvedValueOnce({
-          Items: [{ UserID: 'u2' }],
-        }),
-    };
+  it('profileRepo が複数ユーザーを返す → 全ユーザーを処理する', async () => {
+    // profileRepo（GSI1）が u1・u2 の 2 ユーザーを返す
+    const profileRepo = makeProfileRepo(['u1', 'u2']);
     mockDetectCritical.mockResolvedValue({ isCritical: false });
     mockShouldNotifyNow.mockReturnValue({ notify: false, reason: 'not_due' });
     mockSelectNotificationsToSend.mockReturnValue({
@@ -766,7 +751,7 @@ describe('notifyAllUsers', () => {
     });
 
     const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
-    const result = await notifyAllUsers(makeParams({ docClient: docClient as never }));
+    const result = await notifyAllUsers(makeParams({ profileRepo: profileRepo as never }));
 
     expect(result.skippedUsers + result.failedUsers + result.notifiedUsers).toBe(2);
   });

--- a/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
@@ -49,9 +49,14 @@ const mockGenerateNotesForUser = jest.requireMock('@nagiyu/livetalk-core')
   .generateNotesForUser as jest.Mock;
 
 describe('studyAllUsers', () => {
-  const mockDocClient = {
-    send: jest.fn(),
-  };
+  /**
+   * listAllUserIds を返すスタブ ProfileRepository を作る。
+   */
+  const makeProfileRepo = (userIds: string[]) => ({
+    listAllUserIds: jest.fn().mockResolvedValue(userIds),
+    getById: jest.fn(),
+    upsert: jest.fn(),
+  });
 
   const makeLifecycleRepo = (overrides: Record<string, object | null> = {}) => ({
     get: jest
@@ -71,8 +76,7 @@ describe('studyAllUsers', () => {
   });
 
   const makeParams = (overrides = {}) => ({
-    docClient: mockDocClient as never,
-    tableName: 'test-table',
+    profileRepo: makeProfileRepo(['u1', 'u2']) as never,
     lifecycleRepo: makeLifecycleRepo() as never,
     interestRepo: {} as never,
     knowledgeRepo: {} as never,
@@ -83,9 +87,6 @@ describe('studyAllUsers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetAllCharacterIds.mockReturnValue(['hiyori', 'ageha']);
-    mockDocClient.send.mockResolvedValue({
-      Items: [{ UserID: 'u1' }, { UserID: 'u2' }],
-    });
     mockGenerateNotesForUser.mockResolvedValue({ generatedCount: 0 });
   });
 

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -174,6 +174,9 @@ export {
   buildInterestSK,
   buildInterestSKPrefix,
   buildLifecycleSK,
+  // GSI1: Profile 列挙用 sparse GSI（#3527）
+  PROFILE_GSI_INDEX_NAME,
+  buildProfileGSI1PK,
 } from './mappers/keys.js';
 
 // Repository interfaces

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -3,7 +3,22 @@
  *
  * 設計は `docs/services/livetalk/architecture.md` §3「データモデル概要」の SK パターンに準拠する。
  * PK は全エンティティで `USER#<googleId>` に統一する。
+ *
+ * GSI1: Profile 列挙用 sparse GSI（#3527）
+ * - GSI1PK='PROFILE' の Profile アイテムのみを索引化する
+ * - GSI1SK は生の UserID（USER# プレフィックスなし）
  */
+
+/** Profile 列挙 GSI のインデックス名 */
+export const PROFILE_GSI_INDEX_NAME = 'GSI1';
+
+/**
+ * GSI1 のパーティションキー値を返す。
+ * Profile アイテムのみに付与する（sparse GSI）。
+ */
+export function buildProfileGSI1PK(): string {
+  return 'PROFILE';
+}
 
 export function buildUserPK(userId: string): string {
   return `USER#${userId}`;

--- a/services/livetalk/core/src/mappers/profile.mapper.ts
+++ b/services/livetalk/core/src/mappers/profile.mapper.ts
@@ -5,7 +5,7 @@ import {
   type EntityMapper,
 } from '@nagiyu/aws';
 import type { ProfileEntity, ProfileKey, UserConsents } from '../entities/profile.entity.js';
-import { buildProfileSK, buildUserPK } from './keys.js';
+import { buildProfileSK, buildUserPK, buildProfileGSI1PK } from './keys.js';
 
 export class ProfileMapper implements EntityMapper<ProfileEntity, ProfileKey> {
   public readonly entityType = 'Profile';
@@ -20,6 +20,10 @@ export class ProfileMapper implements EntityMapper<ProfileEntity, ProfileKey> {
       LastActiveAt: entity.LastActiveAt,
       CreatedAt: entity.CreatedAt,
       UpdatedAt: entity.UpdatedAt,
+      // GSI1: Profile 列挙用 sparse GSI 属性（#3527）
+      // GSI1PK='PROFILE' で Profile アイテムのみを索引化、GSI1SK は生の UserID
+      GSI1PK: buildProfileGSI1PK(),
+      GSI1SK: entity.UserID,
     };
     if (entity.Consents !== undefined) {
       item.Consents = entity.Consents;

--- a/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
@@ -1,4 +1,9 @@
-import { GetCommand, PutCommand, QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
 import type {
   CreateProfileInput,

--- a/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
@@ -1,4 +1,4 @@
-import { GetCommand, PutCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, PutCommand, QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
 import type {
   CreateProfileInput,
@@ -6,6 +6,7 @@ import type {
   ProfileKey,
   UpdateProfileInput,
 } from '../entities/profile.entity.js';
+import { PROFILE_GSI_INDEX_NAME, buildProfileGSI1PK } from '../mappers/keys.js';
 import { ProfileMapper } from '../mappers/profile.mapper.js';
 import type { ProfileRepository } from './profile.repository.interface.js';
 
@@ -47,6 +48,38 @@ export class DynamoDBProfileRepository implements ProfileRepository {
       const message = error instanceof Error ? error.message : String(error);
       throw new DatabaseError(message, error instanceof Error ? error : undefined);
     }
+  }
+
+  public async listAllUserIds(): Promise<string[]> {
+    const userIds: string[] = [];
+    let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+    try {
+      do {
+        const result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            IndexName: PROFILE_GSI_INDEX_NAME,
+            KeyConditionExpression: '#gsi1pk = :pk',
+            ExpressionAttributeNames: { '#gsi1pk': 'GSI1PK' },
+            ExpressionAttributeValues: { ':pk': buildProfileGSI1PK() },
+            ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
+          })
+        );
+        for (const item of result.Items ?? []) {
+          // KEYS_ONLY 射影のため GSI1SK（生の UserID）から読み取る
+          if (typeof item.GSI1SK === 'string' && item.GSI1SK) {
+            userIds.push(item.GSI1SK);
+          }
+        }
+        lastEvaluatedKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+      } while (lastEvaluatedKey !== undefined);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+
+    return userIds;
   }
 
   public async upsert(

--- a/services/livetalk/core/src/repositories/in-memory-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-profile.repository.ts
@@ -5,6 +5,7 @@ import type {
   ProfileKey,
   UpdateProfileInput,
 } from '../entities/profile.entity.js';
+import { buildProfileGSI1PK } from '../mappers/keys.js';
 import { ProfileMapper } from '../mappers/profile.mapper.js';
 import type { ProfileRepository } from './profile.repository.interface.js';
 
@@ -24,6 +25,26 @@ export class InMemoryProfileRepository implements ProfileRepository {
     const item = this.store.get(pk, sk);
     if (!item) return null;
     return this.mapper.toEntity(item);
+  }
+
+  public async listAllUserIds(): Promise<string[]> {
+    const userIds: string[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const result = this.store.queryByAttribute(
+        { attributeName: 'GSI1PK', attributeValue: buildProfileGSI1PK() },
+        cursor ? { cursor } : undefined
+      );
+      for (const item of result.items) {
+        if (typeof item.GSI1SK === 'string' && item.GSI1SK) {
+          userIds.push(item.GSI1SK);
+        }
+      }
+      cursor = result.nextCursor;
+    } while (cursor !== undefined);
+
+    return userIds;
   }
 
   public async upsert(

--- a/services/livetalk/core/src/repositories/profile.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/profile.repository.interface.ts
@@ -19,4 +19,10 @@ export interface ProfileRepository {
    * 既存があれば渡された `updates` を適用、無ければ create + updates 反映で新規作成する。
    */
   upsert(input: CreateProfileInput, updates?: UpdateProfileInput): Promise<ProfileEntity>;
+  /**
+   * 全ユーザーの UserID を列挙する。
+   * GSI1（GSI1PK='PROFILE'）を Query して Profile のみを読む（テーブル全体を Scan しない）。
+   * 内部で LastEvaluatedKey をループし全件返す。バッチのユーザー列挙に用いる。
+   */
+  listAllUserIds(): Promise<string[]>;
 }

--- a/services/livetalk/core/tests/unit/mappers/profile.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/profile.mapper.test.ts
@@ -25,6 +25,23 @@ describe('ProfileMapper', () => {
     expect(mapper.toEntity(item)).toEqual(baseEntity);
   });
 
+  it('toItem に GSI1PK="PROFILE" が含まれる（sparse GSI）', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(item.GSI1PK).toBe('PROFILE');
+  });
+
+  it('toItem に GSI1SK=UserID（生の UserID）が含まれる', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(item.GSI1SK).toBe('google-12345');
+  });
+
+  it('toEntity は GSI1PK / GSI1SK を entity に含めない', () => {
+    const item = mapper.toItem(baseEntity);
+    const entity = mapper.toEntity(item);
+    expect(Object.keys(entity)).not.toContain('GSI1PK');
+    expect(Object.keys(entity)).not.toContain('GSI1SK');
+  });
+
   it('Auth 側の情報（DisplayName / Email / GoogleID）は永続化しない', () => {
     const item = mapper.toItem(baseEntity);
     expect(item.DisplayName).toBeUndefined();

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
@@ -1,4 +1,4 @@
-import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { DatabaseError } from '@nagiyu/aws';
 import { DynamoDBProfileRepository } from '../../../src/repositories/dynamodb-profile.repository.js';
 
@@ -115,5 +115,69 @@ describe('DynamoDBProfileRepository', () => {
     await repo.upsert({ UserID: 'u1' }, { Consents: consents });
     const put = (sent[1] as PutCommand).input;
     expect(put.Item?.Consents).toEqual(consents);
+  });
+
+  describe('listAllUserIds', () => {
+    it('GSI1 を QueryCommand で IndexName="GSI1" を指定して送信する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Items: [{ GSI1PK: 'PROFILE', GSI1SK: 'user-1' }] };
+      });
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+
+      const result = await repo.listAllUserIds();
+
+      expect(sent[0]).toBeInstanceOf(QueryCommand);
+      const query = (sent[0] as QueryCommand).input;
+      expect(query.IndexName).toBe('GSI1');
+      expect(result).toEqual(['user-1']);
+    });
+
+    it('複数ページ（LastEvaluatedKey 連鎖）を結合して UserID 配列を返す', async () => {
+      let callCount = 0;
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            Items: [{ GSI1PK: 'PROFILE', GSI1SK: 'user-1' }],
+            LastEvaluatedKey: { GSI1PK: 'PROFILE', GSI1SK: 'user-1' },
+          };
+        }
+        return { Items: [{ GSI1PK: 'PROFILE', GSI1SK: 'user-2' }] };
+      });
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+
+      const result = await repo.listAllUserIds();
+
+      expect(callCount).toBe(2);
+      expect(result).toEqual(['user-1', 'user-2']);
+    });
+
+    it('Items が空のとき空配列を返す', async () => {
+      const client = makeClient(async () => ({ Items: [] }));
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+      expect(await repo.listAllUserIds()).toEqual([]);
+    });
+
+    it('GSI1SK が文字列でない or 空のアイテムを無視する', async () => {
+      const client = makeClient(async () => ({
+        Items: [
+          { GSI1PK: 'PROFILE', GSI1SK: '' },
+          { GSI1PK: 'PROFILE', GSI1SK: 123 },
+          { GSI1PK: 'PROFILE', GSI1SK: 'valid-user' },
+        ],
+      }));
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+      expect(await repo.listAllUserIds()).toEqual(['valid-user']);
+    });
+
+    it('エラーは DatabaseError でラップされる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('QueryCommand 失敗');
+      });
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+      await expect(repo.listAllUserIds()).rejects.toBeInstanceOf(DatabaseError);
+    });
   });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
@@ -75,4 +75,28 @@ describe('InMemoryProfileRepository', () => {
     const updated = await repo.upsert({ UserID: 'u3' }, { Consents: consents });
     expect(updated.Consents).toEqual(consents);
   });
+
+  describe('listAllUserIds', () => {
+    it('upsert した複数ユーザーが全件返る', async () => {
+      await repo.upsert({ UserID: 'user-a' });
+      await repo.upsert({ UserID: 'user-b' });
+      await repo.upsert({ UserID: 'user-c' });
+
+      const result = await repo.listAllUserIds();
+
+      expect(result.sort()).toEqual(['user-a', 'user-b', 'user-c']);
+    });
+
+    it('ユーザーが 0 件のとき空配列を返す', async () => {
+      const result = await repo.listAllUserIds();
+      expect(result).toEqual([]);
+    });
+
+    it('upsert したユーザーの UserID（生の ID）が返る（USER# プレフィックスなし）', async () => {
+      await repo.upsert({ UserID: 'google-xyz' });
+      const result = await repo.listAllUserIds();
+      expect(result).toContain('google-xyz');
+      expect(result.some((id) => id.startsWith('USER#'))).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## 変更の概要

livetalk の毎時バッチ群がユーザー一覧取得にテーブル全件 Scan（`FilterExpression Type='Profile'`）を使っていたのを、Profile 専用の **sparse GSI（GSI1）への Query** に置き換える。あわせて、各 usecase に重複実装されていた `scanAllUserIds` を **core の `ProfileRepository.listAllUserIds()` に一本化**する。

主な変更:

- **infra**: `LiveTalkDynamoDbStack` の MainTable に GSI1 を追加（`GSI1PK`(HASH) / `GSI1SK`(RANGE) / Projection=KEYS_ONLY）。PAY_PER_REQUEST のためキャパシティ指定なし。
- **core**:
  - `ProfileMapper.toItem` が Profile アイテムにのみ `GSI1PK='PROFILE'` / `GSI1SK=<生の UserID>` を付与（sparse 化）。
  - `ProfileRepository` に `listAllUserIds()` を追加。DynamoDB 実装は GSI1 を `LastEvaluatedKey` ループで全件 Query、in-memory 実装は `queryByAttribute` で模倣。
  - `keys.ts` に `PROFILE_GSI_INDEX_NAME` / `buildProfileGSI1PK()` を追加。
- **batch**: `compress-conversations` / `study` / `learn-user-activity` / **`notify`** の 4 usecase からローカル Scan を撤去し `profileRepo.listAllUserIds()` に置換。各 handler で `DynamoDBProfileRepository` を構築・注入。

> Issue 本文では対象を 3 usecase と記載していたが、調査の結果 `notify.usecase.ts` にも同一の全件 Scan が残っていたため、ユーザー列挙集約を完結させる目的で本 PR に含めた（batch から Scan 列挙が完全に消えたことを確認済み）。

## 関連 Issue

#3527 Phase 1（ユーザー列挙の Scan 解消）。
※ 作業ブランチ → integration の PR のため `Closes #` は付けない（親 Issue は integration → develop でクローズ）。

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（develop 反映後に docs 追従要否を判断）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカル実行結果:

- `core`: 77 suites / 1147 tests pass（カバレッジ 80% 閾値クリア）
  - `ProfileMapper.toItem` が `GSI1PK='PROFILE'` / `GSI1SK=UserID` を付与することを検証
  - `DynamoDBProfileRepository.listAllUserIds` が GSI1 を Query し複数ページ（`LastEvaluatedKey` 連鎖）を結合することを検証
  - `InMemoryProfileRepository.listAllUserIds` が登録済み全ユーザーを返すことを検証
- `batch`: 8 suites / 66 tests pass（カバレッジ 80% 閾値クリア）
  - 4 usecase / handler のユーザー列挙供給元を `profileRepo` 経由に差し替え、既存のロジック検証は維持
  - `grep "ScanCommand|scanAllUserIds" services/livetalk/batch/src` がヒット 0
- `infra/livetalk`: 8 suites / 114 tests pass（GSI1 の存在・キー定義を検証）

## レビューポイント

fresh-eyes レビュー（別コンテキスト）で挙がった、**合意済みのトレードオフ**を明示しておく:

1. **既存 Profile アイテムのバックフィルは行わない（自然カバレッジ方針）**
   sparse GSI のため、本変更デプロイ時点で既存の Profile アイテムは次回 upsert（ログイン等の活動で `LastActiveAt` 更新時）まで GSI1 に載らない。アクティブユーザーは自然に索引化されるため、移行用バックフィルは入れない判断。唯一の残存リスクは「デプロイ直後に休眠し 90 日復帰しない、かつ未圧縮メッセージを持つユーザー」の compress 取りこぼし（不可逆）だが、招待制の現規模では確率・被害とも限定的と判断して許容する。
2. **`GSI1PK='PROFILE'` の単一パーティション集中**
   全 Profile が単一 GSI パーティションに集中する。現規模では妥当な割り切り。ユーザー数が大きく増えた場合の分散はフォローアップ事項。

## 補足事項

本 PR は #3527 の Phase 1（Scan 解消）。Phase 2（一覧系 API のページネーション整理 / push 通知集約の固定 100 件撤廃）は別 PR で対応予定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01KPAyuemT4wzg4E2ji94VuA)_