### PR TITLE
livetalk: 一覧系 API の暗黙打ち切りを解消（notes 全件取得 / push pending 集約のページング）（#3527 Phase 2）

### DIFF
--- a/services/livetalk/core/src/repositories/dynamodb-note.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-note.repository.ts
@@ -77,6 +77,42 @@ export class DynamoDBNoteRepository implements NoteRepository {
     return results;
   }
 
+  public async listAll(userId: string, characterId: string): Promise<NoteEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildNoteSKPrefix(characterId);
+    const results: NoteEntity[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: { ':pk': pk, ':prefix': prefix },
+            ScanIndexForward: false,
+            Limit: 100,
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        results.push(this.mapper.toEntity(raw as unknown as DynamoDBItem));
+      }
+
+      if (!result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return results;
+  }
+
   public async get(key: NoteKey): Promise<NoteEntity | null> {
     const pk = buildUserPK(key.userId);
     const sk = buildNoteSK(key.characterId, key.noteId);

--- a/services/livetalk/core/src/repositories/dynamodb-notification-event.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-notification-event.repository.ts
@@ -81,6 +81,55 @@ export class DynamoDBNotificationEventRepository implements NotificationEventRep
     return results;
   }
 
+  public async listLatestUnconsumedByCharacter(
+    userId: string,
+    characterIds: string[]
+  ): Promise<NotificationEventEntity[]> {
+    if (characterIds.length === 0) return [];
+
+    const pk = buildUserPK(userId);
+    const prefix = buildNotifSKPrefix();
+    const target = new Set(characterIds);
+    const map = new Map<string, NotificationEventEntity>();
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: { ':pk': pk, ':prefix': prefix },
+            ScanIndexForward: false,
+            Limit: 100,
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        const entity = this.mapper.toEntity(raw as unknown as DynamoDBItem);
+        if (
+          target.has(entity.CharacterID) &&
+          entity.ConsumedAt === undefined &&
+          !map.has(entity.CharacterID)
+        ) {
+          map.set(entity.CharacterID, entity);
+        }
+      }
+
+      if (map.size >= characterIds.length || !result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return Array.from(map.values());
+  }
+
   public async get(key: NotificationEventKey): Promise<NotificationEventEntity | null> {
     const pk = buildUserPK(key.userId);
     const sk = buildNotifSK(key.notifId);

--- a/services/livetalk/core/src/repositories/dynamodb-notification-event.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-notification-event.repository.ts
@@ -123,7 +123,7 @@ export class DynamoDBNotificationEventRepository implements NotificationEventRep
         }
       }
 
-      if (map.size >= characterIds.length || !result.LastEvaluatedKey) break;
+      if (map.size >= target.size || !result.LastEvaluatedKey) break;
       exclusiveStartKey = result.LastEvaluatedKey;
     }
 

--- a/services/livetalk/core/src/repositories/in-memory-note.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-note.repository.ts
@@ -33,6 +33,19 @@ export class InMemoryNoteRepository implements NoteRepository {
       .slice(0, limit);
   }
 
+  public async listAll(userId: string, characterId: string): Promise<NoteEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildNoteSKPrefix(characterId);
+    // limit を指定しないとデフォルト 100 件で打ち切られるため、十分大きな値を渡す
+    const result = this.store.query(
+      { pk, sk: { operator: 'begins_with', value: prefix } },
+      { limit: Number.MAX_SAFE_INTEGER }
+    );
+    return result.items
+      .map((item) => this.mapper.toEntity(item))
+      .sort((a, b) => b.CreatedAt - a.CreatedAt);
+  }
+
   public async get(key: NoteKey): Promise<NoteEntity | null> {
     const pk = buildUserPK(key.userId);
     const sk = buildNoteSK(key.characterId, key.noteId);

--- a/services/livetalk/core/src/repositories/in-memory-notification-event.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-notification-event.repository.ts
@@ -35,6 +35,38 @@ export class InMemoryNotificationEventRepository implements NotificationEventRep
       .slice(0, limit);
   }
 
+  public async listLatestUnconsumedByCharacter(
+    userId: string,
+    characterIds: string[]
+  ): Promise<NotificationEventEntity[]> {
+    if (characterIds.length === 0) return [];
+
+    const pk = buildUserPK(userId);
+    const prefix = buildNotifSKPrefix();
+    // limit を指定しないとデフォルト 100 件で打ち切られるため、十分大きな値を渡す
+    const result = this.store.query(
+      { pk, sk: { operator: 'begins_with', value: prefix } },
+      { limit: Number.MAX_SAFE_INTEGER }
+    );
+    const sorted = result.items
+      .map((item) => this.mapper.toEntity(item))
+      .sort((a, b) => b.CreatedAt - a.CreatedAt);
+
+    const target = new Set(characterIds);
+    const map = new Map<string, NotificationEventEntity>();
+    for (const entity of sorted) {
+      if (
+        target.has(entity.CharacterID) &&
+        entity.ConsumedAt === undefined &&
+        !map.has(entity.CharacterID)
+      ) {
+        map.set(entity.CharacterID, entity);
+      }
+    }
+
+    return Array.from(map.values());
+  }
+
   public async get(key: NotificationEventKey): Promise<NotificationEventEntity | null> {
     const pk = buildUserPK(key.userId);
     const sk = buildNotifSK(key.notifId);

--- a/services/livetalk/core/src/repositories/note.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/note.repository.interface.ts
@@ -4,6 +4,8 @@ export interface NoteRepository {
   put(input: CreateNoteInput): Promise<NoteEntity>;
   /** キャラ単位のノートを CreatedAt 降順で返す。 */
   list(userId: string, characterId: string, limit?: number): Promise<NoteEntity[]>;
+  /** キャラ単位の全ノートを CreatedAt 降順で返す（固定件数で打ち切らない）。 */
+  listAll(userId: string, characterId: string): Promise<NoteEntity[]>;
   /** 単一ノートを返す。なければ null。 */
   get(key: NoteKey): Promise<NoteEntity | null>;
   /**

--- a/services/livetalk/core/src/repositories/notification-event.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/notification-event.repository.interface.ts
@@ -8,6 +8,15 @@ export interface NotificationEventRepository {
   put(input: CreateNotificationEventInput): Promise<NotificationEventEntity>;
   /** ユーザーの通知履歴を CreatedAt 降順で返す。 */
   listByUser(userId: string, limit?: number): Promise<NotificationEventEntity[]>;
+  /**
+   * 指定キャラクター群について「最新の未消化通知」を 1 件ずつ返す。
+   * CreatedAt 降順に走査し、全キャラで最新未消化が揃うか履歴を尽くすまでページングする（固定件数で打ち切らない）。
+   * 戻り値は未消化通知が存在するキャラクターのエントリのみ（順序不問）。
+   */
+  listLatestUnconsumedByCharacter(
+    userId: string,
+    characterIds: string[]
+  ): Promise<NotificationEventEntity[]>;
   /** 単一通知イベントを返す。なければ null。 */
   get(key: NotificationEventKey): Promise<NotificationEventEntity | null>;
   /** consumedAt を現在時刻で更新する（キャラ第一声表示後に呼ぶ）。 */

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-note.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-note.repository.test.ts
@@ -117,6 +117,76 @@ describe('DynamoDBNoteRepository', () => {
     });
   });
 
+  describe('listAll', () => {
+    it('複数ページを結合して全件返す（LastEvaluatedKey の連鎖）', async () => {
+      let callCount = 0;
+      const page1Item = { ...baseItem, NoteID: 'note-001', SK: 'CHAR#hiyori#NOTE#note-001' };
+      const page2Item = {
+        ...baseItem,
+        NoteID: 'note-002',
+        SK: 'CHAR#hiyori#NOTE#note-002',
+        CreatedAt: fixedNow - 1000,
+      };
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { Items: [page1Item], LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor' } };
+        }
+        return { Items: [page2Item] };
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const list = await repo.listAll('u1', 'hiyori');
+      expect(list).toHaveLength(2);
+      // 2 ページ分クエリされていること
+      expect(callCount).toBe(2);
+    });
+
+    it('100 件を超えても全件返す（件数制限なし）', async () => {
+      // 1 ページ目に 100 件 + LastEvaluatedKey、2 ページ目に 50 件
+      let callCount = 0;
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          const items = Array.from({ length: 100 }, (_, i) => ({
+            ...baseItem,
+            NoteID: `note-${i}`,
+            SK: `CHAR#hiyori#NOTE#note-${i}`,
+          }));
+          return { Items: items, LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor' } };
+        }
+        const items = Array.from({ length: 50 }, (_, i) => ({
+          ...baseItem,
+          NoteID: `note-extra-${i}`,
+          SK: `CHAR#hiyori#NOTE#note-extra-${i}`,
+        }));
+        return { Items: items };
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const list = await repo.listAll('u1', 'hiyori');
+      // list() と異なり 100 件で打ち切らず全 150 件を返す
+      expect(list).toHaveLength(150);
+      expect(callCount).toBe(2);
+    });
+
+    it('LastEvaluatedKey がなければ 1 ページで終了する', async () => {
+      const client = makeClient(async () => ({ Items: [baseItem] }));
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const list = await repo.listAll('u1', 'hiyori');
+      expect(list).toHaveLength(1);
+    });
+
+    it('listAll 失敗時は DatabaseError を投げる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('boom');
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+      await expect(repo.listAll('u1', 'hiyori')).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
   describe('listRecent', () => {
     it('threshold より新しいノートのみ返す', async () => {
       const oldItem = {

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-notification-event.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-notification-event.repository.test.ts
@@ -299,6 +299,60 @@ describe('DynamoDBNotificationEventRepository', () => {
       expect(callCount).toBe(1);
     });
 
+    it('未消化が 0 のキャラが対象に含まれる場合は履歴を走査し尽くし、他キャラは正しく返す', async () => {
+      // 最悪ケース: ageha は未消化が一切無いため早期終了せず、全ページを走査する。
+      // それでも hiyori の最新未消化は取りこぼさず返ること。
+      let callCount = 0;
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            Items: [
+              { ...baseItem, NotifID: 'N-HIY', CharacterID: 'hiyori', SK: 'NOTIF#N-HIY' },
+              // ageha は消化済みのみ（未消化なし）
+              {
+                ...baseItem,
+                NotifID: 'N-AGE-C',
+                CharacterID: 'ageha',
+                SK: 'NOTIF#N-AGE-C',
+                ConsumedAt: fixedNow - 1000,
+              },
+            ],
+            LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor1' },
+          };
+        }
+        if (callCount === 2) {
+          return {
+            Items: [
+              {
+                ...baseItem,
+                NotifID: 'N-AGE-C2',
+                CharacterID: 'ageha',
+                SK: 'NOTIF#N-AGE-C2',
+                ConsumedAt: fixedNow - 2000,
+              },
+            ],
+            LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor2' },
+          };
+        }
+        // 最終ページ（LastEvaluatedKey なし）
+        return { Items: [] };
+      });
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori', 'ageha']);
+      // ageha は未消化なしで充足しないため、終端まで走査する（早期終了しない）
+      expect(callCount).toBe(3);
+      // hiyori の未消化のみ返る
+      expect(result).toHaveLength(1);
+      expect(result[0].CharacterID).toBe('hiyori');
+      expect(result[0].NotifID).toBe('N-HIY');
+    });
+
     it('エラー時は DatabaseError を投げる', async () => {
       const client = makeClient(async () => {
         throw new Error('query 失敗');

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-notification-event.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-notification-event.repository.test.ts
@@ -176,6 +176,144 @@ describe('DynamoDBNotificationEventRepository', () => {
     });
   });
 
+  describe('listLatestUnconsumedByCharacter', () => {
+    it('characterIds が空の場合は即 [] を返す', async () => {
+      const client = makeClient(async () => ({ Items: [] }));
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+      const result = await repo.listLatestUnconsumedByCharacter('u1', []);
+      expect(result).toEqual([]);
+    });
+
+    it('キャラごとに最新未消化通知 1 件を返す', async () => {
+      const hiyoriItem = {
+        ...baseItem,
+        NotifID: 'N-HIY',
+        CharacterID: 'hiyori',
+        SK: 'NOTIF#N-HIY',
+      };
+      const agehaItem = { ...baseItem, NotifID: 'N-AGE', CharacterID: 'ageha', SK: 'NOTIF#N-AGE' };
+      const client = makeClient(async () => ({ Items: [hiyoriItem, agehaItem] }));
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori', 'ageha']);
+      expect(result).toHaveLength(2);
+      const charIds = result.map((e) => e.CharacterID);
+      expect(charIds).toContain('hiyori');
+      expect(charIds).toContain('ageha');
+    });
+
+    it('消化済みイベントはスキップする', async () => {
+      const consumedItem = {
+        ...baseItem,
+        NotifID: 'N-CONSUMED',
+        CharacterID: 'hiyori',
+        SK: 'NOTIF#N-CONSUMED',
+        ConsumedAt: fixedNow - 1000,
+      };
+      const client = makeClient(async () => ({ Items: [consumedItem] }));
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(0);
+    });
+
+    it('未消化が 1 ページ目より後ろにあっても取りこぼさない（複数ページ連鎖）', async () => {
+      // 1 ページ目: hiyori の消化済み通知 100 件
+      // 2 ページ目: hiyori の未消化通知 1 件
+      let callCount = 0;
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          const consumedItems = Array.from({ length: 100 }, (_, i) => ({
+            ...baseItem,
+            NotifID: `N-CONSUMED-${i}`,
+            CharacterID: 'hiyori',
+            SK: `NOTIF#N-CONSUMED-${i}`,
+            ConsumedAt: fixedNow - (i + 1) * 1000,
+          }));
+          return { Items: consumedItems, LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor' } };
+        }
+        // 2 ページ目: 未消化が 1 件
+        return {
+          Items: [
+            {
+              ...baseItem,
+              NotifID: 'N-LATE-UNCONSUMED',
+              CharacterID: 'hiyori',
+              SK: 'NOTIF#N-LATE-UNCONSUMED',
+            },
+          ],
+        };
+      });
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      // 2 ページ目にある未消化を正しく発見できること
+      expect(result).toHaveLength(1);
+      expect(result[0].NotifID).toBe('N-LATE-UNCONSUMED');
+      expect(callCount).toBe(2);
+    });
+
+    it('全キャラ充足したら早期終了する', async () => {
+      // 1 ページ目で hiyori, ageha 双方の未消化が揃う → 2 ページ目を問い合わせない
+      let callCount = 0;
+      const hiyoriItem = {
+        ...baseItem,
+        NotifID: 'N-HIY',
+        CharacterID: 'hiyori',
+        SK: 'NOTIF#N-HIY',
+      };
+      const agehaItem = { ...baseItem, NotifID: 'N-AGE', CharacterID: 'ageha', SK: 'NOTIF#N-AGE' };
+      const client = makeClient(async () => {
+        callCount++;
+        return {
+          Items: [hiyoriItem, agehaItem],
+          LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor' },
+        };
+      });
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori', 'ageha']);
+      expect(result).toHaveLength(2);
+      // 全キャラ充足で break → 1 回しか呼ばれない
+      expect(callCount).toBe(1);
+    });
+
+    it('エラー時は DatabaseError を投げる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('query 失敗');
+      });
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+      await expect(repo.listLatestUnconsumedByCharacter('u1', ['hiyori'])).rejects.toBeInstanceOf(
+        DatabaseError
+      );
+    });
+  });
+
   describe('get', () => {
     it('GetCommand で単一イベントを返す', async () => {
       const sent: unknown[] = [];

--- a/services/livetalk/core/tests/unit/repositories/in-memory-note.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-note.repository.test.ts
@@ -97,4 +97,41 @@ describe('InMemoryNoteRepository', () => {
   it('list は未登録ユーザーに対して空配列を返す', async () => {
     expect(await repo.list('unknown', 'hiyori')).toHaveLength(0);
   });
+
+  describe('listAll', () => {
+    it('全件を CreatedAt 降順で返す（limit による打ち切りなし）', async () => {
+      // 150 件登録
+      for (let i = 0; i < 150; i++) {
+        await repo.put(makeInput({ NoteID: `note-${i}` }));
+        now += 100;
+      }
+      const all = await repo.listAll('u1', 'hiyori');
+      // list(100) とは異なり全 150 件返す
+      expect(all).toHaveLength(150);
+    });
+
+    it('CreatedAt 降順で返す', async () => {
+      await repo.put(makeInput({ NoteID: 'note-old' }));
+      now += 1000;
+      await repo.put(makeInput({ NoteID: 'note-new' }));
+
+      const all = await repo.listAll('u1', 'hiyori');
+      expect(all).toHaveLength(2);
+      expect(all[0].NoteID).toBe('note-new');
+      expect(all[1].NoteID).toBe('note-old');
+    });
+
+    it('別ユーザーのノートは含まない', async () => {
+      await repo.put(makeInput({ UserID: 'u1', NoteID: 'note-u1' }));
+      await repo.put(makeInput({ UserID: 'u2', NoteID: 'note-u2' }));
+
+      const all = await repo.listAll('u1', 'hiyori');
+      expect(all).toHaveLength(1);
+      expect(all[0].NoteID).toBe('note-u1');
+    });
+
+    it('ノートが 0 件の場合は空配列を返す', async () => {
+      expect(await repo.listAll('u1', 'hiyori')).toHaveLength(0);
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-notification-event.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-notification-event.repository.test.ts
@@ -152,6 +152,97 @@ describe('InMemoryNotificationEventRepository', () => {
     });
   });
 
+  describe('listLatestUnconsumedByCharacter', () => {
+    it('characterIds が空の場合は [] を返す', async () => {
+      const store = makeStore();
+      const repo = makeRepo(store);
+      await repo.put(makeInput({ NotifID: 'NOTIF-X' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', []);
+      expect(result).toEqual([]);
+    });
+
+    it('キャラごとに最新未消化通知 1 件を返す', async () => {
+      const store = makeStore();
+      let now = BASE_NOW;
+      const repo = makeRepo(store, () => now);
+
+      now = BASE_NOW + 1000;
+      await repo.put(makeInput({ NotifID: 'N-HIY-OLD', CharacterID: 'hiyori' }));
+      now = BASE_NOW + 2000;
+      await repo.put(makeInput({ NotifID: 'N-HIY-NEW', CharacterID: 'hiyori' }));
+      now = BASE_NOW + 3000;
+      await repo.put(makeInput({ NotifID: 'N-AGE', CharacterID: 'ageha' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori', 'ageha']);
+      expect(result).toHaveLength(2);
+
+      const hiyori = result.find((e) => e.CharacterID === 'hiyori');
+      // 最新（CreatedAt が大きい方）が返ること
+      expect(hiyori?.NotifID).toBe('N-HIY-NEW');
+    });
+
+    it('消化済みイベントはスキップする', async () => {
+      const store = makeStore();
+      const repo = makeRepo(store);
+      const saved = await repo.put(makeInput({ NotifID: 'NOTIF-CONSUME' }));
+      await repo.markConsumed({ userId: 'u1', notifId: saved.NotifID }, BASE_NOW + 1000);
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(0);
+    });
+
+    it('消化済みと未消化が混在する場合、最新未消化を返す', async () => {
+      const store = makeStore();
+      let now = BASE_NOW;
+      const repo = makeRepo(store, () => now);
+
+      // 最新: 消化済み
+      now = BASE_NOW + 2000;
+      const consumed = await repo.put(makeInput({ NotifID: 'N-CONSUMED' }));
+      await repo.markConsumed({ userId: 'u1', notifId: consumed.NotifID }, now + 100);
+
+      // 2 番目: 未消化
+      now = BASE_NOW + 1000;
+      await repo.put(makeInput({ NotifID: 'N-UNCONSUMED' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(1);
+      expect(result[0].NotifID).toBe('N-UNCONSUMED');
+    });
+
+    it('全件走査して未消化を発見する（大量消化済みでも取りこぼさない）', async () => {
+      const store = makeStore();
+      let now = BASE_NOW;
+      const repo = makeRepo(store, () => now);
+
+      // 多数の消化済みを先に（CreatedAt が新しい順）登録
+      for (let i = 100; i >= 1; i--) {
+        now = BASE_NOW + i * 1000;
+        const e = await repo.put(makeInput({ NotifID: `N-CONSUMED-${i}` }));
+        await repo.markConsumed({ userId: 'u1', notifId: e.NotifID }, now + 100);
+      }
+
+      // 最も古い（CreatedAt が最小）の未消化通知
+      now = BASE_NOW;
+      await repo.put(makeInput({ NotifID: 'N-OLDEST-UNCONSUMED' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(1);
+      expect(result[0].NotifID).toBe('N-OLDEST-UNCONSUMED');
+    });
+
+    it('別ユーザーのイベントは混入しない', async () => {
+      const store = makeStore();
+      const repo = makeRepo(store);
+      // u2 のイベントのみ
+      await repo.put(makeInput({ UserID: 'u2', NotifID: 'N-U2' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(0);
+    });
+  });
+
   describe('デフォルト nowMs', () => {
     it('nowMs 省略時は Date.now() が使われる', async () => {
       const store = makeStore();

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -1514,6 +1514,7 @@ describe('runChatUseCase', () => {
       return {
         put: jest.fn(),
         list: jest.fn(async () => notes),
+        listAll: jest.fn(async () => notes),
         get: jest.fn(async () => null),
         listRecent: jest.fn(async () => notes),
       };

--- a/services/livetalk/web/src/app/api/notes/route.ts
+++ b/services/livetalk/web/src/app/api/notes/route.ts
@@ -30,7 +30,7 @@ export const GET = withAuth(getSession, 'livetalk:chat', async (session, request
   const repo = getNoteRepository();
 
   try {
-    const items = await repo.list(userId, characterId);
+    const items = await repo.listAll(userId, characterId);
     const notes = sortNotes(items.map(toNoteListItem));
     return NextResponse.json({ notes });
   } catch (error) {

--- a/services/livetalk/web/src/app/api/push/pending/route.ts
+++ b/services/livetalk/web/src/app/api/push/pending/route.ts
@@ -30,8 +30,7 @@ export interface PendingNotification {
   body: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const GET = withAuth(getSession, 'livetalk:chat', async (session, _request: Request) => {
+export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
   const userId = session.user.googleId;
   const repo = getNotificationEventRepository();
   const characterIds = getAllCharacterIds();

--- a/services/livetalk/web/src/app/api/push/pending/route.ts
+++ b/services/livetalk/web/src/app/api/push/pending/route.ts
@@ -4,6 +4,9 @@
  * 自前起動時に「他キャラクターからの未消化通知」を提示するために使用する。
  * 各キャラクターの最新未消化通知（1 件）を返す。
  *
+ * キャラごとの最新未消化をページングで集約するため、消化済み通知が多い場合でも
+ * 未消化通知を取りこぼさない。
+ *
  * レスポンス例:
  *   [{ characterId: 'ageha', notifId: 'n1', body: 'アゲハより' }]
  *
@@ -11,6 +14,7 @@
  */
 import { NextResponse } from 'next/server';
 import { withAuth } from '@nagiyu/nextjs';
+import { getAllCharacterIds } from '@nagiyu/livetalk-core';
 import { getSession } from '@/lib/server/session';
 import { getNotificationEventRepository } from '@/lib/server/repositories';
 
@@ -26,26 +30,19 @@ export interface PendingNotification {
   body: string;
 }
 
-export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const GET = withAuth(getSession, 'livetalk:chat', async (session, _request: Request) => {
   const userId = session.user.googleId;
   const repo = getNotificationEventRepository();
-  // 全件取得して未消化をキャラクターごとに集約する
-  // listByUser は CreatedAt 降順で返すため、最初に見つかったものが最新となる
-  const events = await repo.listByUser(userId, 100);
+  const characterIds = getAllCharacterIds();
 
-  // 未消化イベントのみ抽出し、キャラクターごとに最新 1 件を集約する
-  const latestByCharacter = new Map<string, PendingNotification>();
-  for (const e of events) {
-    if (e.ConsumedAt !== undefined) continue;
-    // すでに同キャラクターのエントリがあればスキップ（降順なので最初が最新）
-    if (latestByCharacter.has(e.CharacterID)) continue;
-    latestByCharacter.set(e.CharacterID, {
-      characterId: e.CharacterID,
-      notifId: e.NotifID,
-      body: e.Body,
-    });
-  }
+  const events = await repo.listLatestUnconsumedByCharacter(userId, characterIds);
 
-  const result: PendingNotification[] = Array.from(latestByCharacter.values());
+  const result: PendingNotification[] = events.map((e) => ({
+    characterId: e.CharacterID,
+    notifId: e.NotifID,
+    body: e.Body,
+  }));
+
   return NextResponse.json(result, { status: 200 });
 });

--- a/services/livetalk/web/tests/unit/app/api/notes/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/notes/route.test.ts
@@ -42,6 +42,7 @@ const makeEntity = (over: Partial<NoteEntity> = {}): NoteEntity => ({
 const makeRepo = (over: Partial<NoteRepository> = {}): NoteRepository =>
   ({
     list: jest.fn(async () => []),
+    listAll: jest.fn(async () => []),
     get: jest.fn(),
     put: jest.fn(),
     listRecent: jest.fn(),
@@ -61,11 +62,11 @@ describe('GET /api/notes', () => {
 
   it('一覧を作成日時降順で返す（本文は含めない）', async () => {
     mockGetSession.mockResolvedValue(session);
-    const list = jest.fn(async () => [
+    const listAll = jest.fn(async () => [
       makeEntity({ NoteID: 'old', CreatedAt: 100 }),
       makeEntity({ NoteID: 'new', CreatedAt: 300 }),
     ]);
-    mockGetRepo.mockReturnValue(makeRepo({ list }));
+    mockGetRepo.mockReturnValue(makeRepo({ listAll }));
 
     const res = await GET(req());
     expect(res.status).toBe(200);
@@ -75,16 +76,43 @@ describe('GET /api/notes', () => {
     expect(decodeNoteId(json.notes[0].id, 'g1')?.noteId).toBe('new');
   });
 
+  it('listAll が呼ばれる（list ではない）', async () => {
+    mockGetSession.mockResolvedValue(session);
+    const listAll = jest.fn(async () => []);
+    const list = jest.fn(async () => []);
+    mockGetRepo.mockReturnValue(makeRepo({ listAll, list }));
+
+    await GET(req());
+
+    expect(listAll).toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('100 件を超えても全件を返す', async () => {
+    mockGetSession.mockResolvedValue(session);
+    // listAll が 150 件返すシナリオ（全件を打ち切らずに返す）
+    const items = Array.from({ length: 150 }, (_, i) =>
+      makeEntity({ NoteID: `note-${i}`, CreatedAt: i })
+    );
+    const listAll = jest.fn(async () => items);
+    mockGetRepo.mockReturnValue(makeRepo({ listAll }));
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.notes).toHaveLength(150);
+  });
+
   it('characterId クエリを指定するとそのキャラのノートを取得する', async () => {
     mockGetSession.mockResolvedValue(session);
-    const list = jest.fn(async () => [makeEntity({ CharacterID: 'ageha' })]);
-    mockGetRepo.mockReturnValue(makeRepo({ list }));
+    const listAll = jest.fn(async () => [makeEntity({ CharacterID: 'ageha' })]);
+    mockGetRepo.mockReturnValue(makeRepo({ listAll }));
 
     const req2 = () =>
       new Request('http://localhost/api/notes?characterId=ageha', { method: 'GET' });
     const res = await GET(req2());
     expect(res.status).toBe(200);
-    expect(list).toHaveBeenCalledWith('g1', 'ageha');
+    expect(listAll).toHaveBeenCalledWith('g1', 'ageha');
   });
 
   it('不正な characterId は 400', async () => {
@@ -101,7 +129,7 @@ describe('GET /api/notes', () => {
     mockGetSession.mockResolvedValue(session);
     mockGetRepo.mockReturnValue(
       makeRepo({
-        list: jest.fn(async () => {
+        listAll: jest.fn(async () => {
           throw new Error('boom');
         }),
       })

--- a/services/livetalk/web/tests/unit/app/api/push/pending.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/push/pending.test.ts
@@ -4,10 +4,10 @@
 /**
  * GET /api/push/pending のユニットテスト。
  *
- * Phase C 追加 API:
- *   - 未消化通知をキャラクターごとに集約し、各キャラ最新 1 件を返す
- *   - 未消化なしの場合は空配列を返す
- *   - consume 済みはスキップする
+ * ルートは listLatestUnconsumedByCharacter によりキャラごとの最新未消化通知を集約する。
+ * - 未消化通知をキャラクターごとに集約し、各キャラ最新 1 件を返す
+ * - 未消化なしの場合は空配列を返す
+ * - 100 件を超える履歴があっても未消化通知を取りこぼさない
  */
 import { GET } from '@/app/api/push/pending/route';
 import { getSession } from '@/lib/server/session';
@@ -58,10 +58,15 @@ function makeEvent(overrides: Partial<NotificationEventEntity> = {}): Notificati
   };
 }
 
-/** リポジトリモックのファクトリ */
-function makeRepo(events: NotificationEventEntity[]): NotificationEventRepository {
+/**
+ * リポジトリモックのファクトリ。
+ * ルートは listLatestUnconsumedByCharacter を呼ぶため、
+ * 集約済みの結果（各キャラ最新未消化 1 件）を直接返すモックを使う。
+ */
+function makeRepo(aggregatedResult: NotificationEventEntity[]): NotificationEventRepository {
   return {
-    listByUser: jest.fn(async () => events),
+    listLatestUnconsumedByCharacter: jest.fn(async () => aggregatedResult),
+    listByUser: jest.fn(),
     put: jest.fn(),
     get: jest.fn(),
     markConsumed: jest.fn(),
@@ -92,45 +97,22 @@ describe('GET /api/push/pending', () => {
     expect(json).toEqual([]);
   });
 
-  it('全通知が消化済みの場合は空配列を返す', async () => {
-    mockGetSession.mockResolvedValue(validSession);
-    const consumedEvent = makeEvent({
-      CharacterID: 'hiyori',
-      ConsumedAt: Date.now() - 1000,
-    });
-    mockGetNotificationEventRepo.mockReturnValue(makeRepo([consumedEvent]));
-
-    const res = await GET(buildGetRequest());
-    expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json).toEqual([]);
-  });
-
   it('キャラクターごとに最新未消化通知 1 件を集約して返す', async () => {
     mockGetSession.mockResolvedValue(validSession);
 
-    // hiyori: 2 件の未消化（降順なので n-hiyori-1 が最新）
-    const hiyoriEvent1 = makeEvent({
+    // 集約済み結果（各キャラの最新未消化 1 件）
+    const hiyoriEvent = makeEvent({
       NotifID: 'n-hiyori-1',
       CharacterID: 'hiyori',
       Body: 'ひよりの最新本文',
     });
-    const hiyoriEvent2 = makeEvent({
-      NotifID: 'n-hiyori-2',
-      CharacterID: 'hiyori',
-      Body: 'ひよりの古い本文',
-    });
-    // ageha: 1 件の未消化
     const agehaEvent = makeEvent({
       NotifID: 'n-ageha',
       CharacterID: 'ageha',
       Body: 'アゲハの本文',
     });
 
-    // listByUser は CreatedAt 降順で返す（最新が先頭）
-    mockGetNotificationEventRepo.mockReturnValue(
-      makeRepo([hiyoriEvent1, agehaEvent, hiyoriEvent2])
-    );
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([hiyoriEvent, agehaEvent]));
 
     const res = await GET(buildGetRequest());
     expect(res.status).toBe(200);
@@ -139,7 +121,7 @@ describe('GET /api/push/pending', () => {
     // 2 キャラ分のエントリが返る
     expect(json).toHaveLength(2);
 
-    // hiyori の最新（n-hiyori-1）が含まれる
+    // hiyori のエントリが含まれる
     const hiyoriResult = json.find(
       (item: { characterId: string }) => item.characterId === 'hiyori'
     );
@@ -153,30 +135,39 @@ describe('GET /api/push/pending', () => {
     expect(agehaResult.notifId).toBe('n-ageha');
   });
 
-  it('消化済みと未消化が混在する場合、未消化のみ集約する', async () => {
+  it('listLatestUnconsumedByCharacter に getAllCharacterIds の結果が渡される', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const repo = makeRepo([]);
+    mockGetNotificationEventRepo.mockReturnValue(repo);
+
+    await GET(buildGetRequest());
+
+    // getAllCharacterIds() の戻り値（hiyori, ageha）が渡されること
+    expect(repo.listLatestUnconsumedByCharacter).toHaveBeenCalledWith(
+      'g1',
+      expect.arrayContaining(['hiyori', 'ageha'])
+    );
+  });
+
+  it('100 件を超える履歴があっても未消化通知を取りこぼさない（ページング委譲確認）', async () => {
     mockGetSession.mockResolvedValue(validSession);
 
-    // hiyori: 消化済みが先頭（最新）、未消化が 2 番目
-    const consumedEvent = makeEvent({
-      NotifID: 'n-consumed',
+    // 100 件より後ろにある未消化通知がリポジトリ層で拾われ、集約済み結果として返るシナリオ
+    const lateUnconsumed = makeEvent({
+      NotifID: 'n-late-unconsumed',
       CharacterID: 'hiyori',
-      ConsumedAt: Date.now() - 500,
+      Body: '101 件目の未消化通知',
     });
-    const unconsumedEvent = makeEvent({
-      NotifID: 'n-unconsumed',
-      CharacterID: 'hiyori',
-      Body: '未消化の本文',
-    });
-
-    mockGetNotificationEventRepo.mockReturnValue(makeRepo([consumedEvent, unconsumedEvent]));
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([lateUnconsumed]));
 
     const res = await GET(buildGetRequest());
     expect(res.status).toBe(200);
     const json = await res.json();
 
-    // 未消化のみが集約される
+    // リポジトリ層でページングを処理した結果が正しく返る
     expect(json).toHaveLength(1);
-    expect(json[0].notifId).toBe('n-unconsumed');
+    expect(json[0].notifId).toBe('n-late-unconsumed');
+    expect(json[0].body).toBe('101 件目の未消化通知');
   });
 
   it('レスポンスの各エントリに characterId, notifId, body が含まれる', async () => {


### PR DESCRIPTION
## 変更の概要

livetalk の一覧系 API における**固定件数による暗黙打ち切り**を解消し、正しく全件取得・正しく集約するよう修正する（#3527 Phase 2）。

- **notes 一覧（全件取得）**: `GET /api/notes` が `NoteRepository.list`（既定 100 件で打ち切り）を使っていたため、ノートが 100 件を超えると古いものが暗黙に欠落していた。`NoteRepository.listAll(userId, characterId)` を追加し、ルートをこれに切り替え。DynamoDB 実装は `LastEvaluatedKey` を全ページ走査（総件数で打ち切らない）、in-memory 実装はストアの既定 100 件上限を回避して全件返す。レスポンス形 `{ notes }` は不変のためフロント変更なし。
- **push pending 集約（固定 100 撤廃）**: `GET /api/push/pending` が最新 100 件を取得してからキャラごとの最新未消化を集約していたため、消化済み通知が多いキャラで未消化が 100 件より古い位置にあると取りこぼしていた。`NotificationEventRepository.listLatestUnconsumedByCharacter(userId, characterIds)` を追加。`CreatedAt` 降順にページングし、**全キャラの最新未消化が揃うか履歴を走査し尽くすまで**集約する（固定件数で打ち切らない）。ルートは `getAllCharacterIds()` と本メソッドで集約するよう変更。レスポンス形（`PendingNotification[]`）は不変。

いずれもページネーション方針は「内部ループで全件・正しく集約して返す」（カーソルを client に露出する方式は採らない）。既存の `list(limit?)` / `listByUser(limit?)` は他の呼び出し元（`listRecent` 等）が依存するため残置。

## 関連 Issue

#3527 Phase 2（一覧系 API のページネーション方針の整理）。
※ 作業ブランチ → integration の PR のため `Closes #` は付けない。

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（develop 反映後に docs 追従要否を判断）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

ローカル実行結果:

- `core`: 77 suites / 1167 tests pass（カバレッジ 80% 閾値クリア）
  - `DynamoDBNoteRepository.listAll`: 複数ページ結合・100 件超え全件取得・エラー処理
  - `InMemoryNoteRepository.listAll`: 150 件全件・降順・別ユーザー分離
  - `DynamoDBNotificationEventRepository.listLatestUnconsumedByCharacter`: 集約・消化済みスキップ・**未消化が 1 ページ目より後ろでも複数ページ走査で発見**・全キャラ充足での早期終了・空 `characterIds`
  - `InMemoryNotificationEventRepository`: 同等の集約セマンティクス
- `web`: 58 suites / 560 tests pass（カバレッジ 89.65%）
  - notes ルート: `listAll` 経由で全件返却
  - push/pending ルート: `getAllCharacterIds` + 新メソッドで集約、**>100 件履歴でも未消化を取りこぼさない**シナリオ
- prettier / eslint: 変更ファイルすべてクリーン

## レビューポイント

- `listLatestUnconsumedByCharacter` の早期終了条件（`map.size >= characterIds.length || !LastEvaluatedKey`）。未消化が 0 のキャラが含まれる場合は履歴を走査し尽くすが、通知イベントは 30 日 TTL かつ条件付き生成でスパースなため、走査量は実質的に限定される想定。
- push pending の集約対象を `getAllCharacterIds()`（登録済みキャラ）に限定。未登録（廃止）キャラの通知は対象外になるが、キャラは固定レジストリのため妥当と判断。
- notes は「全件返す」方針のため client 向けカーソルは導入していない（現規模では十分）。ノートが非常に多くなった場合のカーソル化はフォローアップ事項。

## 補足事項

#3527 Phase 1（Scan → GSI 化, #3548）に続く Phase 2。これで本 Issue のスコープ（Scan 解消 + 一覧系ページネーション整理）は揃う。integration → develop への取り込みは別途人の確認のうえ実施。


---
_Generated by [Claude Code](https://claude.ai/code/session_01KPAyuemT4wzg4E2ji94VuA)_