### PR TITLE
livetalk(infra): batch ロールに GSI1（index/*）への Query 権限を付与（#3527 GSI IAM 追従）

### DIFF
--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -53,7 +53,14 @@ export class LiveTalkBatchStack extends cdk.Stack {
     // DynamoDB テーブル
     const dynamoTableName = getDynamoDBTableName('livetalk', environment);
     const dynamoTableArn = getDynamoDBTableArn(this.region, this.account, dynamoTableName);
-    const dynamoTable = dynamodb.Table.fromTableArn(this, 'DynamoTable', dynamoTableArn);
+    // GSI1（Profile 列挙用）への Query 権限を grant に含めるため、インデックス情報付きで
+    // インポートする。`fromTableArn` だけだと hasIndex=false となり grantReadWriteData が
+    // `table/.../index/*` を付与せず、batch ロールが GSI1 を Query できず AccessDenied に
+    // なる（#3527）。globalIndexes を渡すことで grant にインデックス ARN を含める。
+    const dynamoTable = dynamodb.Table.fromTableAttributes(this, 'DynamoTable', {
+      tableArn: dynamoTableArn,
+      globalIndexes: ['GSI1'],
+    });
 
     // DLQ（失敗時の保持）
     const dlq = new sqs.Queue(this, 'BatchDlq', {

--- a/infra/livetalk/tests/unit/batch-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-stack.test.js
@@ -219,6 +219,24 @@ describe('LiveTalkBatchStack', () => {
     template.hasOutput('NotifyFunctionArn', Match.anyValue());
   });
 
+  it('DynamoDB の grant に GSI1（index/*）への Query 権限が含まれる', () => {
+    // batch ロールは GSI1 を Query してユーザーを列挙するため、IAM ポリシーの
+    // Resource にテーブル本体に加えて `table/.../index/*` が含まれている必要がある（#3527）。
+    const { template } = synth();
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(['dynamodb:Query']),
+            Resource: Match.arrayWith([
+              Match.stringLikeRegexp('table/nagiyu-livetalk-dynamodb-dev/index/\\*'),
+            ]),
+          }),
+        ]),
+      },
+    });
+  });
+
   it('prod 環境でも正しく生成する', () => {
     const { template } = synth('prod');
     template.hasResourceProperties('AWS::Lambda::Function', {


### PR DESCRIPTION
## 変更の概要

dev 環境で batch Lambda（notify / compress / learn / study）が **`dynamodb:Query on .../index/GSI1` の AccessDeniedException** を出していた不具合を修正する。

### 原因

Phase 1（#3548）で Profile 列挙用の sparse GSI（`GSI1`）を追加し、batch がそれを Query するようになった。しかし `batch-stack.ts` は DynamoDB テーブルを `dynamodb.Table.fromTableArn(...)`（インデックス情報なし）でインポートしており、CDK はこの形でインポートしたテーブルへの `grantReadWriteData` に **`table/.../index/*` を含めない**（`hasIndex=false` のため）。結果、4 つの batch 実行ロールすべてが GSI1 への Query 権限を持たず、`listAllUserIds()` が失敗していた。

実際のエラー（dev / error-events より）:

```
User: ...assumed-role/nagiyu-livetalk-notify-role-dev/nagiyu-livetalk-batch-notify-dev
is not authorized to perform: dynamodb:Query on resource:
arn:aws:dynamodb:us-east-1:...:table/nagiyu-livetalk-dynamodb-dev/index/GSI1
because no identity-based policy allows the dynamodb:Query action
```

CLI でデプロイ済みロールの IAM ポリシーも確認し、`Resource` がテーブル ARN のみで `/index/*` を欠いていることを確定済み。GSI1 自体は dev で `ACTIVE`（デプロイは正常）。

### 修正

`batch-stack.ts` のテーブルインポートを `fromTableArn` から `fromTableAttributes({ tableArn, globalIndexes: ['GSI1'] })` に変更。これにより `hasIndex=true` となり、共有 `dynamoTable` を grant している 4 ロール（compress / learn / study / notify）すべての IAM ポリシー `Resource` に `table/.../index/*` が自動的に含まれる（1 箇所の修正で 4 ロール解消）。

ECS タスクロール（web）も同じ `fromTableArn` パターンだが、web は GSI1 を Query しない（GSI 列挙は batch のみ）ため、最小権限の観点から本修正の対象外とした。

## 関連 Issue

#3527 の Phase 1（GSI 追加, #3548）の dev 反映後に判明したバグ。混入源が同じ（同 GSI）のため新規起票せず本 Issue 管轄で対応。integration/3527 を取り込んだ dev 環境で発生しているため、GSI と IAM を develop 到達前に揃える目的で **integration/3527 宛て**とする。
※ `Closes #` は付けない。

## 変更種別

- [ ] 新規機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した
- [ ] 関連ドキュメントを更新した（コード/IAM から読み取れる内容のため docs 追従不要と判断）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `infra/livetalk` ビルド（tsc）pass。
- `infra/livetalk` 全 8 suites / 115 tests pass。
- 追加テスト: 「DynamoDB の grant に GSI1（`index/*`）への Query 権限が含まれる」。修正前は `Resource` が単一文字列（配列でない）のため `Match.arrayWith` が失敗する＝修正の有効性を実証する非自明なテスト。
- CLI（読み取り専用）で dev の実エラー・GSI ACTIVE 状態・ロールポリシーの欠落を確認済み。

## レビューポイント

- `fromTableAttributes` + `globalIndexes: ['GSI1']` により grant が `table/.../index/*`（ワイルドカード）になる点。GSI への書き込みは不可のため `grantReadWriteData` のうち実効するのは Query 等の読み取りのみ。
- 本修正は dev で発生中のエラーの恒久対処。マージ → dev 再デプロイで IAM ポリシーが更新され解消する見込み。

## 補足事項

本 PR は #3527 Phase 1 で追加した GSI に対する IAM 追従。Phase 2（#3549）とは独立。


---
_Generated by [Claude Code](https://claude.ai/code/session_01KPAyuemT4wzg4E2ji94VuA)_