### PR TITLE
リブトーク: DynamoDB アクセスのスケーラビリティ改善（Scan 解消・ページネーション）（#3527）

### DIFF
--- a/infra/livetalk/lib/batch-stack.ts
+++ b/infra/livetalk/lib/batch-stack.ts
@@ -53,7 +53,14 @@ export class LiveTalkBatchStack extends cdk.Stack {
     // DynamoDB テーブル
     const dynamoTableName = getDynamoDBTableName('livetalk', environment);
     const dynamoTableArn = getDynamoDBTableArn(this.region, this.account, dynamoTableName);
-    const dynamoTable = dynamodb.Table.fromTableArn(this, 'DynamoTable', dynamoTableArn);
+    // GSI1（Profile 列挙用）への Query 権限を grant に含めるため、インデックス情報付きで
+    // インポートする。`fromTableArn` だけだと hasIndex=false となり grantReadWriteData が
+    // `table/.../index/*` を付与せず、batch ロールが GSI1 を Query できず AccessDenied に
+    // なる（#3527）。globalIndexes を渡すことで grant にインデックス ARN を含める。
+    const dynamoTable = dynamodb.Table.fromTableAttributes(this, 'DynamoTable', {
+      tableArn: dynamoTableArn,
+      globalIndexes: ['GSI1'],
+    });
 
     // DLQ（失敗時の保持）
     const dlq = new sqs.Queue(this, 'BatchDlq', {

--- a/infra/livetalk/lib/dynamodb-stack.ts
+++ b/infra/livetalk/lib/dynamodb-stack.ts
@@ -46,8 +46,7 @@ export class LiveTalkDynamoDbStack extends cdk.Stack {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       pointInTimeRecovery: true,
       timeToLiveAttribute: 'TTL',
-      removalPolicy:
-        environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
       encryption: dynamodb.TableEncryption.AWS_MANAGED,
     });
 

--- a/infra/livetalk/lib/dynamodb-stack.ts
+++ b/infra/livetalk/lib/dynamodb-stack.ts
@@ -11,8 +11,9 @@ export interface LiveTalkDynamoDbStackProps extends cdk.StackProps {
  * LiveTalk DynamoDB Single Table スタック
  *
  * - 命名: 共通ヘルパー `getDynamoDBTableName('livetalk', env)` で決定
- * - PK / SK の 2 キー Single Table 構成。MVP では GSI を作成しない
- *   （`docs/services/livetalk/architecture.md` §3「データモデル概要」。MVP では GSI 不要、Phase 進行で必要になれば追加）
+ * - PK / SK の 2 キー Single Table 構成。Profile 列挙のために GSI1 を追加した（#3527）。
+ *   GSI1PK='PROFILE' の sparse GSI で Profile のみ索引化する。
+ *   （`docs/services/livetalk/architecture.md` §3「データモデル概要」参照）
  * - Message は TTL（属性名 `TTL`、Unix 秒）で 90 日後に自動削除
  * - Point-in-time Recovery 有効、AWS マネージドキーで at-rest 暗号化
  * - dev は破棄、prod は保持
@@ -48,6 +49,15 @@ export class LiveTalkDynamoDbStack extends cdk.Stack {
       removalPolicy:
         environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
       encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    // GSI1: Profile のみを sparse 索引化するための GSI（#3527）
+    // GSI1PK='PROFILE' の Profile アイテムのみが対象（sparse GSI）
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'GSI1',
+      partitionKey: { name: 'GSI1PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI1SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY,
     });
 
     cdk.Tags.of(this).add('Application', 'nagiyu');

--- a/infra/livetalk/tests/unit/batch-stack.test.js
+++ b/infra/livetalk/tests/unit/batch-stack.test.js
@@ -219,6 +219,24 @@ describe('LiveTalkBatchStack', () => {
     template.hasOutput('NotifyFunctionArn', Match.anyValue());
   });
 
+  it('DynamoDB の grant に GSI1（index/*）への Query 権限が含まれる', () => {
+    // batch ロールは GSI1 を Query してユーザーを列挙するため、IAM ポリシーの
+    // Resource にテーブル本体に加えて `table/.../index/*` が含まれている必要がある（#3527）。
+    const { template } = synth();
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(['dynamodb:Query']),
+            Resource: Match.arrayWith([
+              Match.stringLikeRegexp('table/nagiyu-livetalk-dynamodb-dev/index/\\*'),
+            ]),
+          }),
+        ]),
+      },
+    });
+  });
+
   it('prod 環境でも正しく生成する', () => {
     const { template } = synth('prod');
     template.hasResourceProperties('AWS::Lambda::Function', {

--- a/infra/livetalk/tests/unit/dynamodb-stack.test.js
+++ b/infra/livetalk/tests/unit/dynamodb-stack.test.js
@@ -23,7 +23,7 @@ describe('LiveTalkDynamoDbStack', () => {
     });
   });
 
-  it('PK / SK の 2 キー Single Table 構成（GSI なし）', () => {
+  it('PK / SK の 2 キー Single Table 構成に GSI1（Profile 列挙用 sparse GSI）を追加する', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::DynamoDB::Table', {
       KeySchema: [
@@ -33,12 +33,23 @@ describe('LiveTalkDynamoDbStack', () => {
       AttributeDefinitions: Match.arrayWith([
         { AttributeName: 'PK', AttributeType: 'S' },
         { AttributeName: 'SK', AttributeType: 'S' },
+        { AttributeName: 'GSI1PK', AttributeType: 'S' },
+        { AttributeName: 'GSI1SK', AttributeType: 'S' },
       ]),
     });
-    // MVP では GSI を作成しない
-    const tableResource = template.findResources('AWS::DynamoDB::Table');
-    const table = Object.values(tableResource)[0];
-    expect(table.Properties.GlobalSecondaryIndexes).toBeUndefined();
+    // GSI1: Profile 列挙用 sparse GSI（#3527）
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: 'GSI1',
+          KeySchema: [
+            { AttributeName: 'GSI1PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI1SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'KEYS_ONLY' },
+        },
+      ],
+    });
   });
 
   it('PAY_PER_REQUEST + PITR + TTL 属性 + AWS_MANAGED 暗号化を設定する', () => {

--- a/services/livetalk/batch/src/handlers/compress-conversations.ts
+++ b/services/livetalk/batch/src/handlers/compress-conversations.ts
@@ -6,6 +6,7 @@ import {
   DynamoDBMemorySummaryRepository,
   DynamoDBMessageRepository,
   DynamoDBMemoryRepository,
+  DynamoDBProfileRepository,
   EmbeddingMemoryRepository,
   OpenAIClient,
   OpenAIEmbeddingClient,
@@ -73,10 +74,10 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const llmClient = new OpenAIClient({ apiKey });
     const interestRepo = new DynamoDBInterestRepository(docClient, tableName);
     const characterStateRepo = new DynamoDBCharacterStateRepository(docClient, tableName);
+    const profileRepo = new DynamoDBProfileRepository(docClient, tableName);
 
     result = await compressAllConversations({
-      docClient,
-      tableName,
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,

--- a/services/livetalk/batch/src/handlers/learn-user-activity.ts
+++ b/services/livetalk/batch/src/handlers/learn-user-activity.ts
@@ -3,6 +3,7 @@ import { getDynamoDBDocumentClient, getTableName, reportErrorEvent } from '@nagi
 import {
   DynamoDBLifecycleRepository,
   DynamoDBMessageRepository,
+  DynamoDBProfileRepository,
   defaultUlidFactory,
 } from '@nagiyu/livetalk-core';
 import { learnAllUserActivities } from '../usecases/learn-user-activity.usecase.js';
@@ -38,10 +39,10 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
 
     const messageRepo = new DynamoDBMessageRepository(docClient, tableName, defaultUlidFactory);
     const lifecycleRepo = new DynamoDBLifecycleRepository(docClient, tableName);
+    const profileRepo = new DynamoDBProfileRepository(docClient, tableName);
 
     const result = await learnAllUserActivities({
-      docClient,
-      tableName,
+      profileRepo,
       messageRepo,
       lifecycleRepo,
     });

--- a/services/livetalk/batch/src/handlers/notify.ts
+++ b/services/livetalk/batch/src/handlers/notify.ts
@@ -6,6 +6,7 @@ import {
   DynamoDBLifecycleRepository,
   DynamoDBMessageRepository,
   DynamoDBNotificationEventRepository,
+  DynamoDBProfileRepository,
   DynamoDBPushSubscriptionRepository,
   OpenAIEmbeddingClient,
   createLLMClient,
@@ -43,6 +44,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const tableName = getTableName();
     const apiKey = process.env.OPENAI_API_KEY ?? '';
 
+    const profileRepo = new DynamoDBProfileRepository(docClient, tableName);
     const lifecycleRepo = new DynamoDBLifecycleRepository(docClient, tableName);
     const messageRepo = new DynamoDBMessageRepository(docClient, tableName);
     const knowledgeRepo = new DynamoDBKnowledgeRepository(docClient, tableName);
@@ -53,8 +55,7 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const embeddingClient = new OpenAIEmbeddingClient({ apiKey });
 
     const result = await notifyAllUsers({
-      docClient,
-      tableName,
+      profileRepo,
       lifecycleRepo,
       messageRepo,
       knowledgeRepo,

--- a/services/livetalk/batch/src/handlers/study.ts
+++ b/services/livetalk/batch/src/handlers/study.ts
@@ -5,6 +5,7 @@ import {
   DynamoDBKnowledgeRepository,
   DynamoDBLifecycleRepository,
   DynamoDBNoteRepository,
+  DynamoDBProfileRepository,
   DynamoDBStudyTopicRepository,
   OpenAIResearchClient,
   defaultUlidFactory,
@@ -46,11 +47,11 @@ export async function handler(event: ScheduledEvent): Promise<HandlerResponse> {
     const knowledgeRepo = new DynamoDBKnowledgeRepository(docClient, tableName);
     const studyTopicRepo = new DynamoDBStudyTopicRepository(docClient, tableName);
     const noteRepo = new DynamoDBNoteRepository(docClient, tableName);
+    const profileRepo = new DynamoDBProfileRepository(docClient, tableName);
     const researchClient = new OpenAIResearchClient({ apiKey });
 
     const result = await studyAllUsers({
-      docClient,
-      tableName,
+      profileRepo,
       lifecycleRepo,
       interestRepo,
       knowledgeRepo,

--- a/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
+++ b/services/livetalk/batch/src/usecases/compress-conversations.usecase.ts
@@ -1,15 +1,14 @@
-import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
   getAllCharacterIds,
   getCharacterDefinitionById,
   compressConversation,
   type CompressConversationParams,
+  type ProfileRepository,
 } from '@nagiyu/livetalk-core';
 
 export type CompressAllConversationsParams = Omit<CompressConversationParams, 'characterName'> & {
-  docClient: DynamoDBDocumentClient;
-  tableName: string;
+  profileRepo: ProfileRepository;
 };
 
 export interface CompressAllConversationsResult {
@@ -22,7 +21,7 @@ export interface CompressAllConversationsResult {
 /**
  * 全アクティブユーザーの全キャラクター会話を圧縮要約する。
  *
- * DynamoDB を Scan して Type='Profile' のアイテムを列挙し、
+ * ProfileRepository（GSI1）でユーザーを列挙し、
  * 各ユーザーについて全キャラクターの会話を圧縮する。
  * キャラクターごとに処理し、あるキャラクターで失敗しても他キャラクターの処理を継続する。
  */
@@ -30,8 +29,7 @@ export async function compressAllConversations(
   params: CompressAllConversationsParams
 ): Promise<CompressAllConversationsResult> {
   const {
-    docClient,
-    tableName,
+    profileRepo,
     llmClient,
     summaryRepo,
     messageRepo,
@@ -42,7 +40,7 @@ export async function compressAllConversations(
     embeddingClient,
   } = params;
 
-  const userIds = await scanAllUserIds(docClient, tableName);
+  const userIds = await profileRepo.listAllUserIds();
 
   logger.info('[compressAllConversations] ユーザー一覧取得完了', {
     userCount: userIds.length,
@@ -117,33 +115,4 @@ export async function compressAllConversations(
 
   logger.info('[compressAllConversations] 全ユーザー処理完了', { ...result });
   return result;
-}
-
-async function scanAllUserIds(
-  docClient: DynamoDBDocumentClient,
-  tableName: string
-): Promise<string[]> {
-  const userIds: string[] = [];
-  let lastEvaluatedKey: Record<string, unknown> | undefined;
-
-  do {
-    const command = new ScanCommand({
-      TableName: tableName,
-      FilterExpression: '#type = :profile',
-      ExpressionAttributeNames: { '#type': 'Type' },
-      ExpressionAttributeValues: { ':profile': 'Profile' },
-      ProjectionExpression: 'UserID',
-      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
-    });
-
-    const response = await docClient.send(command);
-    for (const item of response.Items ?? []) {
-      if (typeof item.UserID === 'string' && item.UserID) {
-        userIds.push(item.UserID);
-      }
-    }
-    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastEvaluatedKey !== undefined);
-
-  return userIds;
 }

--- a/services/livetalk/batch/src/usecases/learn-user-activity.usecase.ts
+++ b/services/livetalk/batch/src/usecases/learn-user-activity.usecase.ts
@@ -1,4 +1,3 @@
-import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
   getAllCharacterIds,
@@ -6,11 +5,11 @@ import {
   learnUserActivity,
   type LifecycleRepository,
   type MessageRepository,
+  type ProfileRepository,
 } from '@nagiyu/livetalk-core';
 
 export interface LearnAllUserActivitiesParams {
-  docClient: DynamoDBDocumentClient;
-  tableName: string;
+  profileRepo: ProfileRepository;
   messageRepo: MessageRepository;
   lifecycleRepo: LifecycleRepository;
   /** 学習基準日時（省略時は実行時刻）。テスト用差し替え可。 */
@@ -27,16 +26,16 @@ export interface LearnAllUserActivitiesResult {
 /**
  * 全アクティブユーザーの活動時間を学習する。
  *
- * DynamoDB を Scan して Type='Profile' のアイテムを列挙し、
+ * ProfileRepository（GSI1）でユーザーを列挙し、
  * 各ユーザーについて全キャラクターの発話履歴を学習する。
  * あるキャラクターで失敗しても他キャラクターの処理は継続する。
  */
 export async function learnAllUserActivities(
   params: LearnAllUserActivitiesParams
 ): Promise<LearnAllUserActivitiesResult> {
-  const { docClient, tableName, messageRepo, lifecycleRepo, now } = params;
+  const { profileRepo, messageRepo, lifecycleRepo, now } = params;
 
-  const userIds = await scanAllUserIds(docClient, tableName);
+  const userIds = await profileRepo.listAllUserIds();
 
   logger.info('[learnAllUserActivities] ユーザー一覧取得完了', {
     userCount: userIds.length,
@@ -105,33 +104,4 @@ export async function learnAllUserActivities(
 
   logger.info('[learnAllUserActivities] 全ユーザー処理完了', { ...result });
   return result;
-}
-
-async function scanAllUserIds(
-  docClient: DynamoDBDocumentClient,
-  tableName: string
-): Promise<string[]> {
-  const userIds: string[] = [];
-  let lastEvaluatedKey: Record<string, unknown> | undefined;
-
-  do {
-    const command = new ScanCommand({
-      TableName: tableName,
-      FilterExpression: '#type = :profile',
-      ExpressionAttributeNames: { '#type': 'Type' },
-      ExpressionAttributeValues: { ':profile': 'Profile' },
-      ProjectionExpression: 'UserID',
-      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
-    });
-
-    const response = await docClient.send(command);
-    for (const item of response.Items ?? []) {
-      if (typeof item.UserID === 'string' && item.UserID) {
-        userIds.push(item.UserID);
-      }
-    }
-    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastEvaluatedKey !== undefined);
-
-  return userIds;
 }

--- a/services/livetalk/batch/src/usecases/notify.usecase.ts
+++ b/services/livetalk/batch/src/usecases/notify.usecase.ts
@@ -486,4 +486,3 @@ async function computeUserDailyNormalCap(params: {
 
   return computeDailyNormalCap(maxFactor);
 }
-

--- a/services/livetalk/batch/src/usecases/notify.usecase.ts
+++ b/services/livetalk/batch/src/usecases/notify.usecase.ts
@@ -1,4 +1,3 @@
-import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import { sendWebPushNotification, getVapidConfig } from '@nagiyu/common/push';
 import {
@@ -21,6 +20,7 @@ import {
   type LifecycleRepository,
   type MessageRepository,
   type NotificationEventRepository,
+  type ProfileRepository,
   type PushSubscriptionRepository,
   type UlidFactory,
   defaultUlidFactory,
@@ -30,8 +30,7 @@ import {
 } from '@nagiyu/livetalk-core';
 
 export interface NotifyAllUsersParams {
-  docClient: DynamoDBDocumentClient;
-  tableName: string;
+  profileRepo: ProfileRepository;
   lifecycleRepo: LifecycleRepository;
   messageRepo: MessageRepository;
   knowledgeRepo: KnowledgeRepository;
@@ -51,10 +50,15 @@ export interface NotifyAllUsersResult {
   failedUserIds: string[];
 }
 
+/**
+ * 全アクティブユーザーへのプッシュ通知を送信する。
+ *
+ * ProfileRepository（GSI1）でユーザーを列挙し、
+ * 各ユーザーについて全キャラクターの通知判定を行う。
+ */
 export async function notifyAllUsers(params: NotifyAllUsersParams): Promise<NotifyAllUsersResult> {
   const {
-    docClient,
-    tableName,
+    profileRepo,
     lifecycleRepo,
     messageRepo,
     knowledgeRepo,
@@ -67,7 +71,7 @@ export async function notifyAllUsers(params: NotifyAllUsersParams): Promise<Noti
     now = () => new Date(),
   } = params;
 
-  const userIds = await scanAllUserIds(docClient, tableName);
+  const userIds = await profileRepo.listAllUserIds();
   logger.info('[notifyAllUsers] ユーザー一覧取得完了', { userCount: userIds.length });
 
   const result: NotifyAllUsersResult = {
@@ -483,31 +487,3 @@ async function computeUserDailyNormalCap(params: {
   return computeDailyNormalCap(maxFactor);
 }
 
-async function scanAllUserIds(
-  docClient: DynamoDBDocumentClient,
-  tableName: string
-): Promise<string[]> {
-  const userIds: string[] = [];
-  let lastEvaluatedKey: Record<string, unknown> | undefined;
-
-  do {
-    const command = new ScanCommand({
-      TableName: tableName,
-      FilterExpression: '#type = :profile',
-      ExpressionAttributeNames: { '#type': 'Type' },
-      ExpressionAttributeValues: { ':profile': 'Profile' },
-      ProjectionExpression: 'UserID',
-      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
-    });
-
-    const response = await docClient.send(command);
-    for (const item of response.Items ?? []) {
-      if (typeof item.UserID === 'string' && item.UserID) {
-        userIds.push(item.UserID);
-      }
-    }
-    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastEvaluatedKey !== undefined);
-
-  return userIds;
-}

--- a/services/livetalk/batch/src/usecases/study.usecase.ts
+++ b/services/livetalk/batch/src/usecases/study.usecase.ts
@@ -1,4 +1,3 @@
-import { ScanCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { logger, toErrorMessage } from '@nagiyu/common';
 import {
   getAllCharacterIds,
@@ -9,14 +8,14 @@ import {
   type KnowledgeRepository,
   type LifecycleRepository,
   type NoteRepository,
+  type ProfileRepository,
   type StudyTopicRepository,
   type UlidFactory,
 } from '@nagiyu/livetalk-core';
 import type { IResearchClient } from '@nagiyu/livetalk-core';
 
 export interface StudyAllUsersParams {
-  docClient: DynamoDBDocumentClient;
-  tableName: string;
+  profileRepo: ProfileRepository;
   lifecycleRepo: LifecycleRepository;
   interestRepo: InterestRepository;
   knowledgeRepo: KnowledgeRepository;
@@ -43,14 +42,13 @@ export interface StudyAllUsersResult {
 /**
  * 全アクティブユーザーに対して勉強バッチを実行する。
  *
- * 各ユーザーについて全キャラクターを走査し、shouldStudyNow 判定を行い、
- * 該当するキャラクターのみ Web リサーチ → 知識ベース保存を実行する。
+ * ProfileRepository（GSI1）でユーザーを列挙し、各ユーザーについて全キャラクターを走査し、
+ * shouldStudyNow 判定を行い、該当するキャラクターのみ Web リサーチ → 知識ベース保存を実行する。
  * あるキャラクターで失敗しても他キャラクターの処理は継続する。
  */
 export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyAllUsersResult> {
   const {
-    docClient,
-    tableName,
+    profileRepo,
     lifecycleRepo,
     interestRepo,
     knowledgeRepo,
@@ -61,7 +59,7 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
     now,
   } = params;
 
-  const userIds = await scanAllUserIds(docClient, tableName);
+  const userIds = await profileRepo.listAllUserIds();
 
   logger.info('[studyAllUsers] ユーザー一覧取得完了', { userCount: userIds.length });
 
@@ -160,33 +158,4 @@ export async function studyAllUsers(params: StudyAllUsersParams): Promise<StudyA
 
   logger.info('[studyAllUsers] 全ユーザー処理完了', { ...result });
   return result;
-}
-
-async function scanAllUserIds(
-  docClient: DynamoDBDocumentClient,
-  tableName: string
-): Promise<string[]> {
-  const userIds: string[] = [];
-  let lastEvaluatedKey: Record<string, unknown> | undefined;
-
-  do {
-    const command = new ScanCommand({
-      TableName: tableName,
-      FilterExpression: '#type = :profile',
-      ExpressionAttributeNames: { '#type': 'Type' },
-      ExpressionAttributeValues: { ':profile': 'Profile' },
-      ProjectionExpression: 'UserID',
-      ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
-    });
-
-    const response = await docClient.send(command);
-    for (const item of response.Items ?? []) {
-      if (typeof item.UserID === 'string' && item.UserID) {
-        userIds.push(item.UserID);
-      }
-    }
-    lastEvaluatedKey = response.LastEvaluatedKey as Record<string, unknown> | undefined;
-  } while (lastEvaluatedKey !== undefined);
-
-  return userIds;
 }

--- a/services/livetalk/batch/tests/unit/handlers/compress-conversations.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/compress-conversations.test.ts
@@ -10,6 +10,7 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBMemorySummaryRepository: jest.fn(),
   DynamoDBMessageRepository: jest.fn(),
   DynamoDBMemoryRepository: jest.fn(),
+  DynamoDBProfileRepository: jest.fn(),
   EmbeddingMemoryRepository: jest.fn(),
   DynamoDBInterestRepository: jest.fn(),
   DynamoDBCharacterStateRepository: jest.fn(),

--- a/services/livetalk/batch/tests/unit/handlers/learn-user-activity.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/learn-user-activity.test.ts
@@ -9,6 +9,7 @@ jest.mock('@nagiyu/aws', () => ({
 jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBMessageRepository: jest.fn(),
   DynamoDBLifecycleRepository: jest.fn(),
+  DynamoDBProfileRepository: jest.fn(),
   defaultUlidFactory: jest.fn(),
 }));
 

--- a/services/livetalk/batch/tests/unit/handlers/notify.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/notify.test.ts
@@ -7,6 +7,7 @@ jest.mock('@nagiyu/aws', () => ({
 }));
 
 jest.mock('@nagiyu/livetalk-core', () => ({
+  DynamoDBProfileRepository: jest.fn(),
   DynamoDBLifecycleRepository: jest.fn(),
   DynamoDBMessageRepository: jest.fn(),
   DynamoDBKnowledgeRepository: jest.fn(),

--- a/services/livetalk/batch/tests/unit/handlers/study.test.ts
+++ b/services/livetalk/batch/tests/unit/handlers/study.test.ts
@@ -12,6 +12,7 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   DynamoDBKnowledgeRepository: jest.fn(),
   DynamoDBStudyTopicRepository: jest.fn(),
   DynamoDBNoteRepository: jest.fn(),
+  DynamoDBProfileRepository: jest.fn(),
   OpenAIResearchClient: jest.fn(),
   defaultUlidFactory: jest.fn(),
 }));

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -3,9 +3,9 @@ import {
   InMemoryMemorySummaryRepository,
   InMemoryMessageRepository,
   InMemoryMemoryRepository,
+  InMemoryProfileRepository,
   type ILLMClient,
 } from '@nagiyu/livetalk-core';
-import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import {
   compressAllConversations,
   type CompressAllConversationsParams,
@@ -33,32 +33,40 @@ const makeLLMClient = (): ILLMClient & { summarizeCalls: number } => {
   };
 };
 
-const makeRepos = () => {
-  const store = new InMemorySingleTableStore();
+const makeRepos = (sharedStore?: InMemorySingleTableStore) => {
+  const store = sharedStore ?? new InMemorySingleTableStore();
   tick = fixedNow;
   const nowMs = () => tick;
   const ulidFactory = () => `ULID-${tick++}`;
   return {
+    store,
     summaryRepo: new InMemoryMemorySummaryRepository(store, nowMs),
     messageRepo: new InMemoryMessageRepository(store, ulidFactory, nowMs),
     memoryRepo: new InMemoryMemoryRepository(store, ulidFactory, nowMs),
+    profileRepo: new InMemoryProfileRepository(store, nowMs),
   };
 };
 
-const makeDocClientMock = (userIds: string[]): DynamoDBDocumentClient => {
-  const items = userIds.map((id) => ({ UserID: id }));
-  return {
-    send: async () => ({ Items: items }),
-  } as unknown as DynamoDBDocumentClient;
+/**
+ * 指定した userIds を持つ InMemoryProfileRepository を作る。
+ * 別ストアを使って profile だけを登録する。
+ */
+const makeProfileRepoWithUsers = async (userIds: string[]): Promise<InMemoryProfileRepository> => {
+  const store = new InMemorySingleTableStore();
+  const nowMs = () => fixedNow;
+  const profileRepo = new InMemoryProfileRepository(store, nowMs);
+  for (const id of userIds) {
+    await profileRepo.upsert({ UserID: id });
+  }
+  return profileRepo;
 };
 
 const makeParams = (
   overrides: Partial<CompressAllConversationsParams> = {}
 ): CompressAllConversationsParams => {
-  const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+  const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos();
   return {
-    docClient: makeDocClientMock([]),
-    tableName: 'test-table',
+    profileRepo,
     summaryRepo,
     messageRepo,
     memoryRepo,
@@ -78,8 +86,8 @@ describe('compressAllConversations', () => {
 
   it('メッセージのないユーザーは処理をスキップする（LLM 呼び出しなし）', async () => {
     const llmClient = makeLLMClient();
-    const docClient = makeDocClientMock(['u1', 'u2']);
-    const result = await compressAllConversations(makeParams({ llmClient, docClient }));
+    const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2']);
+    const result = await compressAllConversations(makeParams({ llmClient, profileRepo }));
     expect(llmClient.summarizeCalls).toBe(0);
     expect(result.processedUsers).toBe(0);
     expect(result.skippedUsers).toBe(2);
@@ -87,14 +95,15 @@ describe('compressAllConversations', () => {
 
   it('hiyori にメッセージのあるユーザー分だけ LLM を呼ぶ', async () => {
     const llmClient = makeLLMClient();
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,
@@ -124,16 +133,17 @@ describe('compressAllConversations', () => {
       },
     };
 
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hi' });
     tick++;
     await messageRepo.create({ UserID: 'u2', CharacterID: 'hiyori', Role: 'user', Text: 'hi2' });
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,
@@ -145,103 +155,16 @@ describe('compressAllConversations', () => {
     expect(result.processedUsers).toBe(1);
   });
 
-  it('DynamoDB Scan が複数ページに渡るとき全ユーザーを処理する', async () => {
+  it('profileRepo が複数ユーザーを返すとき全ユーザーを処理する', async () => {
     const llmClient = makeLLMClient();
-    let pageCount = 0;
-    const pagedDocClient = {
-      send: async () => {
-        pageCount++;
-        if (pageCount === 1) {
-          return {
-            Items: [{ UserID: 'u1' }],
-            LastEvaluatedKey: { PK: 'USER#u1' },
-          };
-        }
-        return { Items: [{ UserID: 'u2' }] };
-      },
-    } as unknown as DynamoDBDocumentClient;
+    const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2']);
 
     const result = await compressAllConversations(
-      makeParams({ llmClient, docClient: pagedDocClient })
+      makeParams({ llmClient, profileRepo })
     );
 
     expect(result.processedUsers).toBe(0);
     expect(result.skippedUsers).toBe(2);
-    expect(pageCount).toBe(2);
-  });
-
-  it('UserID が空や型違いのアイテムを無視する', async () => {
-    const llmClient = makeLLMClient();
-    const docClient = {
-      send: async () => ({
-        Items: [{ UserID: '' }, { UserID: 123 }, { UserID: 'valid-user' }],
-      }),
-    } as unknown as DynamoDBDocumentClient;
-
-    const result = await compressAllConversations(makeParams({ llmClient, docClient }));
-    expect(result.processedUsers).toBe(0);
-    expect(result.skippedUsers).toBe(1);
-  });
-
-  it('複数キャラ（hiyori と ageha）両方のメッセージで LLM が 2 回呼ばれる', async () => {
-    const llmClient = makeLLMClient();
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
-    tick = fixedNow;
-    await messageRepo.create({
-      UserID: 'u1',
-      CharacterID: 'hiyori',
-      Role: 'user',
-      Text: 'hiyori msg',
-    });
-    tick++;
-    await messageRepo.create({
-      UserID: 'u1',
-      CharacterID: 'ageha',
-      Role: 'user',
-      Text: 'ageha msg',
-    });
-
-    const docClient = makeDocClientMock(['u1']);
-    const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
-      summaryRepo,
-      messageRepo,
-      memoryRepo,
-      llmClient,
-    });
-
-    // hiyori と ageha の両方で summarize が呼ばれる
-    expect(llmClient.summarizeCalls).toBe(2);
-    expect(result.processedUsers).toBe(1);
-    expect(result.failedUsers).toBe(0);
-  });
-
-  it('一方のキャラのみメッセージがある場合はそのキャラのみ LLM を呼ぶ', async () => {
-    const llmClient = makeLLMClient();
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
-    tick = fixedNow;
-    // ageha のみメッセージあり
-    await messageRepo.create({
-      UserID: 'u1',
-      CharacterID: 'ageha',
-      Role: 'user',
-      Text: 'ageha only',
-    });
-
-    const docClient = makeDocClientMock(['u1']);
-    const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
-      summaryRepo,
-      messageRepo,
-      memoryRepo,
-      llmClient,
-    });
-
-    expect(llmClient.summarizeCalls).toBe(1);
-    expect(result.processedUsers).toBe(1);
-    expect(result.failedUsers).toBe(0);
   });
 
   it('あるキャラクター処理がエラーでも他キャラは処理され、ユーザーは failed に計上される', async () => {
@@ -261,16 +184,16 @@ describe('compressAllConversations', () => {
       },
     };
 
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hi' });
     tick++;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'hi2' });
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,
@@ -283,6 +206,67 @@ describe('compressAllConversations', () => {
     expect(result.failedUsers).toBe(1);
     expect(result.failedUserIds).toContain('u1');
     expect(result.processedUsers).toBe(0);
+  });
+
+  it('複数キャラ（hiyori と ageha）両方のメッセージで LLM が 2 回呼ばれる', async () => {
+    const llmClient = makeLLMClient();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
+    tick = fixedNow;
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'hiyori',
+      Role: 'user',
+      Text: 'hiyori msg',
+    });
+    tick++;
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'ageha',
+      Role: 'user',
+      Text: 'ageha msg',
+    });
+    await profileRepo.upsert({ UserID: 'u1' });
+
+    const result = await compressAllConversations({
+      profileRepo,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    // hiyori と ageha の両方で summarize が呼ばれる
+    expect(llmClient.summarizeCalls).toBe(2);
+    expect(result.processedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
+  });
+
+  it('一方のキャラのみメッセージがある場合はそのキャラのみ LLM を呼ぶ', async () => {
+    const llmClient = makeLLMClient();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
+    tick = fixedNow;
+    // ageha のみメッセージあり
+    await messageRepo.create({
+      UserID: 'u1',
+      CharacterID: 'ageha',
+      Role: 'user',
+      Text: 'ageha only',
+    });
+    await profileRepo.upsert({ UserID: 'u1' });
+
+    const result = await compressAllConversations({
+      profileRepo,
+      summaryRepo,
+      messageRepo,
+      memoryRepo,
+      llmClient,
+    });
+
+    expect(llmClient.summarizeCalls).toBe(1);
+    expect(result.processedUsers).toBe(1);
+    expect(result.failedUsers).toBe(0);
   });
 
   it('characterName が各キャラの displayName で渡されること（hiyori は 桃瀬ひより）', async () => {
@@ -300,16 +284,16 @@ describe('compressAllConversations', () => {
       },
     };
 
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
     tick++;
     await messageRepo.create({ UserID: 'u1', CharacterID: 'ageha', Role: 'user', Text: 'hey' });
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,
@@ -324,15 +308,16 @@ describe('compressAllConversations', () => {
 
   it('メッセージのあるユーザーは processedUsers、ないユーザーは skippedUsers に計上される（混在ケース）', async () => {
     const llmClient = makeLLMClient();
-    const { summaryRepo, messageRepo, memoryRepo } = makeRepos();
+    const store = new InMemorySingleTableStore();
+    const { summaryRepo, messageRepo, memoryRepo, profileRepo } = makeRepos(store);
     tick = fixedNow;
     // u1 のみメッセージあり（processed）、u2 はメッセージなし（skipped）
     await messageRepo.create({ UserID: 'u1', CharacterID: 'hiyori', Role: 'user', Text: 'hello' });
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await compressAllConversations({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       summaryRepo,
       messageRepo,
       memoryRepo,

--- a/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/compress-conversations.usecase.test.ts
@@ -159,9 +159,7 @@ describe('compressAllConversations', () => {
     const llmClient = makeLLMClient();
     const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2']);
 
-    const result = await compressAllConversations(
-      makeParams({ llmClient, profileRepo })
-    );
+    const result = await compressAllConversations(makeParams({ llmClient, profileRepo }));
 
     expect(result.processedUsers).toBe(0);
     expect(result.skippedUsers).toBe(2);

--- a/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -1,6 +1,9 @@
 import { InMemorySingleTableStore } from '@nagiyu/aws';
-import { InMemoryMessageRepository, InMemoryLifecycleRepository } from '@nagiyu/livetalk-core';
-import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  InMemoryMessageRepository,
+  InMemoryLifecycleRepository,
+  InMemoryProfileRepository,
+} from '@nagiyu/livetalk-core';
 import {
   learnAllUserActivities,
   type LearnAllUserActivitiesParams,
@@ -9,32 +12,38 @@ import {
 const fixedNow = 1_750_000_000_000;
 let tick = fixedNow;
 
-const makeRepos = () => {
-  const store = new InMemorySingleTableStore();
+const makeRepos = (sharedStore?: InMemorySingleTableStore) => {
+  const store = sharedStore ?? new InMemorySingleTableStore();
   tick = fixedNow;
   const nowMs = () => tick;
   const ulidFactory = () => `ULID-${tick++}`;
   return {
+    store,
     messageRepo: new InMemoryMessageRepository(store, ulidFactory, nowMs),
     lifecycleRepo: new InMemoryLifecycleRepository(store, nowMs),
-    store,
+    profileRepo: new InMemoryProfileRepository(store, nowMs),
   };
 };
 
-const makeDocClientMock = (userIds: string[]): DynamoDBDocumentClient => {
-  const items = userIds.map((id) => ({ UserID: id }));
-  return {
-    send: async () => ({ Items: items }),
-  } as unknown as DynamoDBDocumentClient;
+/**
+ * 指定した userIds を持つ InMemoryProfileRepository を作る。
+ */
+const makeProfileRepoWithUsers = async (userIds: string[]): Promise<InMemoryProfileRepository> => {
+  const store = new InMemorySingleTableStore();
+  const nowMs = () => fixedNow;
+  const profileRepo = new InMemoryProfileRepository(store, nowMs);
+  for (const id of userIds) {
+    await profileRepo.upsert({ UserID: id });
+  }
+  return profileRepo;
 };
 
 const makeParams = (
   overrides: Partial<LearnAllUserActivitiesParams> = {}
 ): LearnAllUserActivitiesParams => {
-  const { messageRepo, lifecycleRepo } = makeRepos();
+  const { messageRepo, lifecycleRepo, profileRepo } = makeRepos();
   return {
-    docClient: makeDocClientMock([]),
-    tableName: 'test-table',
+    profileRepo,
     messageRepo,
     lifecycleRepo,
     ...overrides,
@@ -50,8 +59,8 @@ describe('learnAllUserActivities', () => {
   });
 
   it('メッセージのないユーザーは全キャラ skipped にカウントされる', async () => {
-    const docClient = makeDocClientMock(['u1', 'u2']);
-    const result = await learnAllUserActivities(makeParams({ docClient }));
+    const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2']);
+    const result = await learnAllUserActivities(makeParams({ profileRepo }));
     expect(result.skippedUsers).toBe(2);
     expect(result.processedUsers).toBe(0);
     expect(result.failedUsers).toBe(0);
@@ -64,6 +73,7 @@ describe('learnAllUserActivities', () => {
     const ulidFactory = () => `ULID-${tick++}`;
     const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
     const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+    const profileRepo = new InMemoryProfileRepository(store, nowMs);
 
     // u1 に user ロールのメッセージを 5 件作成（fixedNow の 10 日前 = 30 日ウィンドウ内）
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
@@ -76,12 +86,12 @@ describe('learnAllUserActivities', () => {
         Text: `msg ${i}`,
       });
     }
-    // u2 はメッセージなし
+    // u1, u2 を Profile として登録（u2 はメッセージなし）
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo,
       now: () => new Date(fixedNow),
@@ -99,6 +109,7 @@ describe('learnAllUserActivities', () => {
     const ulidFactory = () => `ULID-${tick++}`;
     const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
     const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+    const profileRepo = new InMemoryProfileRepository(store, nowMs);
 
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
     for (let i = 0; i < 5; i++) {
@@ -110,11 +121,10 @@ describe('learnAllUserActivities', () => {
         Text: `ageha msg ${i}`,
       });
     }
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo,
       now: () => new Date(fixedNow),
@@ -132,6 +142,7 @@ describe('learnAllUserActivities', () => {
     const ulidFactory = () => `ULID-${tick++}`;
     const messageRepo = new InMemoryMessageRepository(store, ulidFactory, nowMs);
     const lifecycleRepo = new InMemoryLifecycleRepository(store, nowMs);
+    const profileRepo = new InMemoryProfileRepository(store, nowMs);
 
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
     for (let i = 0; i < 5; i++) {
@@ -152,11 +163,10 @@ describe('learnAllUserActivities', () => {
         Text: `ageha msg ${i}`,
       });
     }
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo,
       now: () => new Date(fixedNow),
@@ -169,7 +179,7 @@ describe('learnAllUserActivities', () => {
   });
 
   it('ユーザー処理が失敗しても他のユーザーは処理継続する', async () => {
-    const { lifecycleRepo } = makeRepos();
+    const { lifecycleRepo, messageRepo } = makeRepos();
     const failingLifecycleRepo = {
       ...lifecycleRepo,
       updateUserActivityProfile: jest.fn().mockRejectedValue(new Error('DB エラー')),
@@ -180,6 +190,8 @@ describe('learnAllUserActivities', () => {
     tick = fixedNow;
     const ulidFactory = () => `ULID-${tick++}`;
     const failingMessageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+    const profileStore = new InMemorySingleTableStore();
+    const profileRepo = new InMemoryProfileRepository(profileStore, () => fixedNow);
 
     // u1 に 5 件（fixedNow の 10 日前 = 30 日ウィンドウ内）
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
@@ -192,11 +204,11 @@ describe('learnAllUserActivities', () => {
         Text: `msg ${i}`,
       });
     }
+    await profileRepo.upsert({ UserID: 'u1' });
+    await profileRepo.upsert({ UserID: 'u2' });
 
-    const docClient = makeDocClientMock(['u1', 'u2']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo: failingMessageRepo,
       lifecycleRepo: failingLifecycleRepo as never,
       now: () => new Date(fixedNow),
@@ -206,28 +218,17 @@ describe('learnAllUserActivities', () => {
     expect(result.failedUserIds).toContain('u1');
   });
 
-  it('DynamoDB の Scan がページネーションする場合も全ユーザーを取得する', async () => {
+  it('profileRepo が複数ユーザーを返すとき全ユーザーを取得する（ページネーション相当）', async () => {
+    const profileRepo = await makeProfileRepoWithUsers(['u1', 'u2', 'u3']);
     const { messageRepo, lifecycleRepo } = makeRepos();
-    let callCount = 0;
-    const paginatedDocClient = {
-      send: async () => {
-        callCount++;
-        if (callCount === 1) {
-          return { Items: [{ UserID: 'u1' }], LastEvaluatedKey: { PK: 'USER#u1' } };
-        }
-        return { Items: [{ UserID: 'u2' }] };
-      },
-    } as unknown as DynamoDBDocumentClient;
 
     const result = await learnAllUserActivities({
-      docClient: paginatedDocClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo,
     });
 
-    expect(result.skippedUsers).toBe(2);
-    expect(callCount).toBe(2);
+    expect(result.skippedUsers).toBe(3);
   });
 
   it('あるキャラクター処理がエラーでも他キャラは処理され、ユーザーは failed に計上される', async () => {
@@ -246,6 +247,8 @@ describe('learnAllUserActivities', () => {
     tick = fixedNow;
     const ulidFactory = () => `ULID-${tick++}`;
     const messageRepo = new InMemoryMessageRepository(store, ulidFactory, () => tick);
+    const profileStore = new InMemorySingleTableStore();
+    const profileRepo = new InMemoryProfileRepository(profileStore, () => fixedNow);
 
     // u1 の hiyori と ageha に 5 件ずつメッセージを作成
     const recentBase = fixedNow - 10 * 24 * 3600 * 1000;
@@ -260,11 +263,10 @@ describe('learnAllUserActivities', () => {
         });
       }
     }
+    await profileRepo.upsert({ UserID: 'u1' });
 
-    const docClient = makeDocClientMock(['u1']);
     const result = await learnAllUserActivities({
-      docClient,
-      tableName: 'test',
+      profileRepo,
       messageRepo,
       lifecycleRepo: failingLifecycleRepo as never,
       now: () => new Date(fixedNow),

--- a/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/learn-user-activity.usecase.test.ts
@@ -179,7 +179,7 @@ describe('learnAllUserActivities', () => {
   });
 
   it('ユーザー処理が失敗しても他のユーザーは処理継続する', async () => {
-    const { lifecycleRepo, messageRepo } = makeRepos();
+    const { lifecycleRepo } = makeRepos();
     const failingLifecycleRepo = {
       ...lifecycleRepo,
       updateUserActivityProfile: jest.fn().mockRejectedValue(new Error('DB エラー')),

--- a/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
@@ -46,6 +46,12 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   OpenAIEmbeddingClient: jest.fn(),
 }));
 
+function makeProfileRepo(userIds: string[] = ['u1']) {
+  return {
+    listAllUserIds: jest.fn().mockResolvedValue(userIds),
+  };
+}
+
 const mockSendWebPush = jest.requireMock('@nagiyu/common/push')
   .sendWebPushNotification as jest.Mock;
 const core = jest.requireMock('@nagiyu/livetalk-core');
@@ -53,14 +59,6 @@ const mockDetectCritical = core.detectCriticalKnowledge as jest.Mock;
 const mockShouldNotifyNow = core.shouldNotifyNow as jest.Mock;
 const mockGetAllCharacterIds = core.getAllCharacterIds as jest.Mock;
 const mockSelectNotificationsToSend = core.selectNotificationsToSend as jest.Mock;
-
-function makeDocClient() {
-  return {
-    send: jest.fn().mockResolvedValue({
-      Items: [{ UserID: 'u1' }],
-    }),
-  };
-}
 
 function makeLifecycleRepo(
   lifecycle = {
@@ -128,8 +126,7 @@ function makeEmbeddingClient() {
 
 function makeParams(overrides = {}) {
   return {
-    docClient: makeDocClient() as never,
-    tableName: 'test-table',
+    profileRepo: makeProfileRepo() as never,
     lifecycleRepo: makeLifecycleRepo() as never,
     messageRepo: makeMessageRepo() as never,
     knowledgeRepo: makeKnowledgeRepo() as never,
@@ -277,11 +274,8 @@ describe('notifyAllUsers', () => {
   });
 
   it('ユーザー処理で例外 → failedUsers にカウントしてループ継続', async () => {
-    const docClient = {
-      send: jest.fn().mockResolvedValue({
-        Items: [{ UserID: 'u1' }, { UserID: 'u2' }],
-      }),
-    };
+    // profileRepo が 2 ユーザーを返す
+    const profileRepo = makeProfileRepo(['u1', 'u2']);
     // pushSubscriptionRepo が throw → processUser 全体が例外
     const pushSubscriptionRepo = {
       listByUser: jest.fn().mockRejectedValue(new Error('DynamoDB エラー')),
@@ -291,7 +285,7 @@ describe('notifyAllUsers', () => {
     const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
     const result = await notifyAllUsers(
       makeParams({
-        docClient: docClient as never,
+        profileRepo: profileRepo as never,
         pushSubscriptionRepo: pushSubscriptionRepo as never,
       })
     );
@@ -746,18 +740,9 @@ describe('notifyAllUsers', () => {
     });
   });
 
-  it('DynamoDB scan がページネーション → 全ユーザーを収集する', async () => {
-    const docClient = {
-      send: jest
-        .fn()
-        .mockResolvedValueOnce({
-          Items: [{ UserID: 'u1' }],
-          LastEvaluatedKey: { pk: 'USER#u1' },
-        })
-        .mockResolvedValueOnce({
-          Items: [{ UserID: 'u2' }],
-        }),
-    };
+  it('profileRepo が複数ユーザーを返す → 全ユーザーを処理する', async () => {
+    // profileRepo（GSI1）が u1・u2 の 2 ユーザーを返す
+    const profileRepo = makeProfileRepo(['u1', 'u2']);
     mockDetectCritical.mockResolvedValue({ isCritical: false });
     mockShouldNotifyNow.mockReturnValue({ notify: false, reason: 'not_due' });
     mockSelectNotificationsToSend.mockReturnValue({
@@ -766,7 +751,7 @@ describe('notifyAllUsers', () => {
     });
 
     const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
-    const result = await notifyAllUsers(makeParams({ docClient: docClient as never }));
+    const result = await notifyAllUsers(makeParams({ profileRepo: profileRepo as never }));
 
     expect(result.skippedUsers + result.failedUsers + result.notifiedUsers).toBe(2);
   });

--- a/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/study.usecase.test.ts
@@ -49,9 +49,14 @@ const mockGenerateNotesForUser = jest.requireMock('@nagiyu/livetalk-core')
   .generateNotesForUser as jest.Mock;
 
 describe('studyAllUsers', () => {
-  const mockDocClient = {
-    send: jest.fn(),
-  };
+  /**
+   * listAllUserIds を返すスタブ ProfileRepository を作る。
+   */
+  const makeProfileRepo = (userIds: string[]) => ({
+    listAllUserIds: jest.fn().mockResolvedValue(userIds),
+    getById: jest.fn(),
+    upsert: jest.fn(),
+  });
 
   const makeLifecycleRepo = (overrides: Record<string, object | null> = {}) => ({
     get: jest
@@ -71,8 +76,7 @@ describe('studyAllUsers', () => {
   });
 
   const makeParams = (overrides = {}) => ({
-    docClient: mockDocClient as never,
-    tableName: 'test-table',
+    profileRepo: makeProfileRepo(['u1', 'u2']) as never,
     lifecycleRepo: makeLifecycleRepo() as never,
     interestRepo: {} as never,
     knowledgeRepo: {} as never,
@@ -83,9 +87,6 @@ describe('studyAllUsers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetAllCharacterIds.mockReturnValue(['hiyori', 'ageha']);
-    mockDocClient.send.mockResolvedValue({
-      Items: [{ UserID: 'u1' }, { UserID: 'u2' }],
-    });
     mockGenerateNotesForUser.mockResolvedValue({ generatedCount: 0 });
   });
 

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -174,6 +174,9 @@ export {
   buildInterestSK,
   buildInterestSKPrefix,
   buildLifecycleSK,
+  // GSI1: Profile 列挙用 sparse GSI（#3527）
+  PROFILE_GSI_INDEX_NAME,
+  buildProfileGSI1PK,
 } from './mappers/keys.js';
 
 // Repository interfaces

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -3,7 +3,22 @@
  *
  * 設計は `docs/services/livetalk/architecture.md` §3「データモデル概要」の SK パターンに準拠する。
  * PK は全エンティティで `USER#<googleId>` に統一する。
+ *
+ * GSI1: Profile 列挙用 sparse GSI（#3527）
+ * - GSI1PK='PROFILE' の Profile アイテムのみを索引化する
+ * - GSI1SK は生の UserID（USER# プレフィックスなし）
  */
+
+/** Profile 列挙 GSI のインデックス名 */
+export const PROFILE_GSI_INDEX_NAME = 'GSI1';
+
+/**
+ * GSI1 のパーティションキー値を返す。
+ * Profile アイテムのみに付与する（sparse GSI）。
+ */
+export function buildProfileGSI1PK(): string {
+  return 'PROFILE';
+}
 
 export function buildUserPK(userId: string): string {
   return `USER#${userId}`;

--- a/services/livetalk/core/src/mappers/profile.mapper.ts
+++ b/services/livetalk/core/src/mappers/profile.mapper.ts
@@ -5,7 +5,7 @@ import {
   type EntityMapper,
 } from '@nagiyu/aws';
 import type { ProfileEntity, ProfileKey, UserConsents } from '../entities/profile.entity.js';
-import { buildProfileSK, buildUserPK } from './keys.js';
+import { buildProfileSK, buildUserPK, buildProfileGSI1PK } from './keys.js';
 
 export class ProfileMapper implements EntityMapper<ProfileEntity, ProfileKey> {
   public readonly entityType = 'Profile';
@@ -20,6 +20,10 @@ export class ProfileMapper implements EntityMapper<ProfileEntity, ProfileKey> {
       LastActiveAt: entity.LastActiveAt,
       CreatedAt: entity.CreatedAt,
       UpdatedAt: entity.UpdatedAt,
+      // GSI1: Profile 列挙用 sparse GSI 属性（#3527）
+      // GSI1PK='PROFILE' で Profile アイテムのみを索引化、GSI1SK は生の UserID
+      GSI1PK: buildProfileGSI1PK(),
+      GSI1SK: entity.UserID,
     };
     if (entity.Consents !== undefined) {
       item.Consents = entity.Consents;

--- a/services/livetalk/core/src/repositories/dynamodb-note.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-note.repository.ts
@@ -77,6 +77,42 @@ export class DynamoDBNoteRepository implements NoteRepository {
     return results;
   }
 
+  public async listAll(userId: string, characterId: string): Promise<NoteEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildNoteSKPrefix(characterId);
+    const results: NoteEntity[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: { ':pk': pk, ':prefix': prefix },
+            ScanIndexForward: false,
+            Limit: 100,
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        results.push(this.mapper.toEntity(raw as unknown as DynamoDBItem));
+      }
+
+      if (!result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return results;
+  }
+
   public async get(key: NoteKey): Promise<NoteEntity | null> {
     const pk = buildUserPK(key.userId);
     const sk = buildNoteSK(key.characterId, key.noteId);

--- a/services/livetalk/core/src/repositories/dynamodb-notification-event.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-notification-event.repository.ts
@@ -81,6 +81,55 @@ export class DynamoDBNotificationEventRepository implements NotificationEventRep
     return results;
   }
 
+  public async listLatestUnconsumedByCharacter(
+    userId: string,
+    characterIds: string[]
+  ): Promise<NotificationEventEntity[]> {
+    if (characterIds.length === 0) return [];
+
+    const pk = buildUserPK(userId);
+    const prefix = buildNotifSKPrefix();
+    const target = new Set(characterIds);
+    const map = new Map<string, NotificationEventEntity>();
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :prefix)',
+            ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+            ExpressionAttributeValues: { ':pk': pk, ':prefix': prefix },
+            ScanIndexForward: false,
+            Limit: 100,
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      }
+
+      for (const raw of result.Items ?? []) {
+        const entity = this.mapper.toEntity(raw as unknown as DynamoDBItem);
+        if (
+          target.has(entity.CharacterID) &&
+          entity.ConsumedAt === undefined &&
+          !map.has(entity.CharacterID)
+        ) {
+          map.set(entity.CharacterID, entity);
+        }
+      }
+
+      if (map.size >= characterIds.length || !result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return Array.from(map.values());
+  }
+
   public async get(key: NotificationEventKey): Promise<NotificationEventEntity | null> {
     const pk = buildUserPK(key.userId);
     const sk = buildNotifSK(key.notifId);

--- a/services/livetalk/core/src/repositories/dynamodb-notification-event.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-notification-event.repository.ts
@@ -123,7 +123,7 @@ export class DynamoDBNotificationEventRepository implements NotificationEventRep
         }
       }
 
-      if (map.size >= characterIds.length || !result.LastEvaluatedKey) break;
+      if (map.size >= target.size || !result.LastEvaluatedKey) break;
       exclusiveStartKey = result.LastEvaluatedKey;
     }
 

--- a/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
@@ -1,4 +1,9 @@
-import { GetCommand, PutCommand, QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
 import type {
   CreateProfileInput,

--- a/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-profile.repository.ts
@@ -1,4 +1,4 @@
-import { GetCommand, PutCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, PutCommand, QueryCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
 import type {
   CreateProfileInput,
@@ -6,6 +6,7 @@ import type {
   ProfileKey,
   UpdateProfileInput,
 } from '../entities/profile.entity.js';
+import { PROFILE_GSI_INDEX_NAME, buildProfileGSI1PK } from '../mappers/keys.js';
 import { ProfileMapper } from '../mappers/profile.mapper.js';
 import type { ProfileRepository } from './profile.repository.interface.js';
 
@@ -47,6 +48,38 @@ export class DynamoDBProfileRepository implements ProfileRepository {
       const message = error instanceof Error ? error.message : String(error);
       throw new DatabaseError(message, error instanceof Error ? error : undefined);
     }
+  }
+
+  public async listAllUserIds(): Promise<string[]> {
+    const userIds: string[] = [];
+    let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+    try {
+      do {
+        const result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            IndexName: PROFILE_GSI_INDEX_NAME,
+            KeyConditionExpression: '#gsi1pk = :pk',
+            ExpressionAttributeNames: { '#gsi1pk': 'GSI1PK' },
+            ExpressionAttributeValues: { ':pk': buildProfileGSI1PK() },
+            ...(lastEvaluatedKey ? { ExclusiveStartKey: lastEvaluatedKey } : {}),
+          })
+        );
+        for (const item of result.Items ?? []) {
+          // KEYS_ONLY 射影のため GSI1SK（生の UserID）から読み取る
+          if (typeof item.GSI1SK === 'string' && item.GSI1SK) {
+            userIds.push(item.GSI1SK);
+          }
+        }
+        lastEvaluatedKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+      } while (lastEvaluatedKey !== undefined);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+
+    return userIds;
   }
 
   public async upsert(

--- a/services/livetalk/core/src/repositories/in-memory-note.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-note.repository.ts
@@ -33,6 +33,19 @@ export class InMemoryNoteRepository implements NoteRepository {
       .slice(0, limit);
   }
 
+  public async listAll(userId: string, characterId: string): Promise<NoteEntity[]> {
+    const pk = buildUserPK(userId);
+    const prefix = buildNoteSKPrefix(characterId);
+    // limit を指定しないとデフォルト 100 件で打ち切られるため、十分大きな値を渡す
+    const result = this.store.query(
+      { pk, sk: { operator: 'begins_with', value: prefix } },
+      { limit: Number.MAX_SAFE_INTEGER }
+    );
+    return result.items
+      .map((item) => this.mapper.toEntity(item))
+      .sort((a, b) => b.CreatedAt - a.CreatedAt);
+  }
+
   public async get(key: NoteKey): Promise<NoteEntity | null> {
     const pk = buildUserPK(key.userId);
     const sk = buildNoteSK(key.characterId, key.noteId);

--- a/services/livetalk/core/src/repositories/in-memory-notification-event.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-notification-event.repository.ts
@@ -35,6 +35,38 @@ export class InMemoryNotificationEventRepository implements NotificationEventRep
       .slice(0, limit);
   }
 
+  public async listLatestUnconsumedByCharacter(
+    userId: string,
+    characterIds: string[]
+  ): Promise<NotificationEventEntity[]> {
+    if (characterIds.length === 0) return [];
+
+    const pk = buildUserPK(userId);
+    const prefix = buildNotifSKPrefix();
+    // limit を指定しないとデフォルト 100 件で打ち切られるため、十分大きな値を渡す
+    const result = this.store.query(
+      { pk, sk: { operator: 'begins_with', value: prefix } },
+      { limit: Number.MAX_SAFE_INTEGER }
+    );
+    const sorted = result.items
+      .map((item) => this.mapper.toEntity(item))
+      .sort((a, b) => b.CreatedAt - a.CreatedAt);
+
+    const target = new Set(characterIds);
+    const map = new Map<string, NotificationEventEntity>();
+    for (const entity of sorted) {
+      if (
+        target.has(entity.CharacterID) &&
+        entity.ConsumedAt === undefined &&
+        !map.has(entity.CharacterID)
+      ) {
+        map.set(entity.CharacterID, entity);
+      }
+    }
+
+    return Array.from(map.values());
+  }
+
   public async get(key: NotificationEventKey): Promise<NotificationEventEntity | null> {
     const pk = buildUserPK(key.userId);
     const sk = buildNotifSK(key.notifId);

--- a/services/livetalk/core/src/repositories/in-memory-profile.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-profile.repository.ts
@@ -5,6 +5,7 @@ import type {
   ProfileKey,
   UpdateProfileInput,
 } from '../entities/profile.entity.js';
+import { buildProfileGSI1PK } from '../mappers/keys.js';
 import { ProfileMapper } from '../mappers/profile.mapper.js';
 import type { ProfileRepository } from './profile.repository.interface.js';
 
@@ -24,6 +25,26 @@ export class InMemoryProfileRepository implements ProfileRepository {
     const item = this.store.get(pk, sk);
     if (!item) return null;
     return this.mapper.toEntity(item);
+  }
+
+  public async listAllUserIds(): Promise<string[]> {
+    const userIds: string[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const result = this.store.queryByAttribute(
+        { attributeName: 'GSI1PK', attributeValue: buildProfileGSI1PK() },
+        cursor ? { cursor } : undefined
+      );
+      for (const item of result.items) {
+        if (typeof item.GSI1SK === 'string' && item.GSI1SK) {
+          userIds.push(item.GSI1SK);
+        }
+      }
+      cursor = result.nextCursor;
+    } while (cursor !== undefined);
+
+    return userIds;
   }
 
   public async upsert(

--- a/services/livetalk/core/src/repositories/note.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/note.repository.interface.ts
@@ -4,6 +4,8 @@ export interface NoteRepository {
   put(input: CreateNoteInput): Promise<NoteEntity>;
   /** キャラ単位のノートを CreatedAt 降順で返す。 */
   list(userId: string, characterId: string, limit?: number): Promise<NoteEntity[]>;
+  /** キャラ単位の全ノートを CreatedAt 降順で返す（固定件数で打ち切らない）。 */
+  listAll(userId: string, characterId: string): Promise<NoteEntity[]>;
   /** 単一ノートを返す。なければ null。 */
   get(key: NoteKey): Promise<NoteEntity | null>;
   /**

--- a/services/livetalk/core/src/repositories/notification-event.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/notification-event.repository.interface.ts
@@ -8,6 +8,15 @@ export interface NotificationEventRepository {
   put(input: CreateNotificationEventInput): Promise<NotificationEventEntity>;
   /** ユーザーの通知履歴を CreatedAt 降順で返す。 */
   listByUser(userId: string, limit?: number): Promise<NotificationEventEntity[]>;
+  /**
+   * 指定キャラクター群について「最新の未消化通知」を 1 件ずつ返す。
+   * CreatedAt 降順に走査し、全キャラで最新未消化が揃うか履歴を尽くすまでページングする（固定件数で打ち切らない）。
+   * 戻り値は未消化通知が存在するキャラクターのエントリのみ（順序不問）。
+   */
+  listLatestUnconsumedByCharacter(
+    userId: string,
+    characterIds: string[]
+  ): Promise<NotificationEventEntity[]>;
   /** 単一通知イベントを返す。なければ null。 */
   get(key: NotificationEventKey): Promise<NotificationEventEntity | null>;
   /** consumedAt を現在時刻で更新する（キャラ第一声表示後に呼ぶ）。 */

--- a/services/livetalk/core/src/repositories/profile.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/profile.repository.interface.ts
@@ -19,4 +19,10 @@ export interface ProfileRepository {
    * 既存があれば渡された `updates` を適用、無ければ create + updates 反映で新規作成する。
    */
   upsert(input: CreateProfileInput, updates?: UpdateProfileInput): Promise<ProfileEntity>;
+  /**
+   * 全ユーザーの UserID を列挙する。
+   * GSI1（GSI1PK='PROFILE'）を Query して Profile のみを読む（テーブル全体を Scan しない）。
+   * 内部で LastEvaluatedKey をループし全件返す。バッチのユーザー列挙に用いる。
+   */
+  listAllUserIds(): Promise<string[]>;
 }

--- a/services/livetalk/core/tests/unit/mappers/profile.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/profile.mapper.test.ts
@@ -25,6 +25,23 @@ describe('ProfileMapper', () => {
     expect(mapper.toEntity(item)).toEqual(baseEntity);
   });
 
+  it('toItem に GSI1PK="PROFILE" が含まれる（sparse GSI）', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(item.GSI1PK).toBe('PROFILE');
+  });
+
+  it('toItem に GSI1SK=UserID（生の UserID）が含まれる', () => {
+    const item = mapper.toItem(baseEntity);
+    expect(item.GSI1SK).toBe('google-12345');
+  });
+
+  it('toEntity は GSI1PK / GSI1SK を entity に含めない', () => {
+    const item = mapper.toItem(baseEntity);
+    const entity = mapper.toEntity(item);
+    expect(Object.keys(entity)).not.toContain('GSI1PK');
+    expect(Object.keys(entity)).not.toContain('GSI1SK');
+  });
+
   it('Auth 側の情報（DisplayName / Email / GoogleID）は永続化しない', () => {
     const item = mapper.toItem(baseEntity);
     expect(item.DisplayName).toBeUndefined();

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-note.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-note.repository.test.ts
@@ -117,6 +117,76 @@ describe('DynamoDBNoteRepository', () => {
     });
   });
 
+  describe('listAll', () => {
+    it('複数ページを結合して全件返す（LastEvaluatedKey の連鎖）', async () => {
+      let callCount = 0;
+      const page1Item = { ...baseItem, NoteID: 'note-001', SK: 'CHAR#hiyori#NOTE#note-001' };
+      const page2Item = {
+        ...baseItem,
+        NoteID: 'note-002',
+        SK: 'CHAR#hiyori#NOTE#note-002',
+        CreatedAt: fixedNow - 1000,
+      };
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { Items: [page1Item], LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor' } };
+        }
+        return { Items: [page2Item] };
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const list = await repo.listAll('u1', 'hiyori');
+      expect(list).toHaveLength(2);
+      // 2 ページ分クエリされていること
+      expect(callCount).toBe(2);
+    });
+
+    it('100 件を超えても全件返す（件数制限なし）', async () => {
+      // 1 ページ目に 100 件 + LastEvaluatedKey、2 ページ目に 50 件
+      let callCount = 0;
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          const items = Array.from({ length: 100 }, (_, i) => ({
+            ...baseItem,
+            NoteID: `note-${i}`,
+            SK: `CHAR#hiyori#NOTE#note-${i}`,
+          }));
+          return { Items: items, LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor' } };
+        }
+        const items = Array.from({ length: 50 }, (_, i) => ({
+          ...baseItem,
+          NoteID: `note-extra-${i}`,
+          SK: `CHAR#hiyori#NOTE#note-extra-${i}`,
+        }));
+        return { Items: items };
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const list = await repo.listAll('u1', 'hiyori');
+      // list() と異なり 100 件で打ち切らず全 150 件を返す
+      expect(list).toHaveLength(150);
+      expect(callCount).toBe(2);
+    });
+
+    it('LastEvaluatedKey がなければ 1 ページで終了する', async () => {
+      const client = makeClient(async () => ({ Items: [baseItem] }));
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+
+      const list = await repo.listAll('u1', 'hiyori');
+      expect(list).toHaveLength(1);
+    });
+
+    it('listAll 失敗時は DatabaseError を投げる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('boom');
+      });
+      const repo = new DynamoDBNoteRepository(client as never, tableName, () => fixedNow);
+      await expect(repo.listAll('u1', 'hiyori')).rejects.toBeInstanceOf(DatabaseError);
+    });
+  });
+
   describe('listRecent', () => {
     it('threshold より新しいノートのみ返す', async () => {
       const oldItem = {

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-notification-event.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-notification-event.repository.test.ts
@@ -299,6 +299,60 @@ describe('DynamoDBNotificationEventRepository', () => {
       expect(callCount).toBe(1);
     });
 
+    it('未消化が 0 のキャラが対象に含まれる場合は履歴を走査し尽くし、他キャラは正しく返す', async () => {
+      // 最悪ケース: ageha は未消化が一切無いため早期終了せず、全ページを走査する。
+      // それでも hiyori の最新未消化は取りこぼさず返ること。
+      let callCount = 0;
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            Items: [
+              { ...baseItem, NotifID: 'N-HIY', CharacterID: 'hiyori', SK: 'NOTIF#N-HIY' },
+              // ageha は消化済みのみ（未消化なし）
+              {
+                ...baseItem,
+                NotifID: 'N-AGE-C',
+                CharacterID: 'ageha',
+                SK: 'NOTIF#N-AGE-C',
+                ConsumedAt: fixedNow - 1000,
+              },
+            ],
+            LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor1' },
+          };
+        }
+        if (callCount === 2) {
+          return {
+            Items: [
+              {
+                ...baseItem,
+                NotifID: 'N-AGE-C2',
+                CharacterID: 'ageha',
+                SK: 'NOTIF#N-AGE-C2',
+                ConsumedAt: fixedNow - 2000,
+              },
+            ],
+            LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor2' },
+          };
+        }
+        // 最終ページ（LastEvaluatedKey なし）
+        return { Items: [] };
+      });
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori', 'ageha']);
+      // ageha は未消化なしで充足しないため、終端まで走査する（早期終了しない）
+      expect(callCount).toBe(3);
+      // hiyori の未消化のみ返る
+      expect(result).toHaveLength(1);
+      expect(result[0].CharacterID).toBe('hiyori');
+      expect(result[0].NotifID).toBe('N-HIY');
+    });
+
     it('エラー時は DatabaseError を投げる', async () => {
       const client = makeClient(async () => {
         throw new Error('query 失敗');

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-notification-event.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-notification-event.repository.test.ts
@@ -176,6 +176,144 @@ describe('DynamoDBNotificationEventRepository', () => {
     });
   });
 
+  describe('listLatestUnconsumedByCharacter', () => {
+    it('characterIds が空の場合は即 [] を返す', async () => {
+      const client = makeClient(async () => ({ Items: [] }));
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+      const result = await repo.listLatestUnconsumedByCharacter('u1', []);
+      expect(result).toEqual([]);
+    });
+
+    it('キャラごとに最新未消化通知 1 件を返す', async () => {
+      const hiyoriItem = {
+        ...baseItem,
+        NotifID: 'N-HIY',
+        CharacterID: 'hiyori',
+        SK: 'NOTIF#N-HIY',
+      };
+      const agehaItem = { ...baseItem, NotifID: 'N-AGE', CharacterID: 'ageha', SK: 'NOTIF#N-AGE' };
+      const client = makeClient(async () => ({ Items: [hiyoriItem, agehaItem] }));
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori', 'ageha']);
+      expect(result).toHaveLength(2);
+      const charIds = result.map((e) => e.CharacterID);
+      expect(charIds).toContain('hiyori');
+      expect(charIds).toContain('ageha');
+    });
+
+    it('消化済みイベントはスキップする', async () => {
+      const consumedItem = {
+        ...baseItem,
+        NotifID: 'N-CONSUMED',
+        CharacterID: 'hiyori',
+        SK: 'NOTIF#N-CONSUMED',
+        ConsumedAt: fixedNow - 1000,
+      };
+      const client = makeClient(async () => ({ Items: [consumedItem] }));
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(0);
+    });
+
+    it('未消化が 1 ページ目より後ろにあっても取りこぼさない（複数ページ連鎖）', async () => {
+      // 1 ページ目: hiyori の消化済み通知 100 件
+      // 2 ページ目: hiyori の未消化通知 1 件
+      let callCount = 0;
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          const consumedItems = Array.from({ length: 100 }, (_, i) => ({
+            ...baseItem,
+            NotifID: `N-CONSUMED-${i}`,
+            CharacterID: 'hiyori',
+            SK: `NOTIF#N-CONSUMED-${i}`,
+            ConsumedAt: fixedNow - (i + 1) * 1000,
+          }));
+          return { Items: consumedItems, LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor' } };
+        }
+        // 2 ページ目: 未消化が 1 件
+        return {
+          Items: [
+            {
+              ...baseItem,
+              NotifID: 'N-LATE-UNCONSUMED',
+              CharacterID: 'hiyori',
+              SK: 'NOTIF#N-LATE-UNCONSUMED',
+            },
+          ],
+        };
+      });
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      // 2 ページ目にある未消化を正しく発見できること
+      expect(result).toHaveLength(1);
+      expect(result[0].NotifID).toBe('N-LATE-UNCONSUMED');
+      expect(callCount).toBe(2);
+    });
+
+    it('全キャラ充足したら早期終了する', async () => {
+      // 1 ページ目で hiyori, ageha 双方の未消化が揃う → 2 ページ目を問い合わせない
+      let callCount = 0;
+      const hiyoriItem = {
+        ...baseItem,
+        NotifID: 'N-HIY',
+        CharacterID: 'hiyori',
+        SK: 'NOTIF#N-HIY',
+      };
+      const agehaItem = { ...baseItem, NotifID: 'N-AGE', CharacterID: 'ageha', SK: 'NOTIF#N-AGE' };
+      const client = makeClient(async () => {
+        callCount++;
+        return {
+          Items: [hiyoriItem, agehaItem],
+          LastEvaluatedKey: { PK: 'USER#u1', SK: 'cursor' },
+        };
+      });
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori', 'ageha']);
+      expect(result).toHaveLength(2);
+      // 全キャラ充足で break → 1 回しか呼ばれない
+      expect(callCount).toBe(1);
+    });
+
+    it('エラー時は DatabaseError を投げる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('query 失敗');
+      });
+      const repo = new DynamoDBNotificationEventRepository(
+        client as never,
+        tableName,
+        () => fixedNow
+      );
+      await expect(repo.listLatestUnconsumedByCharacter('u1', ['hiyori'])).rejects.toBeInstanceOf(
+        DatabaseError
+      );
+    });
+  });
+
   describe('get', () => {
     it('GetCommand で単一イベントを返す', async () => {
       const sent: unknown[] = [];

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-profile.repository.test.ts
@@ -1,4 +1,4 @@
-import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { DatabaseError } from '@nagiyu/aws';
 import { DynamoDBProfileRepository } from '../../../src/repositories/dynamodb-profile.repository.js';
 
@@ -115,5 +115,69 @@ describe('DynamoDBProfileRepository', () => {
     await repo.upsert({ UserID: 'u1' }, { Consents: consents });
     const put = (sent[1] as PutCommand).input;
     expect(put.Item?.Consents).toEqual(consents);
+  });
+
+  describe('listAllUserIds', () => {
+    it('GSI1 を QueryCommand で IndexName="GSI1" を指定して送信する', async () => {
+      const sent: unknown[] = [];
+      const client = makeClient(async (cmd) => {
+        sent.push(cmd);
+        return { Items: [{ GSI1PK: 'PROFILE', GSI1SK: 'user-1' }] };
+      });
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+
+      const result = await repo.listAllUserIds();
+
+      expect(sent[0]).toBeInstanceOf(QueryCommand);
+      const query = (sent[0] as QueryCommand).input;
+      expect(query.IndexName).toBe('GSI1');
+      expect(result).toEqual(['user-1']);
+    });
+
+    it('複数ページ（LastEvaluatedKey 連鎖）を結合して UserID 配列を返す', async () => {
+      let callCount = 0;
+      const client = makeClient(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            Items: [{ GSI1PK: 'PROFILE', GSI1SK: 'user-1' }],
+            LastEvaluatedKey: { GSI1PK: 'PROFILE', GSI1SK: 'user-1' },
+          };
+        }
+        return { Items: [{ GSI1PK: 'PROFILE', GSI1SK: 'user-2' }] };
+      });
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+
+      const result = await repo.listAllUserIds();
+
+      expect(callCount).toBe(2);
+      expect(result).toEqual(['user-1', 'user-2']);
+    });
+
+    it('Items が空のとき空配列を返す', async () => {
+      const client = makeClient(async () => ({ Items: [] }));
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+      expect(await repo.listAllUserIds()).toEqual([]);
+    });
+
+    it('GSI1SK が文字列でない or 空のアイテムを無視する', async () => {
+      const client = makeClient(async () => ({
+        Items: [
+          { GSI1PK: 'PROFILE', GSI1SK: '' },
+          { GSI1PK: 'PROFILE', GSI1SK: 123 },
+          { GSI1PK: 'PROFILE', GSI1SK: 'valid-user' },
+        ],
+      }));
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+      expect(await repo.listAllUserIds()).toEqual(['valid-user']);
+    });
+
+    it('エラーは DatabaseError でラップされる', async () => {
+      const client = makeClient(async () => {
+        throw new Error('QueryCommand 失敗');
+      });
+      const repo = new DynamoDBProfileRepository(client as never, tableName, () => now);
+      await expect(repo.listAllUserIds()).rejects.toBeInstanceOf(DatabaseError);
+    });
   });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-note.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-note.repository.test.ts
@@ -97,4 +97,41 @@ describe('InMemoryNoteRepository', () => {
   it('list は未登録ユーザーに対して空配列を返す', async () => {
     expect(await repo.list('unknown', 'hiyori')).toHaveLength(0);
   });
+
+  describe('listAll', () => {
+    it('全件を CreatedAt 降順で返す（limit による打ち切りなし）', async () => {
+      // 150 件登録
+      for (let i = 0; i < 150; i++) {
+        await repo.put(makeInput({ NoteID: `note-${i}` }));
+        now += 100;
+      }
+      const all = await repo.listAll('u1', 'hiyori');
+      // list(100) とは異なり全 150 件返す
+      expect(all).toHaveLength(150);
+    });
+
+    it('CreatedAt 降順で返す', async () => {
+      await repo.put(makeInput({ NoteID: 'note-old' }));
+      now += 1000;
+      await repo.put(makeInput({ NoteID: 'note-new' }));
+
+      const all = await repo.listAll('u1', 'hiyori');
+      expect(all).toHaveLength(2);
+      expect(all[0].NoteID).toBe('note-new');
+      expect(all[1].NoteID).toBe('note-old');
+    });
+
+    it('別ユーザーのノートは含まない', async () => {
+      await repo.put(makeInput({ UserID: 'u1', NoteID: 'note-u1' }));
+      await repo.put(makeInput({ UserID: 'u2', NoteID: 'note-u2' }));
+
+      const all = await repo.listAll('u1', 'hiyori');
+      expect(all).toHaveLength(1);
+      expect(all[0].NoteID).toBe('note-u1');
+    });
+
+    it('ノートが 0 件の場合は空配列を返す', async () => {
+      expect(await repo.listAll('u1', 'hiyori')).toHaveLength(0);
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-notification-event.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-notification-event.repository.test.ts
@@ -152,6 +152,97 @@ describe('InMemoryNotificationEventRepository', () => {
     });
   });
 
+  describe('listLatestUnconsumedByCharacter', () => {
+    it('characterIds が空の場合は [] を返す', async () => {
+      const store = makeStore();
+      const repo = makeRepo(store);
+      await repo.put(makeInput({ NotifID: 'NOTIF-X' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', []);
+      expect(result).toEqual([]);
+    });
+
+    it('キャラごとに最新未消化通知 1 件を返す', async () => {
+      const store = makeStore();
+      let now = BASE_NOW;
+      const repo = makeRepo(store, () => now);
+
+      now = BASE_NOW + 1000;
+      await repo.put(makeInput({ NotifID: 'N-HIY-OLD', CharacterID: 'hiyori' }));
+      now = BASE_NOW + 2000;
+      await repo.put(makeInput({ NotifID: 'N-HIY-NEW', CharacterID: 'hiyori' }));
+      now = BASE_NOW + 3000;
+      await repo.put(makeInput({ NotifID: 'N-AGE', CharacterID: 'ageha' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori', 'ageha']);
+      expect(result).toHaveLength(2);
+
+      const hiyori = result.find((e) => e.CharacterID === 'hiyori');
+      // 最新（CreatedAt が大きい方）が返ること
+      expect(hiyori?.NotifID).toBe('N-HIY-NEW');
+    });
+
+    it('消化済みイベントはスキップする', async () => {
+      const store = makeStore();
+      const repo = makeRepo(store);
+      const saved = await repo.put(makeInput({ NotifID: 'NOTIF-CONSUME' }));
+      await repo.markConsumed({ userId: 'u1', notifId: saved.NotifID }, BASE_NOW + 1000);
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(0);
+    });
+
+    it('消化済みと未消化が混在する場合、最新未消化を返す', async () => {
+      const store = makeStore();
+      let now = BASE_NOW;
+      const repo = makeRepo(store, () => now);
+
+      // 最新: 消化済み
+      now = BASE_NOW + 2000;
+      const consumed = await repo.put(makeInput({ NotifID: 'N-CONSUMED' }));
+      await repo.markConsumed({ userId: 'u1', notifId: consumed.NotifID }, now + 100);
+
+      // 2 番目: 未消化
+      now = BASE_NOW + 1000;
+      await repo.put(makeInput({ NotifID: 'N-UNCONSUMED' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(1);
+      expect(result[0].NotifID).toBe('N-UNCONSUMED');
+    });
+
+    it('全件走査して未消化を発見する（大量消化済みでも取りこぼさない）', async () => {
+      const store = makeStore();
+      let now = BASE_NOW;
+      const repo = makeRepo(store, () => now);
+
+      // 多数の消化済みを先に（CreatedAt が新しい順）登録
+      for (let i = 100; i >= 1; i--) {
+        now = BASE_NOW + i * 1000;
+        const e = await repo.put(makeInput({ NotifID: `N-CONSUMED-${i}` }));
+        await repo.markConsumed({ userId: 'u1', notifId: e.NotifID }, now + 100);
+      }
+
+      // 最も古い（CreatedAt が最小）の未消化通知
+      now = BASE_NOW;
+      await repo.put(makeInput({ NotifID: 'N-OLDEST-UNCONSUMED' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(1);
+      expect(result[0].NotifID).toBe('N-OLDEST-UNCONSUMED');
+    });
+
+    it('別ユーザーのイベントは混入しない', async () => {
+      const store = makeStore();
+      const repo = makeRepo(store);
+      // u2 のイベントのみ
+      await repo.put(makeInput({ UserID: 'u2', NotifID: 'N-U2' }));
+
+      const result = await repo.listLatestUnconsumedByCharacter('u1', ['hiyori']);
+      expect(result).toHaveLength(0);
+    });
+  });
+
   describe('デフォルト nowMs', () => {
     it('nowMs 省略時は Date.now() が使われる', async () => {
       const store = makeStore();

--- a/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-profile.repository.test.ts
@@ -75,4 +75,28 @@ describe('InMemoryProfileRepository', () => {
     const updated = await repo.upsert({ UserID: 'u3' }, { Consents: consents });
     expect(updated.Consents).toEqual(consents);
   });
+
+  describe('listAllUserIds', () => {
+    it('upsert した複数ユーザーが全件返る', async () => {
+      await repo.upsert({ UserID: 'user-a' });
+      await repo.upsert({ UserID: 'user-b' });
+      await repo.upsert({ UserID: 'user-c' });
+
+      const result = await repo.listAllUserIds();
+
+      expect(result.sort()).toEqual(['user-a', 'user-b', 'user-c']);
+    });
+
+    it('ユーザーが 0 件のとき空配列を返す', async () => {
+      const result = await repo.listAllUserIds();
+      expect(result).toEqual([]);
+    });
+
+    it('upsert したユーザーの UserID（生の ID）が返る（USER# プレフィックスなし）', async () => {
+      await repo.upsert({ UserID: 'google-xyz' });
+      const result = await repo.listAllUserIds();
+      expect(result).toContain('google-xyz');
+      expect(result.some((id) => id.startsWith('USER#'))).toBe(false);
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -1514,6 +1514,7 @@ describe('runChatUseCase', () => {
       return {
         put: jest.fn(),
         list: jest.fn(async () => notes),
+        listAll: jest.fn(async () => notes),
         get: jest.fn(async () => null),
         listRecent: jest.fn(async () => notes),
       };

--- a/services/livetalk/web/src/app/api/notes/route.ts
+++ b/services/livetalk/web/src/app/api/notes/route.ts
@@ -30,7 +30,7 @@ export const GET = withAuth(getSession, 'livetalk:chat', async (session, request
   const repo = getNoteRepository();
 
   try {
-    const items = await repo.list(userId, characterId);
+    const items = await repo.listAll(userId, characterId);
     const notes = sortNotes(items.map(toNoteListItem));
     return NextResponse.json({ notes });
   } catch (error) {

--- a/services/livetalk/web/src/app/api/push/pending/route.ts
+++ b/services/livetalk/web/src/app/api/push/pending/route.ts
@@ -30,8 +30,7 @@ export interface PendingNotification {
   body: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const GET = withAuth(getSession, 'livetalk:chat', async (session, _request: Request) => {
+export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
   const userId = session.user.googleId;
   const repo = getNotificationEventRepository();
   const characterIds = getAllCharacterIds();

--- a/services/livetalk/web/src/app/api/push/pending/route.ts
+++ b/services/livetalk/web/src/app/api/push/pending/route.ts
@@ -4,6 +4,9 @@
  * 自前起動時に「他キャラクターからの未消化通知」を提示するために使用する。
  * 各キャラクターの最新未消化通知（1 件）を返す。
  *
+ * キャラごとの最新未消化をページングで集約するため、消化済み通知が多い場合でも
+ * 未消化通知を取りこぼさない。
+ *
  * レスポンス例:
  *   [{ characterId: 'ageha', notifId: 'n1', body: 'アゲハより' }]
  *
@@ -11,6 +14,7 @@
  */
 import { NextResponse } from 'next/server';
 import { withAuth } from '@nagiyu/nextjs';
+import { getAllCharacterIds } from '@nagiyu/livetalk-core';
 import { getSession } from '@/lib/server/session';
 import { getNotificationEventRepository } from '@/lib/server/repositories';
 
@@ -26,26 +30,19 @@ export interface PendingNotification {
   body: string;
 }
 
-export const GET = withAuth(getSession, 'livetalk:chat', async (session) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const GET = withAuth(getSession, 'livetalk:chat', async (session, _request: Request) => {
   const userId = session.user.googleId;
   const repo = getNotificationEventRepository();
-  // 全件取得して未消化をキャラクターごとに集約する
-  // listByUser は CreatedAt 降順で返すため、最初に見つかったものが最新となる
-  const events = await repo.listByUser(userId, 100);
+  const characterIds = getAllCharacterIds();
 
-  // 未消化イベントのみ抽出し、キャラクターごとに最新 1 件を集約する
-  const latestByCharacter = new Map<string, PendingNotification>();
-  for (const e of events) {
-    if (e.ConsumedAt !== undefined) continue;
-    // すでに同キャラクターのエントリがあればスキップ（降順なので最初が最新）
-    if (latestByCharacter.has(e.CharacterID)) continue;
-    latestByCharacter.set(e.CharacterID, {
-      characterId: e.CharacterID,
-      notifId: e.NotifID,
-      body: e.Body,
-    });
-  }
+  const events = await repo.listLatestUnconsumedByCharacter(userId, characterIds);
 
-  const result: PendingNotification[] = Array.from(latestByCharacter.values());
+  const result: PendingNotification[] = events.map((e) => ({
+    characterId: e.CharacterID,
+    notifId: e.NotifID,
+    body: e.Body,
+  }));
+
   return NextResponse.json(result, { status: 200 });
 });

--- a/services/livetalk/web/tests/unit/app/api/notes/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/notes/route.test.ts
@@ -42,6 +42,7 @@ const makeEntity = (over: Partial<NoteEntity> = {}): NoteEntity => ({
 const makeRepo = (over: Partial<NoteRepository> = {}): NoteRepository =>
   ({
     list: jest.fn(async () => []),
+    listAll: jest.fn(async () => []),
     get: jest.fn(),
     put: jest.fn(),
     listRecent: jest.fn(),
@@ -61,11 +62,11 @@ describe('GET /api/notes', () => {
 
   it('一覧を作成日時降順で返す（本文は含めない）', async () => {
     mockGetSession.mockResolvedValue(session);
-    const list = jest.fn(async () => [
+    const listAll = jest.fn(async () => [
       makeEntity({ NoteID: 'old', CreatedAt: 100 }),
       makeEntity({ NoteID: 'new', CreatedAt: 300 }),
     ]);
-    mockGetRepo.mockReturnValue(makeRepo({ list }));
+    mockGetRepo.mockReturnValue(makeRepo({ listAll }));
 
     const res = await GET(req());
     expect(res.status).toBe(200);
@@ -75,16 +76,43 @@ describe('GET /api/notes', () => {
     expect(decodeNoteId(json.notes[0].id, 'g1')?.noteId).toBe('new');
   });
 
+  it('listAll が呼ばれる（list ではない）', async () => {
+    mockGetSession.mockResolvedValue(session);
+    const listAll = jest.fn(async () => []);
+    const list = jest.fn(async () => []);
+    mockGetRepo.mockReturnValue(makeRepo({ listAll, list }));
+
+    await GET(req());
+
+    expect(listAll).toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('100 件を超えても全件を返す', async () => {
+    mockGetSession.mockResolvedValue(session);
+    // listAll が 150 件返すシナリオ（全件を打ち切らずに返す）
+    const items = Array.from({ length: 150 }, (_, i) =>
+      makeEntity({ NoteID: `note-${i}`, CreatedAt: i })
+    );
+    const listAll = jest.fn(async () => items);
+    mockGetRepo.mockReturnValue(makeRepo({ listAll }));
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.notes).toHaveLength(150);
+  });
+
   it('characterId クエリを指定するとそのキャラのノートを取得する', async () => {
     mockGetSession.mockResolvedValue(session);
-    const list = jest.fn(async () => [makeEntity({ CharacterID: 'ageha' })]);
-    mockGetRepo.mockReturnValue(makeRepo({ list }));
+    const listAll = jest.fn(async () => [makeEntity({ CharacterID: 'ageha' })]);
+    mockGetRepo.mockReturnValue(makeRepo({ listAll }));
 
     const req2 = () =>
       new Request('http://localhost/api/notes?characterId=ageha', { method: 'GET' });
     const res = await GET(req2());
     expect(res.status).toBe(200);
-    expect(list).toHaveBeenCalledWith('g1', 'ageha');
+    expect(listAll).toHaveBeenCalledWith('g1', 'ageha');
   });
 
   it('不正な characterId は 400', async () => {
@@ -101,7 +129,7 @@ describe('GET /api/notes', () => {
     mockGetSession.mockResolvedValue(session);
     mockGetRepo.mockReturnValue(
       makeRepo({
-        list: jest.fn(async () => {
+        listAll: jest.fn(async () => {
           throw new Error('boom');
         }),
       })

--- a/services/livetalk/web/tests/unit/app/api/push/pending.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/push/pending.test.ts
@@ -4,10 +4,10 @@
 /**
  * GET /api/push/pending のユニットテスト。
  *
- * Phase C 追加 API:
- *   - 未消化通知をキャラクターごとに集約し、各キャラ最新 1 件を返す
- *   - 未消化なしの場合は空配列を返す
- *   - consume 済みはスキップする
+ * ルートは listLatestUnconsumedByCharacter によりキャラごとの最新未消化通知を集約する。
+ * - 未消化通知をキャラクターごとに集約し、各キャラ最新 1 件を返す
+ * - 未消化なしの場合は空配列を返す
+ * - 100 件を超える履歴があっても未消化通知を取りこぼさない
  */
 import { GET } from '@/app/api/push/pending/route';
 import { getSession } from '@/lib/server/session';
@@ -58,10 +58,15 @@ function makeEvent(overrides: Partial<NotificationEventEntity> = {}): Notificati
   };
 }
 
-/** リポジトリモックのファクトリ */
-function makeRepo(events: NotificationEventEntity[]): NotificationEventRepository {
+/**
+ * リポジトリモックのファクトリ。
+ * ルートは listLatestUnconsumedByCharacter を呼ぶため、
+ * 集約済みの結果（各キャラ最新未消化 1 件）を直接返すモックを使う。
+ */
+function makeRepo(aggregatedResult: NotificationEventEntity[]): NotificationEventRepository {
   return {
-    listByUser: jest.fn(async () => events),
+    listLatestUnconsumedByCharacter: jest.fn(async () => aggregatedResult),
+    listByUser: jest.fn(),
     put: jest.fn(),
     get: jest.fn(),
     markConsumed: jest.fn(),
@@ -92,45 +97,22 @@ describe('GET /api/push/pending', () => {
     expect(json).toEqual([]);
   });
 
-  it('全通知が消化済みの場合は空配列を返す', async () => {
-    mockGetSession.mockResolvedValue(validSession);
-    const consumedEvent = makeEvent({
-      CharacterID: 'hiyori',
-      ConsumedAt: Date.now() - 1000,
-    });
-    mockGetNotificationEventRepo.mockReturnValue(makeRepo([consumedEvent]));
-
-    const res = await GET(buildGetRequest());
-    expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json).toEqual([]);
-  });
-
   it('キャラクターごとに最新未消化通知 1 件を集約して返す', async () => {
     mockGetSession.mockResolvedValue(validSession);
 
-    // hiyori: 2 件の未消化（降順なので n-hiyori-1 が最新）
-    const hiyoriEvent1 = makeEvent({
+    // 集約済み結果（各キャラの最新未消化 1 件）
+    const hiyoriEvent = makeEvent({
       NotifID: 'n-hiyori-1',
       CharacterID: 'hiyori',
       Body: 'ひよりの最新本文',
     });
-    const hiyoriEvent2 = makeEvent({
-      NotifID: 'n-hiyori-2',
-      CharacterID: 'hiyori',
-      Body: 'ひよりの古い本文',
-    });
-    // ageha: 1 件の未消化
     const agehaEvent = makeEvent({
       NotifID: 'n-ageha',
       CharacterID: 'ageha',
       Body: 'アゲハの本文',
     });
 
-    // listByUser は CreatedAt 降順で返す（最新が先頭）
-    mockGetNotificationEventRepo.mockReturnValue(
-      makeRepo([hiyoriEvent1, agehaEvent, hiyoriEvent2])
-    );
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([hiyoriEvent, agehaEvent]));
 
     const res = await GET(buildGetRequest());
     expect(res.status).toBe(200);
@@ -139,7 +121,7 @@ describe('GET /api/push/pending', () => {
     // 2 キャラ分のエントリが返る
     expect(json).toHaveLength(2);
 
-    // hiyori の最新（n-hiyori-1）が含まれる
+    // hiyori のエントリが含まれる
     const hiyoriResult = json.find(
       (item: { characterId: string }) => item.characterId === 'hiyori'
     );
@@ -153,30 +135,39 @@ describe('GET /api/push/pending', () => {
     expect(agehaResult.notifId).toBe('n-ageha');
   });
 
-  it('消化済みと未消化が混在する場合、未消化のみ集約する', async () => {
+  it('listLatestUnconsumedByCharacter に getAllCharacterIds の結果が渡される', async () => {
+    mockGetSession.mockResolvedValue(validSession);
+    const repo = makeRepo([]);
+    mockGetNotificationEventRepo.mockReturnValue(repo);
+
+    await GET(buildGetRequest());
+
+    // getAllCharacterIds() の戻り値（hiyori, ageha）が渡されること
+    expect(repo.listLatestUnconsumedByCharacter).toHaveBeenCalledWith(
+      'g1',
+      expect.arrayContaining(['hiyori', 'ageha'])
+    );
+  });
+
+  it('100 件を超える履歴があっても未消化通知を取りこぼさない（ページング委譲確認）', async () => {
     mockGetSession.mockResolvedValue(validSession);
 
-    // hiyori: 消化済みが先頭（最新）、未消化が 2 番目
-    const consumedEvent = makeEvent({
-      NotifID: 'n-consumed',
+    // 100 件より後ろにある未消化通知がリポジトリ層で拾われ、集約済み結果として返るシナリオ
+    const lateUnconsumed = makeEvent({
+      NotifID: 'n-late-unconsumed',
       CharacterID: 'hiyori',
-      ConsumedAt: Date.now() - 500,
+      Body: '101 件目の未消化通知',
     });
-    const unconsumedEvent = makeEvent({
-      NotifID: 'n-unconsumed',
-      CharacterID: 'hiyori',
-      Body: '未消化の本文',
-    });
-
-    mockGetNotificationEventRepo.mockReturnValue(makeRepo([consumedEvent, unconsumedEvent]));
+    mockGetNotificationEventRepo.mockReturnValue(makeRepo([lateUnconsumed]));
 
     const res = await GET(buildGetRequest());
     expect(res.status).toBe(200);
     const json = await res.json();
 
-    // 未消化のみが集約される
+    // リポジトリ層でページングを処理した結果が正しく返る
     expect(json).toHaveLength(1);
-    expect(json[0].notifId).toBe('n-unconsumed');
+    expect(json[0].notifId).toBe('n-late-unconsumed');
+    expect(json[0].body).toBe('101 件目の未消化通知');
   });
 
   it('レスポンスの各エントリに characterId, notifId, body が含まれる', async () => {


### PR DESCRIPTION
## 変更の概要

公開フェーズ（ユーザー数増）で詰まる DynamoDB アクセスパターンを解消する。integration ブランチで段階的に積み上げた #3527 の成果を develop へ昇格する。

- **Profile 列挙の脱 Scan（Phase 1）**: 全バッチ（compress / study / learn-user-activity / notify）の「テーブル全体 Scan + FilterExpression」を、Profile のみを索引化する sparse GSI（`GSI1PK='PROFILE'`, KEYS_ONLY）への Query に置換。3 usecase に重複していた `scanAllUserIds` 相当ロジックを core（`ProfileRepository.listAllUserIds`）へ集約。
- **GSI の IAM 追従**: batch ロールに GSI1（`index/*`）への Query 権限を付与。
- **一覧系 API のページネーション（Phase 2）**: notes 一覧の暗黙全件取得と push pending 集約の固定 100 件打ち切りをページング対応に変更。
- **memory 一覧はスコープ外**: memory は tier compaction で件数が有界なため、無限増加の懸念がなく今回の対象外とした（notes / push pending のような暗黙打ち切りは持たない）。

## 関連 Issue

Closes #3527

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（develop 反映後に architecture.md へ GSI1 の設計判断を追従予定）
- [x] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- core: `ProfileRepository.listAllUserIds` の GSI Query（DynamoDB / in-memory 双方）と profile mapper の GSI 属性付与のユニットテスト
- batch: 4 usecase（compress / study / learn-user-activity / notify）の GSI 列挙への置換に伴うユニットテスト更新
- infra: dynamodb-stack（GSI1 定義）・batch-stack（GSI への IAM 権限）のユニットテスト
- web: notes / push pending のページング対応のユニットテスト
- CI（LiveTalk - Build and Push to ECR, run #142）green、dev 環境で GSI1 が ACTIVE・Profile が索引化されることを実機確認済み

## レビューポイント

- sparse GSI の設計（`GSI1PK='PROFILE'` / KEYS_ONLY 射影 / `GSI1SK` に生の UserID）と、クロススタック参照を避けてテーブル名を独立に組み立てる方針（`infra/livetalk/lib/dynamodb-stack.ts` のコメント参照）
- memory 一覧をスコープ外とした判断の妥当性

## 補足事項

- **既存データの扱い**: GSI1 は sparse のため、属性を持つアイテムのみ索引化される。既存 Profile への backfill バッチは作らず、**ユーザー母集団が廃棄可（dev / prod とも少数のシードのみ）なため、データをクリアして再 onboarding する方針**とした（consent フローが GSI 属性付きで Profile を作り直す）。dev は実施・索引化を確認済み。prod は本変更が prod へ昇格した後に同手順を実施する。
- develop 反映後、`docs/services/livetalk/architecture.md` へ GSI1 の設計判断（なぜ sparse GSI か）を直接 docs PR で追従する予定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01KPAyuemT4wzg4E2ji94VuA)_