### PR TITLE
リブトーク: 通知タップ起動時の入力欄プリフィル（#3553 develop 反映）

### DIFF
--- a/services/livetalk/batch/src/usecases/notify.usecase.ts
+++ b/services/livetalk/batch/src/usecases/notify.usecase.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CHARACTER_ID,
   buildCriticalNotificationMessage,
   buildNotificationMessage,
+  buildSuggestedReply,
   detectCriticalKnowledge,
   shouldNotifyNow,
   getAllCharacterIds,
@@ -141,6 +142,8 @@ interface NotificationCandidate {
   knowledgeId: string | undefined;
   title: string;
   body: string;
+  /** 通知タップ起動時に入力欄へプリフィルするユーザー発話 */
+  suggestedReply: string;
   /**
    * そのキャラの直近 normal 通知の CreatedAt（未通知は 0）。
    * normal 候補の選抜（公平性ソート）に使用する。
@@ -260,13 +263,13 @@ async function processUser(params: ProcessUserParams): Promise<boolean> {
     const candidate = candidateMap.get(characterId);
     if (!candidate) continue;
 
-    const { title, body, knowledgeId, kind } = candidate;
+    const { title, body, knowledgeId, kind, suggestedReply } = candidate;
 
-    // B-2: payload に characterId と URL を含める
+    // B-2: payload に characterId と URL を含める（from=push で通知タップ由来であることをフロントに伝える）
     const payload = {
       title,
       body,
-      data: { url: `/?character=${characterId}`, characterId },
+      data: { url: `/?character=${characterId}&from=push`, characterId },
     };
 
     // 全サブスクリプションに送信（失敗はログのみ、無効は削除）
@@ -296,7 +299,7 @@ async function processUser(params: ProcessUserParams): Promise<boolean> {
 
     if (sentCount === 0) continue;
 
-    // 配信履歴を記録（CharacterID を付与）
+    // 配信履歴を記録（CharacterID・SuggestedReply を付与）
     await notifEventRepo.put({
       UserID: userId,
       NotifID: ulidFactory(),
@@ -305,6 +308,7 @@ async function processUser(params: ProcessUserParams): Promise<boolean> {
       Title: title,
       Body: body,
       KnowledgeID: knowledgeId,
+      SuggestedReply: suggestedReply,
       Ttl: ttl,
     });
 
@@ -405,6 +409,7 @@ async function evaluateCharacter(params: {
   let title: string;
   let body: string;
   let knowledgeId: string | undefined;
+  let suggestedReply: string;
 
   if (decision.kind === 'critical') {
     const knowledge = recentKnowledge.find((k) => k.KnowledgeID === decision.knowledgeId);
@@ -415,6 +420,7 @@ async function evaluateCharacter(params: {
     title = msg.title;
     body = msg.body;
     knowledgeId = decision.knowledgeId;
+    suggestedReply = buildSuggestedReply(knowledge?.Topic);
   } else {
     // 直近で使用済みの KnowledgeID を避けてネタを選ぶ（同じ話題の連発を抑制）
     // このキャラの履歴から使用済み KnowledgeID を収集する
@@ -437,6 +443,7 @@ async function evaluateCharacter(params: {
     title = msg.title;
     body = msg.body;
     knowledgeId = freshKnowledge?.KnowledgeID;
+    suggestedReply = buildSuggestedReply(freshKnowledge?.Topic);
   }
 
   return {
@@ -445,6 +452,7 @@ async function evaluateCharacter(params: {
     knowledgeId,
     title,
     body,
+    suggestedReply,
     lastNormalAt,
   };
 }

--- a/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
@@ -796,7 +796,10 @@ describe('notifyAllUsers', () => {
       const notifEventRepo = makeNotifEventRepo();
       const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
       await notifyAllUsers(
-        makeParams({ notifEventRepo: notifEventRepo as never, knowledgeRepo: knowledgeRepo as never })
+        makeParams({
+          notifEventRepo: notifEventRepo as never,
+          knowledgeRepo: knowledgeRepo as never,
+        })
       );
 
       expect(notifEventRepo.put).toHaveBeenCalledWith(

--- a/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
+++ b/services/livetalk/batch/tests/unit/usecases/notify.usecase.test.ts
@@ -26,6 +26,9 @@ jest.mock('@nagiyu/livetalk-core', () => ({
   DEFAULT_CHARACTER_ID: 'hiyori',
   buildNotificationMessage: jest.fn(() => ({ title: 'テスト', body: '本文' })),
   buildCriticalNotificationMessage: jest.fn(() => ({ title: 'テスト（重要）', body: '重要本文' })),
+  buildSuggestedReply: jest.fn((topic?: string) =>
+    topic ? `${topic}について教えて` : '話したいことってなに？'
+  ),
   detectCriticalKnowledge: jest.fn(),
   shouldNotifyNow: jest.fn(),
   getAllCharacterIds: jest.fn(() => ['hiyori']),
@@ -538,7 +541,7 @@ describe('notifyAllUsers', () => {
       const payloadArg = mockSendWebPush.mock.calls[0][1];
       expect(payloadArg.data).toMatchObject({
         characterId: 'hiyori',
-        url: '/?character=hiyori',
+        url: '/?character=hiyori&from=push',
       });
     });
 
@@ -754,6 +757,109 @@ describe('notifyAllUsers', () => {
     const result = await notifyAllUsers(makeParams({ profileRepo: profileRepo as never }));
 
     expect(result.skippedUsers + result.failedUsers + result.notifiedUsers).toBe(2);
+  });
+
+  describe('SuggestedReply の生成と保存', () => {
+    it('normal 通知で SuggestedReply が notifEvent に保存される（topic あり）', async () => {
+      mockDetectCritical.mockResolvedValue({ isCritical: false });
+      mockShouldNotifyNow.mockReturnValue({
+        notify: true,
+        kind: 'normal',
+        toneBucket: 'normal',
+        elapsedMs: DAY,
+      });
+      mockSendWebPush.mockResolvedValue(true);
+
+      const notifEventRepo = makeNotifEventRepo();
+      const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
+      await notifyAllUsers(makeParams({ notifEventRepo: notifEventRepo as never }));
+
+      // knowledge の Topic は 'TypeScript'（makeKnowledgeRepo のデフォルト）
+      expect(notifEventRepo.put).toHaveBeenCalledWith(
+        expect.objectContaining({ SuggestedReply: 'TypeScriptについて教えて' })
+      );
+    });
+
+    it('knowledge がない normal 通知で汎用 SuggestedReply が保存される', async () => {
+      const knowledgeRepo = {
+        list: jest.fn().mockResolvedValue([]),
+      };
+      mockDetectCritical.mockResolvedValue({ isCritical: false });
+      mockShouldNotifyNow.mockReturnValue({
+        notify: true,
+        kind: 'normal',
+        toneBucket: 'normal',
+        elapsedMs: DAY,
+      });
+      mockSendWebPush.mockResolvedValue(true);
+
+      const notifEventRepo = makeNotifEventRepo();
+      const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
+      await notifyAllUsers(
+        makeParams({ notifEventRepo: notifEventRepo as never, knowledgeRepo: knowledgeRepo as never })
+      );
+
+      expect(notifEventRepo.put).toHaveBeenCalledWith(
+        expect.objectContaining({ SuggestedReply: '話したいことってなに？' })
+      );
+    });
+
+    it('critical 通知で SuggestedReply が notifEvent に保存される', async () => {
+      mockDetectCritical.mockResolvedValue({ isCritical: true, knowledgeId: 'k1' });
+      mockShouldNotifyNow.mockReturnValue({ notify: true, kind: 'critical', knowledgeId: 'k1' });
+      mockSelectNotificationsToSend.mockReturnValue({
+        criticalCharacterIds: ['hiyori'],
+        normalCharacterId: null,
+      });
+      mockSendWebPush.mockResolvedValue(true);
+
+      const notifEventRepo = makeNotifEventRepo();
+      const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
+      await notifyAllUsers(makeParams({ notifEventRepo: notifEventRepo as never }));
+
+      expect(notifEventRepo.put).toHaveBeenCalledWith(
+        expect.objectContaining({ SuggestedReply: 'TypeScriptについて教えて' })
+      );
+    });
+  });
+
+  describe('push payload の URL に from=push が含まれる', () => {
+    it('normal 通知の payload URL に &from=push が含まれる', async () => {
+      mockDetectCritical.mockResolvedValue({ isCritical: false });
+      mockShouldNotifyNow.mockReturnValue({
+        notify: true,
+        kind: 'normal',
+        toneBucket: 'normal',
+        elapsedMs: DAY,
+      });
+      mockSelectNotificationsToSend.mockReturnValue({
+        criticalCharacterIds: [],
+        normalCharacterId: 'hiyori',
+      });
+      mockSendWebPush.mockResolvedValue(true);
+
+      const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
+      await notifyAllUsers(makeParams());
+
+      const payloadArg = mockSendWebPush.mock.calls[0][1];
+      expect(payloadArg.data.url).toBe('/?character=hiyori&from=push');
+    });
+
+    it('critical 通知の payload URL にも &from=push が含まれる', async () => {
+      mockDetectCritical.mockResolvedValue({ isCritical: true, knowledgeId: 'k1' });
+      mockShouldNotifyNow.mockReturnValue({ notify: true, kind: 'critical', knowledgeId: 'k1' });
+      mockSelectNotificationsToSend.mockReturnValue({
+        criticalCharacterIds: ['hiyori'],
+        normalCharacterId: null,
+      });
+      mockSendWebPush.mockResolvedValue(true);
+
+      const { notifyAllUsers } = await import('../../../src/usecases/notify.usecase.js');
+      await notifyAllUsers(makeParams());
+
+      const payloadArg = mockSendWebPush.mock.calls[0][1];
+      expect(payloadArg.data.url).toBe('/?character=hiyori&from=push');
+    });
   });
 
   describe('Phase 2 チューニング: 強度サンプリング時刻範囲ベース切り替え', () => {

--- a/services/livetalk/core/src/entities/notification-event.entity.ts
+++ b/services/livetalk/core/src/entities/notification-event.entity.ts
@@ -29,6 +29,12 @@ export interface NotificationEventEntity {
   /** クリティカル通知の場合、元となった KnowledgeID */
   KnowledgeID?: string;
   /**
+   * 通知タップ起動時に入力欄へプリフィルするユーザー発話。
+   * バッチで生成し、first-word API 経由でフロントへ渡す。
+   * 例: 「TypeScriptについて教えて」
+   */
+  SuggestedReply?: string;
+  /**
    * 第一声消化日時（Unix ms）。
    * 起動時にキャラ第一声として表示したら更新する（重複防止）。
    */

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -348,6 +348,7 @@ export type { NotifyDecision, NotifyDecisionInput, ToneBucket } from './notifica
 export {
   buildNotificationMessage,
   buildCriticalNotificationMessage,
+  buildSuggestedReply,
   detectCriticalKnowledge,
   selectNotificationsToSend,
 } from './notification/index.js';

--- a/services/livetalk/core/src/mappers/notification-event.mapper.ts
+++ b/services/livetalk/core/src/mappers/notification-event.mapper.ts
@@ -38,6 +38,7 @@ export class NotificationEventMapper implements EntityMapper<
       Ttl: entity.Ttl,
     };
     if (entity.KnowledgeID !== undefined) item.KnowledgeID = entity.KnowledgeID;
+    if (entity.SuggestedReply !== undefined) item.SuggestedReply = entity.SuggestedReply;
     if (entity.ConsumedAt !== undefined) item.ConsumedAt = entity.ConsumedAt;
     return item;
   }
@@ -61,6 +62,9 @@ export class NotificationEventMapper implements EntityMapper<
     };
     if (item.KnowledgeID !== undefined) {
       entity.KnowledgeID = validateStringField(item.KnowledgeID, 'KnowledgeID');
+    }
+    if (item.SuggestedReply !== undefined) {
+      entity.SuggestedReply = validateStringField(item.SuggestedReply, 'SuggestedReply');
     }
     if (item.ConsumedAt !== undefined) {
       entity.ConsumedAt = validateNumberField(item.ConsumedAt, 'ConsumedAt');

--- a/services/livetalk/core/src/notification/index.ts
+++ b/services/livetalk/core/src/notification/index.ts
@@ -11,7 +11,7 @@ export {
 } from './decision.js';
 export type { NotifyDecision, NotifyDecisionInput, ToneBucket } from './decision.js';
 
-export { buildNotificationMessage, buildCriticalNotificationMessage } from './message-builder.js';
+export { buildNotificationMessage, buildCriticalNotificationMessage, buildSuggestedReply } from './message-builder.js';
 export type { BuildNotificationMessageInput, NotificationMessage } from './message-builder.js';
 
 export { detectCriticalKnowledge } from './escalation.js';

--- a/services/livetalk/core/src/notification/index.ts
+++ b/services/livetalk/core/src/notification/index.ts
@@ -11,7 +11,11 @@ export {
 } from './decision.js';
 export type { NotifyDecision, NotifyDecisionInput, ToneBucket } from './decision.js';
 
-export { buildNotificationMessage, buildCriticalNotificationMessage, buildSuggestedReply } from './message-builder.js';
+export {
+  buildNotificationMessage,
+  buildCriticalNotificationMessage,
+  buildSuggestedReply,
+} from './message-builder.js';
 export type { BuildNotificationMessageInput, NotificationMessage } from './message-builder.js';
 
 export { detectCriticalKnowledge } from './escalation.js';

--- a/services/livetalk/core/src/notification/message-builder.ts
+++ b/services/livetalk/core/src/notification/message-builder.ts
@@ -84,6 +84,20 @@ export function buildNotificationMessage(
 }
 
 /**
+ * 通知タップ起動時に入力欄へプリフィルするユーザー発話を生成する。
+ *
+ * @param knowledgeTopic - 通知の元となったトピック名（省略時は汎用文言を返す）
+ * @returns 入力欄へプリフィルするサジェスト文字列
+ */
+export function buildSuggestedReply(knowledgeTopic?: string): string {
+  if (knowledgeTopic) {
+    const normalizedTopic = normalizeKnowledgeTopic(knowledgeTopic);
+    return `${normalizedTopic}について教えて`;
+  }
+  return '話したいことってなに？';
+}
+
+/**
  * クリティカル通知のメッセージを生成する。
  *
  * @param knowledgeTopic - 通知の元となったトピック名

--- a/services/livetalk/core/tests/unit/mappers/notification-event.mapper.test.ts
+++ b/services/livetalk/core/tests/unit/mappers/notification-event.mapper.test.ts
@@ -98,4 +98,38 @@ describe('NotificationEventMapper', () => {
       expect(item.ConsumedAt).toBeUndefined();
     });
   });
+
+  describe('SuggestedReply のラウンドトリップ', () => {
+    it('SuggestedReply あり → toItem / toEntity のラウンドトリップが成立する', () => {
+      const entityWithSuggestedReply = {
+        ...fullEntity,
+        SuggestedReply: 'TypeScriptについて教えて',
+      };
+      const item = mapper.toItem(entityWithSuggestedReply);
+      const restored = mapper.toEntity(item);
+      expect(restored.SuggestedReply).toBe('TypeScriptについて教えて');
+      expect(item.SuggestedReply).toBe('TypeScriptについて教えて');
+    });
+
+    it('SuggestedReply なし（undefined）→ item に含まれない', () => {
+      const item = mapper.toItem(fullEntity);
+      expect(item.SuggestedReply).toBeUndefined();
+    });
+
+    it('SuggestedReply なし → toEntity でも undefined になる', () => {
+      const item = mapper.toItem(fullEntity);
+      const restored = mapper.toEntity(item);
+      expect(restored.SuggestedReply).toBeUndefined();
+    });
+
+    it('汎用サジェスト文（topic なし）でもラウンドトリップが成立する', () => {
+      const entityWithGenericReply = {
+        ...fullEntity,
+        SuggestedReply: '話したいことってなに？',
+      };
+      const item = mapper.toItem(entityWithGenericReply);
+      const restored = mapper.toEntity(item);
+      expect(restored.SuggestedReply).toBe('話したいことってなに？');
+    });
+  });
 });

--- a/services/livetalk/core/tests/unit/notification/message-builder.test.ts
+++ b/services/livetalk/core/tests/unit/notification/message-builder.test.ts
@@ -1,6 +1,7 @@
 import {
   buildNotificationMessage,
   buildCriticalNotificationMessage,
+  buildSuggestedReply,
 } from '../../../src/notification/message-builder.js';
 
 /**
@@ -263,5 +264,45 @@ describe('normalizeKnowledgeTopic（通知テンプレート堅牢化）', () =>
     );
     expect(msg.body).toContain('カフェラテ');
     expect(msg.body).not.toMatch(/。のこと/);
+  });
+});
+
+describe('buildSuggestedReply', () => {
+  it('topic あり → "〇〇について教えて" を返す', () => {
+    const result = buildSuggestedReply('TypeScript');
+    expect(result).toBe('TypeScriptについて教えて');
+  });
+
+  it('topic あり（別のトピック）→ "〇〇について教えて" を返す', () => {
+    const result = buildSuggestedReply('React');
+    expect(result).toBe('Reactについて教えて');
+  });
+
+  it('topic なし → "話したいことってなに？" を返す', () => {
+    const result = buildSuggestedReply();
+    expect(result).toBe('話したいことってなに？');
+  });
+
+  it('topic が undefined → "話したいことってなに？" を返す', () => {
+    const result = buildSuggestedReply(undefined);
+    expect(result).toBe('話したいことってなに？');
+  });
+
+  it('topic 末尾の句点が正規化されて "〇〇について教えて" を返す', () => {
+    const result = buildSuggestedReply('コーヒーの新作。');
+    expect(result).toBe('コーヒーの新作について教えて');
+    expect(result).not.toMatch(/。について/);
+  });
+
+  it('topic 末尾の読点が正規化されて "〇〇について教えて" を返す', () => {
+    const result = buildSuggestedReply('お菓子の作り方、');
+    expect(result).toBe('お菓子の作り方について教えて');
+    expect(result).not.toMatch(/、について/);
+  });
+
+  it('長いトピック名でも "〇〇について教えて" の形式になる', () => {
+    const longTopic = '日本のスイーツのトレンド';
+    const result = buildSuggestedReply(longTopic);
+    expect(result).toBe(`${longTopic}について教えて`);
   });
 });

--- a/services/livetalk/web/src/app/api/push/first-word/route.ts
+++ b/services/livetalk/web/src/app/api/push/first-word/route.ts
@@ -7,6 +7,7 @@
  *     未指定時: キャラクター概念がないため 204 を返す（呼び出し側は必ず characterId を付与する設計）。
  *
  * レスポンスに characterId を含めることで、page 側でクロス汚染ガードを行える。
+ * suggestedReply は通知タップ起動時に入力欄へプリフィルするユーザー発話。null の場合はプリフィルしない。
  */
 import { NextResponse } from 'next/server';
 import { withAuth } from '@nagiyu/nextjs';
@@ -40,6 +41,7 @@ export const GET = withAuth(getSession, 'livetalk:chat', async (session, request
       body: unconsumed.Body,
       knowledgeId: unconsumed.KnowledgeID ?? null,
       characterId: unconsumed.CharacterID,
+      suggestedReply: unconsumed.SuggestedReply ?? null,
     },
     { status: 200 }
   );

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -95,6 +95,8 @@ function HomePageInner() {
   const [responseText, setResponseText] = useState<string | null>(null);
   const [audioBuffer, setAudioBuffer] = useState<AudioBuffer | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // 通知タップ起動時に入力欄へプリフィルするサジェスト発話
+  const [prefillText, setPrefillText] = useState<string | null>(null);
 
   const [safetyOpen, setSafetyOpen] = useState(false);
   const [safetyResources, setSafetyResources] = useState<SafetyResource[]>([]);
@@ -160,6 +162,7 @@ function HomePageInner() {
             body: string;
             knowledgeId?: string | null;
             characterId: string;
+            suggestedReply?: string | null;
           } | null
         ) => {
           if (!data) return;
@@ -167,6 +170,10 @@ function HomePageInner() {
           firstWordKnowledgeIdRef.current = data.knowledgeId ?? null;
           // 通知元キャラクター ID を保存（クロス汚染防止のためカレントと照合する）
           firstWordCharacterIdRef.current = data.characterId;
+          // 通知タップ起動時（from=push）かつ suggestedReply がある場合は入力欄へプリフィル
+          if (searchParams.get('from') === 'push' && data.suggestedReply) {
+            setPrefillText(data.suggestedReply);
+          }
           // 消化済みマーク
           fetch('/api/push/consumed', {
             method: 'PATCH',
@@ -566,6 +573,7 @@ function HomePageInner() {
           <ChatInput
             onSubmit={handleSubmit}
             disabled={phase !== 'idle' || consentPhase !== 'done'}
+            prefillText={prefillText ?? undefined}
           />
           <Box sx={{ textAlign: 'center', display: 'flex', justifyContent: 'center', gap: 2 }}>
             <Link href="/memory">私が覚えていること</Link>

--- a/services/livetalk/web/src/components/ChatInput.tsx
+++ b/services/livetalk/web/src/components/ChatInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import { Box } from '@mui/material';
 import { Button, TextField } from '@nagiyu/ui';
 
@@ -13,6 +13,13 @@ export interface ChatInputProps {
    * 送信処理中・音声再生中など、入力を無効化したい状態。
    */
   disabled?: boolean;
+  /**
+   * 通知タップ起動時などに入力欄へプリフィルするテキスト。
+   * 変化したとき（非空）に内部 text state へ反映する。
+   * ユーザーの編集は上書きしない（prefillText が再変化しない限り再適用されない）。
+   * 送信時は既存どおり setText('') でクリアされる。
+   */
+  prefillText?: string;
 }
 
 export const CHAT_INPUT_MAX_LENGTH = 200;
@@ -21,8 +28,15 @@ export const CHAT_INPUT_MAX_LENGTH = 200;
  * テキスト入力欄 + 送信ボタン。空文字・空白のみは送信しない。
  * 上限文字数はエコー Phase なので短めに設定（Phase 2 以降で要件に合わせて再調整）。
  */
-export default function ChatInput({ onSubmit, disabled }: ChatInputProps) {
+export default function ChatInput({ onSubmit, disabled, prefillText }: ChatInputProps) {
   const [text, setText] = useState('');
+
+  // prefillText が変化したとき（非空）に入力欄へ反映する
+  useEffect(() => {
+    if (prefillText) {
+      setText(prefillText);
+    }
+  }, [prefillText]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/services/livetalk/web/tests/unit/app/api/push/first-word.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/push/first-word.test.ts
@@ -206,4 +206,48 @@ describe('GET /api/push/first-word', () => {
     expect(json.notifId).toBe('n-ageha');
     expect(json.characterId).toBe('ageha');
   });
+
+  describe('suggestedReply フィールド', () => {
+    it('SuggestedReply がある通知は suggestedReply を返す', async () => {
+      mockGetSession.mockResolvedValue(validSession);
+      const event = makeEvent({
+        CharacterID: 'hiyori',
+        SuggestedReply: 'TypeScriptについて教えて',
+      });
+      mockGetNotificationEventRepo.mockReturnValue(makeRepo([event]));
+
+      const res = await GET(buildGetRequest('hiyori'));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.suggestedReply).toBe('TypeScriptについて教えて');
+    });
+
+    it('SuggestedReply がない通知は suggestedReply が null を返す', async () => {
+      mockGetSession.mockResolvedValue(validSession);
+      const event = makeEvent({
+        CharacterID: 'hiyori',
+        // SuggestedReply は意図的に省略
+      });
+      mockGetNotificationEventRepo.mockReturnValue(makeRepo([event]));
+
+      const res = await GET(buildGetRequest('hiyori'));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.suggestedReply).toBeNull();
+    });
+
+    it('汎用 suggestedReply（topic なし）でも正しく返す', async () => {
+      mockGetSession.mockResolvedValue(validSession);
+      const event = makeEvent({
+        CharacterID: 'hiyori',
+        SuggestedReply: '話したいことってなに？',
+      });
+      mockGetNotificationEventRepo.mockReturnValue(makeRepo([event]));
+
+      const res = await GET(buildGetRequest('hiyori'));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.suggestedReply).toBe('話したいことってなに？');
+    });
+  });
 });

--- a/services/livetalk/web/tests/unit/app/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/page.test.tsx
@@ -782,3 +782,173 @@ describe('characterId の chat リクエストへの反映', () => {
     expect(chatBody.characterId).toBe('hiyori');
   });
 });
+
+describe('通知タップ起動時のプリフィル（from=push + suggestedReply）', () => {
+  it('from=push かつ first-word が suggestedReply を返すとき ChatInput にプリフィルされる', async () => {
+    // searchParams: from=push, character=hiyori
+    mockSearchParamsGet.mockImplementation((key: string) => {
+      if (key === 'from') return 'push';
+      if (key === 'character') return 'hiyori';
+      return null;
+    });
+
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url.startsWith('/api/lifecycle')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url.startsWith('/api/push/first-word')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              notifId: 'n1',
+              body: 'TypeScriptについて調べたよ',
+              knowledgeId: 'k-ts',
+              characterId: 'hiyori',
+              suggestedReply: 'TypeScriptについて教えて',
+            }),
+        });
+      }
+      if (url === '/api/push/consumed') {
+        return Promise.resolve({ ok: true });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    // suggestedReply が入力欄にプリフィルされる
+    await waitFor(() => {
+      expect(input).toHaveValue('TypeScriptについて教えて');
+    });
+  });
+
+  it('from=push なしのとき（自前起動）は suggestedReply があっても入力欄にプリフィルされない', async () => {
+    // searchParams: from なし、character のみ
+    mockSearchParamsGet.mockImplementation((key: string) => {
+      if (key === 'character') return 'hiyori';
+      return null;
+    });
+
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url.startsWith('/api/lifecycle')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url.startsWith('/api/push/first-word')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              notifId: 'n1',
+              body: 'TypeScriptについて調べたよ',
+              knowledgeId: 'k-ts',
+              characterId: 'hiyori',
+              suggestedReply: 'TypeScriptについて教えて',
+            }),
+        });
+      }
+      if (url === '/api/push/consumed') {
+        return Promise.resolve({ ok: true });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    // first-word の取得を待つ
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+      expect(calls.some((url) => url.startsWith('/api/push/first-word'))).toBe(true);
+    });
+
+    // from=push なしなので入力欄はプリフィルされない
+    expect(input).toHaveValue('');
+  });
+
+  it('from=push だが suggestedReply が null のとき入力欄はプリフィルされない', async () => {
+    mockSearchParamsGet.mockImplementation((key: string) => {
+      if (key === 'from') return 'push';
+      if (key === 'character') return 'hiyori';
+      return null;
+    });
+
+    const encoder = new TextEncoder();
+    const chatStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+        controller.close();
+      },
+    });
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/consent') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ consented: true }) });
+      }
+      if (url.startsWith('/api/lifecycle')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ state: 'awake' }) });
+      }
+      if (url.startsWith('/api/push/first-word')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              notifId: 'n1',
+              body: 'ちょっと話したいことがあるよ',
+              knowledgeId: null,
+              characterId: 'hiyori',
+              suggestedReply: null,
+            }),
+        });
+      }
+      if (url === '/api/push/consumed') {
+        return Promise.resolve({ ok: true });
+      }
+      if (url === '/api/push/pending') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, body: chatStream });
+    });
+
+    render(<HomePage />);
+    const input = await waitForInputEnabled();
+
+    // first-word の取得を待つ
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+      expect(calls.some((url) => url.startsWith('/api/push/first-word'))).toBe(true);
+    });
+
+    // suggestedReply が null なので入力欄はプリフィルされない
+    expect(input).toHaveValue('');
+  });
+});

--- a/services/livetalk/web/tests/unit/components/ChatInput.test.tsx
+++ b/services/livetalk/web/tests/unit/components/ChatInput.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatInput from '@/components/ChatInput';
+
+describe('ChatInput', () => {
+  describe('基本動作', () => {
+    it('テキスト入力後に送信ボタンをクリックすると onSubmit が呼ばれる', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(<ChatInput onSubmit={onSubmit} />);
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      await user.type(input, 'こんにちは');
+      await user.click(screen.getByRole('button', { name: '送信' }));
+
+      expect(onSubmit).toHaveBeenCalledWith('こんにちは');
+    });
+
+    it('空文字のままでは送信されない', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(<ChatInput onSubmit={onSubmit} />);
+      await user.click(screen.getByRole('button', { name: '送信' }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('スペースのみの入力では送信されない', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(<ChatInput onSubmit={onSubmit} />);
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      await user.type(input, '   ');
+      await user.click(screen.getByRole('button', { name: '送信' }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('送信後に入力欄がクリアされる', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(<ChatInput onSubmit={onSubmit} />);
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      await user.type(input, 'テスト');
+      await user.click(screen.getByRole('button', { name: '送信' }));
+
+      expect(input).toHaveValue('');
+    });
+
+    it('disabled が true のとき入力欄と送信ボタンが無効化される', () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      render(<ChatInput onSubmit={onSubmit} disabled />);
+
+      expect(screen.getByPlaceholderText('メッセージを入力')).toBeDisabled();
+      expect(screen.getByRole('button', { name: '送信' })).toBeDisabled();
+    });
+  });
+
+  describe('prefillText によるプリフィル', () => {
+    it('prefillText を渡すと入力欄にプリフィルされる', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      render(<ChatInput onSubmit={onSubmit} prefillText="TypeScriptについて教えて" />);
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      await waitFor(() => expect(input).toHaveValue('TypeScriptについて教えて'));
+    });
+
+    it('prefillText が変化すると入力欄に再反映される', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      const { rerender } = render(
+        <ChatInput onSubmit={onSubmit} prefillText="最初のサジェスト" />
+      );
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      await waitFor(() => expect(input).toHaveValue('最初のサジェスト'));
+
+      rerender(<ChatInput onSubmit={onSubmit} prefillText="次のサジェスト" />);
+
+      await waitFor(() => expect(input).toHaveValue('次のサジェスト'));
+    });
+
+    it('prefillText なし（undefined）の場合はプリフィルされない', () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      render(<ChatInput onSubmit={onSubmit} />);
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      expect(input).toHaveValue('');
+    });
+
+    it('prefillText が空文字の場合はプリフィルされない', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(<ChatInput onSubmit={onSubmit} prefillText="" />);
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      expect(input).toHaveValue('');
+
+      // 手動で入力した後に空の prefillText が再変化しても上書きしない
+      await user.type(input, 'ユーザー入力');
+      expect(input).toHaveValue('ユーザー入力');
+    });
+
+    it('プリフィルされた内容はそのまま送信できる', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(<ChatInput onSubmit={onSubmit} prefillText="TypeScriptについて教えて" />);
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      await waitFor(() => expect(input).toHaveValue('TypeScriptについて教えて'));
+
+      await user.click(screen.getByRole('button', { name: '送信' }));
+
+      expect(onSubmit).toHaveBeenCalledWith('TypeScriptについて教えて');
+    });
+
+    it('プリフィル後に送信すると入力欄がクリアされる', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      const user = userEvent.setup();
+
+      render(<ChatInput onSubmit={onSubmit} prefillText="サジェスト" />);
+      const input = screen.getByPlaceholderText('メッセージを入力');
+
+      await waitFor(() => expect(input).toHaveValue('サジェスト'));
+
+      await user.click(screen.getByRole('button', { name: '送信' }));
+
+      expect(input).toHaveValue('');
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/components/ChatInput.test.tsx
+++ b/services/livetalk/web/tests/unit/components/ChatInput.test.tsx
@@ -77,9 +77,7 @@ describe('ChatInput', () => {
     it('prefillText が変化すると入力欄に再反映される', async () => {
       const onSubmit = jest.fn().mockResolvedValue(undefined);
 
-      const { rerender } = render(
-        <ChatInput onSubmit={onSubmit} prefillText="最初のサジェスト" />
-      );
+      const { rerender } = render(<ChatInput onSubmit={onSubmit} prefillText="最初のサジェスト" />);
       const input = screen.getByPlaceholderText('メッセージを入力');
 
       await waitFor(() => expect(input).toHaveValue('最初のサジェスト'));


### PR DESCRIPTION
## 変更の概要

通知タップでアプリを起動したとき、ユーザーの最初の発話（例:「〇〇について教えて」）を**入力欄へプリフィル**し、ユーザーは送信するだけで会話を始められるようにする（自動送信はしない）。

`integration/3553-notification-tap-prefill` の develop 反映 PR。実装単位（#3554）は integration へマージ済みで、dev 環境で実経路の動作確認が完了している。

### なぜ自動送信ではなくプリフィルか
VOICEVOX 音声は送信時の user gesture で AudioContext を unlock している。自動送信だと音声が鳴らないため、プリフィル＋ユーザーの送信タップとすることで音声が正しく再生される。誤タップでの意図しない送信も防げる。

### 仕組み
- 通知生成時（batch）にサジェスト発話を `NotificationEvent.SuggestedReply` として保存
- 通知 payload の `data.url` に `&from=push` を付与
- `first-word` API が `suggestedReply` を返す
- フロントは `from=push` 起動時のみ入力欄へプリフィル（通常起動では出さない）

## 関連 Issue

Closes #3553

## 変更種別

- [x] 新規機能

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（プリフィルの設計判断＝音声制約の根拠を external-design.md に追記予定。本 PR とは別の docs PR で対応）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- core: `buildSuggestedReply`、`SuggestedReply` のマッパー round-trip
- batch: `notifEventRepo.put` に `SuggestedReply` が含まれること、payload の `url` に `from=push` が含まれること
- web: `first-word` レスポンスの `suggestedReply`、`ChatInput` の `prefillText` 反映、`page` の `from=push` 時のみプリフィル
- Fast CI（Lint / Format / Build / Unit / E2E chromium-mobile）グリーン

## dev 動作確認

- `notify-dev` Lambda へデプロイ反映後、本物の notify バッチ経路で critical 通知を発火
- 発火した NotificationEvent に `SuggestedReply`「初夏の新作スイーツについて教えて」が保存されることを DynamoDB で確認
- 実機 PWA で 通知タップ → 入力欄にプリフィルされることを確認

## レビューポイント

- サジェスト発話の文言（topic あり: `〇〇について教えて` / topic なし: `話したいことってなに？`）
- プリフィルを `from=push` 起動時のみに限定する判断
- `NotificationEvent` への新規フィールド追加（後方互換: 旧データは欠落 → プリフィルなし）

## 補足事項

develop 側の先行コミット（#3552 / #3527）は docs/ADR のみで、本 PR の変更（コード）とは非競合。


---
_Generated by [Claude Code](https://claude.ai/code/session_01EBtTM2BGSV4THCYsiCJKXo)_