### PR TITLE
リブトーク チャット API 保護（レート制限・並行制御）を develop へ（#3528）

### DIFF
--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -322,13 +322,10 @@ export const CHAT_RATE_LIMIT_PER_HOUR = 100;
 
 /**
  * in-flight ロックのデフォルト有効期間（ミリ秒）。
- * ストリームタイムアウトと同値に設定する。
+ *
+ * これはクラッシュ/ハング時にロックを解放するための粗いフェイルセーフであり、
+ * 上流の最大ストリーム時間（OpenAI SDK 既定の約 10 分）を上回る値にすることで
+ * 進行中の正常ロックが並行リクエストに奪取されないようにする。
+ * 正常時は finally の releaseLock で即時解放される。
  */
-export const CHAT_LOCK_TTL_MS = 120_000;
-
-/**
- * ストリームのサーバ側タイムアウト（ミリ秒）。
- * ECS セルフホストでは Next.js の maxDuration が効かないため、
- * ストリーム消費ループ全体にデッドラインを設ける。
- */
-export const CHAT_STREAM_TIMEOUT_MS = 120_000;
+export const CHAT_LOCK_TTL_MS = 600_000;

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -307,3 +307,28 @@ export const NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD = 0.15;
  * isUrgent=true とみなす。14 日を超える将来イベントや過去日は時限性なしとして除外する。
  */
 export const NOTIFY_CRITICAL_EVENT_HORIZON_DAYS = 14;
+
+// ---- チャット API 保護ガード（Issue #3528）----
+
+/**
+ * レートリミット: 1 分ウィンドウの上限リクエスト数。
+ */
+export const CHAT_RATE_LIMIT_PER_MINUTE = 10;
+
+/**
+ * レートリミット: 1 時間ウィンドウの上限リクエスト数。
+ */
+export const CHAT_RATE_LIMIT_PER_HOUR = 100;
+
+/**
+ * in-flight ロックのデフォルト有効期間（ミリ秒）。
+ * ストリームタイムアウトと同値に設定する。
+ */
+export const CHAT_LOCK_TTL_MS = 120_000;
+
+/**
+ * ストリームのサーバ側タイムアウト（ミリ秒）。
+ * ECS セルフホストでは Next.js の maxDuration が効かないため、
+ * ストリーム消費ループ全体にデッドラインを設ける。
+ */
+export const CHAT_STREAM_TIMEOUT_MS = 120_000;

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -375,4 +375,23 @@ export {
   NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD,
   NOTIFY_CRITICAL_EVENT_HORIZON_DAYS,
   NOTIFY_INTENSITY_WINDOW_DAYS,
+  // チャット API 保護ガード（Issue #3528）
+  CHAT_RATE_LIMIT_PER_MINUTE,
+  CHAT_RATE_LIMIT_PER_HOUR,
+  CHAT_LOCK_TTL_MS,
+  CHAT_STREAM_TIMEOUT_MS,
 } from './constants.js';
+
+// チャット API 保護ガード（Issue #3528）
+export type {
+  RateLimitWindow,
+  RateLimitResult,
+  AcquireLockResult,
+  ChatGuardRepository,
+} from './repositories/chat-guard.repository.interface.js';
+export { InMemoryChatGuardRepository } from './repositories/in-memory-chat-guard.repository.js';
+export {
+  DynamoDBChatGuardRepository,
+  computeBucket,
+  computeWindowTtlSec,
+} from './repositories/dynamodb-chat-guard.repository.js';

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -379,7 +379,6 @@ export {
   CHAT_RATE_LIMIT_PER_MINUTE,
   CHAT_RATE_LIMIT_PER_HOUR,
   CHAT_LOCK_TTL_MS,
-  CHAT_STREAM_TIMEOUT_MS,
 } from './constants.js';
 
 // チャット API 保護ガード（Issue #3528）

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -146,3 +146,21 @@ export function buildNotifSKPrefix(): string {
 export function buildNotifSK(notifId: string): string {
   return `NOTIF#${notifId}`;
 }
+
+// ---- チャット API 保護ガード（Issue #3528）----
+
+/**
+ * チャットロックアイテムの SK。固定値。
+ * `USER#<userId>` PK 配下の `CHATLOCK` SK に対応する。
+ */
+export function buildChatLockSK(): string {
+  return 'CHATLOCK';
+}
+
+/**
+ * チャットレートリミットアイテムの SK を組み立てる。
+ * `USER#<userId>` PK 配下の `RATELIMIT#<window>#<bucket>` SK に対応する。
+ */
+export function buildChatRateLimitSK(window: string, bucket: string): string {
+  return `RATELIMIT#${window}#${bucket}`;
+}

--- a/services/livetalk/core/src/repositories/chat-guard.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/chat-guard.repository.interface.ts
@@ -1,0 +1,77 @@
+/**
+ * チャット API 保護ガードのリポジトリインターフェース。
+ *
+ * - レート制限: 固定ウィンドウカウンタ（1 分・1 時間の 2 ウィンドウ）
+ * - 並行制御: 同一ユーザーの in-flight リクエストを 1 本に限定するロック
+ */
+
+/**
+ * レート制限ウィンドウの種別。
+ */
+export type RateLimitWindow = '1m' | '1h';
+
+/**
+ * レート制限カウンタのインクリメント結果。
+ */
+export interface RateLimitResult {
+  /** インクリメント後のカウント値 */
+  count: number;
+  /** ウィンドウ種別 */
+  window: RateLimitWindow;
+}
+
+/**
+ * ロック取得の結果。
+ */
+export interface AcquireLockResult {
+  /** ロックを取得できたか */
+  acquired: boolean;
+  /** 取得できた場合のオーナートークン */
+  ownerToken?: string;
+}
+
+/**
+ * チャット API 保護ガードのリポジトリインターフェース。
+ */
+export interface ChatGuardRepository {
+  /**
+   * 指定ウィンドウのレートリミットカウンタをインクリメントして結果を返す。
+   * アイテムが存在しない場合は count=1 で新規作成する。
+   * TTL は当該ウィンドウ満了 + バッファで自動設定される。
+   */
+  incrementRateLimit(
+    userId: string,
+    window: RateLimitWindow,
+    nowMs: number
+  ): Promise<RateLimitResult>;
+
+  /**
+   * in-flight ロックを取得する。
+   *
+   * - アイテムが存在しない場合: 新規作成してロック取得成功
+   * - ExpiresAt < now の場合: 期限切れとして上書き取得成功（DynamoDB TTL 遅延対策）
+   * - ロックが有効な場合: 取得失敗（acquired=false）
+   *
+   * @param userId - ユーザー ID
+   * @param ownerToken - 新規ロックに付与するオーナートークン（ULID 等）
+   * @param lockTtlMs - ロック有効期間（ミリ秒）
+   * @param nowMs - 現在時刻（ミリ秒）
+   */
+  acquireLock(
+    userId: string,
+    ownerToken: string,
+    lockTtlMs: number,
+    nowMs: number
+  ): Promise<AcquireLockResult>;
+
+  /**
+   * in-flight ロックを解放する。
+   *
+   * ownerToken が一致しない場合は削除をスキップする（ConditionalCheckFailed 相当）。
+   * 既に失効・奪取済みの場合も安全に握りつぶす。
+   *
+   * @param userId - ユーザー ID
+   * @param ownerToken - 取得時に保存したオーナートークン
+   */
+  releaseLock(userId: string, ownerToken: string): Promise<void>;
+}

--- a/services/livetalk/core/src/repositories/dynamodb-chat-guard.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-chat-guard.repository.ts
@@ -11,11 +11,7 @@
  * `ExpiresAt < :now` の条件付き UpdateItem で上書き取得できる設計にしている。
  */
 
-import {
-  DeleteCommand,
-  UpdateCommand,
-  type DynamoDBDocumentClient,
-} from '@aws-sdk/lib-dynamodb';
+import { DeleteCommand, UpdateCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { DatabaseError } from '@nagiyu/aws';
 import { buildUserPK, buildChatLockSK, buildChatRateLimitSK } from '../mappers/keys.js';
 import type {

--- a/services/livetalk/core/src/repositories/dynamodb-chat-guard.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-chat-guard.repository.ts
@@ -1,0 +1,183 @@
+/**
+ * ChatGuardRepository の DynamoDB 実装（Issue #3528）。
+ *
+ * Single Table 設計のメインテーブルに相乗りする。PK は既存の `USER#<userId>` を使用する。
+ *
+ * アイテム種別:
+ * - レートリミット: SK = `RATELIMIT#<window>#<bucket>`
+ * - ロック:        SK = `CHATLOCK`
+ *
+ * DynamoDB TTL の物理削除は最大 48h 遅延しうるため、ロック失効判定は TTL に依存せず
+ * `ExpiresAt < :now` の条件付き UpdateItem で上書き取得できる設計にしている。
+ */
+
+import {
+  DeleteCommand,
+  UpdateCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
+import { DatabaseError } from '@nagiyu/aws';
+import { buildUserPK } from '../mappers/keys.js';
+import type {
+  AcquireLockResult,
+  ChatGuardRepository,
+  RateLimitResult,
+  RateLimitWindow,
+} from './chat-guard.repository.interface.js';
+
+/**
+ * ウィンドウのバケット文字列を算出する。
+ * - '1m': エポック分（floor(nowMs / 60000)）
+ * - '1h': エポック時（floor(nowMs / 3600000)）
+ */
+export function computeBucket(window: RateLimitWindow, nowMs: number): string {
+  if (window === '1m') return String(Math.floor(nowMs / 60_000));
+  return String(Math.floor(nowMs / 3_600_000));
+}
+
+/**
+ * ウィンドウ満了 Unix 秒（アイテムの TTL 用）を算出する。
+ * バッファを加算してウィンドウ直後に即座に消えないようにする。
+ * - '1m': 次の分の開始 Unix 秒 + 120s バッファ
+ * - '1h': 次の時間の開始 Unix 秒 + 7200s バッファ
+ */
+export function computeWindowTtlSec(window: RateLimitWindow, nowMs: number): number {
+  if (window === '1m') {
+    return (Math.floor(nowMs / 60_000) + 1) * 60 + 120;
+  }
+  return (Math.floor(nowMs / 3_600_000) + 1) * 3_600 + 7_200;
+}
+
+/**
+ * レートリミットアイテムの SK を組み立てる。
+ */
+function buildRateLimitSK(window: RateLimitWindow, bucket: string): string {
+  return `RATELIMIT#${window}#${bucket}`;
+}
+
+/**
+ * ロックアイテムの SK。固定値。
+ */
+const CHATLOCK_SK = 'CHATLOCK';
+
+export class DynamoDBChatGuardRepository implements ChatGuardRepository {
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly nowMs: () => number;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.nowMs = nowMs;
+  }
+
+  public async incrementRateLimit(
+    userId: string,
+    window: RateLimitWindow,
+    nowMs: number
+  ): Promise<RateLimitResult> {
+    const pk = buildUserPK(userId);
+    const bucket = computeBucket(window, nowMs);
+    const sk = buildRateLimitSK(window, bucket);
+    const ttlSec = computeWindowTtlSec(window, nowMs);
+
+    try {
+      const result = await this.docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+          // Count をアトミックにインクリメントし、TTL は初回のみ設定する。
+          // TTL を毎回上書きしないことでウィンドウ内の自然な満了を担保する。
+          UpdateExpression: 'ADD #cnt :one SET #ttl = if_not_exists(#ttl, :ttl)',
+          ExpressionAttributeNames: {
+            '#cnt': 'Count',
+            '#ttl': 'TTL',
+          },
+          ExpressionAttributeValues: {
+            ':one': 1,
+            ':ttl': ttlSec,
+          },
+          ReturnValues: 'UPDATED_NEW',
+        })
+      );
+      const count = (result.Attributes?.['Count'] as number | undefined) ?? 1;
+      return { count, window };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async acquireLock(
+    userId: string,
+    ownerToken: string,
+    lockTtlMs: number,
+    nowMs: number
+  ): Promise<AcquireLockResult> {
+    const pk = buildUserPK(userId);
+    const sk = CHATLOCK_SK;
+    const expiresAt = nowMs + lockTtlMs;
+    // DynamoDB TTL は Unix 秒。ロック満了の少し後に自動削除されるよう余裕を持たせる。
+    const ttlSec = Math.floor(expiresAt / 1000) + 300;
+
+    try {
+      await this.docClient.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+          UpdateExpression: 'SET OwnerToken = :token, ExpiresAt = :expiresAt, #ttl = :ttl',
+          // attribute_not_exists(SK) → 未取得
+          // ExpiresAt < :now → 期限切れのロックは上書き可
+          ConditionExpression: 'attribute_not_exists(SK) OR ExpiresAt < :now',
+          ExpressionAttributeNames: {
+            '#ttl': 'TTL',
+          },
+          ExpressionAttributeValues: {
+            ':token': ownerToken,
+            ':expiresAt': expiresAt,
+            ':ttl': ttlSec,
+            ':now': nowMs,
+          },
+        })
+      );
+      return { acquired: true, ownerToken };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
+        // 有効なロックが存在するため取得失敗
+        return { acquired: false };
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async releaseLock(userId: string, ownerToken: string): Promise<void> {
+    const pk = buildUserPK(userId);
+    const sk = CHATLOCK_SK;
+
+    try {
+      await this.docClient.send(
+        new DeleteCommand({
+          TableName: this.tableName,
+          Key: { PK: pk, SK: sk },
+          // ownerToken が一致する場合のみ削除する（他リクエストのロックを誤って消さない）。
+          ConditionExpression: 'OwnerToken = :token',
+          ExpressionAttributeValues: {
+            ':token': ownerToken,
+          },
+        })
+      );
+    } catch (error) {
+      if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
+        // ownerToken 不一致（期限切れ・奪取済み）は安全に握りつぶす。
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+}

--- a/services/livetalk/core/src/repositories/dynamodb-chat-guard.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-chat-guard.repository.ts
@@ -17,7 +17,7 @@ import {
   type DynamoDBDocumentClient,
 } from '@aws-sdk/lib-dynamodb';
 import { DatabaseError } from '@nagiyu/aws';
-import { buildUserPK } from '../mappers/keys.js';
+import { buildUserPK, buildChatLockSK, buildChatRateLimitSK } from '../mappers/keys.js';
 import type {
   AcquireLockResult,
   ChatGuardRepository,
@@ -48,18 +48,6 @@ export function computeWindowTtlSec(window: RateLimitWindow, nowMs: number): num
   return (Math.floor(nowMs / 3_600_000) + 1) * 3_600 + 7_200;
 }
 
-/**
- * レートリミットアイテムの SK を組み立てる。
- */
-function buildRateLimitSK(window: RateLimitWindow, bucket: string): string {
-  return `RATELIMIT#${window}#${bucket}`;
-}
-
-/**
- * ロックアイテムの SK。固定値。
- */
-const CHATLOCK_SK = 'CHATLOCK';
-
 export class DynamoDBChatGuardRepository implements ChatGuardRepository {
   private readonly docClient: DynamoDBDocumentClient;
   private readonly tableName: string;
@@ -82,7 +70,7 @@ export class DynamoDBChatGuardRepository implements ChatGuardRepository {
   ): Promise<RateLimitResult> {
     const pk = buildUserPK(userId);
     const bucket = computeBucket(window, nowMs);
-    const sk = buildRateLimitSK(window, bucket);
+    const sk = buildChatRateLimitSK(window, bucket);
     const ttlSec = computeWindowTtlSec(window, nowMs);
 
     try {
@@ -119,7 +107,7 @@ export class DynamoDBChatGuardRepository implements ChatGuardRepository {
     nowMs: number
   ): Promise<AcquireLockResult> {
     const pk = buildUserPK(userId);
-    const sk = CHATLOCK_SK;
+    const sk = buildChatLockSK();
     const expiresAt = nowMs + lockTtlMs;
     // DynamoDB TTL は Unix 秒。ロック満了の少し後に自動削除されるよう余裕を持たせる。
     const ttlSec = Math.floor(expiresAt / 1000) + 300;
@@ -157,7 +145,7 @@ export class DynamoDBChatGuardRepository implements ChatGuardRepository {
 
   public async releaseLock(userId: string, ownerToken: string): Promise<void> {
     const pk = buildUserPK(userId);
-    const sk = CHATLOCK_SK;
+    const sk = buildChatLockSK();
 
     try {
       await this.docClient.send(
@@ -176,8 +164,9 @@ export class DynamoDBChatGuardRepository implements ChatGuardRepository {
         // ownerToken 不一致（期限切れ・奪取済み）は安全に握りつぶす。
         return;
       }
-      const message = error instanceof Error ? error.message : String(error);
-      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+      // DynamoDB 障害時もフェイルオープン方針に合わせて握りつぶす（警告は route 層で行う）。
+      // ロックは TTL（CHAT_LOCK_TTL_MS）で自然失効するため、解放失敗は許容できる。
+      return;
     }
   }
 }

--- a/services/livetalk/core/src/repositories/in-memory-chat-guard.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-chat-guard.repository.ts
@@ -78,7 +78,9 @@ export class InMemoryChatGuardRepository implements ChatGuardRepository {
     const expiresAt = computeWindowExpiresAtSec(window, nowMs);
 
     const existing = this.rateLimitStore.get(key);
-    // 既存アイテムが TTL 切れの場合は新規扱い
+    // ウィンドウが変わると computeBucket が返すバケット文字列が変わるため、
+    // key 自体が別エントリになり、ここには常に「現在のウィンドウ内」のエントリが来る。
+    // isExpired フラグは防衛的に残しているが、通常は到達しないパス。
     const nowSec = Math.floor(nowMs / 1000);
     const isExpired = existing !== undefined && existing.expiresAt <= nowSec;
 

--- a/services/livetalk/core/src/repositories/in-memory-chat-guard.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-chat-guard.repository.ts
@@ -1,0 +1,132 @@
+/**
+ * ChatGuardRepository の InMemory 実装。
+ *
+ * テスト・ローカル開発用。スレッドセーフは保証しない（Node.js のシングルスレッドを前提とする）。
+ */
+
+import { buildUserPK } from '../mappers/keys.js';
+import type {
+  AcquireLockResult,
+  ChatGuardRepository,
+  RateLimitResult,
+  RateLimitWindow,
+} from './chat-guard.repository.interface.js';
+
+interface RateLimitEntry {
+  count: number;
+  /** Unix 秒 */
+  expiresAt: number;
+}
+
+interface LockEntry {
+  ownerToken: string;
+  /** Unix ミリ秒 */
+  expiresAt: number;
+}
+
+/**
+ * ウィンドウバケットキーを組み立てるヘルパー。
+ * `USER#<userId>` PK 配下の `RATELIMIT#<window>#<bucket>` SK に相当する。
+ */
+function buildRateLimitKey(userId: string, window: RateLimitWindow, bucket: string): string {
+  return `${buildUserPK(userId)}:RATELIMIT#${window}#${bucket}`;
+}
+
+/**
+ * ロックキーを組み立てるヘルパー。
+ * `USER#<userId>` PK 配下の `CHATLOCK` SK に相当する。
+ */
+function buildLockKey(userId: string): string {
+  return `${buildUserPK(userId)}:CHATLOCK`;
+}
+
+/**
+ * 現在時刻からバケット文字列を算出する。
+ * - '1m': エポック分（floor(nowMs / 60000)）
+ * - '1h': エポック時（floor(nowMs / 3600000)）
+ */
+export function computeBucket(window: RateLimitWindow, nowMs: number): string {
+  if (window === '1m') return String(Math.floor(nowMs / 60_000));
+  return String(Math.floor(nowMs / 3_600_000));
+}
+
+/**
+ * ウィンドウ満了 Unix 秒（TTL 用）を算出する。
+ * - '1m': 次の分の開始（+1 バケット）
+ * - '1h': 次の時間の開始（+1 バケット）
+ */
+export function computeWindowExpiresAtSec(window: RateLimitWindow, nowMs: number): number {
+  if (window === '1m') {
+    return (Math.floor(nowMs / 60_000) + 1) * 60;
+  }
+  return (Math.floor(nowMs / 3_600_000) + 1) * 3_600;
+}
+
+export class InMemoryChatGuardRepository implements ChatGuardRepository {
+  /** レートリミットエントリのマップ（key = buildRateLimitKey の戻り値） */
+  private readonly rateLimitStore: Map<string, RateLimitEntry> = new Map();
+  /** ロックエントリのマップ（key = buildLockKey の戻り値） */
+  private readonly lockStore: Map<string, LockEntry> = new Map();
+
+  public async incrementRateLimit(
+    userId: string,
+    window: RateLimitWindow,
+    nowMs: number
+  ): Promise<RateLimitResult> {
+    const bucket = computeBucket(window, nowMs);
+    const key = buildRateLimitKey(userId, window, bucket);
+    const expiresAt = computeWindowExpiresAtSec(window, nowMs);
+
+    const existing = this.rateLimitStore.get(key);
+    // 既存アイテムが TTL 切れの場合は新規扱い
+    const nowSec = Math.floor(nowMs / 1000);
+    const isExpired = existing !== undefined && existing.expiresAt <= nowSec;
+
+    if (!existing || isExpired) {
+      this.rateLimitStore.set(key, { count: 1, expiresAt });
+      return { count: 1, window };
+    }
+
+    const newCount = existing.count + 1;
+    this.rateLimitStore.set(key, { count: newCount, expiresAt: existing.expiresAt });
+    return { count: newCount, window };
+  }
+
+  public async acquireLock(
+    userId: string,
+    ownerToken: string,
+    lockTtlMs: number,
+    nowMs: number
+  ): Promise<AcquireLockResult> {
+    const key = buildLockKey(userId);
+    const existing = this.lockStore.get(key);
+
+    // アイテムが存在しないか、ExpiresAt が過去（期限切れ）の場合はロック取得
+    if (!existing || existing.expiresAt < nowMs) {
+      this.lockStore.set(key, { ownerToken, expiresAt: nowMs + lockTtlMs });
+      return { acquired: true, ownerToken };
+    }
+
+    // ロックが有効な場合は取得失敗
+    return { acquired: false };
+  }
+
+  public async releaseLock(userId: string, ownerToken: string): Promise<void> {
+    const key = buildLockKey(userId);
+    const existing = this.lockStore.get(key);
+
+    // ownerToken が一致する場合のみ削除（他リクエストのロックを消さない）
+    if (existing && existing.ownerToken === ownerToken) {
+      this.lockStore.delete(key);
+    }
+    // ownerToken 不一致・アイテムなし（既に失効・奪取済み）は握りつぶす
+  }
+
+  /**
+   * テスト用: 全エントリをクリアする。
+   */
+  public clear(): void {
+    this.rateLimitStore.clear();
+    this.lockStore.clear();
+  }
+}

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-chat-guard.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-chat-guard.repository.test.ts
@@ -1,0 +1,216 @@
+/**
+ * DynamoDBChatGuardRepository のユニットテスト（Issue #3528）。
+ *
+ * DynamoDB クライアントをモックし、送信コマンドの内容と動作を検証する。
+ *
+ * テスト観点:
+ * - incrementRateLimit: UpdateCommand の内容、加算後の count 返却
+ * - incrementRateLimit: DynamoDB エラーを DatabaseError にラップする
+ * - acquireLock: 新規取得時の UpdateCommand（条件式付き）
+ * - acquireLock: ConditionalCheckFailedException で acquired=false を返す
+ * - acquireLock: DynamoDB エラーを DatabaseError にラップする
+ * - releaseLock: ownerToken 一致時の DeleteCommand
+ * - releaseLock: ConditionalCheckFailedException を握りつぶす
+ * - releaseLock: DynamoDB エラーを DatabaseError にラップする
+ * - computeBucket / computeWindowTtlSec の純粋ロジック
+ */
+
+import { DeleteCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { DatabaseError } from '@nagiyu/aws';
+import {
+  DynamoDBChatGuardRepository,
+  computeBucket,
+  computeWindowTtlSec,
+} from '../../../src/repositories/dynamodb-chat-guard.repository.js';
+
+type SendHandler = (command: unknown) => Promise<unknown>;
+const makeClient = (handler: SendHandler) => ({ send: handler });
+
+const fixedNow = 1_705_312_200_000;
+const tableName = 'nagiyu-livetalk-dev';
+
+describe('computeBucket()', () => {
+  it('1m: エポック分を返す', () => {
+    expect(computeBucket('1m', fixedNow)).toBe(String(Math.floor(fixedNow / 60_000)));
+  });
+
+  it('1h: エポック時を返す', () => {
+    expect(computeBucket('1h', fixedNow)).toBe(String(Math.floor(fixedNow / 3_600_000)));
+  });
+});
+
+describe('computeWindowTtlSec()', () => {
+  it('1m: 次分開始 + 120s バッファを返す', () => {
+    const expected = (Math.floor(fixedNow / 60_000) + 1) * 60 + 120;
+    expect(computeWindowTtlSec('1m', fixedNow)).toBe(expected);
+  });
+
+  it('1h: 次時間開始 + 7200s バッファを返す', () => {
+    const expected = (Math.floor(fixedNow / 3_600_000) + 1) * 3_600 + 7_200;
+    expect(computeWindowTtlSec('1h', fixedNow)).toBe(expected);
+  });
+});
+
+describe('DynamoDBChatGuardRepository - incrementRateLimit()', () => {
+  it('UpdateCommand を正しいキーと式で送信する', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      return { Attributes: { Count: 1 } };
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    const result = await repo.incrementRateLimit('u1', '1m', fixedNow);
+
+    expect(sent[0]).toBeInstanceOf(UpdateCommand);
+    const input = (sent[0] as UpdateCommand).input;
+    expect(input.TableName).toBe(tableName);
+    expect(input.Key?.PK).toBe('USER#u1');
+
+    const expectedBucket = computeBucket('1m', fixedNow);
+    expect(input.Key?.SK).toBe(`RATELIMIT#1m#${expectedBucket}`);
+    expect(input.UpdateExpression).toContain('ADD #cnt :one');
+    expect(input.UpdateExpression).toContain('if_not_exists(#ttl, :ttl)');
+    expect(input.ReturnValues).toBe('UPDATED_NEW');
+    expect(result.count).toBe(1);
+    expect(result.window).toBe('1m');
+  });
+
+  it('DynamoDB から返された Count を count として返す', async () => {
+    const client = makeClient(async () => ({ Attributes: { Count: 5 } }));
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    const result = await repo.incrementRateLimit('u1', '1h', fixedNow);
+    expect(result.count).toBe(5);
+    expect(result.window).toBe('1h');
+  });
+
+  it('Attributes が空の場合は count=1 を返す', async () => {
+    const client = makeClient(async () => ({ Attributes: {} }));
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    const result = await repo.incrementRateLimit('u1', '1m', fixedNow);
+    expect(result.count).toBe(1);
+  });
+
+  it('DynamoDB エラーを DatabaseError にラップする', async () => {
+    const client = makeClient(async () => {
+      throw new Error('DynamoDB 接続エラー');
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    await expect(repo.incrementRateLimit('u1', '1m', fixedNow)).rejects.toBeInstanceOf(
+      DatabaseError
+    );
+  });
+
+  it('TTL はバッファ込みの値が設定される', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      return { Attributes: { Count: 1 } };
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    await repo.incrementRateLimit('u1', '1m', fixedNow);
+    const input = (sent[0] as UpdateCommand).input;
+    const expectedTtl = computeWindowTtlSec('1m', fixedNow);
+    expect(input.ExpressionAttributeValues?.[':ttl']).toBe(expectedTtl);
+  });
+});
+
+describe('DynamoDBChatGuardRepository - acquireLock()', () => {
+  it('UpdateCommand を条件式付きで送信する', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      return {};
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    const result = await repo.acquireLock('u1', 'token-abc', 120_000, fixedNow);
+
+    expect(sent[0]).toBeInstanceOf(UpdateCommand);
+    const input = (sent[0] as UpdateCommand).input;
+    expect(input.TableName).toBe(tableName);
+    expect(input.Key?.PK).toBe('USER#u1');
+    expect(input.Key?.SK).toBe('CHATLOCK');
+    expect(input.ConditionExpression).toContain('attribute_not_exists(SK)');
+    expect(input.ConditionExpression).toContain('ExpiresAt < :now');
+    expect(input.ExpressionAttributeValues?.[':token']).toBe('token-abc');
+    expect(input.ExpressionAttributeValues?.[':expiresAt']).toBe(fixedNow + 120_000);
+    expect(input.ExpressionAttributeValues?.[':now']).toBe(fixedNow);
+    expect(result.acquired).toBe(true);
+    expect(result.ownerToken).toBe('token-abc');
+  });
+
+  it('ConditionalCheckFailedException で acquired=false を返す', async () => {
+    const client = makeClient(async () => {
+      const err = Object.assign(new Error('ConditionalCheckFailed'), {
+        name: 'ConditionalCheckFailedException',
+      });
+      throw err;
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    const result = await repo.acquireLock('u1', 'token-abc', 120_000, fixedNow);
+    expect(result.acquired).toBe(false);
+    expect(result.ownerToken).toBeUndefined();
+  });
+
+  it('DynamoDB エラー（ConditionalCheck 以外）を DatabaseError にラップする', async () => {
+    const client = makeClient(async () => {
+      throw new Error('プロビジョニングエラー');
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    await expect(repo.acquireLock('u1', 'token-abc', 120_000, fixedNow)).rejects.toBeInstanceOf(
+      DatabaseError
+    );
+  });
+
+  it('TTL は ExpiresAt / 1000 + バッファ', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      return {};
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    await repo.acquireLock('u1', 'token-abc', 120_000, fixedNow);
+    const input = (sent[0] as UpdateCommand).input;
+    const expectedTtl = Math.floor((fixedNow + 120_000) / 1000) + 300;
+    expect(input.ExpressionAttributeValues?.[':ttl']).toBe(expectedTtl);
+  });
+});
+
+describe('DynamoDBChatGuardRepository - releaseLock()', () => {
+  it('ownerToken 一致時に DeleteCommand を送信する', async () => {
+    const sent: unknown[] = [];
+    const client = makeClient(async (cmd) => {
+      sent.push(cmd);
+      return {};
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    await repo.releaseLock('u1', 'token-abc');
+
+    expect(sent[0]).toBeInstanceOf(DeleteCommand);
+    const input = (sent[0] as DeleteCommand).input;
+    expect(input.TableName).toBe(tableName);
+    expect(input.Key?.PK).toBe('USER#u1');
+    expect(input.Key?.SK).toBe('CHATLOCK');
+    expect(input.ConditionExpression).toBe('OwnerToken = :token');
+    expect(input.ExpressionAttributeValues?.[':token']).toBe('token-abc');
+  });
+
+  it('ConditionalCheckFailedException（ownerToken 不一致）は握りつぶす', async () => {
+    const client = makeClient(async () => {
+      const err = Object.assign(new Error('ConditionalCheckFailed'), {
+        name: 'ConditionalCheckFailedException',
+      });
+      throw err;
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    // エラーにならず正常終了すること
+    await expect(repo.releaseLock('u1', 'token-abc')).resolves.toBeUndefined();
+  });
+
+  it('DynamoDB エラー（ConditionalCheck 以外）を DatabaseError にラップする', async () => {
+    const client = makeClient(async () => {
+      throw new Error('削除エラー');
+    });
+    const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
+    await expect(repo.releaseLock('u1', 'token-abc')).rejects.toBeInstanceOf(DatabaseError);
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-chat-guard.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-chat-guard.repository.test.ts
@@ -11,7 +11,7 @@
  * - acquireLock: DynamoDB エラーを DatabaseError にラップする
  * - releaseLock: ownerToken 一致時の DeleteCommand
  * - releaseLock: ConditionalCheckFailedException を握りつぶす
- * - releaseLock: DynamoDB エラーを DatabaseError にラップする
+ * - releaseLock: DynamoDB エラー（ConditionalCheck 以外）もフェイルオープンで握りつぶす
  * - computeBucket / computeWindowTtlSec の純粋ロジック
  */
 
@@ -206,11 +206,12 @@ describe('DynamoDBChatGuardRepository - releaseLock()', () => {
     await expect(repo.releaseLock('u1', 'token-abc')).resolves.toBeUndefined();
   });
 
-  it('DynamoDB エラー（ConditionalCheck 以外）を DatabaseError にラップする', async () => {
+  it('DynamoDB エラー（ConditionalCheck 以外）はフェイルオープンで握りつぶす', async () => {
     const client = makeClient(async () => {
       throw new Error('削除エラー');
     });
     const repo = new DynamoDBChatGuardRepository(client as never, tableName, () => fixedNow);
-    await expect(repo.releaseLock('u1', 'token-abc')).rejects.toBeInstanceOf(DatabaseError);
+    // フェイルオープン: エラーを throw せず正常終了する
+    await expect(repo.releaseLock('u1', 'token-abc')).resolves.toBeUndefined();
   });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-chat-guard.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-chat-guard.repository.test.ts
@@ -46,7 +46,9 @@ describe('computeBucket()', () => {
 
   it('1m: 次の分の開始は新しいバケット', () => {
     const nextMinuteStartMs = (Math.floor(BASE_NOW_MS / 60_000) + 1) * 60_000;
-    expect(computeBucket('1m', nextMinuteStartMs)).toBe(String(Math.floor(BASE_NOW_MS / 60_000) + 1));
+    expect(computeBucket('1m', nextMinuteStartMs)).toBe(
+      String(Math.floor(BASE_NOW_MS / 60_000) + 1)
+    );
   });
 
   it('1h: 時間の境界直前は同じバケット', () => {
@@ -58,7 +60,9 @@ describe('computeBucket()', () => {
 
   it('1h: 次の時間の開始は新しいバケット', () => {
     const nextHourStartMs = (Math.floor(BASE_NOW_MS / 3_600_000) + 1) * 3_600_000;
-    expect(computeBucket('1h', nextHourStartMs)).toBe(String(Math.floor(BASE_NOW_MS / 3_600_000) + 1));
+    expect(computeBucket('1h', nextHourStartMs)).toBe(
+      String(Math.floor(BASE_NOW_MS / 3_600_000) + 1)
+    );
   });
 });
 

--- a/services/livetalk/core/tests/unit/repositories/in-memory-chat-guard.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-chat-guard.repository.test.ts
@@ -1,0 +1,248 @@
+/**
+ * InMemoryChatGuardRepository のユニットテスト（Issue #3528）。
+ *
+ * テスト観点:
+ * - レート制限: ウィンドウ内カウントアップ、上限ちょうど/超過判定
+ * - レート制限: ウィンドウ跨ぎでリセット（新バケット = count 1 に戻る）
+ * - 並行制御: ロック取得成功 / 2 本目拒否 / ExpiresAt 失効後の奪取
+ * - ロック解放: ownerToken 一致時のみ削除、不一致時はスキップ
+ * - computeBucket / computeWindowExpiresAtSec の純粋ロジック
+ */
+
+import {
+  InMemoryChatGuardRepository,
+  computeBucket,
+  computeWindowExpiresAtSec,
+} from '../../../src/repositories/in-memory-chat-guard.repository.js';
+import type { RateLimitResult } from '../../../src/repositories/chat-guard.repository.interface.js';
+
+// テスト用に固定時刻を使う。
+// 時間・分の開始直後（00:00:01 相当）に設定し、境界値テストで確実に同一バケット内に収まるようにする。
+// 1 分バケット = 28421760（2024-01-15 10:00:00 UTC 相当）
+// 1 時間バケット = 473696（2024-01-15 10:00:00 UTC 相当）
+// 時間の開始 = 473696 * 3600000 = 1705305600000（2024-01-15 10:00:00 UTC）
+const BASE_HOUR_START_MS = 473_696 * 3_600_000; // 時間の開始ミリ秒
+const BASE_NOW_MS = BASE_HOUR_START_MS + 1_000; // 時間の開始から 1 秒後
+// 1 分バケット
+const BASE_MINUTE_BUCKET = String(Math.floor(BASE_NOW_MS / 60_000));
+// 1 時間バケット
+const BASE_HOUR_BUCKET = String(Math.floor(BASE_NOW_MS / 3_600_000));
+
+describe('computeBucket()', () => {
+  it('1m: エポック分を返す', () => {
+    expect(computeBucket('1m', BASE_NOW_MS)).toBe(BASE_MINUTE_BUCKET);
+  });
+
+  it('1h: エポック時を返す', () => {
+    expect(computeBucket('1h', BASE_NOW_MS)).toBe(BASE_HOUR_BUCKET);
+  });
+
+  it('1m: 分の境界直前は同じバケット', () => {
+    // 現在の分バケットの終了直前（次の分の開始 - 1ms）
+    const nextMinuteStartMs = (Math.floor(BASE_NOW_MS / 60_000) + 1) * 60_000;
+    const justBeforeNextMinute = nextMinuteStartMs - 1;
+    expect(computeBucket('1m', justBeforeNextMinute)).toBe(BASE_MINUTE_BUCKET);
+  });
+
+  it('1m: 次の分の開始は新しいバケット', () => {
+    const nextMinuteStartMs = (Math.floor(BASE_NOW_MS / 60_000) + 1) * 60_000;
+    expect(computeBucket('1m', nextMinuteStartMs)).toBe(String(Math.floor(BASE_NOW_MS / 60_000) + 1));
+  });
+
+  it('1h: 時間の境界直前は同じバケット', () => {
+    // 現在の時間バケットの終了直前（次の時間の開始 - 1ms）
+    const nextHourStartMs = (Math.floor(BASE_NOW_MS / 3_600_000) + 1) * 3_600_000;
+    const justBeforeNextHour = nextHourStartMs - 1;
+    expect(computeBucket('1h', justBeforeNextHour)).toBe(BASE_HOUR_BUCKET);
+  });
+
+  it('1h: 次の時間の開始は新しいバケット', () => {
+    const nextHourStartMs = (Math.floor(BASE_NOW_MS / 3_600_000) + 1) * 3_600_000;
+    expect(computeBucket('1h', nextHourStartMs)).toBe(String(Math.floor(BASE_NOW_MS / 3_600_000) + 1));
+  });
+});
+
+describe('computeWindowExpiresAtSec()', () => {
+  it('1m: 次の分の開始 Unix 秒を返す', () => {
+    const expected = (Math.floor(BASE_NOW_MS / 60_000) + 1) * 60;
+    expect(computeWindowExpiresAtSec('1m', BASE_NOW_MS)).toBe(expected);
+  });
+
+  it('1h: 次の時間の開始 Unix 秒を返す', () => {
+    const expected = (Math.floor(BASE_NOW_MS / 3_600_000) + 1) * 3_600;
+    expect(computeWindowExpiresAtSec('1h', BASE_NOW_MS)).toBe(expected);
+  });
+});
+
+describe('InMemoryChatGuardRepository - レート制限', () => {
+  let repo: InMemoryChatGuardRepository;
+
+  beforeEach(() => {
+    repo = new InMemoryChatGuardRepository();
+  });
+
+  it('初回インクリメントは count=1 を返す', async () => {
+    const result = await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    expect(result.count).toBe(1);
+    expect(result.window).toBe('1m');
+  });
+
+  it('同一ウィンドウ内での連続インクリメントは加算される', async () => {
+    await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    const result = await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    expect(result.count).toBe(3);
+  });
+
+  it('上限ちょうど（count=10）は超過しない', async () => {
+    let result: RateLimitResult = { count: 0, window: '1m' };
+    for (let i = 0; i < 10; i++) {
+      result = await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    }
+    expect(result.count).toBe(10);
+  });
+
+  it('上限+1（count=11）で超過判定できる', async () => {
+    for (let i = 0; i < 11; i++) {
+      await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    }
+    const result = await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    expect(result.count).toBe(12);
+  });
+
+  it('ウィンドウ跨ぎ（60 秒後）でカウントがリセットされる', async () => {
+    // 現在のウィンドウで 5 回インクリメント
+    for (let i = 0; i < 5; i++) {
+      await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    }
+    // 60 秒後（新しいウィンドウ）にインクリメント
+    const nextWindowMs = BASE_NOW_MS + 60_000;
+    const result = await repo.incrementRateLimit('u1', '1m', nextWindowMs);
+    // 新しいバケットなので count=1 に戻る
+    expect(result.count).toBe(1);
+  });
+
+  it('1h ウィンドウは別カウンタを持つ', async () => {
+    // 1m を 5 回インクリメント
+    for (let i = 0; i < 5; i++) {
+      await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    }
+    // 1h のカウントは独立している
+    const result = await repo.incrementRateLimit('u1', '1h', BASE_NOW_MS);
+    expect(result.count).toBe(1);
+  });
+
+  it('異なるユーザー間でカウントは独立している', async () => {
+    await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    const u2Result = await repo.incrementRateLimit('u2', '1m', BASE_NOW_MS);
+    expect(u2Result.count).toBe(1);
+  });
+
+  it('TTL 切れのエントリは新規扱いになる', async () => {
+    // 現在のウィンドウでインクリメント（expiresAt は nextMinute）
+    const nowSec = Math.floor(BASE_NOW_MS / 1000);
+    // 現在のウィンドウの expiresAt = (floor(nowMs/60000) + 1) * 60
+    const windowExpiresSec = (Math.floor(BASE_NOW_MS / 60_000) + 1) * 60;
+    // TTL 切れ後の時刻（windowExpiresSec + 1 秒後）
+    const expiredMs = (windowExpiresSec + 1) * 1000;
+
+    // まず現在のバケットでカウントをためる
+    for (let i = 0; i < 5; i++) {
+      await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    }
+
+    // TTL 切れ後は同バケット文字列でも期限切れ扱いで count=1 に戻る
+    // （InMemory 実装は nowSec > expiresAt で判定する）
+    // expiredMs のバケット = floor(expiredMs / 60000)
+    // これは BASE_NOW_MS のバケット +1 以上になる（60 秒以上経過している）
+    const result = await repo.incrementRateLimit('u1', '1m', expiredMs);
+    // 新しいバケットなので count=1
+    expect(result.count).toBe(1);
+    expect(result.count).toBeLessThan(6);
+
+    // nowSec が expiresAt を超えている場合のリセット確認（同一バケットキーのシミュレーション）
+    // InMemory 実装では nowSec <= expiresAt の場合は継続カウント、
+    // nowSec > expiresAt の場合は count=1 にリセットする
+    void nowSec;
+  });
+});
+
+describe('InMemoryChatGuardRepository - ロック', () => {
+  let repo: InMemoryChatGuardRepository;
+  const LOCK_TTL_MS = 120_000;
+
+  beforeEach(() => {
+    repo = new InMemoryChatGuardRepository();
+  });
+
+  it('初回取得は acquired=true', async () => {
+    const result = await repo.acquireLock('u1', 'token-a', LOCK_TTL_MS, BASE_NOW_MS);
+    expect(result.acquired).toBe(true);
+    expect(result.ownerToken).toBe('token-a');
+  });
+
+  it('有効なロックが存在する場合、2 本目は acquired=false', async () => {
+    await repo.acquireLock('u1', 'token-a', LOCK_TTL_MS, BASE_NOW_MS);
+    const result = await repo.acquireLock('u1', 'token-b', LOCK_TTL_MS, BASE_NOW_MS);
+    expect(result.acquired).toBe(false);
+    expect(result.ownerToken).toBeUndefined();
+  });
+
+  it('ExpiresAt < now のロックは期限切れとして上書き取得できる', async () => {
+    // 今から 1ms 後に期限切れになるロックを取得
+    await repo.acquireLock('u1', 'token-a', 1, BASE_NOW_MS);
+    // 2ms 後に別リクエストが奪取を試みる（ExpiresAt < nowMs）
+    const result = await repo.acquireLock('u1', 'token-b', LOCK_TTL_MS, BASE_NOW_MS + 2);
+    expect(result.acquired).toBe(true);
+    expect(result.ownerToken).toBe('token-b');
+  });
+
+  it('ExpiresAt === now のロックはまだ有効（境界値）', async () => {
+    // ExpiresAt = BASE_NOW_MS + LOCK_TTL_MS
+    await repo.acquireLock('u1', 'token-a', LOCK_TTL_MS, BASE_NOW_MS);
+    // ちょうど ExpiresAt のタイミングはまだ有効（< ではなく <= の場合）
+    // InMemory 実装では existing.expiresAt < nowMs で判定するため、
+    // ExpiresAt === nowMs のときは「まだ有効」とみなして取得失敗
+    const expiredAt = BASE_NOW_MS + LOCK_TTL_MS;
+    const result = await repo.acquireLock('u1', 'token-b', LOCK_TTL_MS, expiredAt);
+    // ExpiresAt === nowMs の場合は有効（not expired）なので取得失敗
+    expect(result.acquired).toBe(false);
+  });
+
+  it('異なるユーザーのロックは独立している', async () => {
+    await repo.acquireLock('u1', 'token-a', LOCK_TTL_MS, BASE_NOW_MS);
+    const result = await repo.acquireLock('u2', 'token-b', LOCK_TTL_MS, BASE_NOW_MS);
+    expect(result.acquired).toBe(true);
+  });
+
+  it('releaseLock でロックが解放され、再取得できる', async () => {
+    await repo.acquireLock('u1', 'token-a', LOCK_TTL_MS, BASE_NOW_MS);
+    await repo.releaseLock('u1', 'token-a');
+    const result = await repo.acquireLock('u1', 'token-b', LOCK_TTL_MS, BASE_NOW_MS);
+    expect(result.acquired).toBe(true);
+  });
+
+  it('ownerToken が不一致の場合は releaseLock しても削除されない', async () => {
+    await repo.acquireLock('u1', 'token-a', LOCK_TTL_MS, BASE_NOW_MS);
+    // 別のトークンで解放を試みる（エラーにならず無視される）
+    await repo.releaseLock('u1', 'wrong-token');
+    // ロックは残っているはず
+    const result = await repo.acquireLock('u1', 'token-b', LOCK_TTL_MS, BASE_NOW_MS);
+    expect(result.acquired).toBe(false);
+  });
+
+  it('存在しないロックの releaseLock はエラーにならない', async () => {
+    await expect(repo.releaseLock('u1', 'nonexistent-token')).resolves.toBeUndefined();
+  });
+
+  it('clear() で全エントリが削除される', async () => {
+    await repo.acquireLock('u1', 'token-a', LOCK_TTL_MS, BASE_NOW_MS);
+    await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    repo.clear();
+    const lockResult = await repo.acquireLock('u1', 'token-b', LOCK_TTL_MS, BASE_NOW_MS);
+    const rateResult = await repo.incrementRateLimit('u1', '1m', BASE_NOW_MS);
+    expect(lockResult.acquired).toBe(true);
+    expect(rateResult.count).toBe(1);
+  });
+});

--- a/services/livetalk/web/src/app/api/chat/constants.ts
+++ b/services/livetalk/web/src/app/api/chat/constants.ts
@@ -6,6 +6,12 @@ export const CHAT_ERROR_MESSAGES = {
   EMPTY_TEXT: 'メッセージを入力してください',
   TEXT_TOO_LONG: 'メッセージが長すぎます（200 文字以内で入力してください）',
   INTERNAL_ERROR: '内部エラーが発生しました',
+  /** レートリミット超過（1 分または 1 時間ウィンドウ） */
+  RATE_LIMIT_EXCEEDED: 'リクエストが多すぎます。しばらく待ってから再送してください',
+  /** 同一ユーザーの並行リクエストが実行中 */
+  CONCURRENT_REQUEST: '処理中のリクエストがあります。完了をお待ちください',
+  /** ストリームがタイムアウトした場合の error イベントメッセージ */
+  STREAM_TIMEOUT: '応答がタイムアウトしました',
 } as const;
 
 export const CHAT_MAX_TEXT_LENGTH = 200;

--- a/services/livetalk/web/src/app/api/chat/constants.ts
+++ b/services/livetalk/web/src/app/api/chat/constants.ts
@@ -10,8 +10,6 @@ export const CHAT_ERROR_MESSAGES = {
   RATE_LIMIT_EXCEEDED: 'リクエストが多すぎます。しばらく待ってから再送してください',
   /** 同一ユーザーの並行リクエストが実行中 */
   CONCURRENT_REQUEST: '処理中のリクエストがあります。完了をお待ちください',
-  /** ストリームがタイムアウトした場合の error イベントメッセージ */
-  STREAM_TIMEOUT: '応答がタイムアウトしました',
 } as const;
 
 export const CHAT_MAX_TEXT_LENGTH = 200;

--- a/services/livetalk/web/src/app/api/chat/route.ts
+++ b/services/livetalk/web/src/app/api/chat/route.ts
@@ -4,7 +4,6 @@ import {
   CHAT_LOCK_TTL_MS,
   CHAT_RATE_LIMIT_PER_HOUR,
   CHAT_RATE_LIMIT_PER_MINUTE,
-  CHAT_STREAM_TIMEOUT_MS,
   DEFAULT_CHARACTER_ID,
   defaultUlidFactory,
   runChatUseCase,
@@ -56,10 +55,14 @@ function isChatRequest(body: unknown): body is ChatRequest {
  *
  * ガード適用順（Issue #3528）:
  * 1. バリデーション（既存）
- * 2. レートリミットチェック（超過時は HTTP 429）
- * 3. in-flight ロック取得（取得失敗時は HTTP 429）
- * 4. ストリーム開始（AbortController によるサーバ側タイムアウト付き）
- * 5. finally でロック解放
+ * 2. in-flight ロック取得（取得失敗時は HTTP 429、DB 障害時はフェイルオープンで通す）
+ * 3. レートリミットチェック（超過時は HTTP 429、DB 障害時はフェイルオープンで通す）
+ * 4. ストリーム開始
+ * 5. finally でロック解放（取得できた場合のみ）
+ *
+ * サーバ側タイムアウトは上流クライアントのタイムアウトに委譲する設計
+ * （route 層に決定論的な上限は持たない）。
+ * 上流タイムアウトによるエラーも catch で INTERNAL_ERROR として emit される。
  *
  * レスポンス形式（1 行 1 JSON）:
  *   {"type":"text","delta":"こん"}
@@ -119,17 +122,75 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
   const chatGuardRepository = getChatGuardRepository();
   const nowMs = Date.now();
 
-  // ---- ガード 1: レートリミット ----
+  // ---- ガード 1: in-flight ロック取得 ----
+  // 同一ユーザーの並行リクエストを 1 本に制限する。
+  // DynamoDB 障害時はフェイルオープン（ロック無しで続行）し、警告ログを残す。
+  const ownerToken = defaultUlidFactory(nowMs);
+  let lockAcquired = false;
+
+  let lockResult;
+  try {
+    lockResult = await chatGuardRepository.acquireLock(
+      userId,
+      ownerToken,
+      CHAT_LOCK_TTL_MS,
+      nowMs
+    );
+  } catch (lockErr) {
+    // DynamoDB 障害: フェイルオープン（ロック無しで続行する）
+    console.warn(
+      '[POST /api/chat] ロック取得に失敗したためバイパスしました。障害時フェイルオープン。',
+      lockErr
+    );
+    lockResult = null;
+  }
+
+  if (lockResult !== null) {
+    if (!lockResult.acquired) {
+      return NextResponse.json(
+        { error: 'CONCURRENT_REQUEST', message: CHAT_ERROR_MESSAGES.CONCURRENT_REQUEST },
+        { status: 429 }
+      );
+    }
+    lockAcquired = true;
+  }
+
+  // ---- ガード 2: レートリミット ----
   // 1 分・1 時間の 2 ウィンドウをアトミックにインクリメントし、いずれか超過で 429 を返す。
-  const [limitPerMinResult, limitPerHourResult] = await Promise.all([
-    chatGuardRepository.incrementRateLimit(userId, '1m', nowMs),
-    chatGuardRepository.incrementRateLimit(userId, '1h', nowMs),
-  ]);
+  // ロック取得後にチェックすることで、並行リクエスト（ロック競合で 429 拒否）が
+  // レートカウンタを消費しないようにする。
+  // DynamoDB 障害時はフェイルオープン（レート超過扱いにせず通す）し、警告ログを残す。
+  let limitPerMinResult;
+  let limitPerHourResult;
+  try {
+    [limitPerMinResult, limitPerHourResult] = await Promise.all([
+      chatGuardRepository.incrementRateLimit(userId, '1m', nowMs),
+      chatGuardRepository.incrementRateLimit(userId, '1h', nowMs),
+    ]);
+  } catch (rateErr) {
+    // DynamoDB 障害: フェイルオープン（レートリミットをバイパスして通す）
+    console.warn(
+      '[POST /api/chat] レートリミットのチェックに失敗したためバイパスしました。障害時フェイルオープン。',
+      rateErr
+    );
+    limitPerMinResult = null;
+    limitPerHourResult = null;
+  }
 
   if (
-    limitPerMinResult.count > CHAT_RATE_LIMIT_PER_MINUTE ||
-    limitPerHourResult.count > CHAT_RATE_LIMIT_PER_HOUR
+    limitPerMinResult !== null &&
+    limitPerHourResult !== null &&
+    (limitPerMinResult.count > CHAT_RATE_LIMIT_PER_MINUTE ||
+      limitPerHourResult.count > CHAT_RATE_LIMIT_PER_HOUR)
   ) {
+    // レート超過時はロックを解放してから 429 を返す
+    if (lockAcquired) {
+      try {
+        await chatGuardRepository.releaseLock(userId, ownerToken);
+      } catch (releaseErr) {
+        console.warn('[POST /api/chat] レート超過時のロック解放に失敗しました。', releaseErr);
+      }
+    }
     return NextResponse.json(
       { error: 'RATE_LIMIT_EXCEEDED', message: CHAT_ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
       {
@@ -145,35 +206,7 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
     );
   }
 
-  // ---- ガード 2: in-flight ロック取得 ----
-  // 同一ユーザーの並行リクエストを 1 本に制限する。
-  const ownerToken = defaultUlidFactory(nowMs);
-  const lockResult = await chatGuardRepository.acquireLock(
-    userId,
-    ownerToken,
-    CHAT_LOCK_TTL_MS,
-    nowMs
-  );
-
-  if (!lockResult.acquired) {
-    return NextResponse.json(
-      { error: 'CONCURRENT_REQUEST', message: CHAT_ERROR_MESSAGES.CONCURRENT_REQUEST },
-      { status: 429 }
-    );
-  }
-
   const encoder = new TextEncoder();
-
-  // ---- ガード 3: ストリームのサーバ側タイムアウト ----
-  // ECS セルフホストでは Next.js の maxDuration が効かないため、AbortController で制御する。
-  // runChatUseCase は現時点では AbortSignal を受け取るシグネチャを持たないため、
-  // ストリーム消費ループの外側にデッドラインを置いてループを抜ける方式とする。
-  // （signal の受け渡しが大掛かりになるため、現段階では伝播させない。
-  //   将来的に runChatUseCase が signal を受け取れるようになったら伝播を追加すること。）
-  const abortController = new AbortController();
-  const timeoutId = setTimeout(() => {
-    abortController.abort();
-  }, CHAT_STREAM_TIMEOUT_MS);
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -205,26 +238,21 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
         });
 
         for await (const event of eventGenerator) {
-          // タイムアウト到達時はループを抜けて error event を emit する
-          if (abortController.signal.aborted) {
-            write({ type: 'error', message: CHAT_ERROR_MESSAGES.STREAM_TIMEOUT });
-            return;
-          }
           write(event);
         }
       } catch (err) {
-        if (abortController.signal.aborted) {
-          // タイムアウト由来のエラーは STREAM_TIMEOUT メッセージで統一する
-          write({ type: 'error', message: CHAT_ERROR_MESSAGES.STREAM_TIMEOUT });
-        } else {
-          console.error('[POST /api/chat] ストリーミング中にエラーが発生しました', err);
-          write({ type: 'error', message: CHAT_ERROR_MESSAGES.INTERNAL_ERROR });
-        }
+        console.error('[POST /api/chat] ストリーミング中にエラーが発生しました', err);
+        write({ type: 'error', message: CHAT_ERROR_MESSAGES.INTERNAL_ERROR });
       } finally {
-        clearTimeout(timeoutId);
-        // ownerToken が一致する場合のみロックを解放する。
-        // ConditionalCheckFailed（他リクエストが既に奪取・解放済み）は releaseLock 側で握りつぶす。
-        await chatGuardRepository.releaseLock(userId, ownerToken);
+        // lockAcquired が true のときだけ解放する（DB 障害でバイパスした場合は呼ばない）
+        if (lockAcquired) {
+          try {
+            await chatGuardRepository.releaseLock(userId, ownerToken);
+          } catch (releaseErr) {
+            // ロック解放失敗は警告のみ（フェイルオープン方針に合わせて握りつぶす）
+            console.warn('[POST /api/chat] ロック解放に失敗しました。', releaseErr);
+          }
+        }
         controller.close();
       }
     },

--- a/services/livetalk/web/src/app/api/chat/route.ts
+++ b/services/livetalk/web/src/app/api/chat/route.ts
@@ -1,12 +1,21 @@
 import { NextResponse } from 'next/server';
 import { withAuth } from '@nagiyu/nextjs';
-import { DEFAULT_CHARACTER_ID, runChatUseCase } from '@nagiyu/livetalk-core';
+import {
+  CHAT_LOCK_TTL_MS,
+  CHAT_RATE_LIMIT_PER_HOUR,
+  CHAT_RATE_LIMIT_PER_MINUTE,
+  CHAT_STREAM_TIMEOUT_MS,
+  DEFAULT_CHARACTER_ID,
+  defaultUlidFactory,
+  runChatUseCase,
+} from '@nagiyu/livetalk-core';
 import { getCharacterDefinition, hasCharacter } from '@/lib/characters/registry';
 import { getSession } from '@/lib/server/session';
 import { getLLMClient } from '@/lib/server/llm';
 import { getVoiceClient } from '@/lib/server/voice';
 import {
   getCharacterStateRepository,
+  getChatGuardRepository,
   getKnowledgeRepository,
   getLifecycleRepository,
   getMemoryRepository,
@@ -44,6 +53,13 @@ function isChatRequest(body: unknown): body is ChatRequest {
  * POST /api/chat
  *
  * ユーザー発話を受け取り、LLM 応答を NDJSON ストリームで返す（Phase 2c / Issue #3249）。
+ *
+ * ガード適用順（Issue #3528）:
+ * 1. バリデーション（既存）
+ * 2. レートリミットチェック（超過時は HTTP 429）
+ * 3. in-flight ロック取得（取得失敗時は HTTP 429）
+ * 4. ストリーム開始（AbortController によるサーバ側タイムアウト付き）
+ * 5. finally でロック解放
  *
  * レスポンス形式（1 行 1 JSON）:
  *   {"type":"text","delta":"こん"}
@@ -100,7 +116,64 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
   }
 
   const userId = session.user.googleId;
+  const chatGuardRepository = getChatGuardRepository();
+  const nowMs = Date.now();
+
+  // ---- ガード 1: レートリミット ----
+  // 1 分・1 時間の 2 ウィンドウをアトミックにインクリメントし、いずれか超過で 429 を返す。
+  const [limitPerMinResult, limitPerHourResult] = await Promise.all([
+    chatGuardRepository.incrementRateLimit(userId, '1m', nowMs),
+    chatGuardRepository.incrementRateLimit(userId, '1h', nowMs),
+  ]);
+
+  if (
+    limitPerMinResult.count > CHAT_RATE_LIMIT_PER_MINUTE ||
+    limitPerHourResult.count > CHAT_RATE_LIMIT_PER_HOUR
+  ) {
+    return NextResponse.json(
+      { error: 'RATE_LIMIT_EXCEEDED', message: CHAT_ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+      {
+        status: 429,
+        headers: {
+          // 1 分窓が超過している場合は次の分までの秒数、それ以外は次の時間までの秒数
+          'Retry-After':
+            limitPerMinResult.count > CHAT_RATE_LIMIT_PER_MINUTE
+              ? String(60 - Math.floor((nowMs % 60_000) / 1000))
+              : String(3600 - Math.floor((nowMs % 3_600_000) / 1000)),
+        },
+      }
+    );
+  }
+
+  // ---- ガード 2: in-flight ロック取得 ----
+  // 同一ユーザーの並行リクエストを 1 本に制限する。
+  const ownerToken = defaultUlidFactory(nowMs);
+  const lockResult = await chatGuardRepository.acquireLock(
+    userId,
+    ownerToken,
+    CHAT_LOCK_TTL_MS,
+    nowMs
+  );
+
+  if (!lockResult.acquired) {
+    return NextResponse.json(
+      { error: 'CONCURRENT_REQUEST', message: CHAT_ERROR_MESSAGES.CONCURRENT_REQUEST },
+      { status: 429 }
+    );
+  }
+
   const encoder = new TextEncoder();
+
+  // ---- ガード 3: ストリームのサーバ側タイムアウト ----
+  // ECS セルフホストでは Next.js の maxDuration が効かないため、AbortController で制御する。
+  // runChatUseCase は現時点では AbortSignal を受け取るシグネチャを持たないため、
+  // ストリーム消費ループの外側にデッドラインを置いてループを抜ける方式とする。
+  // （signal の受け渡しが大掛かりになるため、現段階では伝播させない。
+  //   将来的に runChatUseCase が signal を受け取れるようになったら伝播を追加すること。）
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => {
+    abortController.abort();
+  }, CHAT_STREAM_TIMEOUT_MS);
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -132,12 +205,26 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
         });
 
         for await (const event of eventGenerator) {
+          // タイムアウト到達時はループを抜けて error event を emit する
+          if (abortController.signal.aborted) {
+            write({ type: 'error', message: CHAT_ERROR_MESSAGES.STREAM_TIMEOUT });
+            return;
+          }
           write(event);
         }
       } catch (err) {
-        console.error('[POST /api/chat] ストリーミング中にエラーが発生しました', err);
-        write({ type: 'error', message: CHAT_ERROR_MESSAGES.INTERNAL_ERROR });
+        if (abortController.signal.aborted) {
+          // タイムアウト由来のエラーは STREAM_TIMEOUT メッセージで統一する
+          write({ type: 'error', message: CHAT_ERROR_MESSAGES.STREAM_TIMEOUT });
+        } else {
+          console.error('[POST /api/chat] ストリーミング中にエラーが発生しました', err);
+          write({ type: 'error', message: CHAT_ERROR_MESSAGES.INTERNAL_ERROR });
+        }
       } finally {
+        clearTimeout(timeoutId);
+        // ownerToken が一致する場合のみロックを解放する。
+        // ConditionalCheckFailed（他リクエストが既に奪取・解放済み）は releaseLock 側で握りつぶす。
+        await chatGuardRepository.releaseLock(userId, ownerToken);
         controller.close();
       }
     },

--- a/services/livetalk/web/src/app/api/chat/route.ts
+++ b/services/livetalk/web/src/app/api/chat/route.ts
@@ -130,12 +130,7 @@ export const POST = withAuth(getSession, 'livetalk:chat', async (session, reques
 
   let lockResult;
   try {
-    lockResult = await chatGuardRepository.acquireLock(
-      userId,
-      ownerToken,
-      CHAT_LOCK_TTL_MS,
-      nowMs
-    );
+    lockResult = await chatGuardRepository.acquireLock(userId, ownerToken, CHAT_LOCK_TTL_MS, nowMs);
   } catch (lockErr) {
     // DynamoDB 障害: フェイルオープン（ロック無しで続行する）
     console.warn(

--- a/services/livetalk/web/src/lib/server/repositories.ts
+++ b/services/livetalk/web/src/lib/server/repositories.ts
@@ -7,7 +7,12 @@
  * 各リポジトリはシングルトンとして再利用される。
  */
 
-import { InMemorySingleTableStore, registerDynamoRepositories, getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
+import {
+  InMemorySingleTableStore,
+  registerDynamoRepositories,
+  getDynamoDBDocumentClient,
+  getTableName,
+} from '@nagiyu/aws';
 import type {
   CharacterStateRepository,
   ChatGuardRepository,

--- a/services/livetalk/web/src/lib/server/repositories.ts
+++ b/services/livetalk/web/src/lib/server/repositories.ts
@@ -7,9 +7,10 @@
  * 各リポジトリはシングルトンとして再利用される。
  */
 
-import { InMemorySingleTableStore, registerDynamoRepositories } from '@nagiyu/aws';
+import { InMemorySingleTableStore, registerDynamoRepositories, getDynamoDBDocumentClient, getTableName } from '@nagiyu/aws';
 import type {
   CharacterStateRepository,
+  ChatGuardRepository,
   InterestRepository,
   KnowledgeRepository,
   LifecycleRepository,
@@ -23,6 +24,7 @@ import type {
   StudyTopicRepository,
 } from '@nagiyu/livetalk-core';
 import {
+  DynamoDBChatGuardRepository,
   DynamoDBCharacterStateRepository,
   DynamoDBInterestRepository,
   DynamoDBKnowledgeRepository,
@@ -35,6 +37,7 @@ import {
   DynamoDBProfileRepository,
   DynamoDBPushSubscriptionRepository,
   DynamoDBStudyTopicRepository,
+  InMemoryChatGuardRepository,
   InMemoryCharacterStateRepository,
   InMemoryInterestRepository,
   InMemoryKnowledgeRepository,
@@ -187,4 +190,33 @@ export function getNotificationEventRepository(): NotificationEventRepository {
  */
 export function resetRepositoriesForTesting(): void {
   registry.resetAll();
+  chatGuardRepositorySingleton = null;
+}
+
+// ---- ChatGuardRepository のシングルトン管理 ----
+//
+// InMemoryChatGuardRepository は InMemorySingleTableStore を使わず内部 Map で管理するため、
+// registerDynamoRepositories の型パターンには合わない。
+// シンプルなシングルトン変数で管理する。
+
+let chatGuardRepositorySingleton: ChatGuardRepository | null = null;
+
+/**
+ * ChatGuardRepository のシングルトンを返す。
+ * - `USE_IN_MEMORY_DB=true` の場合は InMemory 実装
+ * - それ以外は DynamoDB 実装
+ *   メインテーブルに相乗りするため、docClient / tableName の解決は既存パターン同様。
+ */
+export function getChatGuardRepository(): ChatGuardRepository {
+  if (chatGuardRepositorySingleton) return chatGuardRepositorySingleton;
+
+  if (process.env['USE_IN_MEMORY_DB'] === 'true') {
+    chatGuardRepositorySingleton = new InMemoryChatGuardRepository();
+  } else {
+    // registerDynamoRepositories と同じ方法で docClient / tableName を解決する。
+    const docClient = getDynamoDBDocumentClient();
+    const tableName = getTableName();
+    chatGuardRepositorySingleton = new DynamoDBChatGuardRepository(docClient, tableName);
+  }
+  return chatGuardRepositorySingleton;
 }

--- a/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
@@ -7,6 +7,7 @@ import { getSession } from '@/lib/server/session';
 import { getLLMClient } from '@/lib/server/llm';
 import { getVoiceClient } from '@/lib/server/voice';
 import { getMessageRepository, getChatGuardRepository } from '@/lib/server/repositories';
+import { DatabaseError } from '@nagiyu/aws';
 
 jest.mock('@/lib/server/session', () => ({ getSession: jest.fn() }));
 jest.mock('@/lib/server/llm', () => ({ getLLMClient: jest.fn() }));
@@ -283,6 +284,38 @@ describe('POST /api/chat', () => {
       expect(json.message).toBe(CHAT_ERROR_MESSAGES.INVALID_REQUEST);
     });
 
+    // ---- ガード適用順: ロック取得 → レートリミット ----
+
+    it('ロック取得失敗（acquired=false）は 429 CONCURRENT_REQUEST を返す', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.acquireLock.mockResolvedValue({ acquired: false });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      expect(res.status).toBe(429);
+      const json = await res.json();
+      expect(json.message).toBe(CHAT_ERROR_MESSAGES.CONCURRENT_REQUEST);
+    });
+
+    it('ロック取得失敗時は incrementRateLimit が呼ばれない（レート枠を消費しない）', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.acquireLock.mockResolvedValue({ acquired: false });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      await POST(buildRequest({ text: 'こんにちは' }));
+      expect(guardMock.incrementRateLimit).not.toHaveBeenCalled();
+      expect(mockRunChatUseCase).not.toHaveBeenCalled();
+    });
+
+    it('ロック取得失敗時はストリームを開始しない', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.acquireLock.mockResolvedValue({ acquired: false });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      await POST(buildRequest({ text: 'こんにちは' }));
+      expect(mockRunChatUseCase).not.toHaveBeenCalled();
+    });
+
     // ---- ガード: レートリミット ----
 
     it('1 分ウィンドウ超過（count > 10）は 429 RATE_LIMIT_EXCEEDED を返す', async () => {
@@ -323,7 +356,8 @@ describe('POST /api/chat', () => {
       expect(res.status).toBe(200);
     });
 
-    it('レートリミット超過時はストリームを開始しない（ロックも取得しない）', async () => {
+    it('レート超過時はロックが解放される', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
       const guardMock = makeDefaultGuardMock();
       guardMock.incrementRateLimit
         .mockResolvedValueOnce({ count: 11, window: '1m' })
@@ -331,31 +365,50 @@ describe('POST /api/chat', () => {
       mockGetChatGuardRepository.mockReturnValue(guardMock);
 
       await POST(buildRequest({ text: 'こんにちは' }));
-      expect(guardMock.acquireLock).not.toHaveBeenCalled();
+      expect(guardMock.releaseLock).toHaveBeenCalled();
       expect(mockRunChatUseCase).not.toHaveBeenCalled();
     });
 
-    // ---- ガード: 並行制御 ----
+    // ---- フェイルオープン: DynamoDB 障害 ----
 
-    it('ロック取得失敗（acquired=false）は 429 CONCURRENT_REQUEST を返す', async () => {
+    it('ロック取得が DatabaseError を throw した場合はフェイルオープンで通す', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
       const guardMock = makeDefaultGuardMock();
-      guardMock.acquireLock.mockResolvedValue({ acquired: false });
+      guardMock.acquireLock.mockRejectedValue(new DatabaseError('DynamoDB 障害'));
       mockGetChatGuardRepository.mockReturnValue(guardMock);
 
       const res = await POST(buildRequest({ text: 'こんにちは' }));
-      expect(res.status).toBe(429);
-      const json = await res.json();
-      expect(json.message).toBe(CHAT_ERROR_MESSAGES.CONCURRENT_REQUEST);
+      // フェイルオープン: 障害でもリクエストを通す
+      expect(res.status).toBe(200);
+      expect(mockRunChatUseCase).toHaveBeenCalled();
     });
 
-    it('ロック取得失敗時はストリームを開始しない', async () => {
+    it('ロック取得が DatabaseError の場合は releaseLock が呼ばれない', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
       const guardMock = makeDefaultGuardMock();
-      guardMock.acquireLock.mockResolvedValue({ acquired: false });
+      guardMock.acquireLock.mockRejectedValue(new DatabaseError('DynamoDB 障害'));
       mockGetChatGuardRepository.mockReturnValue(guardMock);
 
-      await POST(buildRequest({ text: 'こんにちは' }));
-      expect(mockRunChatUseCase).not.toHaveBeenCalled();
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      await readNDJSONStream(res);
+
+      // ロックを取得していないため解放は不要
+      expect(guardMock.releaseLock).not.toHaveBeenCalled();
     });
+
+    it('incrementRateLimit が DatabaseError を throw した場合はフェイルオープンで通す', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const guardMock = makeDefaultGuardMock();
+      guardMock.incrementRateLimit.mockRejectedValue(new DatabaseError('DynamoDB 障害'));
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      // フェイルオープン: 障害でもリクエストを通す
+      expect(res.status).toBe(200);
+      expect(mockRunChatUseCase).toHaveBeenCalled();
+    });
+
+    // ---- ロック解放 ----
 
     it('ストリーム完了後に releaseLock が呼ばれる（finally で解放）', async () => {
       const guardMock = makeDefaultGuardMock();

--- a/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
@@ -6,7 +6,7 @@ import { CHAT_ERROR_MESSAGES, CHAT_MAX_TEXT_LENGTH } from '@/app/api/chat/consta
 import { getSession } from '@/lib/server/session';
 import { getLLMClient } from '@/lib/server/llm';
 import { getVoiceClient } from '@/lib/server/voice';
-import { getMessageRepository } from '@/lib/server/repositories';
+import { getMessageRepository, getChatGuardRepository } from '@/lib/server/repositories';
 
 jest.mock('@/lib/server/session', () => ({ getSession: jest.fn() }));
 jest.mock('@/lib/server/llm', () => ({ getLLMClient: jest.fn() }));
@@ -20,6 +20,7 @@ jest.mock('@/lib/server/repositories', () => ({
   getKnowledgeRepository: jest.fn().mockReturnValue({}),
   getStudyTopicRepository: jest.fn().mockReturnValue({}),
   getNoteRepository: jest.fn().mockReturnValue({}),
+  getChatGuardRepository: jest.fn(),
 }));
 jest.mock('@/lib/server/safety', () => ({
   getSafetyEventRepository: jest.fn().mockReturnValue({}),
@@ -42,6 +43,14 @@ import { runChatUseCase } from '@nagiyu/livetalk-core';
 
 const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
 const mockRunChatUseCase = runChatUseCase as jest.Mock;
+const mockGetChatGuardRepository = getChatGuardRepository as jest.Mock;
+
+/** デフォルトのガードモック（全て通過させる） */
+const makeDefaultGuardMock = () => ({
+  incrementRateLimit: jest.fn().mockResolvedValue({ count: 1, window: '1m' }),
+  acquireLock: jest.fn().mockResolvedValue({ acquired: true, ownerToken: 'test-token' }),
+  releaseLock: jest.fn().mockResolvedValue(undefined),
+});
 
 const validSession = {
   user: {
@@ -81,6 +90,7 @@ describe('POST /api/chat', () => {
     (getLLMClient as jest.Mock).mockReturnValue({});
     (getVoiceClient as jest.Mock).mockReturnValue({});
     (getMessageRepository as jest.Mock).mockReturnValue({});
+    mockGetChatGuardRepository.mockReturnValue(makeDefaultGuardMock());
   });
 
   it('未認証は 401', async () => {
@@ -271,6 +281,134 @@ describe('POST /api/chat', () => {
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.message).toBe(CHAT_ERROR_MESSAGES.INVALID_REQUEST);
+    });
+
+    // ---- ガード: レートリミット ----
+
+    it('1 分ウィンドウ超過（count > 10）は 429 RATE_LIMIT_EXCEEDED を返す', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.incrementRateLimit
+        .mockResolvedValueOnce({ count: 11, window: '1m' })
+        .mockResolvedValueOnce({ count: 1, window: '1h' });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      expect(res.status).toBe(429);
+      const json = await res.json();
+      expect(json.message).toBe(CHAT_ERROR_MESSAGES.RATE_LIMIT_EXCEEDED);
+      expect(res.headers.get('Retry-After')).toBeTruthy();
+    });
+
+    it('1 時間ウィンドウ超過（count > 100）は 429 RATE_LIMIT_EXCEEDED を返す', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.incrementRateLimit
+        .mockResolvedValueOnce({ count: 1, window: '1m' })
+        .mockResolvedValueOnce({ count: 101, window: '1h' });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      expect(res.status).toBe(429);
+      const json = await res.json();
+      expect(json.message).toBe(CHAT_ERROR_MESSAGES.RATE_LIMIT_EXCEEDED);
+    });
+
+    it('レートリミット上限ちょうど（count=10）は通過する', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.incrementRateLimit
+        .mockResolvedValueOnce({ count: 10, window: '1m' })
+        .mockResolvedValueOnce({ count: 10, window: '1h' });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      expect(res.status).toBe(200);
+    });
+
+    it('レートリミット超過時はストリームを開始しない（ロックも取得しない）', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.incrementRateLimit
+        .mockResolvedValueOnce({ count: 11, window: '1m' })
+        .mockResolvedValueOnce({ count: 1, window: '1h' });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      await POST(buildRequest({ text: 'こんにちは' }));
+      expect(guardMock.acquireLock).not.toHaveBeenCalled();
+      expect(mockRunChatUseCase).not.toHaveBeenCalled();
+    });
+
+    // ---- ガード: 並行制御 ----
+
+    it('ロック取得失敗（acquired=false）は 429 CONCURRENT_REQUEST を返す', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.acquireLock.mockResolvedValue({ acquired: false });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      expect(res.status).toBe(429);
+      const json = await res.json();
+      expect(json.message).toBe(CHAT_ERROR_MESSAGES.CONCURRENT_REQUEST);
+    });
+
+    it('ロック取得失敗時はストリームを開始しない', async () => {
+      const guardMock = makeDefaultGuardMock();
+      guardMock.acquireLock.mockResolvedValue({ acquired: false });
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      await POST(buildRequest({ text: 'こんにちは' }));
+      expect(mockRunChatUseCase).not.toHaveBeenCalled();
+    });
+
+    it('ストリーム完了後に releaseLock が呼ばれる（finally で解放）', async () => {
+      const guardMock = makeDefaultGuardMock();
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      mockRunChatUseCase.mockImplementation(async function* () {
+        yield { type: 'done' };
+      });
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      await readNDJSONStream(res);
+
+      expect(guardMock.releaseLock).toHaveBeenCalled();
+    });
+
+    it('runChatUseCase がエラーを投げてもストリーム後に releaseLock が呼ばれる', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      const guardMock = makeDefaultGuardMock();
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      mockRunChatUseCase.mockImplementation(async function* () {
+        throw new Error('エラー');
+        yield { type: 'done' as const };
+      });
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      await readNDJSONStream(res);
+
+      expect(guardMock.releaseLock).toHaveBeenCalled();
+    });
+
+    it('releaseLock には acquireLock に渡したのと同じユーザー ID とトークンが渡される', async () => {
+      const guardMock = makeDefaultGuardMock();
+      let capturedOwnerToken: string | undefined;
+      // acquireLock に渡されたトークンをキャプチャし、返却値もそのトークンにする
+      guardMock.acquireLock.mockImplementation(
+        async (_userId: string, ownerToken: string) => {
+          capturedOwnerToken = ownerToken;
+          return { acquired: true, ownerToken };
+        }
+      );
+      mockGetChatGuardRepository.mockReturnValue(guardMock);
+
+      mockRunChatUseCase.mockImplementation(async function* () {
+        yield { type: 'done' };
+      });
+
+      const res = await POST(buildRequest({ text: 'こんにちは' }));
+      await readNDJSONStream(res);
+
+      // acquireLock に渡されたトークンが releaseLock にも渡されることを確認する
+      expect(capturedOwnerToken).toBeDefined();
+      expect(guardMock.releaseLock).toHaveBeenCalledWith('g1', capturedOwnerToken);
     });
   });
 });

--- a/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/chat/route.test.ts
@@ -444,12 +444,10 @@ describe('POST /api/chat', () => {
       const guardMock = makeDefaultGuardMock();
       let capturedOwnerToken: string | undefined;
       // acquireLock に渡されたトークンをキャプチャし、返却値もそのトークンにする
-      guardMock.acquireLock.mockImplementation(
-        async (_userId: string, ownerToken: string) => {
-          capturedOwnerToken = ownerToken;
-          return { acquired: true, ownerToken };
-        }
-      );
+      guardMock.acquireLock.mockImplementation(async (_userId: string, ownerToken: string) => {
+        capturedOwnerToken = ownerToken;
+        return { acquired: true, ownerToken };
+      });
       mockGetChatGuardRepository.mockReturnValue(guardMock);
 
       mockRunChatUseCase.mockImplementation(async function* () {


### PR DESCRIPTION
## 変更の概要

リブトークのチャット API `/api/chat` に、暴走・再送・バグによる OpenAI / VOICEVOX コストの暴発を防ぐアプリ層のガードを追加する（サブ Issue #3528 / 親 #3521）。状態は DynamoDB メインテーブルに相乗りし、新テーブル・IAM 変更なし。`integration/3528-chat-api-protection` を develop へ取り込む。

- **レート制限**: ユーザー単位の固定ウィンドウ・カウンタ（直近 1 分 = 10 回 / 1 時間 = 100 回）。`UpdateItem` の `ADD` でアトミック加算、超過時は HTTP 429（`Retry-After` 付き）。カウンタは TTL で自動掃除。
- **並行制御**: ユーザー単位の in-flight ロック（SK=`CHATLOCK`）。条件付き取得（`attribute_not_exists OR ExpiresAt < now`）で 2 本目以降は HTTP 429。`finally` で解放、`ExpiresAt`/`TTL` でクラッシュ時の自動失効も担保。
- **適用順**: ロック取得 → レート制限。並行で 429 拒否されたリクエストがレート枠を消費しない。
- **障害時フェイルオープン**: ガードの DynamoDB 呼び出しが失敗した場合は警告ログを残してバイパス（保護目的のためベストエフォート）。
- **タイムアウト**: サーバ側の決定論的タイムアウトは持たず、上流クライアント（OpenAI SDK / VOICEVOX）の既存タイムアウトに委譲。これに伴いロックの `ExpiresAt` 窓を 10 分に設定。

### スコープ外（意図的な見送り）

- **OpenAI 利用額ガード（budget alert 等）**: AWS/CDK では制御できず OpenAI コンソール側の運用設定領域のため見送り。

## dev 検証結果

integration ブランチ（dev 自動デプロイ）で実挙動を確認済み：

- レート制限カウンタ（1m/1h）が会話数ぶん正しく加算、TTL も妥当。
- 並行ロックは実行中だけ存在し、完了後に解放（オーファンなし）。
- 並行拒否はレート枠を消費しない（適用順入れ替えが有効）。
- 並行ガードの 429（前リクエスト処理中の再送拒否）も意図どおり発火。

## 関連 Issue

- サブ Issue: #3528（本 PR で develop へ。サブ Issue は手動クローズ運用のため `Closes` は付与しない）
- 親 Issue: #3521（他のサブ Issue #3529–#3532 が未完のため、本 PR ではクローズしない）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した（core にロジック＋リポジトリ、route は配線のみ／エラーメッセージ日本語＋定数化）
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（※コードで自明な範囲のため docs 追従は不要と判断）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）※該当なし
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `services/livetalk/core`: 1209 tests / 79 suites 全パス（カバレッジ閾値クリア）
- `services/livetalk/web`: 573 tests / 58 suites 全パス（カバレッジ閾値クリア）
- 観点: レート上限ちょうど/超過、ウィンドウ跨ぎのリセット、並行ロックの取得競合（2 本目拒否）、`ExpiresAt` 失効後の奪取、`ownerToken` 不一致時の削除スキップ、フェイルオープン、適用順（ロック競合時にレートカウンタを消費しない）。
- dev 環境で DynamoDB のアイテム（RATELIMIT/CHATLOCK）と実挙動を確認済み。

## レビューポイント

- フェイルオープン方針（DynamoDB 障害時にチャットを止めず通す）。
- ロック `ExpiresAt` = 10 分（上流の最大ストリーム時間を上回らせ、正常ロックの奪取を防ぐ）。
- 適用順（ロック→レート）でレート枠を保護。
- IAM 変更なし（既存 `grantReadWriteData` が必要アクションを網羅）。

## 補足事項

- integration → develop の取り込み。develop 反映後、dev 反映を確認のうえサブ Issue #3528 を手動クローズします。
- develop との試験マージはコンフリクトなしを確認済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_013cgEDdDY9ZDRBpQNJxyLvm)_