### PR TITLE
[リブトーク] output_moderation 時の音声・会話履歴すり抜けを修正（develop 取り込み）

### DIFF
--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -163,19 +163,27 @@ async function synthesizeSentence(
 /**
  * 文字列を文単位でストリーム風に yield しながら同時に TTS 合成を行う。
  * セーフティ介入テキストを音声付きで送出するために使う。
+ *
+ * @param options.emitText - true（デフォルト）のとき text イベントを yield する。
+ *   output_moderation フラグ時は false を指定して text イベントを抑制する（表示は safety
+ *   イベントの replacementText に任せ、ストリーム済みの元テキストへの追記を防ぐ）。
  */
 async function* streamSafetyText(
   text: string,
   voiceClient: IVoiceClient,
-  voice: VoiceConfig
+  voice: VoiceConfig,
+  options?: { emitText?: boolean }
 ): AsyncGenerator<ChatEvent> {
+  const emitText = options?.emitText ?? true;
   const buffer = new SentenceBuffer();
   const pendingSynthesis: Array<Promise<SynthesisResult>> = [];
   let sentenceIndex = 0;
 
   // 1 文字ずつ yield してテキストストリーム風に見せる（セーフティ応答は固定文なので全体を送る）
   for (const char of text) {
-    yield { type: 'text', delta: char };
+    if (emitText) {
+      yield { type: 'text', delta: char };
+    }
     for (const sentence of buffer.push(char)) {
       const idx = sentenceIndex++;
       pendingSynthesis.push(synthesizeSentence(voiceClient, sentence, voice, idx));
@@ -599,22 +607,22 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
     pendingSynthesis.push(synthesizeSentence(voiceClient, remaining, character.voiceConfig, idx));
   }
 
-  // 7. sentence events を順番通りに yield（TTS 合計レイテンシを集計）
-  let ttsTotalMs = 0;
-  for (const promise of pendingSynthesis) {
-    const result = await promise;
-    ttsTotalMs += result.elapsedMs;
-    if (result.audio !== null) {
-      yield { type: 'sentence', index: result.index, text: result.text, audio: result.audio };
-    }
-  }
-  metrics.latency.ttsTotal = ttsTotalMs > 0 ? ttsTotalMs : undefined;
+  // 7. Moderation API チェック（fail-warn: エラー時は通常応答を通す）
+  //
+  // 【修正: 音声 emit より前に判定する】
+  // 旧実装では sentence(音声) emit 後に Moderation 判定していたため、フラグ時も
+  // 元返答の音声がすでに送出済みになるすり抜けバグがあった。
+  // 修正後: LLM 完了・sentenceBuffer flush の直後、かつ pendingSynthesis を await する前に
+  // Moderation を判定し、フラグ有無で sentence 送出経路を切り替える。
+  let moderationFlagged = false;
+  let moderationReplacement: string | undefined;
 
-  // 8. Moderation API チェック（fail-warn: エラー時は通常応答を通す）
   if (moderationClient && fullResponseText.trim()) {
     try {
       const modResult = await moderationClient.check(fullResponseText);
       if (modResult.flagged) {
+        moderationFlagged = true;
+
         const flaggedCategories = Object.entries(modResult.categories)
           .filter(([, v]) => v)
           .map(([k]) => k);
@@ -634,12 +642,13 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
           }
         }
 
-        const replacementText = buildModerationReplacementMessage(Date.now());
+        moderationReplacement = buildModerationReplacementMessage(Date.now());
+        // safety イベント（表示の差し替え + モーダル）を先に送出
         yield {
           type: 'safety',
           trigger: 'output_moderation',
           resources: SAFETY_RESOURCES,
-          replacementText,
+          replacementText: moderationReplacement,
         };
       }
     } catch (err) {
@@ -649,6 +658,30 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
       });
     }
   }
+
+  // 8. sentence events を順番通りに yield（TTS 合計レイテンシを集計）
+  //
+  // フラグなし: pendingSynthesis（元返答）をそのまま emit。
+  // フラグあり: 元返答の pendingSynthesis は emit せず（合成はすでに非同期起動済みだが
+  //   unhandled rejection は synthesizeSentence 内部で catch 済みのため安全）、
+  //   置換文を streamSafetyText で TTS 化して sentence events として送出する。
+  //   text イベントは出さない（表示は safety イベントの replacementText 置換に任せる）。
+  let ttsTotalMs = 0;
+  if (!moderationFlagged) {
+    for (const promise of pendingSynthesis) {
+      const result = await promise;
+      ttsTotalMs += result.elapsedMs;
+      if (result.audio !== null) {
+        yield { type: 'sentence', index: result.index, text: result.text, audio: result.audio };
+      }
+    }
+  } else {
+    // 置換文を音声化して sentence として送出（text イベントは抑制）
+    yield* streamSafetyText(moderationReplacement!, voiceClient, character.voiceConfig, {
+      emitText: false,
+    });
+  }
+  metrics.latency.ttsTotal = ttsTotalMs > 0 ? ttsTotalMs : undefined;
 
   // 9. done
   metrics.latency.chatTotal = Math.round(performance.now() - chatStart);
@@ -663,7 +696,8 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
   }
 
   // 10. アシスタントメッセージを保存
-  const assistantText = fullResponseText.trim();
+  // フラグ時は置換文を保存（元の有害テキストを会話履歴に残さない）
+  const assistantText = (moderationFlagged ? moderationReplacement : fullResponseText)?.trim();
   if (assistantText) {
     try {
       await messageRepository.create({

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -960,6 +960,201 @@ describe('runChatUseCase', () => {
     });
   });
 
+  // ── 音声すり抜けバグ修正テスト（output_moderation フラグ時の音声制御） ─────────
+
+  describe('output_moderation フラグ時の音声すり抜け防止', () => {
+    it('フラグ時、元返答テキストを含む sentence イベントが emit されない', async () => {
+      const originalText = '元の危険な応答テキストです。';
+      const llm = makeLLMClient([originalText]);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const moderation = makeModerationClient(true, { 'self-harm': true });
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          moderationClient: moderation,
+        })
+      );
+
+      const sentenceEvents = events.filter((e) => e.type === 'sentence');
+      // 元返答テキストを含む sentence イベントが存在しないこと
+      const hasOriginalText = sentenceEvents.some(
+        (e) => e.type === 'sentence' && e.text === originalText
+      );
+      expect(hasOriginalText).toBe(false);
+    });
+
+    it('フラグ時、置換文の sentence イベントが emit される', async () => {
+      const llm = makeLLMClient(['元の危険な応答。']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const moderation = makeModerationClient(true, { 'self-harm': true });
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          moderationClient: moderation,
+        })
+      );
+
+      const sentenceEvents = events.filter((e) => e.type === 'sentence');
+      // 置換文の sentence イベントが存在すること
+      expect(sentenceEvents.length).toBeGreaterThan(0);
+      // safety イベントの replacementText と sentence イベントのテキストが対応していること
+      const safetyEvent = events.find((e) => e.type === 'safety');
+      expect(safetyEvent?.type).toBe('safety');
+      if (safetyEvent?.type === 'safety') {
+        const replacementText = safetyEvent.replacementText!;
+        // sentence イベントは置換文を分割したものなので、sentence テキストの結合が置換文に一致するか
+        // または置換文そのものが sentence として送出される（1 文の場合）
+        const sentenceTexts = sentenceEvents
+          .filter((e) => e.type === 'sentence')
+          .map((e) => (e.type === 'sentence' ? e.text : ''));
+        const joinedSentences = sentenceTexts.join('');
+        expect(joinedSentences).toBe(replacementText);
+      }
+    });
+
+    it('フラグ時、safety イベントが sentence イベントより前に emit される（イベント順序）', async () => {
+      const llm = makeLLMClient(['危険なコンテンツを含む応答です。']);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const moderation = makeModerationClient(true, { violence: true });
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          moderationClient: moderation,
+        })
+      );
+
+      const safetyIdx = events.findIndex((e) => e.type === 'safety');
+      const firstSentenceIdx = events.findIndex((e) => e.type === 'sentence');
+
+      expect(safetyIdx).toBeGreaterThanOrEqual(0);
+      expect(firstSentenceIdx).toBeGreaterThan(safetyIdx);
+    });
+
+    it('フラグ時、保存される assistant message が置換文である（元返答ではない）', async () => {
+      const originalText = '有害な応答テキストです。';
+      const llm = makeLLMClient([originalText]);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const moderation = makeModerationClient(true, { harassment: true });
+
+      await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          moderationClient: moderation,
+        })
+      );
+
+      // messageRepository.create の呼び出し引数を確認
+      const createCalls = (repo.create as jest.Mock).mock.calls;
+      // assistant ロールの保存呼び出しを探す
+      const assistantCall = createCalls.find(
+        (args: Array<{ Role: string; Text: string }>) => args[0]?.Role === 'assistant'
+      );
+      expect(assistantCall).toBeDefined();
+      const savedText: string = assistantCall[0].Text;
+      // 元返答ではなく置換文が保存されていること
+      expect(savedText).not.toBe(originalText.trim());
+      // 置換文は MODERATION_REPLACEMENT_MESSAGES のいずれかに一致すること
+      expect(savedText.length).toBeGreaterThan(0);
+    });
+
+    it('フラグなし（回帰）: 元返答の sentence イベントが emit され、assistant message に元返答が保存される', async () => {
+      const originalText = '通常の安全な応答テキストです。';
+      const llm = makeLLMClient([originalText]);
+      const voice = makeVoiceClient();
+      const repo = makeRepo();
+      const moderation = makeModerationClient(false);
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          moderationClient: moderation,
+        })
+      );
+
+      // safety イベントなし
+      expect(events.find((e) => e.type === 'safety')).toBeUndefined();
+
+      // 元返答テキストを含む sentence イベントが存在すること
+      const sentenceEvents = events.filter((e) => e.type === 'sentence');
+      expect(sentenceEvents.length).toBeGreaterThan(0);
+      const hasOriginalText = sentenceEvents.some(
+        (e) => e.type === 'sentence' && e.text === originalText
+      );
+      expect(hasOriginalText).toBe(true);
+
+      // assistant message に元返答が保存されていること
+      const createCalls = (repo.create as jest.Mock).mock.calls;
+      const assistantCall = createCalls.find(
+        (args: Array<{ Role: string; Text: string }>) => args[0]?.Role === 'assistant'
+      );
+      expect(assistantCall).toBeDefined();
+      expect(assistantCall[0].Text).toBe(originalText.trim());
+    });
+
+    it('フラグ時、元返答テキストで合成された音声の sentence イベントが emit されない（音声すり抜け防止の直接検証）', async () => {
+      // LLM ストリーム中に非同期で TTS 合成が起動されるが（仕様上許容）、
+      // フラグ時はその音声を sentence として emit せず、置換文の音声のみを emit することを確認する。
+      // voice.synthesize の引数（テキスト）を記録し、sentence イベントのテキストと突き合わせる。
+      const originalText = '危険な応答テキスト。';
+      const synthesizeArgs: string[] = [];
+      const voice: IVoiceClient = {
+        synthesize: jest.fn(async (text: string) => {
+          synthesizeArgs.push(text);
+          return new ArrayBuffer(4);
+        }),
+      };
+      const llm = makeLLMClient([originalText]);
+      const repo = makeRepo();
+      const moderation = makeModerationClient(true, { 'self-harm': true });
+
+      const events = await collectEvents(
+        runChatUseCase({
+          ...baseParams,
+          llmClient: llm,
+          voiceClient: voice,
+          messageRepository: repo,
+          moderationClient: moderation,
+        })
+      );
+
+      // sentence として emit されたテキスト一覧
+      const sentenceTexts = events
+        .filter((e) => e.type === 'sentence')
+        .map((e) => (e.type === 'sentence' ? e.text : ''));
+
+      // 元返答テキストが sentence として emit されていないこと
+      expect(sentenceTexts).not.toContain(originalText);
+
+      // フラグ時、sentence として emit されるのは置換文のみ（空でないこと）
+      expect(sentenceTexts.length).toBeGreaterThan(0);
+      sentenceTexts.forEach((text) => {
+        expect(text).not.toBe(originalText);
+      });
+    });
+  });
+
   // ── Phase 3d: 暗黙確認・訂正検出 ───────────────────────────────────────────
 
   describe('暗黙訂正検出（Phase 3d）', () => {

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -1,5 +1,6 @@
 import { runChatUseCase, type ChatEvent } from '../../../src/usecases/chat-usecase.js';
 import { hiyori } from '../../../src/characters/hiyori.js';
+import { MODERATION_REPLACEMENT_MESSAGES } from '../../../src/safety/templates.js';
 import type { ILLMClient } from '../../../src/llm-client/types.js';
 import type { IVoiceClient } from '../../../src/voice/types.js';
 import type { MemoryRepository } from '../../../src/repositories/memory.repository.interface.js';
@@ -1073,7 +1074,7 @@ describe('runChatUseCase', () => {
       // 元返答ではなく置換文が保存されていること
       expect(savedText).not.toBe(originalText.trim());
       // 置換文は MODERATION_REPLACEMENT_MESSAGES のいずれかに一致すること
-      expect(savedText.length).toBeGreaterThan(0);
+      expect(MODERATION_REPLACEMENT_MESSAGES).toContain(savedText);
     });
 
     it('フラグなし（回帰）: 元返答の sentence イベントが emit され、assistant message に元返答が保存される', async () => {


### PR DESCRIPTION
## 変更の概要

リブトークの出力モデレーション（`output_moderation`）でフラグされた際に、**元の有害な応答が音声で読み上げられ、かつ会話履歴にも保存されてしまう**すり抜けバグを修正する（integration/3558-safety-audio の develop への取り込み）。

旧実装は Moderation 判定を音声 emit の**後**に行っていたため、フラグが出る頃には元返答の音声がすでに emit 済みで、`replacementText` は表示テキストを差し替えるだけだった。結果、**画面は置換文／音声は元の危険な返答**という齟齬が起き、さらにアシスタントメッセージ保存も元返答のままで会話履歴・次回 LLM 文脈に混入していた。

### 修正方針

- Moderation 判定を音声 emit の**前**に移動。
- フラグあり → `safety` イベント（表示差し替え＋モーダル）を先に送り、**置換文を音声化**して emit。元返答の音声は emit しない（`streamSafetyText` に `emitText: false` を追加）。
- アシスタントメッセージ保存時、フラグ時は置換文を保存（元の有害テキストを履歴に残さない）。
- 監査用 `SafetyEvent.ResponseText` には元原文を保持（「何が弾かれたか」は監査ログに残し、会話履歴には残さない分離）。

## 関連 Issue

Closes #3558

## 変更種別

- [x] バグ修正

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（コードで自明な挙動修正のため docs 追従は不要と判断）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

`services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts` に `output_moderation フラグ時の音声すり抜け防止` を追加（計 68 件 PASS）。

- フラグ時、元返答テキストを含む `sentence`（音声）が emit されない
- フラグ時、置換文の `sentence`（音声）が emit され、結合テキストが置換文に一致
- フラグ時、`safety`(output_moderation) が `sentence` より前に emit される（順序検証）
- フラグ時、保存される assistant message が置換文テンプレート（`MODERATION_REPLACEMENT_MESSAGES`）に一致
- フラグなし（回帰）: 元返答の `sentence` が emit され、assistant message に元返答が保存される

## dev 環境での検証結果

integration ブランチ（dev 自動デプロイ）で実際に `output_moderation` を発火させ、DynamoDB（`nagiyu-livetalk-dynamodb-dev`）を照合して確認済み。

- 新規 `SafetyEvent`（`Trigger=output_moderation`, violence）が記録され、モデレーション経路が発火したことを確認。
- 同ターンの保存 assistant メッセージ（`Message`）の `Text` が**置換文**（「ごめんね、さっきの言葉…」）で、**元原文（格ゲー比喩の威勢のいい応答）は履歴に残っていない**ことを確認 → 履歴すり抜けの修正が機能。
- `SafetyEvent.ResponseText` には監査用に元原文が保持されていることを確認（監査と履歴の分離が成立）。
- 音声側も、原文ではなく置換文が読み上げられることを確認。

## レビューポイント

- Moderation 判定 → 音声 emit の順序変更で、フラグ時に元返答の音声・履歴が一切漏れないこと。
- `streamSafetyText` の `emitText` オプション追加が既存呼び出し元（`input_keyword` / `study` 経路）の挙動を変えていないこと。

## 補足事項

- **既知の残存（#3355 へ先送り合意済み）**: フラグ時も LLM ストリーミング中の `text` は逐次表示されるため、元テキストが一瞬画面に出てから置換文へ切り替わるフラッシュが残る。修正前からの既存挙動で、完全解消には非ストリーミング化（#3355 の領域）が必要なため本対応の対象外。
- **モデレーションの過検出（据え置き）**: 比喩的な violence 表現（「ぶった斬る」等）を `violence` 単独で介入対象にしている点は false positive 寄りだが、本 PR のスコープ外として据え置き。本 PR は「介入すると決めた時の漏れ」を塞ぐもので直交する。


---
_Generated by [Claude Code](https://claude.ai/code/session_01SBEwGZ6gXxwk769VmVzVBm)_