### PR TITLE
Portal: AdSense 審査中の仕込み改善（dev noindex / GA 記載整合 / 特集記事）

### DIFF
--- a/infra/common/src/constants/defaults.ts
+++ b/infra/common/src/constants/defaults.ts
@@ -43,6 +43,7 @@ export const DEFAULT_CLOUDFRONT_CONFIG: Required<
   enableHttp2: true,
   enableHttp3: true,
   priceClass: 'PriceClass_100',
+  noindex: false,
 };
 
 /**

--- a/infra/common/src/stacks/cloudfront-stack-base.ts
+++ b/infra/common/src/stacks/cloudfront-stack-base.ts
@@ -142,40 +142,53 @@ export class CloudFrontStackBase extends cdk.Stack {
       ssm.StringParameter.valueForStringParameter(this, SSM_PARAMETERS.ACM_CERTIFICATE_ARN);
     const certificate = acm.Certificate.fromCertificateArn(this, 'Certificate', certArn);
 
-    // セキュリティヘッダーポリシーの作成
-    if (config.enableSecurityHeaders) {
+    // セキュリティヘッダーポリシーの作成（セキュリティヘッダーまたは noindex のいずれかが有効な場合）
+    if (config.enableSecurityHeaders || config.noindex) {
       this.responseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
         this,
         'SecurityHeadersPolicy',
         {
           responseHeadersPolicyName: `nagiyu-${serviceName}-security-headers-${environment}`,
           comment: `Security headers for ${serviceName} service (${environment})`,
-          securityHeadersBehavior: {
-            strictTransportSecurity: {
-              accessControlMaxAge: cdk.Duration.seconds(
-                SECURITY_HEADERS.strictTransportSecurity.accessControlMaxAge
-              ),
-              includeSubdomains: SECURITY_HEADERS.strictTransportSecurity.includeSubdomains,
-              preload: SECURITY_HEADERS.strictTransportSecurity.preload,
-              override: SECURITY_HEADERS.strictTransportSecurity.override,
+          ...(config.enableSecurityHeaders && {
+            securityHeadersBehavior: {
+              strictTransportSecurity: {
+                accessControlMaxAge: cdk.Duration.seconds(
+                  SECURITY_HEADERS.strictTransportSecurity.accessControlMaxAge
+                ),
+                includeSubdomains: SECURITY_HEADERS.strictTransportSecurity.includeSubdomains,
+                preload: SECURITY_HEADERS.strictTransportSecurity.preload,
+                override: SECURITY_HEADERS.strictTransportSecurity.override,
+              },
+              contentTypeOptions: {
+                override: SECURITY_HEADERS.contentTypeOptions.override,
+              },
+              frameOptions: {
+                frameOption: cloudfront.HeadersFrameOption.DENY,
+                override: SECURITY_HEADERS.frameOptions.override,
+              },
+              xssProtection: {
+                protection: SECURITY_HEADERS.xssProtection.protection,
+                modeBlock: SECURITY_HEADERS.xssProtection.modeBlock,
+                override: SECURITY_HEADERS.xssProtection.override,
+              },
+              referrerPolicy: {
+                referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+                override: SECURITY_HEADERS.referrerPolicy.override,
+              },
             },
-            contentTypeOptions: {
-              override: SECURITY_HEADERS.contentTypeOptions.override,
+          }),
+          ...(config.noindex && {
+            customHeadersBehavior: {
+              customHeaders: [
+                {
+                  header: 'X-Robots-Tag',
+                  value: 'noindex, nofollow',
+                  override: true,
+                },
+              ],
             },
-            frameOptions: {
-              frameOption: cloudfront.HeadersFrameOption.DENY,
-              override: SECURITY_HEADERS.frameOptions.override,
-            },
-            xssProtection: {
-              protection: SECURITY_HEADERS.xssProtection.protection,
-              modeBlock: SECURITY_HEADERS.xssProtection.modeBlock,
-              override: SECURITY_HEADERS.xssProtection.override,
-            },
-            referrerPolicy: {
-              referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-              override: SECURITY_HEADERS.referrerPolicy.override,
-            },
-          },
+          }),
         }
       );
     }

--- a/infra/common/src/types/cloudfront-config.ts
+++ b/infra/common/src/types/cloudfront-config.ts
@@ -44,6 +44,12 @@ export interface CloudFrontConfig {
   priceClass?: string;
 
   /**
+   * 検索エンジンにインデックスさせない環境（dev 等）で X-Robots-Tag: noindex, nofollow を付与する
+   * @default false
+   */
+  noindex?: boolean;
+
+  /**
    * カスタム動作の追加設定
    */
   additionalBehaviors?: Record<string, unknown>;

--- a/infra/common/tests/unit/defaults.test.ts
+++ b/infra/common/tests/unit/defaults.test.ts
@@ -31,6 +31,10 @@ describe('defaults', () => {
       expect(DEFAULT_CLOUDFRONT_CONFIG.enableHttp3).toBe(true);
       expect(DEFAULT_CLOUDFRONT_CONFIG.priceClass).toBe('PriceClass_100');
     });
+
+    it('noindex のデフォルト値が false である', () => {
+      expect(DEFAULT_CLOUDFRONT_CONFIG.noindex).toBe(false);
+    });
   });
 
   describe('mergeConfig', () => {

--- a/infra/common/tests/unit/stacks/cloudfront-stack-base.test.ts
+++ b/infra/common/tests/unit/stacks/cloudfront-stack-base.test.ts
@@ -185,6 +185,88 @@ describe('CloudFrontStackBase', () => {
       template.resourceCountIs('AWS::CloudFront::ResponseHeadersPolicy', 0);
     });
 
+    it('noindex: true のとき ResponseHeadersPolicy に X-Robots-Tag カスタムヘッダーが含まれる', () => {
+      // Arrange & Act
+      const stack = new CloudFrontStackBase(app, 'TestCloudFrontStack', {
+        serviceName: 'portal',
+        environment: 'dev',
+        functionUrl: 'https://example.lambda-url.ap-northeast-1.on.aws/',
+        certificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/test',
+        cloudfrontConfig: {
+          noindex: true,
+        },
+      });
+
+      // Assert
+      const template = Template.fromStack(stack);
+      template.resourceCountIs('AWS::CloudFront::ResponseHeadersPolicy', 1);
+      template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+        ResponseHeadersPolicyConfig: {
+          CustomHeadersConfig: {
+            Items: Match.arrayWith([
+              {
+                Header: 'X-Robots-Tag',
+                Value: 'noindex, nofollow',
+                Override: true,
+              },
+            ]),
+          },
+        },
+      });
+    });
+
+    it('デフォルト（noindex 未指定）では X-Robots-Tag カスタムヘッダーが含まれない', () => {
+      // Arrange & Act
+      const stack = new CloudFrontStackBase(app, 'TestCloudFrontStack', {
+        serviceName: 'tools',
+        environment: 'dev',
+        functionUrl: 'https://example.lambda-url.ap-northeast-1.on.aws/',
+        certificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/test',
+      });
+
+      // Assert
+      const template = Template.fromStack(stack);
+      const templateJson = JSON.stringify(template.toJSON());
+      expect(templateJson).not.toContain('X-Robots-Tag');
+    });
+
+    it('enableSecurityHeaders: false かつ noindex: true のときポリシーが作成されカスタムヘッダーのみ持つ', () => {
+      // Arrange & Act
+      const stack = new CloudFrontStackBase(app, 'TestCloudFrontStack', {
+        serviceName: 'portal',
+        environment: 'dev',
+        functionUrl: 'https://example.lambda-url.ap-northeast-1.on.aws/',
+        certificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/test',
+        cloudfrontConfig: {
+          enableSecurityHeaders: false,
+          noindex: true,
+        },
+      });
+
+      // Assert
+      const template = Template.fromStack(stack);
+      // ポリシーが 1 つ作成される
+      template.resourceCountIs('AWS::CloudFront::ResponseHeadersPolicy', 1);
+      // X-Robots-Tag カスタムヘッダーが存在する
+      template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+        ResponseHeadersPolicyConfig: {
+          CustomHeadersConfig: {
+            Items: Match.arrayWith([
+              {
+                Header: 'X-Robots-Tag',
+                Value: 'noindex, nofollow',
+                Override: true,
+              },
+            ]),
+          },
+        },
+      });
+      // SecurityHeadersConfig が存在しない
+      const templateJson = JSON.stringify(template.toJSON());
+      expect(templateJson).not.toContain('SecurityHeadersConfig');
+      expect(templateJson).not.toContain('StrictTransportSecurity');
+    });
+
     it('should support TLS 1.3', () => {
       // Arrange & Act
       const stack = new CloudFrontStackBase(app, 'TestCloudFrontStack', {

--- a/infra/root/cloudfront-lambda-stack.ts
+++ b/infra/root/cloudfront-lambda-stack.ts
@@ -28,6 +28,7 @@ export class CloudFrontLambdaStack extends CloudFrontStackBase {
       cloudfrontConfig: {
         domainName,
         enableSecurityHeaders: true,
+        noindex: environment !== 'prod',
       },
     };
 

--- a/services/portal/web/src/app/about/page.tsx
+++ b/services/portal/web/src/app/about/page.tsx
@@ -201,8 +201,8 @@ export default function AboutPage() {
           プライバシーとセキュリティ
         </Typography>
         <Typography variant="body1" sx={{ mb: 2 }}>
-          ユーザーのプライバシーを最優先に考えています。 Google Analytics
-          による匿名のアクセス統計と、Google AdSense による広告配信のみ行っています。
+          ユーザーのプライバシーを最優先に考えています。外部サービスの利用は Google AdSense
+          による広告配信のみです。
         </Typography>
         <Typography variant="body2" color="text.secondary">
           詳細は <Link href="/privacy">プライバシーポリシー</Link> をご確認ください。

--- a/services/portal/web/src/content/tech/cdk-iam-least-privilege.md
+++ b/services/portal/web/src/content/tech/cdk-iam-least-privilege.md
@@ -7,6 +7,7 @@ updatedAt: '2026-05-31'
 author: 'なぎゆー'
 tags: ['AWS', 'CDK', 'IAM', 'セキュリティ']
 categories: ['aws']
+featured: true
 ---
 
 ## はじめに

--- a/services/portal/web/src/content/tech/github-actions-monorepo-deploy.md
+++ b/services/portal/web/src/content/tech/github-actions-monorepo-deploy.md
@@ -7,6 +7,7 @@ updatedAt: '2026-06-06'
 author: 'なぎゆー'
 tags: ['GitHub Actions', 'CI/CD', 'monorepo']
 categories: ['dev-stack']
+featured: true
 ---
 
 ## はじめに


### PR DESCRIPTION
## 変更の概要

AdSense 再審査中に仕込める軽量改善 3 項目を、項目別コミットで実装した。

1. **dev 環境の noindex 化**: infra-common の CloudFront 設定にオプトインの `noindex` オプションを追加し、有効時に ResponseHeadersPolicy で `X-Robots-Tag: noindex, nofollow` を付与する。Portal の CloudFront スタックで `environment !== 'prod'` のとき有効化し、dev.nagiyu.com（本番と同一内容で全クロール許可だった）をインデックス対象外にする。**robots.txt は意図的に `Allow: /` のまま**（Disallow するとクローラがヘッダーを読めなくなるため）
2. **About ページの GA 記載修正**: 未実装の Google Analytics への言及を削除し、外部サービス利用は Google AdSense のみという実態に合わせた
3. **特集記事の反映**: `featured: true` が 0 本でトップページの特集セクションが非表示のままだったため、運営者選定の 2 本（`cdk-iam-least-privilege` / `github-actions-monorepo-deploy`）に設定

## 関連 Issue

#3561（`Closes` は使用しない。本 Issue は申請台帳を兼ねるため、dev 反映確認後も運営者が記録に使用する）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（対象なし。docs 追従判断は develop 反映後に実施）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）→ 該当なし
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- infra/common: 9 suites / 87 tests 全パス（カバレッジ Stmts 96.31% / Branch 90.16%）
  - `noindex: true` で ResponseHeadersPolicy に `X-Robots-Tag` カスタムヘッダーが含まれる
  - デフォルト（未指定）では `X-Robots-Tag` が含まれない
  - `enableSecurityHeaders: false` かつ `noindex: true` でポリシーが作成され、セキュリティヘッダーなしでカスタムヘッダーのみ持つ
  - `DEFAULT_CLOUDFRONT_CONFIG.noindex` のデフォルトが `false`
- services/portal/web: 11 suites / 289 tests 全パス（カバレッジ Stmts 99.72% / Branch 96.51%）

## レビューポイント

- `cloudfront-stack-base.ts` の ResponseHeadersPolicy 生成条件を `enableSecurityHeaders || noindex` に変更した。既存サービス（noindex 未指定）は挙動不変だが、共有スタック基盤の変更のため影響範囲の確認をお願いしたい
- dev の robots.txt を Disallow にしない判断（noindex ヘッダーをクローラに読ませるため Allow を維持）が意図どおりか
- About の修正文言「外部サービスの利用は Google AdSense による広告配信のみです。」が実態と合っているか

## スクリーンショット（該当する場合）

UI 変更は About の 1 文修正と、トップページ特集セクションの表示開始（既存実装の `featured: true` 0 件 → 2 件化）のみ。

## 補足事項

- dev 反映後、`curl -sI https://dev.nagiyu.com/ | grep -i x-robots` で `X-Robots-Tag: noindex, nofollow` が返ること、本番相当（nagiyu.com）には付与されないことを確認する
- 申請台帳（GSC 登録・申請日・不合格文面の記録）は #3561 本文を参照

https://claude.ai/code/session_01JgqzF32HehierGTeGm4GGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgqzF32HehierGTeGm4GGm)_