### PR TITLE
docs: infra-common README に CloudFront noindex オプションを追記

### DIFF
--- a/docs/infra/common/README.md
+++ b/docs/infra/common/README.md
@@ -405,13 +405,14 @@ const responseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(this, 'Securi
 
 ### CloudFront
 
-| 設定項目              | デフォルト値   | 説明                         |
-| --------------------- | -------------- | ---------------------------- |
-| enableSecurityHeaders | true           | セキュリティヘッダーの有効化 |
-| minimumTlsVersion     | 1.2            | 最小 TLS バージョン          |
-| enableHttp2           | true           | HTTP/2 の有効化              |
-| enableHttp3           | true           | HTTP/3 の有効化              |
-| priceClass            | PriceClass_100 | 価格クラス                   |
+| 設定項目              | デフォルト値   | 説明                                                                                                       |
+| --------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- |
+| enableSecurityHeaders | true           | セキュリティヘッダーの有効化                                                                               |
+| minimumTlsVersion     | 1.2            | 最小 TLS バージョン                                                                                        |
+| enableHttp2           | true           | HTTP/2 の有効化                                                                                            |
+| enableHttp3           | true           | HTTP/3 の有効化                                                                                            |
+| priceClass            | PriceClass_100 | 価格クラス                                                                                                 |
+| noindex               | false          | `X-Robots-Tag: noindex, nofollow` の付与（dev 等の非本番環境を検索エンジンのインデックス対象から外す用途） |
 
 ## セキュリティヘッダー一覧
 


### PR DESCRIPTION
## 変更の概要

PR #3563（dev 環境の noindex 化）で infra-common の CloudFront 設定に追加した `noindex` オプションを、`docs/infra/common/README.md` の CloudFront デフォルト値一覧に追記する。設定オプションの一覧表が実装と乖離するのを防ぐドキュメント追従のみの変更。

## 関連 Issue

#3561（`Closes` は使用しない。本 Issue は申請台帳を兼ねるため運営者が継続使用する）

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した → ドキュメントのみのため該当なし
- [x] 関連ドキュメントを更新した
- [ ] CI/CD 設定を追加・更新した → 該当なし
- [ ] ローカルでテストが全て通ることを確認した → コード変更なし
- [x] ビルドエラーがないことを確認した（Prettier チェック通過）

## テスト内容

- `npx prettier --check docs/infra/common/README.md` 通過（表の整形崩れなし）

## レビューポイント

- 表の説明文の粒度が既存行と揃っているか

## スクリーンショット（該当する場合)

該当なし（ドキュメントのみ）

## 補足事項

- 非デプロイの軽量変更のため integration は切らず develop 直接

https://claude.ai/code/session_01JgqzF32HehierGTeGm4GGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgqzF32HehierGTeGm4GGm)_