### PR TITLE
Portal: 撤廃記事の 301 リダイレクトと Portal 以外の全サブドメイン noindex（AdSense 第 2 弾）

### DIFF
--- a/.github/workflows/ui-storybook-verify.yml
+++ b/.github/workflows/ui-storybook-verify.yml
@@ -30,7 +30,7 @@ jobs:
           cache-dependency-path: './package-lock.json'
 
       - name: Format Check
-        run: npx prettier --check "infra/ui-storybook/**/*.{ts,js,json}"
+        run: npm run format:check --workspace=@nagiyu/infra-ui-storybook
 
       - name: Test
         run: npm run test --workspace=@nagiyu/infra-ui-storybook

--- a/.github/workflows/ui-storybook-verify.yml
+++ b/.github/workflows/ui-storybook-verify.yml
@@ -1,0 +1,39 @@
+name: UI Storybook Infra - Verification
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - integration/**
+    paths:
+      - 'infra/ui-storybook/**'
+      - 'infra/common/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ui-storybook-verify.yml'
+
+jobs:
+  verify:
+    name: Verify infra/ui-storybook
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js and install dependencies
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: '24'
+          cache-dependency-path: './package-lock.json'
+
+      - name: Format Check
+        run: npx prettier --check "infra/ui-storybook/**/*.{ts,js,json}"
+
+      - name: Test
+        run: npm run test --workspace=@nagiyu/infra-ui-storybook
+
+      - name: Build
+        run: npm run build --workspace=@nagiyu/infra-ui-storybook

--- a/infra/admin/lib/cloudfront-stack.ts
+++ b/infra/admin/lib/cloudfront-stack.ts
@@ -24,6 +24,8 @@ export class CloudFrontStack extends CloudFrontStackBase {
         priceClass: environment === 'prod' ? 'PriceClass_All' : 'PriceClass_100',
         // HTTP/3 を有効化（既存設定を維持）
         enableHttp3: true,
+        // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+        noindex: true,
       },
     };
 

--- a/infra/auth/lib/cloudfront-stack.ts
+++ b/infra/auth/lib/cloudfront-stack.ts
@@ -24,6 +24,8 @@ export class CloudFrontStack extends CloudFrontStackBase {
         priceClass: environment === 'prod' ? 'PriceClass_All' : 'PriceClass_100',
         // HTTP/3 を有効化（既存設定を維持）
         enableHttp3: true,
+        // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+        noindex: true,
       },
     };
 

--- a/infra/codec-converter/lib/codec-converter-stack.ts
+++ b/infra/codec-converter/lib/codec-converter-stack.ts
@@ -352,6 +352,25 @@ export class CodecConverterStack extends cdk.Stack {
           ? `codec-converter.${baseDomain}`
           : `${envName}-codec-converter.${baseDomain}`;
 
+      // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+      const noindexHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+        this,
+        'NoindexHeadersPolicy',
+        {
+          responseHeadersPolicyName: `nagiyu-codec-converter-noindex-${envName}`,
+          comment: `X-Robots-Tag: noindex, nofollow for codec-converter (${envName})`,
+          customHeadersBehavior: {
+            customHeaders: [
+              {
+                header: 'X-Robots-Tag',
+                value: 'noindex, nofollow',
+                override: true,
+              },
+            ],
+          },
+        }
+      );
+
       // CloudFront Distribution
       const distribution = new cloudfront.Distribution(this, 'Distribution', {
         comment: `Codec Converter distribution for ${envName}`,
@@ -363,6 +382,7 @@ export class CodecConverterStack extends cdk.Stack {
           allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          responseHeadersPolicy: noindexHeadersPolicy,
           compress: true,
         },
         additionalBehaviors: {
@@ -372,6 +392,7 @@ export class CodecConverterStack extends cdk.Stack {
             allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
             cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
             originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+            responseHeadersPolicy: noindexHeadersPolicy,
             compress: true,
           },
           '/_next/static/*': {
@@ -383,6 +404,7 @@ export class CodecConverterStack extends cdk.Stack {
               maxTtl: cdk.Duration.days(365),
               minTtl: cdk.Duration.days(365),
             }),
+            responseHeadersPolicy: noindexHeadersPolicy,
             compress: true,
           },
           '/favicon.ico': {
@@ -394,6 +416,7 @@ export class CodecConverterStack extends cdk.Stack {
               maxTtl: cdk.Duration.days(1),
               minTtl: cdk.Duration.days(1),
             }),
+            responseHeadersPolicy: noindexHeadersPolicy,
             compress: true,
           },
         },

--- a/infra/codec-converter/test/codec-converter.test.ts
+++ b/infra/codec-converter/test/codec-converter.test.ts
@@ -202,3 +202,38 @@ test('Lambda has Batch permissions', () => {
     },
   });
 });
+
+test('X-Robots-Tag: noindex, nofollow ヘッダーポリシーが作成される', () => {
+  const { stack } = createTestStack();
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+    ResponseHeadersPolicyConfig: Match.objectLike({
+      Name: Match.stringLikeRegexp('nagiyu-codec-converter-noindex-.*'),
+      CustomHeadersConfig: {
+        Items: Match.arrayWith([
+          {
+            Header: 'X-Robots-Tag',
+            Value: 'noindex, nofollow',
+            Override: true,
+          },
+        ]),
+      },
+    }),
+  });
+});
+
+test('CloudFront defaultBehavior に X-Robots-Tag ヘッダーポリシーが適用される', () => {
+  const { stack } = createTestStack();
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::CloudFront::Distribution', {
+    DistributionConfig: Match.objectLike({
+      DefaultCacheBehavior: Match.objectLike({
+        ResponseHeadersPolicyId: Match.objectLike({
+          Ref: Match.stringLikeRegexp('^NoindexHeadersPolicy'),
+        }),
+      }),
+    }),
+  });
+});

--- a/infra/livetalk/lib/cloudfront-stack.ts
+++ b/infra/livetalk/lib/cloudfront-stack.ts
@@ -59,11 +59,7 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
       this,
       SSM_PARAMETERS.ACM_CERTIFICATE_ARN
     );
-    const certificate = acm.Certificate.fromCertificateArn(
-      this,
-      'Certificate',
-      certificateArn
-    );
+    const certificate = acm.Certificate.fromCertificateArn(this, 'Certificate', certificateArn);
 
     const albDnsName = ssm.StringParameter.valueForStringParameter(
       this,
@@ -129,8 +125,7 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
         allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
         cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-        originRequestPolicy:
-          cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
         responseHeadersPolicy: noindexHeadersPolicy,
         compress: true,
       },

--- a/infra/livetalk/lib/cloudfront-stack.ts
+++ b/infra/livetalk/lib/cloudfront-stack.ts
@@ -90,6 +90,25 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
       ),
     });
 
+    // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+    const noindexHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+      this,
+      'NoindexHeadersPolicy',
+      {
+        responseHeadersPolicyName: `nagiyu-livetalk-noindex-${environment}`,
+        comment: `X-Robots-Tag: noindex, nofollow for livetalk (${environment})`,
+        customHeadersBehavior: {
+          customHeaders: [
+            {
+              header: 'X-Robots-Tag',
+              value: 'noindex, nofollow',
+              override: true,
+            },
+          ],
+        },
+      }
+    );
+
     this.distribution = new cloudfront.Distribution(this, 'Distribution', {
       comment: `LiveTalk Service Distribution (${environment})`,
       domainNames: [customDomain],
@@ -112,6 +131,7 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
         originRequestPolicy:
           cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        responseHeadersPolicy: noindexHeadersPolicy,
         compress: true,
       },
       additionalBehaviors: {
@@ -121,6 +141,7 @@ export class LiveTalkCloudFrontStack extends cdk.Stack {
           allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
           cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          responseHeadersPolicy: noindexHeadersPolicy,
           compress: true,
           functionAssociations: [
             {

--- a/infra/livetalk/tests/unit/cloudfront-stack.test.js
+++ b/infra/livetalk/tests/unit/cloudfront-stack.test.js
@@ -299,4 +299,61 @@ describe('LiveTalkCloudFrontStack', () => {
       }),
     });
   });
+
+  it('X-Robots-Tag: noindex, nofollow ヘッダーポリシーが作成されること', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+      ResponseHeadersPolicyConfig: Match.objectLike({
+        Name: 'nagiyu-livetalk-noindex-dev',
+        CustomHeadersConfig: {
+          Items: Match.arrayWith([
+            {
+              Header: 'X-Robots-Tag',
+              Value: 'noindex, nofollow',
+              Override: true,
+            },
+          ]),
+        },
+      }),
+    });
+  });
+
+  it('defaultBehavior に X-Robots-Tag ヘッダーポリシーが適用されること', () => {
+    const template = synth('dev');
+    // ResponseHeadersPolicy の論理 ID を含む参照が DefaultCacheBehavior に存在することを確認
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          ResponseHeadersPolicyId: Match.objectLike({
+            Ref: Match.stringLikeRegexp('^NoindexHeadersPolicy'),
+          }),
+        }),
+      }),
+    });
+  });
+
+  it('/assets/* ビヘイビアにも X-Robots-Tag ヘッダーポリシーが適用されること', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        CacheBehaviors: Match.arrayWith([
+          Match.objectLike({
+            PathPattern: '/assets/*',
+            ResponseHeadersPolicyId: Match.objectLike({
+              Ref: Match.stringLikeRegexp('^NoindexHeadersPolicy'),
+            }),
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it('prod 環境でも X-Robots-Tag ヘッダーポリシー名に prod が含まれること', () => {
+    const template = synth('prod');
+    template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+      ResponseHeadersPolicyConfig: Match.objectLike({
+        Name: 'nagiyu-livetalk-noindex-prod',
+      }),
+    });
+  });
 });

--- a/infra/niconico-mylist-assistant/lib/cloudfront-stack.ts
+++ b/infra/niconico-mylist-assistant/lib/cloudfront-stack.ts
@@ -21,12 +21,12 @@ export class CloudFrontStack extends CloudFrontStackBase {
       serviceName: 'niconico-mylist-assistant',
       environment: environment as 'dev' | 'prod',
       functionUrl,
-      cloudfrontConfig:
-        environment === 'prod'
-          ? {
-              priceClass: 'PriceClass_All',
-            }
-          : undefined,
+      cloudfrontConfig: {
+        // prod 環境ではグローバル配信（全リージョン）
+        ...(environment === 'prod' ? { priceClass: 'PriceClass_All' } : {}),
+        // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+        noindex: true,
+      },
     };
 
     super(scope, id, baseProps);

--- a/infra/quick-clip/lib/cloudfront-stack.ts
+++ b/infra/quick-clip/lib/cloudfront-stack.ts
@@ -21,6 +21,8 @@ export class CloudFrontStack extends CloudFrontStackBase {
         // Route53/ACM は CloudFrontStackBase が参照する共通パラメータに依存する。
         // そのため quick-clip 側ではドメイン名のみ指定し、証明書/レコードは共有基盤設定に従う。
         domainName: environment === 'prod' ? 'quick-clip.nagiyu.com' : 'dev-quick-clip.nagiyu.com',
+        // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+        noindex: true,
       },
     };
 

--- a/infra/share-together/lib/cloudfront-stack.ts
+++ b/infra/share-together/lib/cloudfront-stack.ts
@@ -21,6 +21,8 @@ export class CloudFrontStack extends CloudFrontStackBase {
           environment === 'prod'
             ? 'share-together.nagiyu.com'
             : 'dev-share-together.nagiyu.com',
+        // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+        noindex: true,
       },
     };
 

--- a/infra/share-together/lib/cloudfront-stack.ts
+++ b/infra/share-together/lib/cloudfront-stack.ts
@@ -18,9 +18,7 @@ export class CloudFrontStack extends CloudFrontStackBase {
       functionUrl,
       cloudfrontConfig: {
         domainName:
-          environment === 'prod'
-            ? 'share-together.nagiyu.com'
-            : 'dev-share-together.nagiyu.com',
+          environment === 'prod' ? 'share-together.nagiyu.com' : 'dev-share-together.nagiyu.com',
         // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
         noindex: true,
       },

--- a/infra/stock-tracker/lib/cloudfront-stack.ts
+++ b/infra/stock-tracker/lib/cloudfront-stack.ts
@@ -22,6 +22,8 @@ export class CloudFrontStack extends CloudFrontStackBase {
       serviceName: 'stock-tracker',
       environment: environment as 'dev' | 'prod',
       functionUrl,
+      // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+      cloudfrontConfig: { noindex: true },
     };
 
     super(scope, id, baseProps);

--- a/infra/tools/lib/cloudfront-stack.ts
+++ b/infra/tools/lib/cloudfront-stack.ts
@@ -20,6 +20,8 @@ export class CloudFrontStack extends CloudFrontStackBase {
       cloudfrontConfig: {
         // セキュリティヘッダーを有効化（新規追加）
         enableSecurityHeaders: true,
+        // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+        noindex: true,
       },
     };
 

--- a/infra/ui-storybook/jest.config.js
+++ b/infra/ui-storybook/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.{js,ts}'],
+  modulePathIgnorePatterns: ['<rootDir>/../../package.json'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }],
+  },
+};

--- a/infra/ui-storybook/lib/storybook-stack.ts
+++ b/infra/ui-storybook/lib/storybook-stack.ts
@@ -64,6 +64,25 @@ export class StorybookStack extends cdk.Stack {
     );
     const certificate = acm.Certificate.fromCertificateArn(this, 'Certificate', certificateArn);
 
+    // 検索エンジンにインデックスさせない（Portal 以外は常に noindex）
+    const noindexHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+      this,
+      'NoindexHeadersPolicy',
+      {
+        responseHeadersPolicyName: `nagiyu-ui-storybook-noindex-${environment}`,
+        comment: `X-Robots-Tag: noindex, nofollow for ui-storybook (${environment})`,
+        customHeadersBehavior: {
+          customHeaders: [
+            {
+              header: 'X-Robots-Tag',
+              value: 'noindex, nofollow',
+              override: true,
+            },
+          ],
+        },
+      }
+    );
+
     // CloudFront ディストリビューション
     // - S3 オリジン (Origin Access Control 自動構成)
     // - 静的サイト用キャッシュ最適化
@@ -75,6 +94,7 @@ export class StorybookStack extends cdk.Stack {
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
         cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
         cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        responseHeadersPolicy: noindexHeadersPolicy,
         compress: true,
       },
       defaultRootObject: 'index.html',

--- a/infra/ui-storybook/package.json
+++ b/infra/ui-storybook/package.json
@@ -7,6 +7,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "cdk": "npx cdk",
     "bootstrap": "npx cdk bootstrap",
     "synth": "npx cdk synth",

--- a/infra/ui-storybook/package.json
+++ b/infra/ui-storybook/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
+    "test": "jest",
     "cdk": "npx cdk",
     "bootstrap": "npx cdk bootstrap",
     "synth": "npx cdk synth",
@@ -19,5 +20,8 @@
     "aws-cdk-lib": "^2.258.0",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21"
+  },
+  "devDependencies": {
+    "ts-jest": "^29.4.11"
   }
 }

--- a/infra/ui-storybook/tests/unit/storybook-stack.test.js
+++ b/infra/ui-storybook/tests/unit/storybook-stack.test.js
@@ -1,0 +1,153 @@
+const cdk = require('aws-cdk-lib');
+const { Template, Match } = require('aws-cdk-lib/assertions');
+const fs = require('fs');
+const path = require('path');
+
+require('ts-node/register/transpile-only');
+const { StorybookStack } = require('../../lib/storybook-stack');
+
+// BucketDeployment は Source.asset() のパスが存在しないと CDK synth で失敗するため
+// テスト実行前にダミーの storybook-static ディレクトリを一時作成する
+const STORYBOOK_STATIC_DIR = path.join(__dirname, '../../../../libs/ui/storybook-static');
+let createdDir = false;
+
+beforeAll(() => {
+  if (!fs.existsSync(STORYBOOK_STATIC_DIR)) {
+    fs.mkdirSync(STORYBOOK_STATIC_DIR, { recursive: true });
+    createdDir = true;
+  }
+});
+
+afterAll(() => {
+  if (createdDir) {
+    fs.rmdirSync(STORYBOOK_STATIC_DIR);
+  }
+});
+
+const STACK_ENV = { account: '000000000000', region: 'us-east-1' };
+
+const synth = () => {
+  const app = new cdk.App();
+  const stack = new StorybookStack(app, 'TestStorybookStack', {
+    environment: 'dev',
+    env: STACK_ENV,
+  });
+  return Template.fromStack(stack);
+};
+
+describe('StorybookStack', () => {
+  it('dev-storybook.nagiyu.com を Aliases に設定する', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        Aliases: ['dev-storybook.nagiyu.com'],
+      }),
+    });
+  });
+
+  it('S3 バケットを Block Public Access + S3 マネージド暗号化で作成する', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: 'nagiyu-ui-storybook-s3-dev',
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+    });
+  });
+
+  it('CloudFront Distribution が作成されること', () => {
+    const template = synth();
+    template.resourceCountIs('AWS::CloudFront::Distribution', 1);
+  });
+
+  it('Viewer Protocol Policy を REDIRECT_TO_HTTPS で構成する', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          ViewerProtocolPolicy: 'redirect-to-https',
+        }),
+      }),
+    });
+  });
+
+  it('TLS 1.2 以上の MinimumProtocolVersion を設定する', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        ViewerCertificate: Match.objectLike({
+          MinimumProtocolVersion: 'TLSv1.2_2021',
+        }),
+      }),
+    });
+  });
+
+  it('価格クラスを PriceClass_100 に設定する', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        PriceClass: 'PriceClass_100',
+      }),
+    });
+  });
+
+  it('HTTP/2 + HTTP/3 を有効化する', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        HttpVersion: 'http2and3',
+        IPV6Enabled: true,
+      }),
+    });
+  });
+
+  it('Route53 ALIAS A レコードを dev-storybook で作成する', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::Route53::RecordSet', {
+      Type: 'A',
+      Name: {
+        'Fn::Join': ['', Match.arrayWith(['dev-storybook.'])],
+      },
+    });
+  });
+
+  it('X-Robots-Tag: noindex, nofollow ヘッダーポリシーが作成されること', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+      ResponseHeadersPolicyConfig: Match.objectLike({
+        Name: 'nagiyu-ui-storybook-noindex-dev',
+        CustomHeadersConfig: {
+          Items: Match.arrayWith([
+            {
+              Header: 'X-Robots-Tag',
+              Value: 'noindex, nofollow',
+              Override: true,
+            },
+          ]),
+        },
+      }),
+    });
+  });
+
+  it('defaultBehavior に X-Robots-Tag ヘッダーポリシーが適用されること', () => {
+    const template = synth();
+    template.hasResourceProperties('AWS::CloudFront::Distribution', {
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          ResponseHeadersPolicyId: Match.objectLike({
+            Ref: Match.stringLikeRegexp('^NoindexHeadersPolicy'),
+          }),
+        }),
+      }),
+    });
+  });
+
+  it('ACM 証明書を SSM パラメータから参照する', () => {
+    const template = synth();
+    const templateJson = JSON.stringify(template.toJSON());
+    expect(templateJson).toContain('/nagiyu/shared/acm/certificate-arn');
+  });
+});

--- a/infra/ui-storybook/tsconfig.json
+++ b/infra/ui-storybook/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "./dist",
     "rootDir": "."
   },
-  "include": ["bin/**/*", "lib/**/*"],
+  "include": ["bin/**/*", "lib/**/*", "tests/**/*"],
   "exclude": ["node_modules", "cdk.out"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,6 +238,9 @@
         "aws-cdk-lib": "^2.258.0",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
+      },
+      "devDependencies": {
+        "ts-jest": "^29.4.11"
       }
     },
     "libs/aws": {
@@ -14473,6 +14476,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14494,6 +14498,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14515,6 +14520,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14536,6 +14542,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14557,6 +14564,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14578,6 +14586,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14599,6 +14608,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14620,6 +14630,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14641,6 +14652,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14662,6 +14674,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -14683,6 +14696,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/services/portal/web/next.config.ts
+++ b/services/portal/web/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from 'next';
 import path from 'path';
+import { buildRedirects } from './src/lib/redirects';
 
 const nextConfig: NextConfig = {
   output: 'standalone', // Lambda デプロイ用
@@ -11,6 +12,10 @@ const nextConfig: NextConfig = {
   // Keep isomorphic-dompurify (and its jsdom dependency) as native Node.js modules
   // to avoid webpack bundling issues with jsdom's __dirname-based CSS file loading
   serverExternalPackages: ['isomorphic-dompurify'],
+  // 撤廃記事の 301 リダイレクト（SEO 整備）
+  async redirects() {
+    return buildRedirects();
+  },
 };
 
 export default nextConfig;

--- a/services/portal/web/src/lib/redirects.ts
+++ b/services/portal/web/src/lib/redirects.ts
@@ -1,0 +1,65 @@
+import type { Redirect } from 'next/dist/lib/load-custom-routes';
+
+/**
+ * 撤廃記事から新しいコンテンツへの恒久リダイレクトマッピング
+ *
+ * 旧 URL が 404 で残存しているため、301 リダイレクトで検索インデックスを整備する。
+ * source: 旧記事 URL（撤廃済み）
+ * destination: 移転先コンテンツ URL（実在する記事・カテゴリ・サービス）
+ */
+export const RETIRED_ARTICLE_REDIRECTS: ReadonlyArray<{
+  source: string;
+  destination: string;
+}> = [
+  {
+    source: '/tech/eventbridge-scheduler',
+    destination: '/tech/eventbridge-rule-scheduling',
+  },
+  {
+    source: '/tech/aws-batch-parallelism',
+    destination: '/tech/aws-batch-architecture',
+  },
+  {
+    source: '/tech/cloudfront-functions-vs-edge',
+    destination: '/tech/cloudfront-cache-strategy',
+  },
+  {
+    source: '/tech/aws-ses-transactional-mail',
+    destination: '/tech/category/aws',
+  },
+  {
+    source: '/tech/aws-waf-protection',
+    destination: '/tech/category/aws',
+  },
+  {
+    source: '/tech/cognito-oauth-implementation',
+    destination: '/tech/category/aws',
+  },
+  {
+    source: '/tech/vapid-web-push',
+    destination: '/tech/category/dev-stack',
+  },
+  {
+    source: '/tech/web-push-server-implementation',
+    destination: '/tech/category/dev-stack',
+  },
+  {
+    source: '/tech/video-codec-comparison',
+    destination: '/services/codec-converter',
+  },
+  {
+    source: '/tech/zod-runtime-validation',
+    destination: '/tech/discriminated-union-api',
+  },
+] as const;
+
+/**
+ * Next.js redirects() 関数に渡す形式に変換する
+ */
+export function buildRedirects(): Redirect[] {
+  return RETIRED_ARTICLE_REDIRECTS.map(({ source, destination }) => ({
+    source,
+    destination,
+    permanent: true,
+  }));
+}

--- a/services/portal/web/tests/unit/lib/redirects.test.ts
+++ b/services/portal/web/tests/unit/lib/redirects.test.ts
@@ -1,0 +1,137 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { RETIRED_ARTICLE_REDIRECTS, buildRedirects } from '../../../src/lib/redirects';
+
+/**
+ * src/content/tech/ 配下の .md ファイルから slug 一覧を取得するヘルパー
+ */
+function getActualArticleSlugs(): Set<string> {
+  const techDir = path.join(process.cwd(), 'src', 'content', 'tech');
+  const files = fs.readdirSync(techDir).filter((f) => f.endsWith('.md'));
+  return new Set(files.map((f) => f.replace(/\.md$/, '')));
+}
+
+/**
+ * src/content/tech-category/ 配下の .md ファイルから slug 一覧を取得するヘルパー
+ */
+function getActualCategorySlugs(): Set<string> {
+  const categoryDir = path.join(process.cwd(), 'src', 'content', 'tech-category');
+  const files = fs.readdirSync(categoryDir).filter((f) => f.endsWith('.md'));
+  return new Set(files.map((f) => f.replace(/\.md$/, '')));
+}
+
+/**
+ * src/content/services/ 配下のディレクトリ名からサービス slug 一覧を取得するヘルパー
+ */
+function getActualServiceSlugs(): Set<string> {
+  const servicesDir = path.join(process.cwd(), 'src', 'content', 'services');
+  const entries = fs.readdirSync(servicesDir, { withFileTypes: true });
+  return new Set(entries.filter((e) => e.isDirectory()).map((e) => e.name));
+}
+
+describe('RETIRED_ARTICLE_REDIRECTS', () => {
+  describe('source の重複・競合チェック', () => {
+    it('source に現存する記事 slug と重複がないこと', () => {
+      const articleSlugs = getActualArticleSlugs();
+      const conflictingSources = RETIRED_ARTICLE_REDIRECTS.filter(({ source }) => {
+        // source は /tech/{slug} 形式
+        const match = source.match(/^\/tech\/([^/]+)$/);
+        if (!match) return false;
+        return articleSlugs.has(match[1]);
+      });
+
+      expect(conflictingSources).toHaveLength(0);
+    });
+
+    it('source の重複がないこと', () => {
+      const sources = RETIRED_ARTICLE_REDIRECTS.map(({ source }) => source);
+      const uniqueSources = new Set(sources);
+      expect(uniqueSources.size).toBe(sources.length);
+    });
+  });
+
+  describe('destination の実在チェック', () => {
+    it('/tech/{slug} 形式の destination に実在する記事 slug が対応していること', () => {
+      const articleSlugs = getActualArticleSlugs();
+      const techArticleDestinations = RETIRED_ARTICLE_REDIRECTS.filter(({ destination }) =>
+        /^\/tech\/[^/]+$/.test(destination)
+      ).filter(({ destination }) => {
+        // /tech/category/* は除外
+        return !destination.startsWith('/tech/category/');
+      });
+
+      const notFound = techArticleDestinations.filter(({ destination }) => {
+        const slug = destination.replace('/tech/', '');
+        return !articleSlugs.has(slug);
+      });
+
+      expect(notFound).toHaveLength(0);
+    });
+
+    it('/tech/category/{slug} 形式の destination に実在するカテゴリ slug が対応していること', () => {
+      const categorySlugs = getActualCategorySlugs();
+      const categoryDestinations = RETIRED_ARTICLE_REDIRECTS.filter(({ destination }) =>
+        /^\/tech\/category\/[^/]+$/.test(destination)
+      );
+
+      const notFound = categoryDestinations.filter(({ destination }) => {
+        const slug = destination.replace('/tech/category/', '');
+        return !categorySlugs.has(slug);
+      });
+
+      expect(notFound).toHaveLength(0);
+    });
+
+    it('/services/{slug} 形式の destination に実在するサービス slug が対応していること', () => {
+      const serviceSlugs = getActualServiceSlugs();
+      const serviceDestinations = RETIRED_ARTICLE_REDIRECTS.filter(({ destination }) =>
+        /^\/services\/[^/]+$/.test(destination)
+      );
+
+      const notFound = serviceDestinations.filter(({ destination }) => {
+        const slug = destination.replace('/services/', '');
+        return !serviceSlugs.has(slug);
+      });
+
+      expect(notFound).toHaveLength(0);
+    });
+  });
+
+  describe('マッピング件数', () => {
+    it('10 件のリダイレクトが定義されていること', () => {
+      expect(RETIRED_ARTICLE_REDIRECTS).toHaveLength(10);
+    });
+  });
+});
+
+describe('buildRedirects', () => {
+  it('permanent: true の Next.js Redirect 配列を返すこと', () => {
+    const redirects = buildRedirects();
+
+    expect(redirects.length).toBe(RETIRED_ARTICLE_REDIRECTS.length);
+    for (const redirect of redirects) {
+      expect(redirect.permanent).toBe(true);
+      expect(typeof redirect.source).toBe('string');
+      expect(typeof redirect.destination).toBe('string');
+    }
+  });
+
+  it('buildRedirects() の source/destination が RETIRED_ARTICLE_REDIRECTS と一致すること', () => {
+    const redirects = buildRedirects();
+
+    RETIRED_ARTICLE_REDIRECTS.forEach(({ source, destination }, index) => {
+      expect(redirects[index].source).toBe(source);
+      expect(redirects[index].destination).toBe(destination);
+    });
+  });
+
+  it('特定のリダイレクトが含まれること（スモークテスト）', () => {
+    const redirects = buildRedirects();
+    const redirectMap = new Map(redirects.map((r) => [r.source, r.destination]));
+
+    expect(redirectMap.get('/tech/eventbridge-scheduler')).toBe('/tech/eventbridge-rule-scheduling');
+    expect(redirectMap.get('/tech/video-codec-comparison')).toBe('/services/codec-converter');
+    expect(redirectMap.get('/tech/zod-runtime-validation')).toBe('/tech/discriminated-union-api');
+    expect(redirectMap.get('/tech/aws-ses-transactional-mail')).toBe('/tech/category/aws');
+  });
+});

--- a/services/portal/web/tests/unit/lib/redirects.test.ts
+++ b/services/portal/web/tests/unit/lib/redirects.test.ts
@@ -129,7 +129,9 @@ describe('buildRedirects', () => {
     const redirects = buildRedirects();
     const redirectMap = new Map(redirects.map((r) => [r.source, r.destination]));
 
-    expect(redirectMap.get('/tech/eventbridge-scheduler')).toBe('/tech/eventbridge-rule-scheduling');
+    expect(redirectMap.get('/tech/eventbridge-scheduler')).toBe(
+      '/tech/eventbridge-rule-scheduling'
+    );
     expect(redirectMap.get('/tech/video-codec-comparison')).toBe('/services/codec-converter');
     expect(redirectMap.get('/tech/zod-runtime-validation')).toBe('/tech/discriminated-union-api');
     expect(redirectMap.get('/tech/aws-ses-transactional-mail')).toBe('/tech/category/aws');


### PR DESCRIPTION
## 変更の概要

AdSense 審査対応の第 2 弾（#3561 スコープ 4〜5）。GSC ドメインプロパティのインデックスカバレッジ実測で判明した事実に基づく対応。

1. **撤廃記事 10 本の 301 リダイレクト**: GSC で既知 URL の 1/4（12 件）が 404 のまま残存していたため、`next.config.ts` の `redirects()` で書き直し先の記事・近接記事・カテゴリハブへ恒久リダイレクトする。マッピングは `src/lib/redirects.ts` に定数として分離
2. **Portal 以外の全サブドメインに `X-Robots-Tag: noindex, nofollow` を付与**: AdSense の審査・サイト管理はルートドメイン単位のため、検索インデックスに出すのは Portal（nagiyu.com）のみとする。GSC 実測で stock-tracker のログイン必須ページがソフト 404 判定、dev-share-together 等がクロールされている事実も確認済み
   - CloudFrontStackBase 利用の 7 サービス（admin / auth / quick-clip / share-together / tools / stock-tracker / niconico-mylist-assistant）: infra-common の `noindex: true` を環境を問わず指定
   - 独自実装の 3 スタック（livetalk / codec-converter / ui-storybook）: `X-Robots-Tag` カスタムヘッダーのみ持つ ResponseHeadersPolicy を作成し全ビヘイビアに適用
3. **ui-storybook の infra 検証ワークフローを新設**（`ui-storybook-verify.yml`）: これまで ui-storybook はデプロイ専用ワークフローのみで検証 CI が無く、本 PR で新設した `infra/ui-storybook/tests/` が CI で実行されない状態だったため、`infra-common-verify.yml` をモデルに Format Check + Test + Build を追加

## 関連 Issue

#3561（`Closes` は使用しない。本 Issue は申請台帳を兼ねるため運営者が継続使用する）

## 変更種別

- [x] 新規機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] CI/CD 更新
- [x] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した → docs 追従判断は develop 反映後に実施
- [x] CI/CD 設定を追加・更新した（ui-storybook に test script / jest 設定 / verify ワークフローを新設。テストパターンは livetalk と同一）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した（infra 全体 `tsc --noEmit` クリア）

## テスト内容

- **portal web**: 12 suites / 298 tests 全パス（カバレッジ閾値クリア）。新規 `redirects.test.ts` で「各 destination が実在する記事 slug・カテゴリ slug・サービス slug に対応」「source が現存記事と重複しない」ことを検証
- **infra/livetalk**: 119 tests 全パス（X-Robots-Tag アサーション 5 件追加）
- **infra/codec-converter**: 13 tests 全パス（同 2 件追加）
- **infra/ui-storybook**: 11 tests 新設・全パス（新設の verify ワークフローで CI 実行）
- **infra/common**: 87 tests 全パス（変更なし・回帰確認）

## レビューポイント

- **アプリ系サブドメインを本番含めて全 noindex にする方針**（運営者合意済み）: tools 等が検索結果から消えていく。検索流入は Portal に集約する割り切り
- 301 のマッピング先の妥当性（特に `video-codec-comparison → /services/codec-converter`、`zod-runtime-validation → /tech/discriminated-union-api`）
- `package-lock.json` の差分は ui-storybook への ts-jest 追加（livetalk と同一版）と、lock 再生成に伴う既知の `"peer": true` メタデータ揺れ

## スクリーンショット（該当する場合）

UI 変更なし（リダイレクトとレスポンスヘッダーのみ）

## 補足事項

- dev 反映後の確認コマンド: `curl -sI https://dev-tools.nagiyu.com/ | grep -i x-robots` 等（各サブドメイン）。本番側は master 反映後に同様に確認
- GSC 実測値・経緯は #3561 本文の「スコープ第 2 弾」「申請台帳」を参照

https://claude.ai/code/session_01JgqzF32HehierGTeGm4GGm