### PR TITLE
リブトーク: データ取得系 useEffect を custom hook に切り出す（#3529 Phase 2）

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { Box, Container, Stack, Typography } from '@mui/material';
 import { Link } from '@nagiyu/ui';
@@ -12,38 +11,23 @@ import CharacterCanvas from '@/components/CharacterCanvas';
 import ConsentModal from '@/components/ConsentModal';
 import SafetyModal from '@/components/SafetyModal';
 import NotificationToggle from '@/components/NotificationToggle';
-import type { LifecycleState, SafetyResource } from '@nagiyu/livetalk-core';
+import type { SafetyResource } from '@nagiyu/livetalk-core';
 import InstallGuide from '@/components/InstallGuide';
 import NotificationPermission from '@/components/NotificationPermission';
 import CharacterSelectButton from '@/components/CharacterSelectButton';
 import { useCharacter } from '@/lib/characters/CharacterContext';
 import { getCharacterDisplay, hasCharacterProfile } from '@/lib/characters/client-profiles';
-import {
-  isStandalone,
-  isPushSupported,
-  shouldShowInstallGuide,
-  shouldShowNotificationPermission,
-} from '@/lib/pwa/standalone';
-import { PWA_MESSAGES } from '@/lib/pwa/messages';
 import { reportClientError } from '@/lib/client-logger';
 import { useAudioContext } from '@/lib/audio/useAudioContext';
 import { useAudioQueue } from '@/lib/audio/useAudioQueue';
-
-/**
- * pending API のレスポンス型（キャラクターごとの未消化通知）。
- */
-interface PendingNotification {
-  /** 通知元キャラクター ID */
-  characterId: string;
-  /** 通知 ID */
-  notifId: string;
-  /** 通知本文 */
-  body: string;
-}
+import { useConsent } from '@/lib/home/useConsent';
+import { useOnboarding } from '@/lib/home/useOnboarding';
+import { useFirstWord } from '@/lib/home/useFirstWord';
+import { usePendingNotifications } from '@/lib/home/usePendingNotifications';
+import { useLifecycle } from '@/lib/home/useLifecycle';
+import { useCharacterQuerySync } from '@/lib/home/useCharacterQuerySync';
 
 type ChatPhase = 'idle' | 'loading' | 'streaming';
-type ConsentPhase = 'checking' | 'required' | 'done';
-type OnboardingPhase = 'install' | 'notification' | null;
 
 type ChatStreamEvent =
   | { type: 'text'; delta: string }
@@ -54,7 +38,7 @@ type ChatStreamEvent =
       resources: SafetyResource[];
       replacementText?: string;
     }
-  | { type: 'lifecycle'; state: LifecycleState }
+  | { type: 'lifecycle'; state: import('@nagiyu/livetalk-core').LifecycleState }
   | { type: 'done' }
   | { type: 'error'; message: string };
 
@@ -80,8 +64,7 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
  * （App Router の prerender 要件。下部の default export でラップする）。
  */
 function HomePageInner() {
-  const { characterId, setCharacterId } = useCharacter();
-  const searchParams = useSearchParams();
+  const { characterId } = useCharacter();
   const { data: session } = useSession();
   const isAdmin =
     !!session?.user &&
@@ -89,28 +72,13 @@ function HomePageInner() {
     Array.isArray(session.user.roles) &&
     hasPermission(session.user.roles, 'livetalk:admin');
 
-  const [consentPhase, setConsentPhase] = useState<ConsentPhase>('checking');
-  const [onboardingPhase, setOnboardingPhase] = useState<OnboardingPhase>(null);
-  const [onboardingText, setOnboardingText] = useState<string | null>(null);
   const [phase, setPhase] = useState<ChatPhase>('idle');
   const [userText, setUserText] = useState<string | null>(null);
   const [responseText, setResponseText] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  // 通知タップ起動時に入力欄へプリフィルするサジェスト発話
-  const [prefillText, setPrefillText] = useState<string | null>(null);
 
   const [safetyOpen, setSafetyOpen] = useState(false);
   const [safetyResources, setSafetyResources] = useState<SafetyResource[]>([]);
-  const [lifecycleState, setLifecycleState] = useState<LifecycleState>('awake');
-
-  // キャラ第一声（未消化の通知から表示）
-  const [firstWordText, setFirstWordText] = useState<string | null>(null);
-  // 第一声の元となった KnowledgeID（次の chat 送信時に文脈として渡す）
-  const firstWordKnowledgeIdRef = useRef<string | null>(null);
-  // 第一声の通知元キャラクター ID（クロス汚染防止のためカレントと照合する）
-  const firstWordCharacterIdRef = useRef<string | null>(null);
-  // 他キャラクターの未消化通知（自前起動時に提示する）
-  const [pendingNotifications, setPendingNotifications] = useState<PendingNotification[]>([]);
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const sentenceReceivedRef = useRef(0);
@@ -128,136 +96,31 @@ function HomePageInner() {
     handlePlaybackError: advanceOnError,
   } = useAudioQueue({ onDrained: () => setPhase('idle') });
 
-  useEffect(() => {
-    fetch('/api/consent')
-      .then((res) => res.json())
-      .then((data: { consented: boolean }) => {
-        setConsentPhase(data.consented ? 'done' : 'required');
-      })
-      .catch(() => {
-        // 取得失敗時はモーダルを表示してユーザーに同意を促す
-        setConsentPhase('required');
-      });
-  }, []);
+  // URL クエリパラメータ ?character=<id> をカレントキャラクターに反映する
+  useCharacterQuerySync();
 
-  // push クリック起動時: URL の ?character=<id> を読み、カレントキャラを切替える。
-  // searchParams は Next.js の useSearchParams で取得。
-  // 依存配列に searchParams を含めることで、SPA 遷移でも正しく動作する。
-  useEffect(() => {
-    const characterQuery = searchParams.get('character');
-    if (characterQuery && hasCharacterProfile(characterQuery)) {
-      setCharacterId(characterQuery);
-    }
-    // searchParams の変化のみに依存する（setCharacterId は安定した関数参照）
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  // 同意状態管理 hook
+  const { consentPhase, markConsented } = useConsent();
 
-  // カレント characterId の未消化通知を第一声として取得・表示する。
-  // characterId が変わるたびに再取得し、前のキャラの knowledgeId をクリアする。
-  useEffect(() => {
-    // キャラクター切替時は前のキャラの第一声 knowledgeId をクリアする（クロス汚染防止）
-    firstWordKnowledgeIdRef.current = null;
-    firstWordCharacterIdRef.current = null;
-    setFirstWordText(null);
+  // オンボーディング管理 hook（consentPhase 依存）
+  const {
+    onboardingPhase,
+    onboardingText,
+    clearOnboardingText,
+    handleInstallSkip,
+    handleNotificationGranted,
+    handleNotificationSkip,
+  } = useOnboarding(consentPhase);
 
-    fetch(`/api/push/first-word?characterId=${encodeURIComponent(characterId)}`)
-      .then((res) => (res.ok ? res.json() : null))
-      .then(
-        (
-          data: {
-            notifId: string;
-            body: string;
-            knowledgeId?: string | null;
-            characterId: string;
-            suggestedReply?: string | null;
-          } | null
-        ) => {
-          if (!data) return;
-          setFirstWordText(data.body);
-          firstWordKnowledgeIdRef.current = data.knowledgeId ?? null;
-          // 通知元キャラクター ID を保存（クロス汚染防止のためカレントと照合する）
-          firstWordCharacterIdRef.current = data.characterId;
-          // 通知タップ起動時（from=push）かつ suggestedReply がある場合は入力欄へプリフィル
-          if (searchParams.get('from') === 'push' && data.suggestedReply) {
-            setPrefillText(data.suggestedReply);
-          }
-          // 消化済みマーク
-          fetch('/api/push/consumed', {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ notifId: data.notifId }),
-          }).catch(() => {});
-        }
-      )
-      .catch(() => {});
-  }, [characterId]);
+  // カレントキャラの第一声（未消化通知）管理 hook
+  const { firstWordText, prefillText, consumeKnowledgeId, clearFirstWordText } =
+    useFirstWord(characterId);
 
-  // 自前起動時: カレント以外に未消化通知があれば提示する。
-  // このエフェクトはマウント時（初回起動）にのみ実行する。
-  useEffect(() => {
-    fetch('/api/push/pending')
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: PendingNotification[] | null) => {
-        if (!data || data.length === 0) return;
-        setPendingNotifications(data);
-      })
-      .catch(() => {});
-    // マウント時のみ実行（依存配列は空）
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // 他キャラクターの未消化通知管理 hook
+  const { pendingNotifications } = usePendingNotifications();
 
-  // 同意完了後にオンボーディング（ホーム画面追加・通知許可）の表示要否を判定する。
-  useEffect(() => {
-    if (consentPhase !== 'done') return;
-    if (!isStandalone() && shouldShowInstallGuide()) {
-      setOnboardingPhase('install');
-      setOnboardingText(PWA_MESSAGES.INSTALL_PROMPT);
-    } else if (
-      isStandalone() &&
-      isPushSupported() &&
-      typeof window !== 'undefined' &&
-      window.Notification.permission !== 'granted' &&
-      shouldShowNotificationPermission()
-    ) {
-      setOnboardingPhase('notification');
-      setOnboardingText(PWA_MESSAGES.NOTIFICATION_PROMPT);
-    }
-  }, [consentPhase]);
-
-  // 起動時・キャラ切替時に生活サイクル状態を取得し、初回発話を待たずに Live2D へ反映する。
-  // 失敗時は現状維持（'awake'）。演出のための取得なので UI は止めない。
-  useEffect(() => {
-    fetch(`/api/lifecycle?characterId=${encodeURIComponent(characterId)}`)
-      .then((res) => res.json())
-      .then((data: { state: LifecycleState }) => {
-        if (data.state === 'awake' || data.state === 'sleeping') {
-          setLifecycleState(data.state);
-        }
-      })
-      .catch(() => {
-        // 取得失敗時は初期値 'awake' のまま
-      });
-  }, [characterId]);
-
-  const handleInstallSkip = useCallback(() => {
-    setOnboardingPhase(null);
-    setOnboardingText(null);
-  }, []);
-
-  const handleNotificationGranted = useCallback(() => {
-    setOnboardingPhase(null);
-    setOnboardingText(PWA_MESSAGES.NOTIFICATION_GRANTED);
-    setTimeout(() => {
-      setOnboardingText((current) =>
-        current === PWA_MESSAGES.NOTIFICATION_GRANTED ? null : current
-      );
-    }, 4000);
-  }, []);
-
-  const handleNotificationSkip = useCallback(() => {
-    setOnboardingPhase(null);
-    setOnboardingText(null);
-  }, []);
+  // ライフサイクル状態管理 hook
+  const { lifecycleState, setLifecycleState } = useLifecycle(characterId);
 
   const handleSubmit = useCallback(
     async (text: string) => {
@@ -272,17 +135,12 @@ function HomePageInner() {
 
       // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）。
       // クロス汚染防止: カレントキャラ == 通知元キャラのときのみ渡す（C3-3）。
-      const firstWordNotifCharId = firstWordCharacterIdRef.current;
-      const rawKnowledgeId = firstWordKnowledgeIdRef.current;
-      const notifKnowledgeId =
-        rawKnowledgeId !== null && firstWordNotifCharId === characterId ? rawKnowledgeId : null;
-      firstWordKnowledgeIdRef.current = null;
-      firstWordCharacterIdRef.current = null;
+      const notifKnowledgeId = consumeKnowledgeId(characterId);
 
       setUserText(text);
       setResponseText('');
-      setFirstWordText(null);
-      setOnboardingText(null);
+      clearFirstWordText();
+      clearOnboardingText();
       setErrorMessage(null);
       setPhase('loading');
       // キューをリセット（setAudioBuffer(null) + clearAudioQueue() 相当）
@@ -421,7 +279,18 @@ function HomePageInner() {
         );
       }
     },
-    [ensureUnlocked, getContext, reset, enqueue, markStreamDone, characterId]
+    [
+      ensureUnlocked,
+      getContext,
+      reset,
+      enqueue,
+      markStreamDone,
+      characterId,
+      consumeKnowledgeId,
+      clearFirstWordText,
+      clearOnboardingText,
+      setLifecycleState,
+    ]
   );
 
   const handlePlaybackError = useCallback(
@@ -444,10 +313,7 @@ function HomePageInner() {
 
   return (
     <>
-      <ConsentModal
-        open={consentPhase === 'required'}
-        onConsented={() => setConsentPhase('done')}
-      />
+      <ConsentModal open={consentPhase === 'required'} onConsented={markConsented} />
       <SafetyModal
         open={safetyOpen}
         resources={safetyResources}

--- a/services/livetalk/web/src/lib/home/types.ts
+++ b/services/livetalk/web/src/lib/home/types.ts
@@ -1,0 +1,29 @@
+'use client';
+
+/**
+ * 同意フェーズ。
+ * - checking: /api/consent を確認中
+ * - required: 未同意（モーダル表示）
+ * - done: 同意済み
+ */
+export type ConsentPhase = 'checking' | 'required' | 'done';
+
+/**
+ * オンボーディングフェーズ。
+ * - install: ホーム画面追加ガイド表示中
+ * - notification: 通知許可リクエスト表示中
+ * - null: 表示なし
+ */
+export type OnboardingPhase = 'install' | 'notification' | null;
+
+/**
+ * pending API のレスポンス型（キャラクターごとの未消化通知）。
+ */
+export interface PendingNotification {
+  /** 通知元キャラクター ID */
+  characterId: string;
+  /** 通知 ID */
+  notifId: string;
+  /** 通知本文 */
+  body: string;
+}

--- a/services/livetalk/web/src/lib/home/useCharacterQuerySync.ts
+++ b/services/livetalk/web/src/lib/home/useCharacterQuerySync.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useCharacter } from '../characters/CharacterContext';
+import { hasCharacterProfile } from '../characters/client-profiles';
+
+/**
+ * URL クエリパラメータ ?character=<id> をカレントキャラクターに反映するカスタム hook。
+ *
+ * push クリック起動時: URL の ?character=<id> を読み、カレントキャラを切替える。
+ * searchParams は Next.js の useSearchParams で取得。
+ * 依存配列に searchParams を含めることで、SPA 遷移でも正しく動作する。
+ *
+ * 副作用のみで戻り値なし。
+ */
+export function useCharacterQuerySync(): void {
+  const searchParams = useSearchParams();
+  const { setCharacterId } = useCharacter();
+
+  useEffect(() => {
+    const characterQuery = searchParams.get('character');
+    if (characterQuery && hasCharacterProfile(characterQuery)) {
+      setCharacterId(characterQuery);
+    }
+    // searchParams の変化のみに依存する（setCharacterId は安定した関数参照）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+}

--- a/services/livetalk/web/src/lib/home/useConsent.ts
+++ b/services/livetalk/web/src/lib/home/useConsent.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { ConsentPhase } from './types';
+
+/**
+ * useConsent の戻り値型。
+ */
+export interface UseConsentResult {
+  /** 現在の同意フェーズ */
+  consentPhase: ConsentPhase;
+  /** 同意済みにマークする（ConsentModal の onConsented に渡す）。 */
+  markConsented: () => void;
+}
+
+/**
+ * 同意状態を管理するカスタム hook。
+ *
+ * マウント時に /api/consent を取得し、同意済みかどうかを判定する。
+ * 取得失敗時はモーダルを表示してユーザーに同意を促す。
+ */
+export function useConsent(): UseConsentResult {
+  const [consentPhase, setConsentPhase] = useState<ConsentPhase>('checking');
+
+  useEffect(() => {
+    fetch('/api/consent')
+      .then((res) => res.json())
+      .then((data: { consented: boolean }) => {
+        setConsentPhase(data.consented ? 'done' : 'required');
+      })
+      .catch(() => {
+        // 取得失敗時はモーダルを表示してユーザーに同意を促す
+        setConsentPhase('required');
+      });
+  }, []);
+
+  const markConsented = useCallback(() => {
+    setConsentPhase('done');
+  }, []);
+
+  return { consentPhase, markConsented };
+}

--- a/services/livetalk/web/src/lib/home/useFirstWord.ts
+++ b/services/livetalk/web/src/lib/home/useFirstWord.ts
@@ -1,0 +1,115 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+/**
+ * useFirstWord の戻り値型。
+ */
+export interface UseFirstWordResult {
+  /** 第一声テキスト（未消化通知から取得）。null はまだ取得していないか消去済み。 */
+  firstWordText: string | null;
+  /** 通知タップ起動時の入力欄プリフィルテキスト。null はプリフィルなし。 */
+  prefillText: string | null;
+  /**
+   * handleSubmit 送信前に呼ぶ。クロス汚染防止ガードを適用して knowledgeId を取り出し、
+   * 両 ref をクリアした上で結果を返す。
+   *
+   * クロス汚染防止: カレントキャラ == 通知元キャラのときのみ knowledgeId を返す（C3-3）。
+   *
+   * @param currentCharacterId 現在選択中のキャラクター ID
+   * @returns 有効な knowledgeId（クロス汚染がある場合は null）
+   */
+  consumeKnowledgeId: (currentCharacterId: string) => string | null;
+  /** handleSubmit 送信前に firstWordText をクリアする関数 */
+  clearFirstWordText: () => void;
+}
+
+/**
+ * カレントキャラの未消化通知を第一声として取得・表示するカスタム hook。
+ *
+ * characterId が変わるたびに再取得し、前のキャラの knowledgeId をクリアする。
+ * 通知タップ起動時（from=push）かつ suggestedReply がある場合は prefillText を設定する。
+ */
+export function useFirstWord(characterId: string): UseFirstWordResult {
+  const searchParams = useSearchParams();
+
+  const [firstWordText, setFirstWordText] = useState<string | null>(null);
+  const [prefillText, setPrefillText] = useState<string | null>(null);
+
+  // 第一声の元となった KnowledgeID（次の chat 送信時に文脈として渡す）
+  const firstWordKnowledgeIdRef = useRef<string | null>(null);
+  // 第一声の通知元キャラクター ID（クロス汚染防止のためカレントと照合する）
+  const firstWordCharacterIdRef = useRef<string | null>(null);
+
+  // カレント characterId の未消化通知を第一声として取得・表示する。
+  // characterId が変わるたびに再取得し、前のキャラの knowledgeId をクリアする。
+  useEffect(() => {
+    // キャラクター切替時は前のキャラの第一声 knowledgeId をクリアする（クロス汚染防止）
+    firstWordKnowledgeIdRef.current = null;
+    firstWordCharacterIdRef.current = null;
+    setFirstWordText(null);
+
+    fetch(`/api/push/first-word?characterId=${encodeURIComponent(characterId)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then(
+        (
+          data: {
+            notifId: string;
+            body: string;
+            knowledgeId?: string | null;
+            characterId: string;
+            suggestedReply?: string | null;
+          } | null
+        ) => {
+          if (!data) return;
+          setFirstWordText(data.body);
+          firstWordKnowledgeIdRef.current = data.knowledgeId ?? null;
+          // 通知元キャラクター ID を保存（クロス汚染防止のためカレントと照合する）
+          firstWordCharacterIdRef.current = data.characterId;
+          // 通知タップ起動時（from=push）かつ suggestedReply がある場合は入力欄へプリフィル
+          if (searchParams.get('from') === 'push' && data.suggestedReply) {
+            setPrefillText(data.suggestedReply);
+          }
+          // 消化済みマーク
+          fetch('/api/push/consumed', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ notifId: data.notifId }),
+          }).catch(() => {});
+        }
+      )
+      .catch(() => {});
+    // searchParams の変化のみに依存せず characterId のみを依存として保つ
+    // （searchParams は first-word 取得時の from/suggestedReply 判定に使うが、
+    //  searchParams が変化しても再取得は不要。characterId が同一の場合は再 fetch しない）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [characterId]);
+
+  /**
+   * クロス汚染防止ガードを適用して knowledgeId を取り出し、両 ref をクリアする。
+   * handleSubmit の送信前（273-280 行のロジックをそのまま移設）。
+   */
+  const consumeKnowledgeId = useCallback((currentCharacterId: string): string | null => {
+    const firstWordNotifCharId = firstWordCharacterIdRef.current;
+    const rawKnowledgeId = firstWordKnowledgeIdRef.current;
+    const notifKnowledgeId =
+      rawKnowledgeId !== null && firstWordNotifCharId === currentCharacterId
+        ? rawKnowledgeId
+        : null;
+    firstWordKnowledgeIdRef.current = null;
+    firstWordCharacterIdRef.current = null;
+    return notifKnowledgeId;
+  }, []);
+
+  const clearFirstWordText = useCallback(() => {
+    setFirstWordText(null);
+  }, []);
+
+  return {
+    firstWordText,
+    prefillText,
+    consumeKnowledgeId,
+    clearFirstWordText,
+  };
+}

--- a/services/livetalk/web/src/lib/home/useLifecycle.ts
+++ b/services/livetalk/web/src/lib/home/useLifecycle.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
+import type { LifecycleState } from '@nagiyu/livetalk-core';
+
+/**
+ * useLifecycle の戻り値型。
+ */
+export interface UseLifecycleResult {
+  /** 現在のライフサイクル状態 */
+  lifecycleState: LifecycleState;
+  /**
+   * ライフサイクル状態を更新する関数。
+   * handleSubmit のストリームイベント処理（lifecycle イベント受信時）で使う。
+   */
+  setLifecycleState: Dispatch<SetStateAction<LifecycleState>>;
+}
+
+/**
+ * キャラクターの生活サイクル状態を管理するカスタム hook。
+ *
+ * 起動時・キャラ切替時に /api/lifecycle を取得し、Live2D に反映する。
+ * 失敗時は現状維持（'awake'）。演出のための取得なので UI は止めない。
+ */
+export function useLifecycle(characterId: string): UseLifecycleResult {
+  const [lifecycleState, setLifecycleState] = useState<LifecycleState>('awake');
+
+  // 起動時・キャラ切替時に生活サイクル状態を取得し、初回発話を待たずに Live2D へ反映する。
+  // 失敗時は現状維持（'awake'）。演出のための取得なので UI は止めない。
+  useEffect(() => {
+    fetch(`/api/lifecycle?characterId=${encodeURIComponent(characterId)}`)
+      .then((res) => res.json())
+      .then((data: { state: LifecycleState }) => {
+        if (data.state === 'awake' || data.state === 'sleeping') {
+          setLifecycleState(data.state);
+        }
+      })
+      .catch(() => {
+        // 取得失敗時は初期値 'awake' のまま
+      });
+  }, [characterId]);
+
+  return { lifecycleState, setLifecycleState };
+}

--- a/services/livetalk/web/src/lib/home/useOnboarding.ts
+++ b/services/livetalk/web/src/lib/home/useOnboarding.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  isStandalone,
+  isPushSupported,
+  shouldShowInstallGuide,
+  shouldShowNotificationPermission,
+} from '../pwa/standalone';
+import { PWA_MESSAGES } from '../pwa/messages';
+import type { ConsentPhase, OnboardingPhase } from './types';
+
+/**
+ * useOnboarding の戻り値型。
+ */
+export interface UseOnboardingResult {
+  /** 現在のオンボーディングフェーズ */
+  onboardingPhase: OnboardingPhase;
+  /** オンボーディング表示テキスト（通知許可完了後の一時メッセージを含む） */
+  onboardingText: string | null;
+  /** handleSubmit からオンボーディングテキストをクリアするための関数 */
+  clearOnboardingText: () => void;
+  /** ホーム画面追加ガイドをスキップするハンドラ */
+  handleInstallSkip: () => void;
+  /** 通知許可が完了したときのハンドラ（4 秒後に自動クリア） */
+  handleNotificationGranted: () => void;
+  /** 通知許可をスキップするハンドラ */
+  handleNotificationSkip: () => void;
+}
+
+/**
+ * オンボーディング（ホーム画面追加・通知許可）を管理するカスタム hook。
+ *
+ * 同意完了後（consentPhase === 'done'）にオンボーディング表示要否を判定する。
+ */
+export function useOnboarding(consentPhase: ConsentPhase): UseOnboardingResult {
+  const [onboardingPhase, setOnboardingPhase] = useState<OnboardingPhase>(null);
+  const [onboardingText, setOnboardingText] = useState<string | null>(null);
+
+  // 同意完了後にオンボーディング（ホーム画面追加・通知許可）の表示要否を判定する。
+  useEffect(() => {
+    if (consentPhase !== 'done') return;
+    if (!isStandalone() && shouldShowInstallGuide()) {
+      setOnboardingPhase('install');
+      setOnboardingText(PWA_MESSAGES.INSTALL_PROMPT);
+    } else if (
+      isStandalone() &&
+      isPushSupported() &&
+      typeof window !== 'undefined' &&
+      window.Notification.permission !== 'granted' &&
+      shouldShowNotificationPermission()
+    ) {
+      setOnboardingPhase('notification');
+      setOnboardingText(PWA_MESSAGES.NOTIFICATION_PROMPT);
+    }
+  }, [consentPhase]);
+
+  const clearOnboardingText = useCallback(() => {
+    setOnboardingText(null);
+  }, []);
+
+  const handleInstallSkip = useCallback(() => {
+    setOnboardingPhase(null);
+    setOnboardingText(null);
+  }, []);
+
+  const handleNotificationGranted = useCallback(() => {
+    setOnboardingPhase(null);
+    setOnboardingText(PWA_MESSAGES.NOTIFICATION_GRANTED);
+    setTimeout(() => {
+      setOnboardingText((current) =>
+        current === PWA_MESSAGES.NOTIFICATION_GRANTED ? null : current
+      );
+    }, 4000);
+  }, []);
+
+  const handleNotificationSkip = useCallback(() => {
+    setOnboardingPhase(null);
+    setOnboardingText(null);
+  }, []);
+
+  return {
+    onboardingPhase,
+    onboardingText,
+    clearOnboardingText,
+    handleInstallSkip,
+    handleNotificationGranted,
+    handleNotificationSkip,
+  };
+}

--- a/services/livetalk/web/src/lib/home/usePendingNotifications.ts
+++ b/services/livetalk/web/src/lib/home/usePendingNotifications.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { PendingNotification } from './types';
+
+/**
+ * usePendingNotifications の戻り値型。
+ */
+export interface UsePendingNotificationsResult {
+  /** カレント以外の未消化通知一覧 */
+  pendingNotifications: PendingNotification[];
+}
+
+/**
+ * マウント時に /api/push/pending を取得し、他キャラクターの未消化通知一覧を返すカスタム hook。
+ *
+ * このエフェクトはマウント時（初回起動）にのみ実行する。
+ */
+export function usePendingNotifications(): UsePendingNotificationsResult {
+  const [pendingNotifications, setPendingNotifications] = useState<PendingNotification[]>([]);
+
+  // 自前起動時: カレント以外に未消化通知があれば提示する。
+  // このエフェクトはマウント時（初回起動）にのみ実行する。
+  useEffect(() => {
+    fetch('/api/push/pending')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: PendingNotification[] | null) => {
+        if (!data || data.length === 0) return;
+        setPendingNotifications(data);
+      })
+      .catch(() => {});
+    // マウント時のみ実行（依存配列は空）
+  }, []);
+
+  return { pendingNotifications };
+}

--- a/services/livetalk/web/tests/unit/lib/home/useCharacterQuerySync.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useCharacterQuerySync.test.ts
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+import { useCharacterQuerySync } from '@/lib/home/useCharacterQuerySync';
+
+// useSearchParams をモック化
+const mockSearchParamsGet = jest.fn().mockReturnValue(null);
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(() => ({
+    get: mockSearchParamsGet,
+  })),
+}));
+
+// CharacterContext の useCharacter をモック化
+const mockSetCharacterId = jest.fn();
+jest.mock('@/lib/characters/CharacterContext', () => ({
+  useCharacter: jest.fn(() => ({
+    characterId: 'hiyori',
+    setCharacterId: mockSetCharacterId,
+  })),
+}));
+
+// hasCharacterProfile をモック化（hiyori と ageha は有効、other は無効）
+jest.mock('@/lib/characters/client-profiles', () => ({
+  hasCharacterProfile: jest.fn((id: string) => ['hiyori', 'ageha'].includes(id)),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+  mockSearchParamsGet.mockReturnValue(null);
+});
+
+describe('useCharacterQuerySync', () => {
+  describe('?character クエリがない場合', () => {
+    it('character クエリがないとき setCharacterId は呼ばれない', () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('有効な ?character クエリがある場合', () => {
+    it('?character=ageha のとき setCharacterId(ageha) が呼ばれる', () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'character') return 'ageha';
+        return null;
+      });
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).toHaveBeenCalledWith('ageha');
+    });
+
+    it('?character=hiyori のとき setCharacterId(hiyori) が呼ばれる', () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'character') return 'hiyori';
+        return null;
+      });
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).toHaveBeenCalledWith('hiyori');
+    });
+  });
+
+  describe('無効な ?character クエリがある場合', () => {
+    it('登録されていないキャラクター ID のとき setCharacterId は呼ばれない', () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'character') return 'unknown-character-xyz';
+        return null;
+      });
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).not.toHaveBeenCalled();
+    });
+
+    it('空文字のとき setCharacterId は呼ばれない', () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'character') return '';
+        return null;
+      });
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('戻り値', () => {
+    it('戻り値は void（undefined）', () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      const { result } = renderHook(() => useCharacterQuerySync());
+      expect(result.current).toBeUndefined();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useConsent.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useConsent.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useConsent } from '@/lib/home/useConsent';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useConsent', () => {
+  describe('初期値', () => {
+    it('初期状態は checking', () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: true }),
+      });
+      const { result } = renderHook(() => useConsent());
+      expect(result.current.consentPhase).toBe('checking');
+    });
+  });
+
+  describe('/api/consent 取得', () => {
+    it('consented: true のとき consentPhase が done になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: true }),
+      });
+      const { result } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('done'));
+    });
+
+    it('consented: false のとき consentPhase が required になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: false }),
+      });
+      const { result } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('required'));
+    });
+
+    it('取得失敗時は consentPhase が required になる', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+      const { result } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('required'));
+    });
+
+    it('/api/consent に fetch が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: true }),
+      });
+      renderHook(() => useConsent());
+      await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/consent'));
+    });
+  });
+
+  describe('markConsented', () => {
+    it('markConsented を呼ぶと consentPhase が done になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: false }),
+      });
+      const { result } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('required'));
+
+      act(() => {
+        result.current.markConsented();
+      });
+
+      expect(result.current.consentPhase).toBe('done');
+    });
+
+    it('markConsented は安定した関数参照を持つ', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: true }),
+      });
+      const { result, rerender } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('done'));
+
+      const firstRef = result.current.markConsented;
+      rerender();
+      expect(result.current.markConsented).toBe(firstRef);
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useFirstWord.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useFirstWord.test.ts
@@ -1,0 +1,407 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useFirstWord } from '@/lib/home/useFirstWord';
+
+// useSearchParams をモック化
+const mockSearchParamsGet = jest.fn().mockReturnValue(null);
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(() => ({
+    get: mockSearchParamsGet,
+  })),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+  mockSearchParamsGet.mockReturnValue(null);
+});
+
+describe('useFirstWord', () => {
+  describe('初期値', () => {
+    it('初期状態は firstWordText と prefillText が null', () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false });
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      expect(result.current.firstWordText).toBeNull();
+      expect(result.current.prefillText).toBeNull();
+    });
+  });
+
+  describe('first-word 取得', () => {
+    it('characterId 付きで /api/push/first-word を取得する', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({ ok: false });
+        }
+        return Promise.resolve({ ok: true });
+      });
+      renderHook(() => useFirstWord('hiyori'));
+
+      await waitFor(() => {
+        const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+        expect(calls.some((url) => url.includes('/api/push/first-word?characterId=hiyori'))).toBe(
+          true
+        );
+      });
+    });
+
+    it('ok: true かつデータあり → firstWordText が設定される', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: 'テスト第一声',
+                knowledgeId: 'k-xyz',
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('テスト第一声'));
+    });
+
+    it('ok: false のとき firstWordText は null のまま', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false });
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await act(async () => {});
+      expect(result.current.firstWordText).toBeNull();
+    });
+
+    it('取得成功時に /api/push/consumed が PATCH で呼ばれる', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: null,
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => {
+        const consumedCall = (global.fetch as jest.Mock).mock.calls.find(
+          ([url]: [string]) => url === '/api/push/consumed'
+        );
+        expect(consumedCall).toBeDefined();
+        expect(consumedCall[1].method).toBe('PATCH');
+        const body = JSON.parse(consumedCall[1].body as string);
+        expect(body.notifId).toBe('n1');
+      });
+    });
+
+    it('fetch 失敗時はクラッシュしない', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await act(async () => {});
+      expect(result.current.firstWordText).toBeNull();
+    });
+  });
+
+  describe('characterId が変わったとき', () => {
+    it('characterId が変わると再 fetch し前の firstWordText がクリアされる', async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          callCount++;
+          if (callCount === 1) {
+            return Promise.resolve({
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  notifId: 'n1',
+                  body: 'ひよりの声',
+                  knowledgeId: 'k1',
+                  characterId: 'hiyori',
+                }),
+            });
+          }
+          return Promise.resolve({ ok: false });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result, rerender } = renderHook(({ characterId }) => useFirstWord(characterId), {
+        initialProps: { characterId: 'hiyori' },
+      });
+
+      await waitFor(() => expect(result.current.firstWordText).toBe('ひよりの声'));
+
+      rerender({ characterId: 'ageha' });
+
+      // キャラ切替直後に null になる（effect の先頭でクリア）
+      expect(result.current.firstWordText).toBeNull();
+    });
+  });
+
+  describe('prefillText（from=push + suggestedReply）', () => {
+    it('from=push かつ suggestedReply あり → prefillText が設定される', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'from') return 'push';
+        return null;
+      });
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k1',
+                characterId: 'hiyori',
+                suggestedReply: 'TypeScriptについて教えて',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.prefillText).toBe('TypeScriptについて教えて'));
+    });
+
+    it('from=push でない場合は suggestedReply があっても prefillText が null のまま', async () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k1',
+                characterId: 'hiyori',
+                suggestedReply: '返信テキスト',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+      expect(result.current.prefillText).toBeNull();
+    });
+
+    it('from=push でも suggestedReply が null なら prefillText は null のまま', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'from') return 'push';
+        return null;
+      });
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k1',
+                characterId: 'hiyori',
+                suggestedReply: null,
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+      expect(result.current.prefillText).toBeNull();
+    });
+  });
+
+  describe('consumeKnowledgeId（クロス汚染防止ガード）', () => {
+    it('カレントキャラ == 通知元キャラのとき knowledgeId を返し ref をクリアする', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k-hiyori',
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      let knowledgeId: string | null = null;
+      act(() => {
+        knowledgeId = result.current.consumeKnowledgeId('hiyori');
+      });
+
+      // カレント == 通知元 → knowledgeId が返る
+      expect(knowledgeId).toBe('k-hiyori');
+    });
+
+    it('2 回目の consumeKnowledgeId は null を返す（ref がクリアされている）', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k-hiyori',
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      act(() => {
+        result.current.consumeKnowledgeId('hiyori');
+      });
+      let secondKnowledgeId: string | null = null;
+      act(() => {
+        secondKnowledgeId = result.current.consumeKnowledgeId('hiyori');
+      });
+
+      expect(secondKnowledgeId).toBeNull();
+    });
+
+    it('カレントキャラ != 通知元キャラのとき null を返す（クロス汚染防止）', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k-ageha',
+                // 通知元は ageha だがカレントは hiyori でチェックする
+                characterId: 'ageha',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      let knowledgeId: string | null = null;
+      act(() => {
+        // カレントキャラとして 'hiyori' を渡す（通知元は 'ageha'）
+        knowledgeId = result.current.consumeKnowledgeId('hiyori');
+      });
+
+      // クロス汚染防止 → null
+      expect(knowledgeId).toBeNull();
+    });
+
+    it('knowledgeId が null の first-word でも consumeKnowledgeId は null を返す', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: null,
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      let knowledgeId: string | null = null;
+      act(() => {
+        knowledgeId = result.current.consumeKnowledgeId('hiyori');
+      });
+
+      expect(knowledgeId).toBeNull();
+    });
+  });
+
+  describe('clearFirstWordText', () => {
+    it('clearFirstWordText を呼ぶと firstWordText が null になる', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: null,
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      act(() => {
+        result.current.clearFirstWordText();
+      });
+
+      expect(result.current.firstWordText).toBeNull();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useLifecycle.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useLifecycle.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useLifecycle } from '@/lib/home/useLifecycle';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useLifecycle', () => {
+  describe('初期値', () => {
+    it('初期状態は lifecycleState が awake', () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      expect(result.current.lifecycleState).toBe('awake');
+    });
+  });
+
+  describe('/api/lifecycle 取得', () => {
+    it('characterId 付きで /api/lifecycle を取得する', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+      renderHook(() => useLifecycle('hiyori'));
+
+      await waitFor(() => {
+        const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+        expect(calls.some((url) => url.includes('/api/lifecycle?characterId=hiyori'))).toBe(true);
+      });
+    });
+
+    it('state: sleeping が返ったとき lifecycleState が sleeping になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'sleeping' }),
+      });
+
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await waitFor(() => expect(result.current.lifecycleState).toBe('sleeping'));
+    });
+
+    it('state: awake が返ったとき lifecycleState が awake になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'sleeping' }),
+      });
+
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await waitFor(() => expect(result.current.lifecycleState).toBe('sleeping'));
+
+      // awake に戻る fetch
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+    });
+
+    it('fetch 失敗時は初期値 awake を維持する', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await act(async () => {});
+      expect(result.current.lifecycleState).toBe('awake');
+    });
+
+    it('不明な state 値が返ってきた場合は state を更新しない', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'unknown-state' }),
+      });
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await act(async () => {});
+      // 有効な state 以外は無視して初期値 awake のまま
+      expect(result.current.lifecycleState).toBe('awake');
+    });
+  });
+
+  describe('characterId が変わったとき', () => {
+    it('characterId が変わると再 fetch する', async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation(() => {
+        callCount++;
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ state: 'awake' }),
+        });
+      });
+
+      const { rerender } = renderHook(({ characterId }) => useLifecycle(characterId), {
+        initialProps: { characterId: 'hiyori' },
+      });
+      await waitFor(() => expect(callCount).toBe(1));
+
+      rerender({ characterId: 'ageha' });
+      await waitFor(() => expect(callCount).toBe(2));
+    });
+  });
+
+  describe('setLifecycleState（公開）', () => {
+    it('setLifecycleState を呼ぶと lifecycleState が更新される', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await waitFor(() => expect(result.current.lifecycleState).toBe('awake'));
+
+      act(() => {
+        result.current.setLifecycleState('sleeping');
+      });
+      expect(result.current.lifecycleState).toBe('sleeping');
+    });
+
+    it('setLifecycleState は安定した関数参照を持つ', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+      const { result, rerender } = renderHook(() => useLifecycle('hiyori'));
+      await waitFor(() => expect(result.current.lifecycleState).toBe('awake'));
+
+      const firstRef = result.current.setLifecycleState;
+      rerender();
+      expect(result.current.setLifecycleState).toBe(firstRef);
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useOnboarding.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useOnboarding.test.ts
@@ -1,0 +1,213 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useOnboarding } from '@/lib/home/useOnboarding';
+
+// オンボーディング判定関数をモック
+jest.mock('@/lib/pwa/standalone', () => ({
+  isStandalone: jest.fn().mockReturnValue(false),
+  isPushSupported: jest.fn().mockReturnValue(false),
+  shouldShowInstallGuide: jest.fn().mockReturnValue(false),
+  shouldShowNotificationPermission: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('@/lib/pwa/messages', () => ({
+  PWA_MESSAGES: {
+    INSTALL_PROMPT: 'お家を作ってほしいな…',
+    NOTIFICATION_PROMPT: '来てくれてありがとう！',
+    NOTIFICATION_GRANTED: 'やった！',
+  },
+}));
+
+import {
+  isStandalone,
+  isPushSupported,
+  shouldShowInstallGuide,
+  shouldShowNotificationPermission,
+} from '@/lib/pwa/standalone';
+import { PWA_MESSAGES } from '@/lib/pwa/messages';
+
+afterEach(() => {
+  jest.clearAllMocks();
+  // モックを既定値（表示なし）に戻す
+  (isStandalone as jest.Mock).mockReturnValue(false);
+  (isPushSupported as jest.Mock).mockReturnValue(false);
+  (shouldShowInstallGuide as jest.Mock).mockReturnValue(false);
+  (shouldShowNotificationPermission as jest.Mock).mockReturnValue(false);
+});
+
+describe('useOnboarding', () => {
+  describe('初期値', () => {
+    it('初期状態は onboardingPhase が null, onboardingText が null', () => {
+      const { result } = renderHook(() => useOnboarding('checking'));
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBeNull();
+    });
+  });
+
+  describe('consentPhase が done のとき', () => {
+    it('スタンドアロンでなく shouldShowInstallGuide が true なら install フェーズになる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(false);
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('install'));
+      expect(result.current.onboardingText).toBe(PWA_MESSAGES.INSTALL_PROMPT);
+    });
+
+    it('スタンドアロン + push サポート + 通知未許可 + shouldShowNotificationPermission が true なら notification フェーズになる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      // window.Notification.permission を 'default' に設定
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'default' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('notification'));
+      expect(result.current.onboardingText).toBe(PWA_MESSAGES.NOTIFICATION_PROMPT);
+    });
+
+    it('通知が granted 済みなら notification フェーズにならない', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'granted' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      // consentPhase=done でも notification にならない
+      await act(async () => {});
+      expect(result.current.onboardingPhase).toBeNull();
+    });
+
+    it('すべての条件が false なら onboardingPhase は null のまま', async () => {
+      const { result } = renderHook(() => useOnboarding('done'));
+      await act(async () => {});
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBeNull();
+    });
+  });
+
+  describe('consentPhase が done でない場合', () => {
+    it('checking のときはオンボーディング判定が走らない', async () => {
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+      const { result } = renderHook(() => useOnboarding('checking'));
+      await act(async () => {});
+      expect(result.current.onboardingPhase).toBeNull();
+    });
+
+    it('required のときはオンボーディング判定が走らない', async () => {
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+      const { result } = renderHook(() => useOnboarding('required'));
+      await act(async () => {});
+      expect(result.current.onboardingPhase).toBeNull();
+    });
+  });
+
+  describe('ハンドラ', () => {
+    it('handleInstallSkip で onboardingPhase と onboardingText がクリアされる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(false);
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('install'));
+
+      act(() => {
+        result.current.handleInstallSkip();
+      });
+
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBeNull();
+    });
+
+    it('handleNotificationSkip で onboardingPhase と onboardingText がクリアされる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'default' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('notification'));
+
+      act(() => {
+        result.current.handleNotificationSkip();
+      });
+
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBeNull();
+    });
+
+    it('handleNotificationGranted で onboardingPhase がクリアされ NOTIFICATION_GRANTED テキストが設定される', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'default' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('notification'));
+
+      act(() => {
+        result.current.handleNotificationGranted();
+      });
+
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBe(PWA_MESSAGES.NOTIFICATION_GRANTED);
+    });
+
+    it('handleNotificationGranted から 4 秒後に onboardingText が自動クリアされる', async () => {
+      jest.useFakeTimers();
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'default' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('notification'));
+
+      act(() => {
+        result.current.handleNotificationGranted();
+      });
+      expect(result.current.onboardingText).toBe(PWA_MESSAGES.NOTIFICATION_GRANTED);
+
+      act(() => {
+        jest.advanceTimersByTime(4000);
+      });
+      expect(result.current.onboardingText).toBeNull();
+
+      jest.useRealTimers();
+    });
+
+    it('clearOnboardingText で onboardingText が null になる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(false);
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingText).toBe(PWA_MESSAGES.INSTALL_PROMPT));
+
+      act(() => {
+        result.current.clearOnboardingText();
+      });
+
+      expect(result.current.onboardingText).toBeNull();
+      // onboardingPhase はそのまま
+      expect(result.current.onboardingPhase).toBe('install');
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/usePendingNotifications.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/usePendingNotifications.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePendingNotifications } from '@/lib/home/usePendingNotifications';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('usePendingNotifications', () => {
+  describe('初期値', () => {
+    it('初期状態は pendingNotifications が空配列', () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      const { result } = renderHook(() => usePendingNotifications());
+      expect(result.current.pendingNotifications).toEqual([]);
+    });
+  });
+
+  describe('/api/push/pending 取得', () => {
+    it('マウント時に /api/push/pending を取得する', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      renderHook(() => usePendingNotifications());
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/push/pending');
+      });
+    });
+
+    it('通知データがある場合は pendingNotifications が更新される', async () => {
+      const pendingData = [
+        { characterId: 'ageha', notifId: 'n1', body: 'アゲハより' },
+        { characterId: 'koharu', notifId: 'n2', body: '小春より' },
+      ];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(pendingData),
+      });
+
+      const { result } = renderHook(() => usePendingNotifications());
+      await waitFor(() => expect(result.current.pendingNotifications).toHaveLength(2));
+      expect(result.current.pendingNotifications[0].characterId).toBe('ageha');
+      expect(result.current.pendingNotifications[1].characterId).toBe('koharu');
+    });
+
+    it('空配列のとき pendingNotifications が空のまま', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      const { result } = renderHook(() => usePendingNotifications());
+      await act(async () => {});
+      expect(result.current.pendingNotifications).toEqual([]);
+    });
+
+    it('ok: false のとき pendingNotifications が空のまま', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false });
+      const { result } = renderHook(() => usePendingNotifications());
+      await act(async () => {});
+      expect(result.current.pendingNotifications).toEqual([]);
+    });
+
+    it('fetch 失敗時はクラッシュせず pendingNotifications が空のまま', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+      const { result } = renderHook(() => usePendingNotifications());
+      await act(async () => {});
+      expect(result.current.pendingNotifications).toEqual([]);
+    });
+
+    it('マウント後の再レンダリングでは再 fetch しない', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      const { rerender } = renderHook(() => usePendingNotifications());
+      await act(async () => {});
+      rerender();
+      rerender();
+      // マウント時の 1 回のみ
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

`services/livetalk/web/src/app/page.tsx` に同居していたデータ取得系の useEffect 群を `src/lib/home/` 配下の custom hook に切り出すリファクタリング（**挙動不変**）。Phase 1（音声まわりの hook 化）に続く #3529 の第 2 弾。

新規 hook（`src/lib/home/`）:
- `useConsent` — 同意状態取得 + `markConsented`
- `useOnboarding(consentPhase)` — オンボーディング判定 + 3 ハンドラ（4 秒後自動クリア含む）+ `clearOnboardingText`
- `useFirstWord(characterId)` — 第一声取得 + `consumeKnowledgeId`（**クロス汚染防止ガードを hook 内に整理**）+ `clearFirstWordText`
- `usePendingNotifications` — 他キャラ未消化通知の取得（マウント時のみ）
- `useLifecycle(characterId)` — 生活サイクル状態取得 + `setLifecycleState`（ストリームイベントが更新するため公開）
- `useCharacterQuerySync` — `?character=` クエリのカレントキャラ反映
- `types.ts` — `ConsentPhase` / `OnboardingPhase` / `PendingNotification` 型（page.tsx から移設）

`page.tsx` は上記 hook を呼ぶ形に書き換え、`handleSubmit` 内の ref 直接操作を `consumeKnowledgeId` / `clearFirstWordText` / `clearOnboardingText` 経由に変更。**561 行 → 427 行**に減少。

> クロス汚染防止は「hook に閉じて整理する程度」の方針合意どおり、ロジックは変えず `consumeKnowledgeId` に移設（リクエスト ID 照合の本格導入はしていない）。

## 関連 Issue

#3529 （親 Issue: #3521）

## 変更種別

- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した（UI/ロジック分離・lib にロジック集約・パスエイリアス不使用）
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（永続ドキュメントへの追従は develop 反映後に判断）
- [ ] CI/CD 設定を追加・更新した（該当なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `tests/unit/lib/home/` に 6 hook の単体テストを追加（`global.fetch` / `next/navigation` / `useCharacter` 等をモックし、`renderHook` で検証）。
  - `useFirstWord`: カレント一致で knowledgeId 返却 / 不一致で null（クロス汚染防止）/ 2 回目クリア / prefill（from=push）等。
- 既存 `tests/unit/app/page.test.tsx`（挙動の回帰テスト）を緑のまま維持。

検証結果（ローカル）:
- `npm test`: 673 件全パス（67 スイート）
- カバレッジ: global 90.95% / branch 93.2% / func 82.78%（閾値 80% 超）、`src/lib/home` の各 hook はほぼ 100%
- `tsc --noEmit`: 変更ファイルに型エラー 0 件（残 34 件は本変更と無関係の既存エラー、`develop` と同数）
- `prettier --check`: クリーン / `eslint`: 0 errors, 0 warnings

## レビューポイント

- `useFirstWord.consumeKnowledgeId` のクロス汚染防止ガードが元の `handleSubmit`（旧 273-280 行）と等価であること。
- `useLifecycle` が `setLifecycleState` を公開し、`handleSubmit` のストリームイベント（`lifecycle`）が従来どおり状態更新できること。
- `useOnboarding` の `onboardingText` / `clearOnboardingText` と `useFirstWord` の `firstWordText` が、`ResponseDisplay` の表示優先順（onboarding ?? firstWord ?? response）を変えていないこと。
- 各 effect の依存配列・`eslint-disable` の意図を保持していること。

## 補足事項

#3529 の段階的リファクタリングの第 2 弾。`integration/3529-livetalk-frontend` に積み上げ。残 Phase: チャット送信フローの hook 化（handleSubmit + NDJSON）/ Live2D 内部 API の型整備。`handleSubmit` 本体とチャット送信系 state は Phase 3 で扱うため本 PR では page.tsx に残置。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FLhrr8dDji5yKVxmSuu7Ce)_