### PR TITLE
リブトーク: チャット送信フローを useChatStream hook に切り出す（#3529 Phase 3）

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useCallback, useRef, useState } from 'react';
+import { Suspense, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { Box, Container, Stack, Typography } from '@mui/material';
 import { Link } from '@nagiyu/ui';
@@ -11,13 +11,11 @@ import CharacterCanvas from '@/components/CharacterCanvas';
 import ConsentModal from '@/components/ConsentModal';
 import SafetyModal from '@/components/SafetyModal';
 import NotificationToggle from '@/components/NotificationToggle';
-import type { SafetyResource } from '@nagiyu/livetalk-core';
 import InstallGuide from '@/components/InstallGuide';
 import NotificationPermission from '@/components/NotificationPermission';
 import CharacterSelectButton from '@/components/CharacterSelectButton';
 import { useCharacter } from '@/lib/characters/CharacterContext';
 import { getCharacterDisplay, hasCharacterProfile } from '@/lib/characters/client-profiles';
-import { reportClientError } from '@/lib/client-logger';
 import { useAudioContext } from '@/lib/audio/useAudioContext';
 import { useAudioQueue } from '@/lib/audio/useAudioQueue';
 import { useConsent } from '@/lib/home/useConsent';
@@ -26,30 +24,8 @@ import { useFirstWord } from '@/lib/home/useFirstWord';
 import { usePendingNotifications } from '@/lib/home/usePendingNotifications';
 import { useLifecycle } from '@/lib/home/useLifecycle';
 import { useCharacterQuerySync } from '@/lib/home/useCharacterQuerySync';
-
-type ChatPhase = 'idle' | 'loading' | 'streaming';
-
-type ChatStreamEvent =
-  | { type: 'text'; delta: string }
-  | { type: 'sentence'; index: number; text: string; audio: string }
-  | {
-      type: 'safety';
-      trigger: 'input_keyword' | 'output_moderation';
-      resources: SafetyResource[];
-      replacementText?: string;
-    }
-  | { type: 'lifecycle'; state: import('@nagiyu/livetalk-core').LifecycleState }
-  | { type: 'done' }
-  | { type: 'error'; message: string };
-
-function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const binaryString = atob(base64);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-  return bytes.buffer;
-}
+import { useChatStream } from '@/lib/home/useChatStream';
+import type { ChatPhase } from '@/lib/home/types';
 
 /**
  * Phase 2c のチャット画面（Phase 2f で Web Audio 再生に切替）。
@@ -72,16 +48,10 @@ function HomePageInner() {
     Array.isArray(session.user.roles) &&
     hasPermission(session.user.roles, 'livetalk:admin');
 
+  // phase は page.tsx の state のまま残す。
+  // useAudioQueue の onDrained が setPhase('idle') を呼ぶため、
+  // useChatStream 内に持たせると循環依存になる。
   const [phase, setPhase] = useState<ChatPhase>('idle');
-  const [userText, setUserText] = useState<string | null>(null);
-  const [responseText, setResponseText] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const [safetyOpen, setSafetyOpen] = useState(false);
-  const [safetyResources, setSafetyResources] = useState<SafetyResource[]>([]);
-
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const sentenceReceivedRef = useRef(0);
 
   // AudioContext 管理 hook（iOS Safari の autoplay 制約対策）
   const { audioContext, ensureUnlocked, getContext } = useAudioContext();
@@ -122,191 +92,30 @@ function HomePageInner() {
   // ライフサイクル状態管理 hook
   const { lifecycleState, setLifecycleState } = useLifecycle(characterId);
 
-  const handleSubmit = useCallback(
-    async (text: string) => {
-      // user gesture の同期スタック内で AudioContext を resume する（iOS Safari 対策）
-      await ensureUnlocked();
-      const audioCtx = getContext();
-
-      // 前回リクエストをキャンセル
-      abortControllerRef.current?.abort();
-      const controller = new AbortController();
-      abortControllerRef.current = controller;
-
-      // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）。
-      // クロス汚染防止: カレントキャラ == 通知元キャラのときのみ渡す（C3-3）。
-      const notifKnowledgeId = consumeKnowledgeId(characterId);
-
-      setUserText(text);
-      setResponseText('');
-      clearFirstWordText();
-      clearOnboardingText();
-      setErrorMessage(null);
-      setPhase('loading');
-      // キューをリセット（setAudioBuffer(null) + clearAudioQueue() 相当）
-      reset();
-      sentenceReceivedRef.current = 0;
-
-      try {
-        const chatBody: { text: string; characterId?: string; knowledgeId?: string } = {
-          text,
-          characterId,
-        };
-        if (notifKnowledgeId) chatBody.knowledgeId = notifKnowledgeId;
-
-        const response = await fetch('/api/chat', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(chatBody),
-          signal: controller.signal,
-        });
-
-        if (!response.ok || !response.body) {
-          setErrorMessage('応答の取得に失敗しました。時間を置いて再度お試しください。');
-          setPhase('idle');
-          reportClientError('error', 'チャット fetch 失敗', `HTTP ${response.status}`, {
-            screen: 'chat',
-            audioContextState: getContext()?.state,
-          });
-          return;
-        }
-
-        setPhase('streaming');
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let lineBuffer = '';
-
-        const handleEvent = async (event: ChatStreamEvent) => {
-          if (event.type === 'text') {
-            setResponseText((prev) => (prev ?? '') + event.delta);
-          } else if (event.type === 'sentence' && event.audio) {
-            sentenceReceivedRef.current++;
-            if (!audioCtx) {
-              // AudioContext が無いブラウザ（極めて稀）: 音声をスキップしてテキストだけ表示
-              return;
-            }
-            try {
-              const arrayBuffer = base64ToArrayBuffer(event.audio);
-              const decoded = await audioCtx.decodeAudioData(arrayBuffer);
-              // decode 済みバッファをキューに追加（空きなら即再生開始）
-              enqueue(decoded);
-            } catch (err) {
-              console.error('[LiveTalk] 音声 decode に失敗しました', err);
-              reportClientError(
-                'warning',
-                '音声 decode 失敗',
-                err instanceof Error ? err.message : '不明なエラー',
-                {
-                  screen: 'chat',
-                  audioContextState: getContext()?.state,
-                  sentenceReceived: sentenceReceivedRef.current,
-                }
-              );
-            }
-          } else if (event.type === 'lifecycle') {
-            setLifecycleState(event.state);
-          } else if (event.type === 'safety') {
-            if (event.trigger === 'output_moderation' && event.replacementText) {
-              setResponseText(event.replacementText);
-            }
-            setSafetyResources(event.resources);
-            setSafetyOpen(true);
-          } else if (event.type === 'done') {
-            // ストリーム完了をマーク（キューと current が空なら onDrained → setPhase('idle')）
-            markStreamDone();
-          } else if (event.type === 'error') {
-            setErrorMessage(event.message ?? '内部エラーが発生しました。');
-            // ストリームエラー時もストリーム完了扱い（advance のみ hook に委譲）
-            markStreamDone();
-            reportClientError(
-              'error',
-              'チャット stream エラー',
-              event.message ?? '内部エラーが発生しました',
-              {
-                screen: 'chat',
-                audioContextState: getContext()?.state,
-                sentenceReceived: sentenceReceivedRef.current,
-                // markStreamDone 後なので streamDone は true
-                streamDone: true,
-              }
-            );
-          }
-        };
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          lineBuffer += decoder.decode(value, { stream: true });
-          const lines = lineBuffer.split('\n');
-          lineBuffer = lines.pop() ?? '';
-
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-            try {
-              await handleEvent(JSON.parse(trimmed) as ChatStreamEvent);
-            } catch {
-              // malformed line はスキップ
-            }
-          }
-        }
-
-        // ストリーム終端の残余行
-        if (lineBuffer.trim()) {
-          try {
-            await handleEvent(JSON.parse(lineBuffer.trim()) as ChatStreamEvent);
-          } catch {
-            // skip
-          }
-        }
-      } catch (error) {
-        if (error instanceof Error && error.name === 'AbortError') return;
-        console.error('[LiveTalk] チャット応答の取得に失敗しました', error);
-        setErrorMessage('エラーが発生しました。時間を置いて再度お試しください。');
-        setPhase('idle');
-        reportClientError(
-          'error',
-          'チャット通信エラー',
-          error instanceof Error ? error.message : '不明なエラー',
-          {
-            screen: 'chat',
-            audioContextState: getContext()?.state,
-            sentenceReceived: sentenceReceivedRef.current,
-            stack: error instanceof Error ? error.stack : undefined,
-          }
-        );
-      }
-    },
-    [
-      ensureUnlocked,
-      getContext,
-      reset,
-      enqueue,
-      markStreamDone,
-      characterId,
-      consumeKnowledgeId,
-      clearFirstWordText,
-      clearOnboardingText,
-      setLifecycleState,
-    ]
-  );
-
-  const handlePlaybackError = useCallback(
-    (error: Error) => {
-      console.error('[LiveTalk] 音声再生エラー', error);
-      setErrorMessage('音声再生中にエラーが発生しました。');
-      // advance のみ hook に委譲（ログ・setErrorMessage・reportClientError はここで処理）
-      advanceOnError();
-      reportClientError('warning', '音声再生エラー', error.message, {
-        screen: 'chat',
-        audioContextState: getContext()?.state,
-        sentenceReceived: sentenceReceivedRef.current,
-      });
-    },
-    [advanceOnError, getContext]
-  );
+  // チャット送信フロー hook（handleSubmit + NDJSON parse + ストリームイベント分岐 + handlePlaybackError）
+  const {
+    userText,
+    responseText,
+    errorMessage,
+    safetyOpen,
+    safetyResources,
+    closeSafety,
+    handleSubmit,
+    handlePlaybackError,
+  } = useChatStream({
+    characterId,
+    setPhase,
+    ensureUnlocked,
+    getContext,
+    enqueue,
+    markStreamDone,
+    resetAudioQueue: reset,
+    advanceOnError,
+    consumeKnowledgeId,
+    clearFirstWordText,
+    clearOnboardingText,
+    setLifecycleState,
+  });
 
   const statusText =
     phase === 'loading' ? '考え中…' : phase === 'streaming' ? '話している' : '待機中';
@@ -314,11 +123,7 @@ function HomePageInner() {
   return (
     <>
       <ConsentModal open={consentPhase === 'required'} onConsented={markConsented} />
-      <SafetyModal
-        open={safetyOpen}
-        resources={safetyResources}
-        onClose={() => setSafetyOpen(false)}
-      />
+      <SafetyModal open={safetyOpen} resources={safetyResources} onClose={closeSafety} />
       <Container
         maxWidth="sm"
         sx={{

--- a/services/livetalk/web/src/lib/home/types.ts
+++ b/services/livetalk/web/src/lib/home/types.ts
@@ -1,6 +1,14 @@
 'use client';
 
 /**
+ * チャットフェーズ。
+ * - idle: 待機中（入力受付可）
+ * - loading: リクエスト送信中（応答待ち）
+ * - streaming: NDJSON ストリーム受信中
+ */
+export type ChatPhase = 'idle' | 'loading' | 'streaming';
+
+/**
  * 同意フェーズ。
  * - checking: /api/consent を確認中
  * - required: 未同意（モーダル表示）

--- a/services/livetalk/web/src/lib/home/useChatStream.ts
+++ b/services/livetalk/web/src/lib/home/useChatStream.ts
@@ -1,0 +1,325 @@
+'use client';
+
+import { type Dispatch, type SetStateAction, useCallback, useRef, useState } from 'react';
+import type { LifecycleState, SafetyResource } from '@nagiyu/livetalk-core';
+import { reportClientError } from '../client-logger';
+import type { ChatPhase } from './types';
+
+/**
+ * NDJSON ストリームのイベント型。
+ */
+type ChatStreamEvent =
+  | { type: 'text'; delta: string }
+  | { type: 'sentence'; index: number; text: string; audio: string }
+  | {
+      type: 'safety';
+      trigger: 'input_keyword' | 'output_moderation';
+      resources: SafetyResource[];
+      replacementText?: string;
+    }
+  | { type: 'lifecycle'; state: LifecycleState }
+  | { type: 'done' }
+  | { type: 'error'; message: string };
+
+/**
+ * base64 文字列を ArrayBuffer に変換するユーティリティ関数。
+ */
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+/**
+ * useChatStream への依存を注入する引数型。
+ *
+ * phase/setPhase は page.tsx の useState のまま残す。
+ * useAudioQueue の onDrained が setPhase('idle') を呼ぶため、
+ * useChatStream 内に phase を持たせると循環依存になる。
+ */
+export interface UseChatStreamDeps {
+  /** カレントキャラクター ID */
+  characterId: string;
+  /** ChatPhase の setter（page.tsx の useState から渡す） */
+  setPhase: Dispatch<SetStateAction<ChatPhase>>;
+  /** AudioContext を unlock する関数（iOS Safari autoplay 制約対策） */
+  ensureUnlocked: () => Promise<void>;
+  /** AudioContext インスタンスを取得する関数 */
+  getContext: () => AudioContext | null;
+  /** decode 済み AudioBuffer をキューに追加する関数 */
+  enqueue: (buffer: AudioBuffer) => void;
+  /** ストリーム完了をマークする関数 */
+  markStreamDone: () => void;
+  /** 音声キューをリセットする関数（useAudioQueue の reset） */
+  resetAudioQueue: () => void;
+  /** 再生エラー時にキューを advance する関数（useAudioQueue の handlePlaybackError） */
+  advanceOnError: () => void;
+  /** knowledgeId を取り出してクリアする関数（クロス汚染防止ガード付き） */
+  consumeKnowledgeId: (currentCharacterId: string) => string | null;
+  /** 第一声テキストをクリアする関数 */
+  clearFirstWordText: () => void;
+  /** オンボーディングテキストをクリアする関数 */
+  clearOnboardingText: () => void;
+  /** ライフサイクル状態を更新する setter */
+  setLifecycleState: Dispatch<SetStateAction<LifecycleState>>;
+}
+
+/**
+ * useChatStream の戻り値型。
+ */
+export interface UseChatStreamResult {
+  /** ユーザー入力テキスト（送信済み） */
+  userText: string | null;
+  /** AI 応答テキスト（逐次追記） */
+  responseText: string | null;
+  /** エラーメッセージ（null = エラーなし） */
+  errorMessage: string | null;
+  /** セーフティモーダルの表示状態 */
+  safetyOpen: boolean;
+  /** セーフティリソース一覧 */
+  safetyResources: SafetyResource[];
+  /** セーフティモーダルを閉じる関数 */
+  closeSafety: () => void;
+  /** チャット送信ハンドラ */
+  handleSubmit: (text: string) => Promise<void>;
+  /** 音声再生エラーハンドラ（CharacterCanvas の onPlaybackError に渡す） */
+  handlePlaybackError: (error: Error) => void;
+}
+
+/**
+ * チャット送信フロー（handleSubmit + NDJSON parse + ストリームイベント分岐 + handlePlaybackError）
+ * を管理するカスタム hook。
+ *
+ * phase/setPhase は page.tsx の useState のまま残す設計（useAudioQueue との循環依存回避）。
+ * setPhase を deps として受け取り、loading/streaming/idle の遷移はこの hook 内から呼ぶ。
+ */
+export function useChatStream(deps: UseChatStreamDeps): UseChatStreamResult {
+  const {
+    characterId,
+    setPhase,
+    ensureUnlocked,
+    getContext,
+    enqueue,
+    markStreamDone,
+    resetAudioQueue,
+    advanceOnError,
+    consumeKnowledgeId,
+    clearFirstWordText,
+    clearOnboardingText,
+    setLifecycleState,
+  } = deps;
+
+  const [userText, setUserText] = useState<string | null>(null);
+  const [responseText, setResponseText] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [safetyOpen, setSafetyOpen] = useState(false);
+  const [safetyResources, setSafetyResources] = useState<SafetyResource[]>([]);
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const sentenceReceivedRef = useRef(0);
+
+  const closeSafety = useCallback(() => {
+    setSafetyOpen(false);
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (text: string) => {
+      // user gesture の同期スタック内で AudioContext を resume する（iOS Safari 対策）
+      await ensureUnlocked();
+      const audioCtx = getContext();
+
+      // 前回リクエストをキャンセル
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）。
+      // クロス汚染防止: カレントキャラ == 通知元キャラのときのみ渡す（C3-3）。
+      const notifKnowledgeId = consumeKnowledgeId(characterId);
+
+      setUserText(text);
+      setResponseText('');
+      clearFirstWordText();
+      clearOnboardingText();
+      setErrorMessage(null);
+      setPhase('loading');
+      // キューをリセット（setAudioBuffer(null) + clearAudioQueue() 相当）
+      resetAudioQueue();
+      sentenceReceivedRef.current = 0;
+
+      try {
+        const chatBody: { text: string; characterId?: string; knowledgeId?: string } = {
+          text,
+          characterId,
+        };
+        if (notifKnowledgeId) chatBody.knowledgeId = notifKnowledgeId;
+
+        const response = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(chatBody),
+          signal: controller.signal,
+        });
+
+        if (!response.ok || !response.body) {
+          setErrorMessage('応答の取得に失敗しました。時間を置いて再度お試しください。');
+          setPhase('idle');
+          reportClientError('error', 'チャット fetch 失敗', `HTTP ${response.status}`, {
+            screen: 'chat',
+            audioContextState: getContext()?.state,
+          });
+          return;
+        }
+
+        setPhase('streaming');
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let lineBuffer = '';
+
+        const handleEvent = async (event: ChatStreamEvent) => {
+          if (event.type === 'text') {
+            setResponseText((prev) => (prev ?? '') + event.delta);
+          } else if (event.type === 'sentence' && event.audio) {
+            sentenceReceivedRef.current++;
+            if (!audioCtx) {
+              // AudioContext が無いブラウザ（極めて稀）: 音声をスキップしてテキストだけ表示
+              return;
+            }
+            try {
+              const arrayBuffer = base64ToArrayBuffer(event.audio);
+              const decoded = await audioCtx.decodeAudioData(arrayBuffer);
+              // decode 済みバッファをキューに追加（空きなら即再生開始）
+              enqueue(decoded);
+            } catch (err) {
+              console.error('[LiveTalk] 音声 decode に失敗しました', err);
+              reportClientError(
+                'warning',
+                '音声 decode 失敗',
+                err instanceof Error ? err.message : '不明なエラー',
+                {
+                  screen: 'chat',
+                  audioContextState: getContext()?.state,
+                  sentenceReceived: sentenceReceivedRef.current,
+                }
+              );
+            }
+          } else if (event.type === 'lifecycle') {
+            setLifecycleState(event.state);
+          } else if (event.type === 'safety') {
+            if (event.trigger === 'output_moderation' && event.replacementText) {
+              setResponseText(event.replacementText);
+            }
+            setSafetyResources(event.resources);
+            setSafetyOpen(true);
+          } else if (event.type === 'done') {
+            // ストリーム完了をマーク（キューと current が空なら onDrained → setPhase('idle')）
+            markStreamDone();
+          } else if (event.type === 'error') {
+            setErrorMessage(event.message ?? '内部エラーが発生しました。');
+            // ストリームエラー時もストリーム完了扱い（advance のみ hook に委譲）
+            markStreamDone();
+            reportClientError(
+              'error',
+              'チャット stream エラー',
+              event.message ?? '内部エラーが発生しました',
+              {
+                screen: 'chat',
+                audioContextState: getContext()?.state,
+                sentenceReceived: sentenceReceivedRef.current,
+                // markStreamDone 後なので streamDone は true
+                streamDone: true,
+              }
+            );
+          }
+        };
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          lineBuffer += decoder.decode(value, { stream: true });
+          const lines = lineBuffer.split('\n');
+          lineBuffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            try {
+              await handleEvent(JSON.parse(trimmed) as ChatStreamEvent);
+            } catch {
+              // malformed line はスキップ
+            }
+          }
+        }
+
+        // ストリーム終端の残余行
+        if (lineBuffer.trim()) {
+          try {
+            await handleEvent(JSON.parse(lineBuffer.trim()) as ChatStreamEvent);
+          } catch {
+            // skip
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') return;
+        console.error('[LiveTalk] チャット応答の取得に失敗しました', error);
+        setErrorMessage('エラーが発生しました。時間を置いて再度お試しください。');
+        setPhase('idle');
+        reportClientError(
+          'error',
+          'チャット通信エラー',
+          error instanceof Error ? error.message : '不明なエラー',
+          {
+            screen: 'chat',
+            audioContextState: getContext()?.state,
+            sentenceReceived: sentenceReceivedRef.current,
+            stack: error instanceof Error ? error.stack : undefined,
+          }
+        );
+      }
+    },
+    [
+      ensureUnlocked,
+      getContext,
+      resetAudioQueue,
+      enqueue,
+      markStreamDone,
+      characterId,
+      consumeKnowledgeId,
+      clearFirstWordText,
+      clearOnboardingText,
+      setLifecycleState,
+      setPhase,
+    ]
+  );
+
+  const handlePlaybackError = useCallback(
+    (error: Error) => {
+      console.error('[LiveTalk] 音声再生エラー', error);
+      setErrorMessage('音声再生中にエラーが発生しました。');
+      // advance のみ hook に委譲（ログ・setErrorMessage・reportClientError はここで処理）
+      advanceOnError();
+      reportClientError('warning', '音声再生エラー', error.message, {
+        screen: 'chat',
+        audioContextState: getContext()?.state,
+        sentenceReceived: sentenceReceivedRef.current,
+      });
+    },
+    [advanceOnError, getContext]
+  );
+
+  return {
+    userText,
+    responseText,
+    errorMessage,
+    safetyOpen,
+    safetyResources,
+    closeSafety,
+    handleSubmit,
+    handlePlaybackError,
+  };
+}

--- a/services/livetalk/web/tests/unit/lib/home/useChatStream.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useChatStream.test.ts
@@ -1,0 +1,760 @@
+// jsdom は TextEncoder / TextDecoder / ReadableStream を提供しない場合があるため補完
+import { TextEncoder, TextDecoder } from 'util';
+import { ReadableStream } from 'stream/web';
+Object.assign(global, { TextEncoder, TextDecoder, ReadableStream });
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { LifecycleState } from '@nagiyu/livetalk-core';
+import { useChatStream, type UseChatStreamDeps } from '@/lib/home/useChatStream';
+import type { ChatPhase } from '@/lib/home/types';
+
+// reportClientError をモック化（fetch 呼び出しを排除）
+jest.mock('@/lib/client-logger', () => ({
+  reportClientError: jest.fn(),
+}));
+
+import { reportClientError } from '@/lib/client-logger';
+const mockReportClientError = reportClientError as jest.Mock;
+
+// NDJSON 行を TextEncoder で ReadableStream に変換するヘルパー
+function makeNdjsonStream(lines: unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(JSON.stringify(line) + '\n'));
+      }
+      controller.close();
+    },
+  });
+}
+
+// deps のデフォルトスタブを生成するヘルパー
+// jest.fn() のインスタンスを UseChatStreamDeps の各フィールドにキャストして返す
+function makeDeps(overrides: Partial<UseChatStreamDeps> = {}): UseChatStreamDeps {
+  return {
+    characterId: 'hiyori',
+    setPhase: jest.fn() as unknown as Dispatch<SetStateAction<ChatPhase>>,
+    ensureUnlocked: jest.fn().mockResolvedValue(undefined) as () => Promise<void>,
+    getContext: jest.fn().mockReturnValue(null) as () => AudioContext | null,
+    enqueue: jest.fn() as (buffer: AudioBuffer) => void,
+    markStreamDone: jest.fn() as () => void,
+    resetAudioQueue: jest.fn() as () => void,
+    advanceOnError: jest.fn() as () => void,
+    consumeKnowledgeId: jest.fn().mockReturnValue(null) as (
+      currentCharacterId: string
+    ) => string | null,
+    clearFirstWordText: jest.fn() as () => void,
+    clearOnboardingText: jest.fn() as () => void,
+    setLifecycleState: jest.fn() as unknown as Dispatch<SetStateAction<LifecycleState>>,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useChatStream', () => {
+  describe('初期値', () => {
+    it('初期状態は userText / responseText / errorMessage が null、safetyOpen が false', () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, body: null, status: 500 });
+      const { result } = renderHook(() => useChatStream(makeDeps()));
+
+      expect(result.current.userText).toBeNull();
+      expect(result.current.responseText).toBeNull();
+      expect(result.current.errorMessage).toBeNull();
+      expect(result.current.safetyOpen).toBe(false);
+      expect(result.current.safetyResources).toEqual([]);
+    });
+  });
+
+  describe('closeSafety', () => {
+    it('closeSafety を呼ぶと safetyOpen が false になる', async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              JSON.stringify({
+                type: 'safety',
+                trigger: 'input_keyword',
+                resources: [{ title: 'サポート', url: 'https://example.com' }],
+              }) + '\n'
+            )
+          );
+          controller.close();
+        },
+      });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: stream, status: 200 });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(result.current.safetyOpen).toBe(true));
+
+      act(() => {
+        result.current.closeSafety();
+      });
+      expect(result.current.safetyOpen).toBe(false);
+    });
+  });
+
+  describe('handleSubmit: 状態リセット', () => {
+    it('送信時に setPhase("loading") が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.setPhase).toHaveBeenCalledWith('loading');
+    });
+
+    it('送信時に clearFirstWordText と clearOnboardingText が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.clearFirstWordText).toHaveBeenCalled();
+      expect(deps.clearOnboardingText).toHaveBeenCalled();
+    });
+
+    it('送信時に resetAudioQueue が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.resetAudioQueue).toHaveBeenCalled();
+    });
+
+    it('送信時に ensureUnlocked が先行して呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const callOrder: string[] = [];
+      const deps = makeDeps({
+        ensureUnlocked: jest.fn().mockImplementation(async () => {
+          callOrder.push('ensureUnlocked');
+        }),
+        setPhase: jest.fn().mockImplementation(() => {
+          callOrder.push('setPhase');
+        }) as Dispatch<SetStateAction<ChatPhase>>,
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      // ensureUnlocked は setPhase より先に呼ばれる
+      expect(callOrder[0]).toBe('ensureUnlocked');
+    });
+
+    it('送信時に userText が設定される', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('こんにちは');
+      });
+
+      expect(result.current.userText).toBe('こんにちは');
+    });
+  });
+
+  describe('handleSubmit: response.ok=false の場合', () => {
+    it('HTTP エラー時に errorMessage が設定され setPhase("idle") が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        body: null,
+        status: 500,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(result.current.errorMessage).toBe(
+        '応答の取得に失敗しました。時間を置いて再度お試しください。'
+      );
+      expect(deps.setPhase).toHaveBeenCalledWith('idle');
+    });
+
+    it('HTTP エラー時に reportClientError が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        body: null,
+        status: 500,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'error',
+        'チャット fetch 失敗',
+        'HTTP 500',
+        expect.objectContaining({ screen: 'chat' })
+      );
+    });
+  });
+
+  describe('handleSubmit: streaming フェーズ', () => {
+    it('ストリーム開始後に setPhase("streaming") が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.setPhase).toHaveBeenCalledWith('streaming');
+    });
+  });
+
+  describe('handleSubmit: text イベント', () => {
+    it('text イベントで responseText が追記される', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'text', delta: 'こんに' },
+          { type: 'text', delta: 'ちは' },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      // React の state 更新は関数形式で追記されるため最終的な値を確認
+      await waitFor(() => expect(result.current.responseText).toBe('こんにちは'));
+    });
+  });
+
+  describe('handleSubmit: sentence イベント', () => {
+    it('sentence イベントで AudioContext がある場合 decodeAudioData が呼ばれ enqueue される', async () => {
+      const mockDecodeAudioData = jest.fn().mockResolvedValue({} as AudioBuffer);
+      const mockAudioCtx = {
+        state: 'running' as AudioContextState,
+        decodeAudioData: mockDecodeAudioData,
+      };
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'sentence', index: 0, text: 'こんにちは', audio: 'AAAAAA==' },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        getContext: jest.fn().mockReturnValue(mockAudioCtx as unknown as AudioContext),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(mockDecodeAudioData).toHaveBeenCalledTimes(1));
+      expect(deps.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('AudioContext が null の場合 enqueue は呼ばれない（音声スキップ）', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'sentence', index: 0, text: 'こんにちは', audio: 'AAAAAA==' },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        getContext: jest.fn().mockReturnValue(null),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('decodeAudioData が失敗してもクラッシュせず reportClientError が呼ばれる', async () => {
+      const mockDecodeAudioData = jest.fn().mockRejectedValue(new Error('decode failure'));
+      const mockAudioCtx = {
+        state: 'running' as AudioContextState,
+        decodeAudioData: mockDecodeAudioData,
+      };
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'sentence', index: 0, text: 'こんにちは', audio: 'AAAAAA==' },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        getContext: jest.fn().mockReturnValue(mockAudioCtx as unknown as AudioContext),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(mockDecodeAudioData).toHaveBeenCalledTimes(1));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[LiveTalk] 音声 decode に失敗しました',
+        expect.any(Error)
+      );
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'warning',
+        '音声 decode 失敗',
+        'decode failure',
+        expect.objectContaining({ screen: 'chat', sentenceReceived: 1 })
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('handleSubmit: lifecycle イベント', () => {
+    it('lifecycle イベントで setLifecycleState が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'lifecycle', state: 'sleeping' }, { type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.setLifecycleState).toHaveBeenCalledWith('sleeping');
+    });
+  });
+
+  describe('handleSubmit: safety イベント', () => {
+    it('safety イベントで safetyOpen が true になり safetyResources が設定される', async () => {
+      const resources = [{ title: 'サポート', url: 'https://example.com' }];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'safety', trigger: 'input_keyword', resources },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(result.current.safetyOpen).toBe(true));
+      expect(result.current.safetyResources).toEqual(resources);
+    });
+
+    it('safety trigger=output_moderation かつ replacementText がある場合 responseText が上書きされる', async () => {
+      const resources = [{ title: 'サポート', url: 'https://example.com' }];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'text', delta: '元のテキスト' },
+          {
+            type: 'safety',
+            trigger: 'output_moderation',
+            resources,
+            replacementText: '代替テキスト',
+          },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(result.current.safetyOpen).toBe(true));
+      expect(result.current.responseText).toBe('代替テキスト');
+    });
+
+    it('safety trigger=input_keyword の場合 responseText は上書きされない', async () => {
+      const resources = [{ title: 'サポート', url: 'https://example.com' }];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'text', delta: '元のテキスト' },
+          { type: 'safety', trigger: 'input_keyword', resources },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(result.current.safetyOpen).toBe(true));
+      // input_keyword は responseText を上書きしない
+      await waitFor(() => expect(result.current.responseText).toBe('元のテキスト'));
+    });
+  });
+
+  describe('handleSubmit: done イベント', () => {
+    it('done イベントで markStreamDone が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.markStreamDone).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleSubmit: error イベント', () => {
+    it('error イベントで errorMessage が設定され markStreamDone と reportClientError が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'error', message: 'サーバーエラーです' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(result.current.errorMessage).toBe('サーバーエラーです');
+      expect(deps.markStreamDone).toHaveBeenCalled();
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'error',
+        'チャット stream エラー',
+        'サーバーエラーです',
+        expect.objectContaining({ screen: 'chat', streamDone: true })
+      );
+    });
+  });
+
+  describe('handleSubmit: AbortError', () => {
+    it('AbortError は無視されエラーメッセージが設定されない', async () => {
+      const abortError = new Error('AbortError');
+      abortError.name = 'AbortError';
+      global.fetch = jest.fn().mockRejectedValue(abortError);
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(result.current.errorMessage).toBeNull();
+      expect(deps.setPhase).not.toHaveBeenCalledWith('idle');
+    });
+
+    it('2 回目の送信前に前回 AbortController が abort される（AbortError は無視）', async () => {
+      // 1 回目は即 AbortError を throw するようにして abort 確認を行う
+      // （void act は非同期漏れを起こすため使わず、2 回 fetch を呼ぶことで確認する）
+      let callCount = 0;
+      const abortErrors: DOMException[] = [];
+
+      global.fetch = jest.fn().mockImplementation((_url: string, options: RequestInit) => {
+        callCount++;
+        const signal = options?.signal;
+        if (callCount === 1) {
+          // 1 回目は done ストリームを返す
+          return Promise.resolve({
+            ok: true,
+            body: makeNdjsonStream([{ type: 'done' }]),
+            status: 200,
+          });
+        }
+        // 2 回目以降も done ストリームを返す
+        if (signal?.aborted) {
+          const err = new DOMException('Aborted', 'AbortError');
+          abortErrors.push(err);
+          return Promise.reject(err);
+        }
+        return Promise.resolve({
+          ok: true,
+          body: makeNdjsonStream([{ type: 'done' }]),
+          status: 200,
+        });
+      });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      // 1 回目送信
+      await act(async () => {
+        await result.current.handleSubmit('1回目');
+      });
+
+      // 2 回目送信（前回の abort controller が abort される）
+      await act(async () => {
+        await result.current.handleSubmit('2回目');
+      });
+
+      // 2 回の fetch が呼ばれたことを確認（前回 abort + 新リクエスト）
+      expect(callCount).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('handleSubmit: 通信エラー catch', () => {
+    it('fetch が例外を投げたとき errorMessage が設定され setPhase("idle") と reportClientError が呼ばれる', async () => {
+      const networkError = new Error('ネットワークエラー');
+      global.fetch = jest.fn().mockRejectedValue(networkError);
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(result.current.errorMessage).toBe(
+        'エラーが発生しました。時間を置いて再度お試しください。'
+      );
+      expect(deps.setPhase).toHaveBeenCalledWith('idle');
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'error',
+        'チャット通信エラー',
+        'ネットワークエラー',
+        expect.objectContaining({ screen: 'chat', stack: expect.any(String) })
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('handleSubmit: malformed 行スキップ', () => {
+    it('malformed JSON 行はスキップされクラッシュしない', async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          // 不正な JSON を含む NDJSON
+          controller.enqueue(encoder.encode('{"type":"text","delta":"こんにちは"}\n'));
+          controller.enqueue(encoder.encode('{invalid json}\n'));
+          controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+          controller.close();
+        },
+      });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: stream, status: 200 });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      // malformed 行はスキップ、done は処理される
+      expect(deps.markStreamDone).toHaveBeenCalled();
+      await waitFor(() => expect(result.current.responseText).toBe('こんにちは'));
+    });
+
+    it('空行はスキップされクラッシュしない', async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('\n\n'));
+          controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+          controller.close();
+        },
+      });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: stream, status: 200 });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.markStreamDone).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSubmit: knowledgeId の伝播', () => {
+    it('consumeKnowledgeId が knowledgeId を返す場合 chatBody に含まれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        consumeKnowledgeId: jest.fn().mockReturnValue('k-xyz'),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      const chatCall = (global.fetch as jest.Mock).mock.calls.find(
+        ([url]: [string]) => url === '/api/chat'
+      );
+      expect(chatCall).toBeDefined();
+      const chatBody = JSON.parse(chatCall[1].body as string);
+      expect(chatBody.knowledgeId).toBe('k-xyz');
+    });
+
+    it('consumeKnowledgeId が null を返す場合 chatBody に knowledgeId が含まれない', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        consumeKnowledgeId: jest.fn().mockReturnValue(null),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      const chatCall = (global.fetch as jest.Mock).mock.calls.find(
+        ([url]: [string]) => url === '/api/chat'
+      );
+      expect(chatCall).toBeDefined();
+      const chatBody = JSON.parse(chatCall[1].body as string);
+      expect(chatBody.knowledgeId).toBeUndefined();
+    });
+  });
+
+  describe('handleSubmit: ストリーム終端の残余行処理', () => {
+    it('改行で終わらない残余行でも最後のイベントが処理される', async () => {
+      const encoder = new TextEncoder();
+      // 最後の行に改行を付けない（残余行として lineBuffer に残る）
+      const stream = new ReadableStream({
+        start(controller) {
+          // done を改行なしで送信
+          controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' })));
+          controller.close();
+        },
+      });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: stream, status: 200 });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      // 残余行の done も処理される
+      expect(deps.markStreamDone).toHaveBeenCalled();
+    });
+  });
+
+  describe('handlePlaybackError', () => {
+    it('handlePlaybackError で errorMessage が設定され advanceOnError と reportClientError が呼ばれる', () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, body: null, status: 500 });
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      act(() => {
+        result.current.handlePlaybackError(new Error('再生エラー'));
+      });
+
+      expect(result.current.errorMessage).toBe('音声再生中にエラーが発生しました。');
+      expect(deps.advanceOnError).toHaveBeenCalled();
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'warning',
+        '音声再生エラー',
+        '再生エラー',
+        expect.objectContaining({ screen: 'chat' })
+      );
+      expect(consoleSpy).toHaveBeenCalledWith('[LiveTalk] 音声再生エラー', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('関数参照の安定性', () => {
+    it('handleSubmit と handlePlaybackError は再レンダリングで参照が変わらない', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, body: null, status: 500 });
+      const deps = makeDeps();
+      const { result, rerender } = renderHook(() => useChatStream(deps));
+
+      const firstHandleSubmit = result.current.handleSubmit;
+      const firstHandlePlaybackError = result.current.handlePlaybackError;
+
+      rerender();
+
+      expect(result.current.handleSubmit).toBe(firstHandleSubmit);
+      expect(result.current.handlePlaybackError).toBe(firstHandlePlaybackError);
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

`services/livetalk/web/src/app/page.tsx` に直書きされていたチャット送信フロー（`handleSubmit` + `/api/chat` の NDJSON ストリーム読取 + イベント分岐 + 音声再生エラーハンドラ）を `src/lib/home/useChatStream.ts` に切り出すリファクタリング（**挙動不変**）。Phase 1（音声）・Phase 2（データ取得系）に続く #3529 の第 3 弾で、hook 抽出の本丸。

- `useChatStream(deps)` — `handleSubmit` / `handlePlaybackError` と、`userText`/`responseText`/`errorMessage`/`safety*` の state、`abortControllerRef`/`sentenceReceivedRef` を集約。`base64ToArrayBuffer` と `ChatStreamEvent` 型も同ファイルへ移設。
- `page.tsx`: 各 hook を合成して JSX に配線するだけの薄い構成に（**427 行 → 232 行**、Phase 1 開始時 601 行から大幅減）。
- `ChatPhase` 型を `types.ts` に移設。

### 設計判断: `phase` は page.tsx に残す
`useAudioQueue` の `onDrained` が `setPhase('idle')` を呼ぶため、`phase` を `useChatStream` に持たせると `useChatStream ↔ useAudioQueue` が循環依存になる。これを避けるため **`phase`/`setPhase` は page.tsx の state のまま残し、`setPhase` を `useChatStream` に依存注入**する（依存方向を一方向に保つ）。

## 関連 Issue

#3529 （親 Issue: #3521）

## 変更種別

- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した（UI/ロジック分離・lib にロジック集約）
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（永続ドキュメントへの追従は develop 反映後に判断）
- [ ] CI/CD 設定を追加・更新した（該当なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `tests/unit/lib/home/useChatStream.test.ts`（30 ケース）: text 追記 / sentence の decode→enqueue / audioCtx 無しスキップ / decode 失敗 / lifecycle / safety（replacementText 上書き）/ done / error / `response.ok=false` / AbortError / 通信エラー catch / malformed・空行スキップ / 終端残余行 / 参照安定性。`ReadableStream` を `TextEncoder` で組み立て現実的に検証。
- 既存 `tests/unit/app/page.test.tsx`（handleSubmit を UI 経由で広く検証する回帰テスト）を緑のまま維持。

検証結果（ローカル）:
- `npm test`: 703 件全パス（68 スイート）
- カバレッジ: global 91.76% / branch 92.14% / func 83.2%、`src/lib/home` 94.56%、`useChatStream.ts` Stmts 99.4%（閾値 80% 超）
- `tsc --noEmit`: 変更ファイルに型エラー 0 件（残 34 件は本変更と無関係の既存エラー、`develop` と同数）
- `prettier --check`: クリーン / `eslint`: 0 errors

**fresh-eyes レビュー（Opus・別コンテキスト）実施**: 抽出前 `handleSubmit` と全行突き合わせて挙動完全一致を確認、クリティカル/仕様確認要の指摘なし。

## レビューポイント

- NDJSON 行バッファリング（`lines.pop()` 残余保持・終端残余行）と `handleEvent` 全分岐が元と等価であること。
- `handleSubmit` の `useCallback` 依存配列（元の 10 個 + `setPhase`）の妥当性。
- `setPhase` を deps 経由で受け取る循環依存回避設計。

## 補足事項

#3529 の段階的リファクタリングの第 3 弾。残るは Phase 4（Live2D 内部 API キャストの型整備）のみ。`integration/3529-livetalk-frontend` に積み上げ、Phase 4 完了後に integration → develop の取りまとめ PR を（人確認のうえ）作成予定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FLhrr8dDji5yKVxmSuu7Ce)_