### PR TITLE
リブトーク: Live2DCanvas の内部 API キャストを公開型に置換（#3529 Phase 4）

### DIFF
--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -27,6 +27,8 @@ function waitForCubismCore(timeout = 10000): Promise<void> {
 }
 
 type Live2DModelInstance = import('pixi-live2d-display-lipsyncpatch/cubism4').Live2DModel;
+type Cubism4InternalModelType =
+  import('pixi-live2d-display-lipsyncpatch/cubism4').Cubism4InternalModel;
 
 /**
  * 上半身フォーカスのレイアウト。
@@ -238,16 +240,10 @@ export default function Live2DCanvas({
     let source: AudioBufferSourceNode | null = null;
     let analyser: AnalyserNode | null = null;
 
-    // 型情報がない internal API を扱うための narrowing
-    const motionManager = (
-      model.internalModel as unknown as {
-        motionManager: {
-          currentAudio?: { ended: boolean } | undefined;
-          currentAnalyzer?: AnalyserNode | undefined;
-          currentContext?: AudioContext | undefined;
-        };
-      }
-    ).motionManager;
+    // Cubism4 の公開型でアクセスする（ライブラリの MotionManager が
+    // currentAudio / currentAnalyzer / currentContext を型として公開している）
+    const internalModel = model.internalModel as Cubism4InternalModelType;
+    const motionManager = internalModel.motionManager;
 
     try {
       source = audioContext.createBufferSource();
@@ -266,7 +262,10 @@ export default function Live2DCanvas({
       // ライブラリ内部のリップシンク駆動ループに自前 AnalyserNode を hijack 注入。
       // updateParameters 内で `if (this.lipSync && motionManager.currentAudio)` を
       // 通過させるため、currentAudio には truthy なオブジェクトを置く。
-      motionManager.currentAudio = { ended: false };
+      // ライブラリは currentAudio が truthy のときだけリップシンク（ParamMouthOpenY 更新）を
+      // 駆動する。実際の HTMLAudioElement は使わず Web Audio 経由で再生するため、
+      // truthy なダミーを注入する（意図的な hijack）。
+      motionManager.currentAudio = { ended: false } as unknown as HTMLAudioElement;
       motionManager.currentAnalyzer = analyser;
       motionManager.currentContext = audioContext;
 
@@ -333,12 +332,8 @@ export default function Live2DCanvas({
     const BLINK_INTERVAL_MIN_MS = 3000;
     const BLINK_INTERVAL_RANGE_MS = 3000;
 
-    const internalModel = model.internalModel as unknown as {
-      coreModel?: { setParameterValueById?: (id: string, value: number) => void };
-      eyeBlink?: unknown;
-      on?: (event: string, handler: () => void) => void;
-      off?: (event: string, handler: () => void) => void;
-    };
+    // Cubism4 の公開型でアクセスする
+    const internalModel = model.internalModel as Cubism4InternalModelType;
 
     // 三角波で瞬きの開き値（0〜0.3）を計算する。瞬き窓の外は 0.3（半目）。
     let blinkStart = -Infinity;
@@ -385,10 +380,19 @@ export default function Live2DCanvas({
     const savedEyeBlink = internalModel.eyeBlink;
     internalModel.eyeBlink = undefined;
 
-    internalModel.on?.('afterMotionUpdate', applyEyes);
+    // ライブラリの型定義上、InternalModel は utils.EventEmitter（eventemitter3）を
+    // 継承しているが、eventemitter3 が export = 形式のため TypeScript の型解決で
+    // on/off がインスタンスメソッドとして継承されない。
+    // 実際には EventEmitter のメソッドが存在するため、on/off 呼び出しのみ
+    // 最小限のキャストで対処する（ad-hoc な unknown キャストへの退行を避ける）。
+    const emitter = internalModel as unknown as {
+      on: (event: string, fn: () => void) => void;
+      off: (event: string, fn: () => void) => void;
+    };
+    emitter.on('afterMotionUpdate', applyEyes);
 
     return () => {
-      internalModel.off?.('afterMotionUpdate', applyEyes);
+      emitter.off('afterMotionUpdate', applyEyes);
       internalModel.eyeBlink = savedEyeBlink;
     };
     // characterId が変更されてもモデルロード effect（依存 [characterId]）が旧モデルを


### PR DESCRIPTION
## 変更の概要

`services/livetalk/web/src/components/Live2DCanvas.tsx` の `pixi-live2d-display-lipsyncpatch` 内部 API への `as unknown as {...}` アドホックキャスト 2 箇所を、ライブラリの**公開型**で置換し型穴を塞ぐリファクタリング（**挙動不変**）。#3529 の第 4 弾（最終）。

- 型エイリアス `Cubism4InternalModelType`（`= import('pixi-live2d-display-lipsyncpatch/cubism4').Cubism4InternalModel`）を追加。
- **音声再生 useEffect**: `model.internalModel as unknown as {...}` → `as Cubism4InternalModelType`。`motionManager.currentAnalyzer`(AnalyserNode) / `currentContext`(AudioContext) が公開型どおり型チェックされるように。
- **sleeping 目制御 useEffect**: 同様に `Cubism4InternalModelType` 経由で `coreModel`(CubismModel) / `eyeBlink`(CubismEyeBlink) にアクセス。

### 残した最小キャスト（2 箇所・理由付き）
1. `motionManager.currentAudio = { ended: false } as unknown as HTMLAudioElement`（268 行）— ライブラリは `currentAudio` が truthy のときだけリップシンク駆動ループを回す。実 `HTMLAudioElement` は使わず Web Audio で再生するための**意図的なダミー注入（hijack）**。型（`HTMLAudioElement`）と本質的に競合するため局所キャストで残置。
2. `on`/`off` 呼び出し（388 行）— `eventemitter3` が `export =` 形式のため、`InternalModel extends utils.EventEmitter` の継承チェーンで `on`/`off` が TS の型解決上インスタンスメソッドとして引き継がれない。ad-hoc な全体キャストへの退行を避け、**`on`/`off` の 2 メソッドのみに限定**したキャストに留めた。

> 広範な内部 API を覆い隠していた 2 つの大きな ad-hoc キャストを、本質的に必要な 2 つの最小キャストへ縮小。`coreModel.setParameterValueById` / `eyeBlink` / `currentAnalyzer` / `currentContext` / `motionManager` がライブラリ実型で型チェックされ、ライブラリ更新時に tsc が破壊を検知できるようになった（Issue の「型穴」懸念に対応）。

## 関連 Issue

#3529 （親 Issue: #3521）

## 変更種別

- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（Live2DCanvas はブラウザ専用・`collectCoverageFrom` 対象外のため新規テストなし。既存テストは緑維持）
- [x] 関連ドキュメントを更新した（永続ドキュメントへの追従は develop 反映後に判断）
- [ ] CI/CD 設定を追加・更新した（該当なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- 型のみの変更（挙動不変）のため新規テストなし。`Live2DCanvas` は PixiJS/WebGL 依存で単体テスト対象外（`jest.config` の `collectCoverageFrom` は `src/lib/**` のみ）。
- 既存 `tests/unit/app/page.test.tsx` 等は緑のまま維持。

検証結果（ローカル）:
- `tsc --noEmit`: `Live2DCanvas.tsx` 型エラー 0 件（残 34 件は本変更と無関係の既存エラー、`develop` と同数）。**本 Phase は tsc が主目的**。
- `npm test`: 703 件全パス（68 スイート）
- `prettier --check`: クリーン / `eslint`: 0 errors

## レビューポイント

- `Cubism4InternalModelType` キャストで `coreModel.setParameterValueById` / `eyeBlink` / `motionManager.*` が型どおりアクセスできていること。
- 残した 2 つの最小キャスト（`currentAudio` hijack・`on`/`off`）の妥当性。
- `coreModel?.setParameterValueById?.` の防御的 optional chaining と try/catch を温存し挙動を変えていないこと。

## 補足事項

#3529 の段階的リファクタリングの**最終 Phase**。これで全 4 Phase（音声 / データ取得 / チャット送信 / Live2D 型）が `integration/3529-livetalk-frontend` に出揃う。本 PR マージ・dev 確認後、integration → develop の取りまとめ PR を（人確認のうえ）作成予定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FLhrr8dDji5yKVxmSuu7Ce)_