### PR TITLE
リブトーク: チャット画面フロントエンドの構造整理（page.tsx 分割・音声キュー state machine 化）

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -26,6 +26,8 @@ import {
 } from '@/lib/pwa/standalone';
 import { PWA_MESSAGES } from '@/lib/pwa/messages';
 import { reportClientError } from '@/lib/client-logger';
+import { useAudioContext } from '@/lib/audio/useAudioContext';
+import { useAudioQueue } from '@/lib/audio/useAudioQueue';
 
 /**
  * pending API のレスポンス型（キャラクターごとの未消化通知）。
@@ -93,7 +95,6 @@ function HomePageInner() {
   const [phase, setPhase] = useState<ChatPhase>('idle');
   const [userText, setUserText] = useState<string | null>(null);
   const [responseText, setResponseText] = useState<string | null>(null);
-  const [audioBuffer, setAudioBuffer] = useState<AudioBuffer | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   // 通知タップ起動時に入力欄へプリフィルするサジェスト発話
   const [prefillText, setPrefillText] = useState<string | null>(null);
@@ -111,15 +112,15 @@ function HomePageInner() {
   // 他キャラクターの未消化通知（自前起動時に提示する）
   const [pendingNotifications, setPendingNotifications] = useState<PendingNotification[]>([]);
 
-  const audioQueueRef = useRef<AudioBuffer[]>([]);
-  const isPlayingRef = useRef(false);
-  const streamDoneRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const sentenceReceivedRef = useRef(0);
-  // AudioContext は子コンポーネント（CharacterCanvas）に prop で渡すため state で持つ。
-  // 同期アクセス用に ref も併用する（callback 内で最新値を読むため）。
-  const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
-  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  // AudioContext 管理 hook（iOS Safari の autoplay 制約対策）
+  const { audioContext, ensureUnlocked, getContext } = useAudioContext();
+
+  // 音声キュー管理 hook（再生待ちバッファ列と再生状態の state machine）
+  const { audioBuffer, enqueue, markStreamDone, reset, handlePlaybackEnd, handlePlaybackError: advanceOnError } =
+    useAudioQueue({ onDrained: () => setPhase('idle') });
 
   useEffect(() => {
     fetch('/api/consent')
@@ -232,28 +233,6 @@ function HomePageInner() {
       });
   }, [characterId]);
 
-  // iOS Safari の Web Audio autoplay 制約対策。
-  // user gesture（handleSubmit）の同期スタックで AudioContext を作成・resume することで、
-  // 以降の AudioBufferSourceNode.start() が transient activation token を消費せず
-  // いつでも再生可能になる。HTMLAudioElement の per-element 制約は別系統で、
-  // この対策では効かないため、再生は Web Audio API のみで完結させる（CharacterCanvas 参照）。
-  const ensureAudioContextUnlocked = useCallback(async () => {
-    if (typeof window === 'undefined') return;
-    const AudioContextClass =
-      window.AudioContext ??
-      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AudioContextClass) return;
-    if (!audioCtxRef.current) {
-      const ctx = new AudioContextClass();
-      audioCtxRef.current = ctx;
-      // 子コンポーネント（CharacterCanvas）に prop で渡すため state も更新
-      setAudioContext(ctx);
-    }
-    if (audioCtxRef.current.state === 'suspended') {
-      await audioCtxRef.current.resume();
-    }
-  }, []);
-
   const handleInstallSkip = useCallback(() => {
     setOnboardingPhase(null);
     setOnboardingText(null);
@@ -274,30 +253,11 @@ function HomePageInner() {
     setOnboardingText(null);
   }, []);
 
-  const clearAudioQueue = useCallback(() => {
-    audioQueueRef.current = [];
-    isPlayingRef.current = false;
-    streamDoneRef.current = false;
-  }, []);
-
-  // キューから次の音声を再生、またはストリーム完了済みならアイドルに戻る
-  const advanceAudioQueue = useCallback(() => {
-    if (isPlayingRef.current) return;
-
-    const nextBuffer = audioQueueRef.current.shift();
-    if (nextBuffer) {
-      isPlayingRef.current = true;
-      setAudioBuffer(nextBuffer);
-    } else if (streamDoneRef.current) {
-      setPhase('idle');
-    }
-  }, []);
-
   const handleSubmit = useCallback(
     async (text: string) => {
       // user gesture の同期スタック内で AudioContext を resume する（iOS Safari 対策）
-      await ensureAudioContextUnlocked();
-      const audioCtx = audioCtxRef.current;
+      await ensureUnlocked();
+      const audioCtx = getContext();
 
       // 前回リクエストをキャンセル
       abortControllerRef.current?.abort();
@@ -319,8 +279,8 @@ function HomePageInner() {
       setOnboardingText(null);
       setErrorMessage(null);
       setPhase('loading');
-      setAudioBuffer(null);
-      clearAudioQueue();
+      // キューをリセット（setAudioBuffer(null) + clearAudioQueue() 相当）
+      reset();
       sentenceReceivedRef.current = 0;
 
       try {
@@ -342,7 +302,7 @@ function HomePageInner() {
           setPhase('idle');
           reportClientError('error', 'チャット fetch 失敗', `HTTP ${response.status}`, {
             screen: 'chat',
-            audioContextState: audioCtxRef.current?.state,
+            audioContextState: getContext()?.state,
           });
           return;
         }
@@ -365,8 +325,8 @@ function HomePageInner() {
             try {
               const arrayBuffer = base64ToArrayBuffer(event.audio);
               const decoded = await audioCtx.decodeAudioData(arrayBuffer);
-              audioQueueRef.current.push(decoded);
-              advanceAudioQueue();
+              // decode 済みバッファをキューに追加（空きなら即再生開始）
+              enqueue(decoded);
             } catch (err) {
               console.error('[LiveTalk] 音声 decode に失敗しました', err);
               reportClientError(
@@ -375,7 +335,7 @@ function HomePageInner() {
                 err instanceof Error ? err.message : '不明なエラー',
                 {
                   screen: 'chat',
-                  audioContextState: audioCtxRef.current?.state,
+                  audioContextState: getContext()?.state,
                   sentenceReceived: sentenceReceivedRef.current,
                 }
               );
@@ -389,21 +349,22 @@ function HomePageInner() {
             setSafetyResources(event.resources);
             setSafetyOpen(true);
           } else if (event.type === 'done') {
-            streamDoneRef.current = true;
-            advanceAudioQueue();
+            // ストリーム完了をマーク（キューと current が空なら onDrained → setPhase('idle')）
+            markStreamDone();
           } else if (event.type === 'error') {
             setErrorMessage(event.message ?? '内部エラーが発生しました。');
-            streamDoneRef.current = true;
-            advanceAudioQueue();
+            // ストリームエラー時もストリーム完了扱い（advance のみ hook に委譲）
+            markStreamDone();
             reportClientError(
               'error',
               'チャット stream エラー',
               event.message ?? '内部エラーが発生しました',
               {
                 screen: 'chat',
-                audioContextState: audioCtxRef.current?.state,
+                audioContextState: getContext()?.state,
                 sentenceReceived: sentenceReceivedRef.current,
-                streamDone: streamDoneRef.current,
+                // markStreamDone 後なので streamDone は true
+                streamDone: true,
               }
             );
           }
@@ -447,36 +408,29 @@ function HomePageInner() {
           error instanceof Error ? error.message : '不明なエラー',
           {
             screen: 'chat',
-            audioContextState: audioCtxRef.current?.state,
+            audioContextState: getContext()?.state,
             sentenceReceived: sentenceReceivedRef.current,
             stack: error instanceof Error ? error.stack : undefined,
           }
         );
       }
     },
-    [ensureAudioContextUnlocked, clearAudioQueue, advanceAudioQueue, characterId]
+    [ensureUnlocked, getContext, reset, enqueue, markStreamDone, characterId]
   );
-
-  const handlePlaybackEnd = useCallback(() => {
-    setAudioBuffer(null);
-    isPlayingRef.current = false;
-    advanceAudioQueue();
-  }, [advanceAudioQueue]);
 
   const handlePlaybackError = useCallback(
     (error: Error) => {
       console.error('[LiveTalk] 音声再生エラー', error);
       setErrorMessage('音声再生中にエラーが発生しました。');
-      setAudioBuffer(null);
-      isPlayingRef.current = false;
-      advanceAudioQueue();
+      // advance のみ hook に委譲（ログ・setErrorMessage・reportClientError はここで処理）
+      advanceOnError();
       reportClientError('warning', '音声再生エラー', error.message, {
         screen: 'chat',
-        audioContextState: audioCtxRef.current?.state,
+        audioContextState: getContext()?.state,
         sentenceReceived: sentenceReceivedRef.current,
       });
     },
-    [advanceAudioQueue]
+    [advanceOnError, getContext]
   );
 
   const statusText =

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { Box, Container, Stack, Typography } from '@mui/material';
 import { Link } from '@nagiyu/ui';
@@ -12,38 +11,23 @@ import CharacterCanvas from '@/components/CharacterCanvas';
 import ConsentModal from '@/components/ConsentModal';
 import SafetyModal from '@/components/SafetyModal';
 import NotificationToggle from '@/components/NotificationToggle';
-import type { LifecycleState, SafetyResource } from '@nagiyu/livetalk-core';
+import type { SafetyResource } from '@nagiyu/livetalk-core';
 import InstallGuide from '@/components/InstallGuide';
 import NotificationPermission from '@/components/NotificationPermission';
 import CharacterSelectButton from '@/components/CharacterSelectButton';
 import { useCharacter } from '@/lib/characters/CharacterContext';
 import { getCharacterDisplay, hasCharacterProfile } from '@/lib/characters/client-profiles';
-import {
-  isStandalone,
-  isPushSupported,
-  shouldShowInstallGuide,
-  shouldShowNotificationPermission,
-} from '@/lib/pwa/standalone';
-import { PWA_MESSAGES } from '@/lib/pwa/messages';
 import { reportClientError } from '@/lib/client-logger';
 import { useAudioContext } from '@/lib/audio/useAudioContext';
 import { useAudioQueue } from '@/lib/audio/useAudioQueue';
-
-/**
- * pending API のレスポンス型（キャラクターごとの未消化通知）。
- */
-interface PendingNotification {
-  /** 通知元キャラクター ID */
-  characterId: string;
-  /** 通知 ID */
-  notifId: string;
-  /** 通知本文 */
-  body: string;
-}
+import { useConsent } from '@/lib/home/useConsent';
+import { useOnboarding } from '@/lib/home/useOnboarding';
+import { useFirstWord } from '@/lib/home/useFirstWord';
+import { usePendingNotifications } from '@/lib/home/usePendingNotifications';
+import { useLifecycle } from '@/lib/home/useLifecycle';
+import { useCharacterQuerySync } from '@/lib/home/useCharacterQuerySync';
 
 type ChatPhase = 'idle' | 'loading' | 'streaming';
-type ConsentPhase = 'checking' | 'required' | 'done';
-type OnboardingPhase = 'install' | 'notification' | null;
 
 type ChatStreamEvent =
   | { type: 'text'; delta: string }
@@ -54,7 +38,7 @@ type ChatStreamEvent =
       resources: SafetyResource[];
       replacementText?: string;
     }
-  | { type: 'lifecycle'; state: LifecycleState }
+  | { type: 'lifecycle'; state: import('@nagiyu/livetalk-core').LifecycleState }
   | { type: 'done' }
   | { type: 'error'; message: string };
 
@@ -80,8 +64,7 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
  * （App Router の prerender 要件。下部の default export でラップする）。
  */
 function HomePageInner() {
-  const { characterId, setCharacterId } = useCharacter();
-  const searchParams = useSearchParams();
+  const { characterId } = useCharacter();
   const { data: session } = useSession();
   const isAdmin =
     !!session?.user &&
@@ -89,28 +72,13 @@ function HomePageInner() {
     Array.isArray(session.user.roles) &&
     hasPermission(session.user.roles, 'livetalk:admin');
 
-  const [consentPhase, setConsentPhase] = useState<ConsentPhase>('checking');
-  const [onboardingPhase, setOnboardingPhase] = useState<OnboardingPhase>(null);
-  const [onboardingText, setOnboardingText] = useState<string | null>(null);
   const [phase, setPhase] = useState<ChatPhase>('idle');
   const [userText, setUserText] = useState<string | null>(null);
   const [responseText, setResponseText] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  // 通知タップ起動時に入力欄へプリフィルするサジェスト発話
-  const [prefillText, setPrefillText] = useState<string | null>(null);
 
   const [safetyOpen, setSafetyOpen] = useState(false);
   const [safetyResources, setSafetyResources] = useState<SafetyResource[]>([]);
-  const [lifecycleState, setLifecycleState] = useState<LifecycleState>('awake');
-
-  // キャラ第一声（未消化の通知から表示）
-  const [firstWordText, setFirstWordText] = useState<string | null>(null);
-  // 第一声の元となった KnowledgeID（次の chat 送信時に文脈として渡す）
-  const firstWordKnowledgeIdRef = useRef<string | null>(null);
-  // 第一声の通知元キャラクター ID（クロス汚染防止のためカレントと照合する）
-  const firstWordCharacterIdRef = useRef<string | null>(null);
-  // 他キャラクターの未消化通知（自前起動時に提示する）
-  const [pendingNotifications, setPendingNotifications] = useState<PendingNotification[]>([]);
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const sentenceReceivedRef = useRef(0);
@@ -128,136 +96,31 @@ function HomePageInner() {
     handlePlaybackError: advanceOnError,
   } = useAudioQueue({ onDrained: () => setPhase('idle') });
 
-  useEffect(() => {
-    fetch('/api/consent')
-      .then((res) => res.json())
-      .then((data: { consented: boolean }) => {
-        setConsentPhase(data.consented ? 'done' : 'required');
-      })
-      .catch(() => {
-        // 取得失敗時はモーダルを表示してユーザーに同意を促す
-        setConsentPhase('required');
-      });
-  }, []);
+  // URL クエリパラメータ ?character=<id> をカレントキャラクターに反映する
+  useCharacterQuerySync();
 
-  // push クリック起動時: URL の ?character=<id> を読み、カレントキャラを切替える。
-  // searchParams は Next.js の useSearchParams で取得。
-  // 依存配列に searchParams を含めることで、SPA 遷移でも正しく動作する。
-  useEffect(() => {
-    const characterQuery = searchParams.get('character');
-    if (characterQuery && hasCharacterProfile(characterQuery)) {
-      setCharacterId(characterQuery);
-    }
-    // searchParams の変化のみに依存する（setCharacterId は安定した関数参照）
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  // 同意状態管理 hook
+  const { consentPhase, markConsented } = useConsent();
 
-  // カレント characterId の未消化通知を第一声として取得・表示する。
-  // characterId が変わるたびに再取得し、前のキャラの knowledgeId をクリアする。
-  useEffect(() => {
-    // キャラクター切替時は前のキャラの第一声 knowledgeId をクリアする（クロス汚染防止）
-    firstWordKnowledgeIdRef.current = null;
-    firstWordCharacterIdRef.current = null;
-    setFirstWordText(null);
+  // オンボーディング管理 hook（consentPhase 依存）
+  const {
+    onboardingPhase,
+    onboardingText,
+    clearOnboardingText,
+    handleInstallSkip,
+    handleNotificationGranted,
+    handleNotificationSkip,
+  } = useOnboarding(consentPhase);
 
-    fetch(`/api/push/first-word?characterId=${encodeURIComponent(characterId)}`)
-      .then((res) => (res.ok ? res.json() : null))
-      .then(
-        (
-          data: {
-            notifId: string;
-            body: string;
-            knowledgeId?: string | null;
-            characterId: string;
-            suggestedReply?: string | null;
-          } | null
-        ) => {
-          if (!data) return;
-          setFirstWordText(data.body);
-          firstWordKnowledgeIdRef.current = data.knowledgeId ?? null;
-          // 通知元キャラクター ID を保存（クロス汚染防止のためカレントと照合する）
-          firstWordCharacterIdRef.current = data.characterId;
-          // 通知タップ起動時（from=push）かつ suggestedReply がある場合は入力欄へプリフィル
-          if (searchParams.get('from') === 'push' && data.suggestedReply) {
-            setPrefillText(data.suggestedReply);
-          }
-          // 消化済みマーク
-          fetch('/api/push/consumed', {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ notifId: data.notifId }),
-          }).catch(() => {});
-        }
-      )
-      .catch(() => {});
-  }, [characterId]);
+  // カレントキャラの第一声（未消化通知）管理 hook
+  const { firstWordText, prefillText, consumeKnowledgeId, clearFirstWordText } =
+    useFirstWord(characterId);
 
-  // 自前起動時: カレント以外に未消化通知があれば提示する。
-  // このエフェクトはマウント時（初回起動）にのみ実行する。
-  useEffect(() => {
-    fetch('/api/push/pending')
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: PendingNotification[] | null) => {
-        if (!data || data.length === 0) return;
-        setPendingNotifications(data);
-      })
-      .catch(() => {});
-    // マウント時のみ実行（依存配列は空）
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // 他キャラクターの未消化通知管理 hook
+  const { pendingNotifications } = usePendingNotifications();
 
-  // 同意完了後にオンボーディング（ホーム画面追加・通知許可）の表示要否を判定する。
-  useEffect(() => {
-    if (consentPhase !== 'done') return;
-    if (!isStandalone() && shouldShowInstallGuide()) {
-      setOnboardingPhase('install');
-      setOnboardingText(PWA_MESSAGES.INSTALL_PROMPT);
-    } else if (
-      isStandalone() &&
-      isPushSupported() &&
-      typeof window !== 'undefined' &&
-      window.Notification.permission !== 'granted' &&
-      shouldShowNotificationPermission()
-    ) {
-      setOnboardingPhase('notification');
-      setOnboardingText(PWA_MESSAGES.NOTIFICATION_PROMPT);
-    }
-  }, [consentPhase]);
-
-  // 起動時・キャラ切替時に生活サイクル状態を取得し、初回発話を待たずに Live2D へ反映する。
-  // 失敗時は現状維持（'awake'）。演出のための取得なので UI は止めない。
-  useEffect(() => {
-    fetch(`/api/lifecycle?characterId=${encodeURIComponent(characterId)}`)
-      .then((res) => res.json())
-      .then((data: { state: LifecycleState }) => {
-        if (data.state === 'awake' || data.state === 'sleeping') {
-          setLifecycleState(data.state);
-        }
-      })
-      .catch(() => {
-        // 取得失敗時は初期値 'awake' のまま
-      });
-  }, [characterId]);
-
-  const handleInstallSkip = useCallback(() => {
-    setOnboardingPhase(null);
-    setOnboardingText(null);
-  }, []);
-
-  const handleNotificationGranted = useCallback(() => {
-    setOnboardingPhase(null);
-    setOnboardingText(PWA_MESSAGES.NOTIFICATION_GRANTED);
-    setTimeout(() => {
-      setOnboardingText((current) =>
-        current === PWA_MESSAGES.NOTIFICATION_GRANTED ? null : current
-      );
-    }, 4000);
-  }, []);
-
-  const handleNotificationSkip = useCallback(() => {
-    setOnboardingPhase(null);
-    setOnboardingText(null);
-  }, []);
+  // ライフサイクル状態管理 hook
+  const { lifecycleState, setLifecycleState } = useLifecycle(characterId);
 
   const handleSubmit = useCallback(
     async (text: string) => {
@@ -272,17 +135,12 @@ function HomePageInner() {
 
       // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）。
       // クロス汚染防止: カレントキャラ == 通知元キャラのときのみ渡す（C3-3）。
-      const firstWordNotifCharId = firstWordCharacterIdRef.current;
-      const rawKnowledgeId = firstWordKnowledgeIdRef.current;
-      const notifKnowledgeId =
-        rawKnowledgeId !== null && firstWordNotifCharId === characterId ? rawKnowledgeId : null;
-      firstWordKnowledgeIdRef.current = null;
-      firstWordCharacterIdRef.current = null;
+      const notifKnowledgeId = consumeKnowledgeId(characterId);
 
       setUserText(text);
       setResponseText('');
-      setFirstWordText(null);
-      setOnboardingText(null);
+      clearFirstWordText();
+      clearOnboardingText();
       setErrorMessage(null);
       setPhase('loading');
       // キューをリセット（setAudioBuffer(null) + clearAudioQueue() 相当）
@@ -421,7 +279,18 @@ function HomePageInner() {
         );
       }
     },
-    [ensureUnlocked, getContext, reset, enqueue, markStreamDone, characterId]
+    [
+      ensureUnlocked,
+      getContext,
+      reset,
+      enqueue,
+      markStreamDone,
+      characterId,
+      consumeKnowledgeId,
+      clearFirstWordText,
+      clearOnboardingText,
+      setLifecycleState,
+    ]
   );
 
   const handlePlaybackError = useCallback(
@@ -444,10 +313,7 @@ function HomePageInner() {
 
   return (
     <>
-      <ConsentModal
-        open={consentPhase === 'required'}
-        onConsented={() => setConsentPhase('done')}
-      />
+      <ConsentModal open={consentPhase === 'required'} onConsented={markConsented} />
       <SafetyModal
         open={safetyOpen}
         resources={safetyResources}

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -119,8 +119,14 @@ function HomePageInner() {
   const { audioContext, ensureUnlocked, getContext } = useAudioContext();
 
   // 音声キュー管理 hook（再生待ちバッファ列と再生状態の state machine）
-  const { audioBuffer, enqueue, markStreamDone, reset, handlePlaybackEnd, handlePlaybackError: advanceOnError } =
-    useAudioQueue({ onDrained: () => setPhase('idle') });
+  const {
+    audioBuffer,
+    enqueue,
+    markStreamDone,
+    reset,
+    handlePlaybackEnd,
+    handlePlaybackError: advanceOnError,
+  } = useAudioQueue({ onDrained: () => setPhase('idle') });
 
   useEffect(() => {
     fetch('/api/consent')

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useCallback, useRef, useState } from 'react';
+import { Suspense, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { Box, Container, Stack, Typography } from '@mui/material';
 import { Link } from '@nagiyu/ui';
@@ -11,13 +11,11 @@ import CharacterCanvas from '@/components/CharacterCanvas';
 import ConsentModal from '@/components/ConsentModal';
 import SafetyModal from '@/components/SafetyModal';
 import NotificationToggle from '@/components/NotificationToggle';
-import type { SafetyResource } from '@nagiyu/livetalk-core';
 import InstallGuide from '@/components/InstallGuide';
 import NotificationPermission from '@/components/NotificationPermission';
 import CharacterSelectButton from '@/components/CharacterSelectButton';
 import { useCharacter } from '@/lib/characters/CharacterContext';
 import { getCharacterDisplay, hasCharacterProfile } from '@/lib/characters/client-profiles';
-import { reportClientError } from '@/lib/client-logger';
 import { useAudioContext } from '@/lib/audio/useAudioContext';
 import { useAudioQueue } from '@/lib/audio/useAudioQueue';
 import { useConsent } from '@/lib/home/useConsent';
@@ -26,30 +24,8 @@ import { useFirstWord } from '@/lib/home/useFirstWord';
 import { usePendingNotifications } from '@/lib/home/usePendingNotifications';
 import { useLifecycle } from '@/lib/home/useLifecycle';
 import { useCharacterQuerySync } from '@/lib/home/useCharacterQuerySync';
-
-type ChatPhase = 'idle' | 'loading' | 'streaming';
-
-type ChatStreamEvent =
-  | { type: 'text'; delta: string }
-  | { type: 'sentence'; index: number; text: string; audio: string }
-  | {
-      type: 'safety';
-      trigger: 'input_keyword' | 'output_moderation';
-      resources: SafetyResource[];
-      replacementText?: string;
-    }
-  | { type: 'lifecycle'; state: import('@nagiyu/livetalk-core').LifecycleState }
-  | { type: 'done' }
-  | { type: 'error'; message: string };
-
-function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const binaryString = atob(base64);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-  return bytes.buffer;
-}
+import { useChatStream } from '@/lib/home/useChatStream';
+import type { ChatPhase } from '@/lib/home/types';
 
 /**
  * Phase 2c のチャット画面（Phase 2f で Web Audio 再生に切替）。
@@ -72,16 +48,10 @@ function HomePageInner() {
     Array.isArray(session.user.roles) &&
     hasPermission(session.user.roles, 'livetalk:admin');
 
+  // phase は page.tsx の state のまま残す。
+  // useAudioQueue の onDrained が setPhase('idle') を呼ぶため、
+  // useChatStream 内に持たせると循環依存になる。
   const [phase, setPhase] = useState<ChatPhase>('idle');
-  const [userText, setUserText] = useState<string | null>(null);
-  const [responseText, setResponseText] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const [safetyOpen, setSafetyOpen] = useState(false);
-  const [safetyResources, setSafetyResources] = useState<SafetyResource[]>([]);
-
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const sentenceReceivedRef = useRef(0);
 
   // AudioContext 管理 hook（iOS Safari の autoplay 制約対策）
   const { audioContext, ensureUnlocked, getContext } = useAudioContext();
@@ -122,191 +92,30 @@ function HomePageInner() {
   // ライフサイクル状態管理 hook
   const { lifecycleState, setLifecycleState } = useLifecycle(characterId);
 
-  const handleSubmit = useCallback(
-    async (text: string) => {
-      // user gesture の同期スタック内で AudioContext を resume する（iOS Safari 対策）
-      await ensureUnlocked();
-      const audioCtx = getContext();
-
-      // 前回リクエストをキャンセル
-      abortControllerRef.current?.abort();
-      const controller = new AbortController();
-      abortControllerRef.current = controller;
-
-      // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）。
-      // クロス汚染防止: カレントキャラ == 通知元キャラのときのみ渡す（C3-3）。
-      const notifKnowledgeId = consumeKnowledgeId(characterId);
-
-      setUserText(text);
-      setResponseText('');
-      clearFirstWordText();
-      clearOnboardingText();
-      setErrorMessage(null);
-      setPhase('loading');
-      // キューをリセット（setAudioBuffer(null) + clearAudioQueue() 相当）
-      reset();
-      sentenceReceivedRef.current = 0;
-
-      try {
-        const chatBody: { text: string; characterId?: string; knowledgeId?: string } = {
-          text,
-          characterId,
-        };
-        if (notifKnowledgeId) chatBody.knowledgeId = notifKnowledgeId;
-
-        const response = await fetch('/api/chat', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(chatBody),
-          signal: controller.signal,
-        });
-
-        if (!response.ok || !response.body) {
-          setErrorMessage('応答の取得に失敗しました。時間を置いて再度お試しください。');
-          setPhase('idle');
-          reportClientError('error', 'チャット fetch 失敗', `HTTP ${response.status}`, {
-            screen: 'chat',
-            audioContextState: getContext()?.state,
-          });
-          return;
-        }
-
-        setPhase('streaming');
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let lineBuffer = '';
-
-        const handleEvent = async (event: ChatStreamEvent) => {
-          if (event.type === 'text') {
-            setResponseText((prev) => (prev ?? '') + event.delta);
-          } else if (event.type === 'sentence' && event.audio) {
-            sentenceReceivedRef.current++;
-            if (!audioCtx) {
-              // AudioContext が無いブラウザ（極めて稀）: 音声をスキップしてテキストだけ表示
-              return;
-            }
-            try {
-              const arrayBuffer = base64ToArrayBuffer(event.audio);
-              const decoded = await audioCtx.decodeAudioData(arrayBuffer);
-              // decode 済みバッファをキューに追加（空きなら即再生開始）
-              enqueue(decoded);
-            } catch (err) {
-              console.error('[LiveTalk] 音声 decode に失敗しました', err);
-              reportClientError(
-                'warning',
-                '音声 decode 失敗',
-                err instanceof Error ? err.message : '不明なエラー',
-                {
-                  screen: 'chat',
-                  audioContextState: getContext()?.state,
-                  sentenceReceived: sentenceReceivedRef.current,
-                }
-              );
-            }
-          } else if (event.type === 'lifecycle') {
-            setLifecycleState(event.state);
-          } else if (event.type === 'safety') {
-            if (event.trigger === 'output_moderation' && event.replacementText) {
-              setResponseText(event.replacementText);
-            }
-            setSafetyResources(event.resources);
-            setSafetyOpen(true);
-          } else if (event.type === 'done') {
-            // ストリーム完了をマーク（キューと current が空なら onDrained → setPhase('idle')）
-            markStreamDone();
-          } else if (event.type === 'error') {
-            setErrorMessage(event.message ?? '内部エラーが発生しました。');
-            // ストリームエラー時もストリーム完了扱い（advance のみ hook に委譲）
-            markStreamDone();
-            reportClientError(
-              'error',
-              'チャット stream エラー',
-              event.message ?? '内部エラーが発生しました',
-              {
-                screen: 'chat',
-                audioContextState: getContext()?.state,
-                sentenceReceived: sentenceReceivedRef.current,
-                // markStreamDone 後なので streamDone は true
-                streamDone: true,
-              }
-            );
-          }
-        };
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          lineBuffer += decoder.decode(value, { stream: true });
-          const lines = lineBuffer.split('\n');
-          lineBuffer = lines.pop() ?? '';
-
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-            try {
-              await handleEvent(JSON.parse(trimmed) as ChatStreamEvent);
-            } catch {
-              // malformed line はスキップ
-            }
-          }
-        }
-
-        // ストリーム終端の残余行
-        if (lineBuffer.trim()) {
-          try {
-            await handleEvent(JSON.parse(lineBuffer.trim()) as ChatStreamEvent);
-          } catch {
-            // skip
-          }
-        }
-      } catch (error) {
-        if (error instanceof Error && error.name === 'AbortError') return;
-        console.error('[LiveTalk] チャット応答の取得に失敗しました', error);
-        setErrorMessage('エラーが発生しました。時間を置いて再度お試しください。');
-        setPhase('idle');
-        reportClientError(
-          'error',
-          'チャット通信エラー',
-          error instanceof Error ? error.message : '不明なエラー',
-          {
-            screen: 'chat',
-            audioContextState: getContext()?.state,
-            sentenceReceived: sentenceReceivedRef.current,
-            stack: error instanceof Error ? error.stack : undefined,
-          }
-        );
-      }
-    },
-    [
-      ensureUnlocked,
-      getContext,
-      reset,
-      enqueue,
-      markStreamDone,
-      characterId,
-      consumeKnowledgeId,
-      clearFirstWordText,
-      clearOnboardingText,
-      setLifecycleState,
-    ]
-  );
-
-  const handlePlaybackError = useCallback(
-    (error: Error) => {
-      console.error('[LiveTalk] 音声再生エラー', error);
-      setErrorMessage('音声再生中にエラーが発生しました。');
-      // advance のみ hook に委譲（ログ・setErrorMessage・reportClientError はここで処理）
-      advanceOnError();
-      reportClientError('warning', '音声再生エラー', error.message, {
-        screen: 'chat',
-        audioContextState: getContext()?.state,
-        sentenceReceived: sentenceReceivedRef.current,
-      });
-    },
-    [advanceOnError, getContext]
-  );
+  // チャット送信フロー hook（handleSubmit + NDJSON parse + ストリームイベント分岐 + handlePlaybackError）
+  const {
+    userText,
+    responseText,
+    errorMessage,
+    safetyOpen,
+    safetyResources,
+    closeSafety,
+    handleSubmit,
+    handlePlaybackError,
+  } = useChatStream({
+    characterId,
+    setPhase,
+    ensureUnlocked,
+    getContext,
+    enqueue,
+    markStreamDone,
+    resetAudioQueue: reset,
+    advanceOnError,
+    consumeKnowledgeId,
+    clearFirstWordText,
+    clearOnboardingText,
+    setLifecycleState,
+  });
 
   const statusText =
     phase === 'loading' ? '考え中…' : phase === 'streaming' ? '話している' : '待機中';
@@ -314,11 +123,7 @@ function HomePageInner() {
   return (
     <>
       <ConsentModal open={consentPhase === 'required'} onConsented={markConsented} />
-      <SafetyModal
-        open={safetyOpen}
-        resources={safetyResources}
-        onClose={() => setSafetyOpen(false)}
-      />
+      <SafetyModal open={safetyOpen} resources={safetyResources} onClose={closeSafety} />
       <Container
         maxWidth="sm"
         sx={{

--- a/services/livetalk/web/src/components/Live2DCanvas.tsx
+++ b/services/livetalk/web/src/components/Live2DCanvas.tsx
@@ -27,6 +27,8 @@ function waitForCubismCore(timeout = 10000): Promise<void> {
 }
 
 type Live2DModelInstance = import('pixi-live2d-display-lipsyncpatch/cubism4').Live2DModel;
+type Cubism4InternalModelType =
+  import('pixi-live2d-display-lipsyncpatch/cubism4').Cubism4InternalModel;
 
 /**
  * 上半身フォーカスのレイアウト。
@@ -238,16 +240,10 @@ export default function Live2DCanvas({
     let source: AudioBufferSourceNode | null = null;
     let analyser: AnalyserNode | null = null;
 
-    // 型情報がない internal API を扱うための narrowing
-    const motionManager = (
-      model.internalModel as unknown as {
-        motionManager: {
-          currentAudio?: { ended: boolean } | undefined;
-          currentAnalyzer?: AnalyserNode | undefined;
-          currentContext?: AudioContext | undefined;
-        };
-      }
-    ).motionManager;
+    // Cubism4 の公開型でアクセスする（ライブラリの MotionManager が
+    // currentAudio / currentAnalyzer / currentContext を型として公開している）
+    const internalModel = model.internalModel as Cubism4InternalModelType;
+    const motionManager = internalModel.motionManager;
 
     try {
       source = audioContext.createBufferSource();
@@ -266,7 +262,10 @@ export default function Live2DCanvas({
       // ライブラリ内部のリップシンク駆動ループに自前 AnalyserNode を hijack 注入。
       // updateParameters 内で `if (this.lipSync && motionManager.currentAudio)` を
       // 通過させるため、currentAudio には truthy なオブジェクトを置く。
-      motionManager.currentAudio = { ended: false };
+      // ライブラリは currentAudio が truthy のときだけリップシンク（ParamMouthOpenY 更新）を
+      // 駆動する。実際の HTMLAudioElement は使わず Web Audio 経由で再生するため、
+      // truthy なダミーを注入する（意図的な hijack）。
+      motionManager.currentAudio = { ended: false } as unknown as HTMLAudioElement;
       motionManager.currentAnalyzer = analyser;
       motionManager.currentContext = audioContext;
 
@@ -333,12 +332,8 @@ export default function Live2DCanvas({
     const BLINK_INTERVAL_MIN_MS = 3000;
     const BLINK_INTERVAL_RANGE_MS = 3000;
 
-    const internalModel = model.internalModel as unknown as {
-      coreModel?: { setParameterValueById?: (id: string, value: number) => void };
-      eyeBlink?: unknown;
-      on?: (event: string, handler: () => void) => void;
-      off?: (event: string, handler: () => void) => void;
-    };
+    // Cubism4 の公開型でアクセスする
+    const internalModel = model.internalModel as Cubism4InternalModelType;
 
     // 三角波で瞬きの開き値（0〜0.3）を計算する。瞬き窓の外は 0.3（半目）。
     let blinkStart = -Infinity;
@@ -385,10 +380,19 @@ export default function Live2DCanvas({
     const savedEyeBlink = internalModel.eyeBlink;
     internalModel.eyeBlink = undefined;
 
-    internalModel.on?.('afterMotionUpdate', applyEyes);
+    // ライブラリの型定義上、InternalModel は utils.EventEmitter（eventemitter3）を
+    // 継承しているが、eventemitter3 が export = 形式のため TypeScript の型解決で
+    // on/off がインスタンスメソッドとして継承されない。
+    // 実際には EventEmitter のメソッドが存在するため、on/off 呼び出しのみ
+    // 最小限のキャストで対処する（ad-hoc な unknown キャストへの退行を避ける）。
+    const emitter = internalModel as unknown as {
+      on: (event: string, fn: () => void) => void;
+      off: (event: string, fn: () => void) => void;
+    };
+    emitter.on('afterMotionUpdate', applyEyes);
 
     return () => {
-      internalModel.off?.('afterMotionUpdate', applyEyes);
+      emitter.off('afterMotionUpdate', applyEyes);
       internalModel.eyeBlink = savedEyeBlink;
     };
     // characterId が変更されてもモデルロード effect（依存 [characterId]）が旧モデルを

--- a/services/livetalk/web/src/lib/audio/useAudioContext.ts
+++ b/services/livetalk/web/src/lib/audio/useAudioContext.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * useAudioContext の戻り値型。
+ */
+export interface UseAudioContextResult {
+  /**
+   * AudioContext インスタンス（子コンポーネントへ prop として渡す用）。
+   * user gesture 前は null。
+   */
+  audioContext: AudioContext | null;
+  /**
+   * user gesture の同期スタックで呼ぶことで、iOS Safari の autoplay 制約を解除する。
+   *
+   * iOS Safari の Web Audio autoplay 制約対策。
+   * user gesture（handleSubmit 等）の同期スタックで AudioContext を作成・resume することで、
+   * 以降の AudioBufferSourceNode.start() が transient activation token を消費せず
+   * いつでも再生可能になる。HTMLAudioElement の per-element 制約は別系統で、
+   * この対策では効かないため、再生は Web Audio API のみで完結させる（CharacterCanvas 参照）。
+   */
+  ensureUnlocked: () => Promise<void>;
+  /**
+   * ref の最新値を同期で読む。
+   * reportClientError 等で audioContext の状態を参照する際に使用する
+   * （callback 内で最新値を読むため state ではなく ref を使う）。
+   */
+  getContext: () => AudioContext | null;
+}
+
+/**
+ * AudioContext を管理するカスタム hook。
+ *
+ * iOS Safari の Web Audio autoplay 制約対策として、user gesture で
+ * AudioContext を作成・resume する仕組みをカプセル化する。
+ *
+ * - audioContext: 子コンポーネント（CharacterCanvas）に prop で渡す state
+ * - ensureUnlocked: handleSubmit 等の user gesture 同期スタックで呼ぶ
+ * - getContext: callback 内で ref の最新値を同期参照する
+ */
+export function useAudioContext(): UseAudioContextResult {
+  // 子コンポーネント（CharacterCanvas）に prop で渡すため state で持つ
+  const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
+  // callback 内で最新値を同期参照するための ref
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  const ensureUnlocked = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    // window.AudioContext ?? webkitAudioContext のフォールバック（iOS Safari 対応）
+    const AudioContextClass =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) return;
+    if (!audioCtxRef.current) {
+      const ctx = new AudioContextClass();
+      audioCtxRef.current = ctx;
+      // 子コンポーネント（CharacterCanvas）に prop で渡すため state も更新
+      setAudioContext(ctx);
+    }
+    if (audioCtxRef.current.state === 'suspended') {
+      await audioCtxRef.current.resume();
+    }
+  }, []);
+
+  const getContext = useCallback((): AudioContext | null => {
+    return audioCtxRef.current;
+  }, []);
+
+  return { audioContext, ensureUnlocked, getContext };
+}

--- a/services/livetalk/web/src/lib/audio/useAudioQueue.ts
+++ b/services/livetalk/web/src/lib/audio/useAudioQueue.ts
@@ -1,0 +1,190 @@
+'use client';
+
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+
+/**
+ * useAudioQueue の内部 reducer state。
+ *
+ * isPlaying は current !== null で導出できるため保持しない。
+ */
+interface AudioQueueState {
+  /** 再生待ちバッファの列。先頭から順に再生される。 */
+  queue: AudioBuffer[];
+  /** 現在再生中のバッファ（null = 再生中なし）。CharacterCanvas に渡す。 */
+  current: AudioBuffer | null;
+  /** ストリームが完了したかどうか（done/error イベントで true になる）。 */
+  streamDone: boolean;
+}
+
+type AudioQueueAction =
+  | { type: 'ENQUEUE'; buffer: AudioBuffer }
+  | { type: 'PLAYBACK_END' }
+  | { type: 'PLAYBACK_ERROR' }
+  | { type: 'MARK_STREAM_DONE' }
+  | { type: 'RESET' };
+
+const initialState: AudioQueueState = {
+  queue: [],
+  current: null,
+  streamDone: false,
+};
+
+/**
+ * 音声キューの状態遷移 reducer。
+ *
+ * 状態遷移の対応関係（旧実装 → reducer アクション）:
+ * - clearAudioQueue: RESET
+ * - advanceAudioQueue（キュー先頭を current に移す）: ENQUEUE / PLAYBACK_END / PLAYBACK_ERROR / MARK_STREAM_DONE の末尾で暗黙に実行
+ * - sentence 受信時の push + advance: ENQUEUE
+ * - done/error イベント時の streamDone=true + advance: MARK_STREAM_DONE
+ * - handlePlaybackEnd の isPlaying=false + advance: PLAYBACK_END
+ * - handlePlaybackError の isPlaying=false + advance: PLAYBACK_ERROR
+ */
+function audioQueueReducer(state: AudioQueueState, action: AudioQueueAction): AudioQueueState {
+  switch (action.type) {
+    case 'ENQUEUE': {
+      // 再生中でなければ即 current に昇格し再生開始。再生中なら queue に追加。
+      if (state.current === null) {
+        return { ...state, current: action.buffer };
+      }
+      return { ...state, queue: [...state.queue, action.buffer] };
+    }
+    case 'PLAYBACK_END':
+    case 'PLAYBACK_ERROR': {
+      // 現在の再生終了 → キューの先頭を次の current に昇格
+      const [next, ...rest] = state.queue;
+      return {
+        ...state,
+        current: next ?? null,
+        queue: rest,
+      };
+    }
+    case 'MARK_STREAM_DONE': {
+      // ストリーム完了マーク。再生中でなくキューも空なら drain 判定のトリガーになる。
+      // （onDrained の発火は useEffect で監視する）
+      if (state.current === null && state.queue.length === 0) {
+        // キューも current も空 → drain 可能な状態に遷移
+        return { ...state, streamDone: true };
+      }
+      return { ...state, streamDone: true };
+    }
+    case 'RESET': {
+      return { ...initialState };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+/**
+ * useAudioQueue のオプション。
+ */
+export interface UseAudioQueueOptions {
+  /**
+   * キューが空になりストリームも完了した（drain した）瞬間に呼ばれるコールバック。
+   * page 側で `setPhase('idle')` するために使う。
+   *
+   * ref に退避して effect の依存から外すため、参照変更による誤発火は起きない。
+   */
+  onDrained: () => void;
+}
+
+/**
+ * useAudioQueue の戻り値型。
+ */
+export interface UseAudioQueueResult {
+  /**
+   * 現在再生中のバッファ（CharacterCanvas に prop で渡す）。
+   * 再生中でなければ null。
+   */
+  audioBuffer: AudioBuffer | null;
+  /**
+   * decode 済みバッファをキューに追加する。
+   * キューが空（再生中なし）なら即座に再生開始する。
+   * sentence 受信時に呼ぶ。
+   */
+  enqueue: (buffer: AudioBuffer) => void;
+  /**
+   * ストリーム完了をマークする。
+   * done/error イベント受信時に呼ぶ。
+   * キューと current がどちらも空なら onDrained を発火させる。
+   */
+  markStreamDone: () => void;
+  /**
+   * キューを初期化する（clearAudioQueue 相当）。
+   * handleSubmit 冒頭で呼ぶ。
+   */
+  reset: () => void;
+  /**
+   * 再生完了コールバック（CharacterCanvas の onPlaybackEnd に渡す）。
+   * current を null にしてキューの次バッファへ進む。
+   */
+  handlePlaybackEnd: () => void;
+  /**
+   * 再生エラー時の advance のみを担当するコールバック。
+   * ログ・setErrorMessage・reportClientError は呼び出し側（page）に残す。
+   */
+  handlePlaybackError: () => void;
+}
+
+/**
+ * 音声キューを useReducer ベースの state machine で管理するカスタム hook。
+ *
+ * 旧実装の audioQueueRef / isPlayingRef / streamDoneRef / audioBuffer state の
+ * 手動管理を置き換える。挙動は旧実装と厳密に同一。
+ *
+ * 順序保証: useReducer の dispatch は同期的に順次適用されるため、
+ * sentence の連続到着でも取りこぼしなく順番再生される。
+ *
+ * onDrained の誤発火防止: streamDone=false の初期状態では onDrained は発火しない。
+ * reset 直後は streamDone=false に戻るため、reset 後の drain 誤発火も起きない。
+ */
+export function useAudioQueue(options: UseAudioQueueOptions): UseAudioQueueResult {
+  const [state, dispatch] = useReducer(audioQueueReducer, initialState);
+
+  // onDrained を ref に退避することで、useEffect の依存配列から外し、
+  // コールバック参照変更による誤発火を防ぐ
+  const onDrainedRef = useRef(options.onDrained);
+  useEffect(() => {
+    onDrainedRef.current = options.onDrained;
+  }, [options.onDrained]);
+
+  // drain 判定: streamDone=true かつ current=null かつ queue 空のとき onDrained を発火
+  // reset 直後は streamDone=false なので発火しない（誤発火防止）
+  useEffect(() => {
+    if (state.streamDone && state.current === null && state.queue.length === 0) {
+      onDrainedRef.current();
+    }
+    // state 変化のみに依存する（onDrainedRef は ref なので依存不要）
+  }, [state.streamDone, state.current, state.queue]);
+
+  const enqueue = useCallback((buffer: AudioBuffer) => {
+    dispatch({ type: 'ENQUEUE', buffer });
+  }, []);
+
+  const markStreamDone = useCallback(() => {
+    dispatch({ type: 'MARK_STREAM_DONE' });
+  }, []);
+
+  const reset = useCallback(() => {
+    dispatch({ type: 'RESET' });
+  }, []);
+
+  const handlePlaybackEnd = useCallback(() => {
+    dispatch({ type: 'PLAYBACK_END' });
+  }, []);
+
+  const handlePlaybackError = useCallback(() => {
+    dispatch({ type: 'PLAYBACK_ERROR' });
+  }, []);
+
+  return {
+    audioBuffer: state.current,
+    enqueue,
+    markStreamDone,
+    reset,
+    handlePlaybackEnd,
+    handlePlaybackError,
+  };
+}

--- a/services/livetalk/web/src/lib/audio/useAudioQueue.ts
+++ b/services/livetalk/web/src/lib/audio/useAudioQueue.ts
@@ -156,8 +156,10 @@ export function useAudioQueue(options: UseAudioQueueOptions): UseAudioQueueResul
     if (state.streamDone && state.current === null && state.queue.length === 0) {
       onDrainedRef.current();
     }
-    // state 変化のみに依存する（onDrainedRef は ref なので依存不要）
-  }, [state.streamDone, state.current, state.queue]);
+    // state 変化ごとに条件判定する（onDrainedRef は ref なので依存不要）。
+    // drain 条件は終端状態でのみ真になり、その後の遷移は RESET（streamDone=false）の
+    // ため、onDrained は 1 回の drain につき 1 回だけ発火する。
+  }, [state]);
 
   const enqueue = useCallback((buffer: AudioBuffer) => {
     dispatch({ type: 'ENQUEUE', buffer });

--- a/services/livetalk/web/src/lib/home/types.ts
+++ b/services/livetalk/web/src/lib/home/types.ts
@@ -1,0 +1,29 @@
+'use client';
+
+/**
+ * 同意フェーズ。
+ * - checking: /api/consent を確認中
+ * - required: 未同意（モーダル表示）
+ * - done: 同意済み
+ */
+export type ConsentPhase = 'checking' | 'required' | 'done';
+
+/**
+ * オンボーディングフェーズ。
+ * - install: ホーム画面追加ガイド表示中
+ * - notification: 通知許可リクエスト表示中
+ * - null: 表示なし
+ */
+export type OnboardingPhase = 'install' | 'notification' | null;
+
+/**
+ * pending API のレスポンス型（キャラクターごとの未消化通知）。
+ */
+export interface PendingNotification {
+  /** 通知元キャラクター ID */
+  characterId: string;
+  /** 通知 ID */
+  notifId: string;
+  /** 通知本文 */
+  body: string;
+}

--- a/services/livetalk/web/src/lib/home/types.ts
+++ b/services/livetalk/web/src/lib/home/types.ts
@@ -1,6 +1,14 @@
 'use client';
 
 /**
+ * チャットフェーズ。
+ * - idle: 待機中（入力受付可）
+ * - loading: リクエスト送信中（応答待ち）
+ * - streaming: NDJSON ストリーム受信中
+ */
+export type ChatPhase = 'idle' | 'loading' | 'streaming';
+
+/**
  * 同意フェーズ。
  * - checking: /api/consent を確認中
  * - required: 未同意（モーダル表示）

--- a/services/livetalk/web/src/lib/home/useCharacterQuerySync.ts
+++ b/services/livetalk/web/src/lib/home/useCharacterQuerySync.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useCharacter } from '../characters/CharacterContext';
+import { hasCharacterProfile } from '../characters/client-profiles';
+
+/**
+ * URL クエリパラメータ ?character=<id> をカレントキャラクターに反映するカスタム hook。
+ *
+ * push クリック起動時: URL の ?character=<id> を読み、カレントキャラを切替える。
+ * searchParams は Next.js の useSearchParams で取得。
+ * 依存配列に searchParams を含めることで、SPA 遷移でも正しく動作する。
+ *
+ * 副作用のみで戻り値なし。
+ */
+export function useCharacterQuerySync(): void {
+  const searchParams = useSearchParams();
+  const { setCharacterId } = useCharacter();
+
+  useEffect(() => {
+    const characterQuery = searchParams.get('character');
+    if (characterQuery && hasCharacterProfile(characterQuery)) {
+      setCharacterId(characterQuery);
+    }
+    // searchParams の変化のみに依存する（setCharacterId は安定した関数参照）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+}

--- a/services/livetalk/web/src/lib/home/useChatStream.ts
+++ b/services/livetalk/web/src/lib/home/useChatStream.ts
@@ -1,0 +1,325 @@
+'use client';
+
+import { type Dispatch, type SetStateAction, useCallback, useRef, useState } from 'react';
+import type { LifecycleState, SafetyResource } from '@nagiyu/livetalk-core';
+import { reportClientError } from '../client-logger';
+import type { ChatPhase } from './types';
+
+/**
+ * NDJSON ストリームのイベント型。
+ */
+type ChatStreamEvent =
+  | { type: 'text'; delta: string }
+  | { type: 'sentence'; index: number; text: string; audio: string }
+  | {
+      type: 'safety';
+      trigger: 'input_keyword' | 'output_moderation';
+      resources: SafetyResource[];
+      replacementText?: string;
+    }
+  | { type: 'lifecycle'; state: LifecycleState }
+  | { type: 'done' }
+  | { type: 'error'; message: string };
+
+/**
+ * base64 文字列を ArrayBuffer に変換するユーティリティ関数。
+ */
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+/**
+ * useChatStream への依存を注入する引数型。
+ *
+ * phase/setPhase は page.tsx の useState のまま残す。
+ * useAudioQueue の onDrained が setPhase('idle') を呼ぶため、
+ * useChatStream 内に phase を持たせると循環依存になる。
+ */
+export interface UseChatStreamDeps {
+  /** カレントキャラクター ID */
+  characterId: string;
+  /** ChatPhase の setter（page.tsx の useState から渡す） */
+  setPhase: Dispatch<SetStateAction<ChatPhase>>;
+  /** AudioContext を unlock する関数（iOS Safari autoplay 制約対策） */
+  ensureUnlocked: () => Promise<void>;
+  /** AudioContext インスタンスを取得する関数 */
+  getContext: () => AudioContext | null;
+  /** decode 済み AudioBuffer をキューに追加する関数 */
+  enqueue: (buffer: AudioBuffer) => void;
+  /** ストリーム完了をマークする関数 */
+  markStreamDone: () => void;
+  /** 音声キューをリセットする関数（useAudioQueue の reset） */
+  resetAudioQueue: () => void;
+  /** 再生エラー時にキューを advance する関数（useAudioQueue の handlePlaybackError） */
+  advanceOnError: () => void;
+  /** knowledgeId を取り出してクリアする関数（クロス汚染防止ガード付き） */
+  consumeKnowledgeId: (currentCharacterId: string) => string | null;
+  /** 第一声テキストをクリアする関数 */
+  clearFirstWordText: () => void;
+  /** オンボーディングテキストをクリアする関数 */
+  clearOnboardingText: () => void;
+  /** ライフサイクル状態を更新する setter */
+  setLifecycleState: Dispatch<SetStateAction<LifecycleState>>;
+}
+
+/**
+ * useChatStream の戻り値型。
+ */
+export interface UseChatStreamResult {
+  /** ユーザー入力テキスト（送信済み） */
+  userText: string | null;
+  /** AI 応答テキスト（逐次追記） */
+  responseText: string | null;
+  /** エラーメッセージ（null = エラーなし） */
+  errorMessage: string | null;
+  /** セーフティモーダルの表示状態 */
+  safetyOpen: boolean;
+  /** セーフティリソース一覧 */
+  safetyResources: SafetyResource[];
+  /** セーフティモーダルを閉じる関数 */
+  closeSafety: () => void;
+  /** チャット送信ハンドラ */
+  handleSubmit: (text: string) => Promise<void>;
+  /** 音声再生エラーハンドラ（CharacterCanvas の onPlaybackError に渡す） */
+  handlePlaybackError: (error: Error) => void;
+}
+
+/**
+ * チャット送信フロー（handleSubmit + NDJSON parse + ストリームイベント分岐 + handlePlaybackError）
+ * を管理するカスタム hook。
+ *
+ * phase/setPhase は page.tsx の useState のまま残す設計（useAudioQueue との循環依存回避）。
+ * setPhase を deps として受け取り、loading/streaming/idle の遷移はこの hook 内から呼ぶ。
+ */
+export function useChatStream(deps: UseChatStreamDeps): UseChatStreamResult {
+  const {
+    characterId,
+    setPhase,
+    ensureUnlocked,
+    getContext,
+    enqueue,
+    markStreamDone,
+    resetAudioQueue,
+    advanceOnError,
+    consumeKnowledgeId,
+    clearFirstWordText,
+    clearOnboardingText,
+    setLifecycleState,
+  } = deps;
+
+  const [userText, setUserText] = useState<string | null>(null);
+  const [responseText, setResponseText] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [safetyOpen, setSafetyOpen] = useState(false);
+  const [safetyResources, setSafetyResources] = useState<SafetyResource[]>([]);
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const sentenceReceivedRef = useRef(0);
+
+  const closeSafety = useCallback(() => {
+    setSafetyOpen(false);
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (text: string) => {
+      // user gesture の同期スタック内で AudioContext を resume する（iOS Safari 対策）
+      await ensureUnlocked();
+      const audioCtx = getContext();
+
+      // 前回リクエストをキャンセル
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      // 送信前に第一声 knowledgeId を取り出してクリア（1 ターン限り有効）。
+      // クロス汚染防止: カレントキャラ == 通知元キャラのときのみ渡す（C3-3）。
+      const notifKnowledgeId = consumeKnowledgeId(characterId);
+
+      setUserText(text);
+      setResponseText('');
+      clearFirstWordText();
+      clearOnboardingText();
+      setErrorMessage(null);
+      setPhase('loading');
+      // キューをリセット（setAudioBuffer(null) + clearAudioQueue() 相当）
+      resetAudioQueue();
+      sentenceReceivedRef.current = 0;
+
+      try {
+        const chatBody: { text: string; characterId?: string; knowledgeId?: string } = {
+          text,
+          characterId,
+        };
+        if (notifKnowledgeId) chatBody.knowledgeId = notifKnowledgeId;
+
+        const response = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(chatBody),
+          signal: controller.signal,
+        });
+
+        if (!response.ok || !response.body) {
+          setErrorMessage('応答の取得に失敗しました。時間を置いて再度お試しください。');
+          setPhase('idle');
+          reportClientError('error', 'チャット fetch 失敗', `HTTP ${response.status}`, {
+            screen: 'chat',
+            audioContextState: getContext()?.state,
+          });
+          return;
+        }
+
+        setPhase('streaming');
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let lineBuffer = '';
+
+        const handleEvent = async (event: ChatStreamEvent) => {
+          if (event.type === 'text') {
+            setResponseText((prev) => (prev ?? '') + event.delta);
+          } else if (event.type === 'sentence' && event.audio) {
+            sentenceReceivedRef.current++;
+            if (!audioCtx) {
+              // AudioContext が無いブラウザ（極めて稀）: 音声をスキップしてテキストだけ表示
+              return;
+            }
+            try {
+              const arrayBuffer = base64ToArrayBuffer(event.audio);
+              const decoded = await audioCtx.decodeAudioData(arrayBuffer);
+              // decode 済みバッファをキューに追加（空きなら即再生開始）
+              enqueue(decoded);
+            } catch (err) {
+              console.error('[LiveTalk] 音声 decode に失敗しました', err);
+              reportClientError(
+                'warning',
+                '音声 decode 失敗',
+                err instanceof Error ? err.message : '不明なエラー',
+                {
+                  screen: 'chat',
+                  audioContextState: getContext()?.state,
+                  sentenceReceived: sentenceReceivedRef.current,
+                }
+              );
+            }
+          } else if (event.type === 'lifecycle') {
+            setLifecycleState(event.state);
+          } else if (event.type === 'safety') {
+            if (event.trigger === 'output_moderation' && event.replacementText) {
+              setResponseText(event.replacementText);
+            }
+            setSafetyResources(event.resources);
+            setSafetyOpen(true);
+          } else if (event.type === 'done') {
+            // ストリーム完了をマーク（キューと current が空なら onDrained → setPhase('idle')）
+            markStreamDone();
+          } else if (event.type === 'error') {
+            setErrorMessage(event.message ?? '内部エラーが発生しました。');
+            // ストリームエラー時もストリーム完了扱い（advance のみ hook に委譲）
+            markStreamDone();
+            reportClientError(
+              'error',
+              'チャット stream エラー',
+              event.message ?? '内部エラーが発生しました',
+              {
+                screen: 'chat',
+                audioContextState: getContext()?.state,
+                sentenceReceived: sentenceReceivedRef.current,
+                // markStreamDone 後なので streamDone は true
+                streamDone: true,
+              }
+            );
+          }
+        };
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          lineBuffer += decoder.decode(value, { stream: true });
+          const lines = lineBuffer.split('\n');
+          lineBuffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            try {
+              await handleEvent(JSON.parse(trimmed) as ChatStreamEvent);
+            } catch {
+              // malformed line はスキップ
+            }
+          }
+        }
+
+        // ストリーム終端の残余行
+        if (lineBuffer.trim()) {
+          try {
+            await handleEvent(JSON.parse(lineBuffer.trim()) as ChatStreamEvent);
+          } catch {
+            // skip
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') return;
+        console.error('[LiveTalk] チャット応答の取得に失敗しました', error);
+        setErrorMessage('エラーが発生しました。時間を置いて再度お試しください。');
+        setPhase('idle');
+        reportClientError(
+          'error',
+          'チャット通信エラー',
+          error instanceof Error ? error.message : '不明なエラー',
+          {
+            screen: 'chat',
+            audioContextState: getContext()?.state,
+            sentenceReceived: sentenceReceivedRef.current,
+            stack: error instanceof Error ? error.stack : undefined,
+          }
+        );
+      }
+    },
+    [
+      ensureUnlocked,
+      getContext,
+      resetAudioQueue,
+      enqueue,
+      markStreamDone,
+      characterId,
+      consumeKnowledgeId,
+      clearFirstWordText,
+      clearOnboardingText,
+      setLifecycleState,
+      setPhase,
+    ]
+  );
+
+  const handlePlaybackError = useCallback(
+    (error: Error) => {
+      console.error('[LiveTalk] 音声再生エラー', error);
+      setErrorMessage('音声再生中にエラーが発生しました。');
+      // advance のみ hook に委譲（ログ・setErrorMessage・reportClientError はここで処理）
+      advanceOnError();
+      reportClientError('warning', '音声再生エラー', error.message, {
+        screen: 'chat',
+        audioContextState: getContext()?.state,
+        sentenceReceived: sentenceReceivedRef.current,
+      });
+    },
+    [advanceOnError, getContext]
+  );
+
+  return {
+    userText,
+    responseText,
+    errorMessage,
+    safetyOpen,
+    safetyResources,
+    closeSafety,
+    handleSubmit,
+    handlePlaybackError,
+  };
+}

--- a/services/livetalk/web/src/lib/home/useConsent.ts
+++ b/services/livetalk/web/src/lib/home/useConsent.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { ConsentPhase } from './types';
+
+/**
+ * useConsent の戻り値型。
+ */
+export interface UseConsentResult {
+  /** 現在の同意フェーズ */
+  consentPhase: ConsentPhase;
+  /** 同意済みにマークする（ConsentModal の onConsented に渡す）。 */
+  markConsented: () => void;
+}
+
+/**
+ * 同意状態を管理するカスタム hook。
+ *
+ * マウント時に /api/consent を取得し、同意済みかどうかを判定する。
+ * 取得失敗時はモーダルを表示してユーザーに同意を促す。
+ */
+export function useConsent(): UseConsentResult {
+  const [consentPhase, setConsentPhase] = useState<ConsentPhase>('checking');
+
+  useEffect(() => {
+    fetch('/api/consent')
+      .then((res) => res.json())
+      .then((data: { consented: boolean }) => {
+        setConsentPhase(data.consented ? 'done' : 'required');
+      })
+      .catch(() => {
+        // 取得失敗時はモーダルを表示してユーザーに同意を促す
+        setConsentPhase('required');
+      });
+  }, []);
+
+  const markConsented = useCallback(() => {
+    setConsentPhase('done');
+  }, []);
+
+  return { consentPhase, markConsented };
+}

--- a/services/livetalk/web/src/lib/home/useFirstWord.ts
+++ b/services/livetalk/web/src/lib/home/useFirstWord.ts
@@ -1,0 +1,115 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+/**
+ * useFirstWord の戻り値型。
+ */
+export interface UseFirstWordResult {
+  /** 第一声テキスト（未消化通知から取得）。null はまだ取得していないか消去済み。 */
+  firstWordText: string | null;
+  /** 通知タップ起動時の入力欄プリフィルテキスト。null はプリフィルなし。 */
+  prefillText: string | null;
+  /**
+   * handleSubmit 送信前に呼ぶ。クロス汚染防止ガードを適用して knowledgeId を取り出し、
+   * 両 ref をクリアした上で結果を返す。
+   *
+   * クロス汚染防止: カレントキャラ == 通知元キャラのときのみ knowledgeId を返す（C3-3）。
+   *
+   * @param currentCharacterId 現在選択中のキャラクター ID
+   * @returns 有効な knowledgeId（クロス汚染がある場合は null）
+   */
+  consumeKnowledgeId: (currentCharacterId: string) => string | null;
+  /** handleSubmit 送信前に firstWordText をクリアする関数 */
+  clearFirstWordText: () => void;
+}
+
+/**
+ * カレントキャラの未消化通知を第一声として取得・表示するカスタム hook。
+ *
+ * characterId が変わるたびに再取得し、前のキャラの knowledgeId をクリアする。
+ * 通知タップ起動時（from=push）かつ suggestedReply がある場合は prefillText を設定する。
+ */
+export function useFirstWord(characterId: string): UseFirstWordResult {
+  const searchParams = useSearchParams();
+
+  const [firstWordText, setFirstWordText] = useState<string | null>(null);
+  const [prefillText, setPrefillText] = useState<string | null>(null);
+
+  // 第一声の元となった KnowledgeID（次の chat 送信時に文脈として渡す）
+  const firstWordKnowledgeIdRef = useRef<string | null>(null);
+  // 第一声の通知元キャラクター ID（クロス汚染防止のためカレントと照合する）
+  const firstWordCharacterIdRef = useRef<string | null>(null);
+
+  // カレント characterId の未消化通知を第一声として取得・表示する。
+  // characterId が変わるたびに再取得し、前のキャラの knowledgeId をクリアする。
+  useEffect(() => {
+    // キャラクター切替時は前のキャラの第一声 knowledgeId をクリアする（クロス汚染防止）
+    firstWordKnowledgeIdRef.current = null;
+    firstWordCharacterIdRef.current = null;
+    setFirstWordText(null);
+
+    fetch(`/api/push/first-word?characterId=${encodeURIComponent(characterId)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then(
+        (
+          data: {
+            notifId: string;
+            body: string;
+            knowledgeId?: string | null;
+            characterId: string;
+            suggestedReply?: string | null;
+          } | null
+        ) => {
+          if (!data) return;
+          setFirstWordText(data.body);
+          firstWordKnowledgeIdRef.current = data.knowledgeId ?? null;
+          // 通知元キャラクター ID を保存（クロス汚染防止のためカレントと照合する）
+          firstWordCharacterIdRef.current = data.characterId;
+          // 通知タップ起動時（from=push）かつ suggestedReply がある場合は入力欄へプリフィル
+          if (searchParams.get('from') === 'push' && data.suggestedReply) {
+            setPrefillText(data.suggestedReply);
+          }
+          // 消化済みマーク
+          fetch('/api/push/consumed', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ notifId: data.notifId }),
+          }).catch(() => {});
+        }
+      )
+      .catch(() => {});
+    // searchParams の変化のみに依存せず characterId のみを依存として保つ
+    // （searchParams は first-word 取得時の from/suggestedReply 判定に使うが、
+    //  searchParams が変化しても再取得は不要。characterId が同一の場合は再 fetch しない）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [characterId]);
+
+  /**
+   * クロス汚染防止ガードを適用して knowledgeId を取り出し、両 ref をクリアする。
+   * handleSubmit の送信前（273-280 行のロジックをそのまま移設）。
+   */
+  const consumeKnowledgeId = useCallback((currentCharacterId: string): string | null => {
+    const firstWordNotifCharId = firstWordCharacterIdRef.current;
+    const rawKnowledgeId = firstWordKnowledgeIdRef.current;
+    const notifKnowledgeId =
+      rawKnowledgeId !== null && firstWordNotifCharId === currentCharacterId
+        ? rawKnowledgeId
+        : null;
+    firstWordKnowledgeIdRef.current = null;
+    firstWordCharacterIdRef.current = null;
+    return notifKnowledgeId;
+  }, []);
+
+  const clearFirstWordText = useCallback(() => {
+    setFirstWordText(null);
+  }, []);
+
+  return {
+    firstWordText,
+    prefillText,
+    consumeKnowledgeId,
+    clearFirstWordText,
+  };
+}

--- a/services/livetalk/web/src/lib/home/useLifecycle.ts
+++ b/services/livetalk/web/src/lib/home/useLifecycle.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
+import type { LifecycleState } from '@nagiyu/livetalk-core';
+
+/**
+ * useLifecycle の戻り値型。
+ */
+export interface UseLifecycleResult {
+  /** 現在のライフサイクル状態 */
+  lifecycleState: LifecycleState;
+  /**
+   * ライフサイクル状態を更新する関数。
+   * handleSubmit のストリームイベント処理（lifecycle イベント受信時）で使う。
+   */
+  setLifecycleState: Dispatch<SetStateAction<LifecycleState>>;
+}
+
+/**
+ * キャラクターの生活サイクル状態を管理するカスタム hook。
+ *
+ * 起動時・キャラ切替時に /api/lifecycle を取得し、Live2D に反映する。
+ * 失敗時は現状維持（'awake'）。演出のための取得なので UI は止めない。
+ */
+export function useLifecycle(characterId: string): UseLifecycleResult {
+  const [lifecycleState, setLifecycleState] = useState<LifecycleState>('awake');
+
+  // 起動時・キャラ切替時に生活サイクル状態を取得し、初回発話を待たずに Live2D へ反映する。
+  // 失敗時は現状維持（'awake'）。演出のための取得なので UI は止めない。
+  useEffect(() => {
+    fetch(`/api/lifecycle?characterId=${encodeURIComponent(characterId)}`)
+      .then((res) => res.json())
+      .then((data: { state: LifecycleState }) => {
+        if (data.state === 'awake' || data.state === 'sleeping') {
+          setLifecycleState(data.state);
+        }
+      })
+      .catch(() => {
+        // 取得失敗時は初期値 'awake' のまま
+      });
+  }, [characterId]);
+
+  return { lifecycleState, setLifecycleState };
+}

--- a/services/livetalk/web/src/lib/home/useOnboarding.ts
+++ b/services/livetalk/web/src/lib/home/useOnboarding.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  isStandalone,
+  isPushSupported,
+  shouldShowInstallGuide,
+  shouldShowNotificationPermission,
+} from '../pwa/standalone';
+import { PWA_MESSAGES } from '../pwa/messages';
+import type { ConsentPhase, OnboardingPhase } from './types';
+
+/**
+ * useOnboarding の戻り値型。
+ */
+export interface UseOnboardingResult {
+  /** 現在のオンボーディングフェーズ */
+  onboardingPhase: OnboardingPhase;
+  /** オンボーディング表示テキスト（通知許可完了後の一時メッセージを含む） */
+  onboardingText: string | null;
+  /** handleSubmit からオンボーディングテキストをクリアするための関数 */
+  clearOnboardingText: () => void;
+  /** ホーム画面追加ガイドをスキップするハンドラ */
+  handleInstallSkip: () => void;
+  /** 通知許可が完了したときのハンドラ（4 秒後に自動クリア） */
+  handleNotificationGranted: () => void;
+  /** 通知許可をスキップするハンドラ */
+  handleNotificationSkip: () => void;
+}
+
+/**
+ * オンボーディング（ホーム画面追加・通知許可）を管理するカスタム hook。
+ *
+ * 同意完了後（consentPhase === 'done'）にオンボーディング表示要否を判定する。
+ */
+export function useOnboarding(consentPhase: ConsentPhase): UseOnboardingResult {
+  const [onboardingPhase, setOnboardingPhase] = useState<OnboardingPhase>(null);
+  const [onboardingText, setOnboardingText] = useState<string | null>(null);
+
+  // 同意完了後にオンボーディング（ホーム画面追加・通知許可）の表示要否を判定する。
+  useEffect(() => {
+    if (consentPhase !== 'done') return;
+    if (!isStandalone() && shouldShowInstallGuide()) {
+      setOnboardingPhase('install');
+      setOnboardingText(PWA_MESSAGES.INSTALL_PROMPT);
+    } else if (
+      isStandalone() &&
+      isPushSupported() &&
+      typeof window !== 'undefined' &&
+      window.Notification.permission !== 'granted' &&
+      shouldShowNotificationPermission()
+    ) {
+      setOnboardingPhase('notification');
+      setOnboardingText(PWA_MESSAGES.NOTIFICATION_PROMPT);
+    }
+  }, [consentPhase]);
+
+  const clearOnboardingText = useCallback(() => {
+    setOnboardingText(null);
+  }, []);
+
+  const handleInstallSkip = useCallback(() => {
+    setOnboardingPhase(null);
+    setOnboardingText(null);
+  }, []);
+
+  const handleNotificationGranted = useCallback(() => {
+    setOnboardingPhase(null);
+    setOnboardingText(PWA_MESSAGES.NOTIFICATION_GRANTED);
+    setTimeout(() => {
+      setOnboardingText((current) =>
+        current === PWA_MESSAGES.NOTIFICATION_GRANTED ? null : current
+      );
+    }, 4000);
+  }, []);
+
+  const handleNotificationSkip = useCallback(() => {
+    setOnboardingPhase(null);
+    setOnboardingText(null);
+  }, []);
+
+  return {
+    onboardingPhase,
+    onboardingText,
+    clearOnboardingText,
+    handleInstallSkip,
+    handleNotificationGranted,
+    handleNotificationSkip,
+  };
+}

--- a/services/livetalk/web/src/lib/home/usePendingNotifications.ts
+++ b/services/livetalk/web/src/lib/home/usePendingNotifications.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { PendingNotification } from './types';
+
+/**
+ * usePendingNotifications の戻り値型。
+ */
+export interface UsePendingNotificationsResult {
+  /** カレント以外の未消化通知一覧 */
+  pendingNotifications: PendingNotification[];
+}
+
+/**
+ * マウント時に /api/push/pending を取得し、他キャラクターの未消化通知一覧を返すカスタム hook。
+ *
+ * このエフェクトはマウント時（初回起動）にのみ実行する。
+ */
+export function usePendingNotifications(): UsePendingNotificationsResult {
+  const [pendingNotifications, setPendingNotifications] = useState<PendingNotification[]>([]);
+
+  // 自前起動時: カレント以外に未消化通知があれば提示する。
+  // このエフェクトはマウント時（初回起動）にのみ実行する。
+  useEffect(() => {
+    fetch('/api/push/pending')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: PendingNotification[] | null) => {
+        if (!data || data.length === 0) return;
+        setPendingNotifications(data);
+      })
+      .catch(() => {});
+    // マウント時のみ実行（依存配列は空）
+  }, []);
+
+  return { pendingNotifications };
+}

--- a/services/livetalk/web/tests/unit/lib/audio/useAudioContext.test.ts
+++ b/services/livetalk/web/tests/unit/lib/audio/useAudioContext.test.ts
@@ -1,0 +1,169 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAudioContext } from '@/lib/audio/useAudioContext';
+
+/** window.AudioContext をモック化し、cleanup 用のリストアを返す */
+function setupMockAudioContext(state: 'suspended' | 'running' = 'suspended') {
+  const mockResume = jest.fn().mockResolvedValue(undefined);
+  const instance = { state, resume: mockResume };
+  const MockAudioContext = jest.fn(() => instance);
+
+  Object.defineProperty(window, 'AudioContext', {
+    writable: true,
+    configurable: true,
+    value: MockAudioContext,
+  });
+
+  return { MockAudioContext, instance, mockResume };
+}
+
+/** window.AudioContext と window.webkitAudioContext を両方 undefined にする */
+function removeAudioContext() {
+  Object.defineProperty(window, 'AudioContext', {
+    writable: true,
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(window, 'webkitAudioContext', {
+    writable: true,
+    configurable: true,
+    value: undefined,
+  });
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+  removeAudioContext();
+});
+
+describe('useAudioContext', () => {
+  describe('AudioContext 作成と resume', () => {
+    it('初期値は audioContext が null', () => {
+      const { result } = renderHook(() => useAudioContext());
+      expect(result.current.audioContext).toBeNull();
+    });
+
+    it('ensureUnlocked 呼び出しで AudioContext が作成される（suspended 状態）', async () => {
+      const { MockAudioContext, mockResume } = setupMockAudioContext('suspended');
+      const { result } = renderHook(() => useAudioContext());
+
+      await act(async () => {
+        await result.current.ensureUnlocked();
+      });
+
+      expect(MockAudioContext).toHaveBeenCalledTimes(1);
+      expect(result.current.audioContext).not.toBeNull();
+      // suspended 状態なので resume が呼ばれる
+      expect(mockResume).toHaveBeenCalledTimes(1);
+    });
+
+    it('AudioContext が running 状態のとき resume は呼ばれない', async () => {
+      const { MockAudioContext, mockResume } = setupMockAudioContext('running');
+      const { result } = renderHook(() => useAudioContext());
+
+      await act(async () => {
+        await result.current.ensureUnlocked();
+      });
+
+      expect(MockAudioContext).toHaveBeenCalledTimes(1);
+      expect(mockResume).not.toHaveBeenCalled();
+    });
+
+    it('2 回目の ensureUnlocked では AudioContext を再生成しない', async () => {
+      const { MockAudioContext, mockResume } = setupMockAudioContext('suspended');
+      const { result } = renderHook(() => useAudioContext());
+
+      await act(async () => {
+        await result.current.ensureUnlocked();
+      });
+      await act(async () => {
+        await result.current.ensureUnlocked();
+      });
+
+      // インスタンスは 1 回だけ作成される
+      expect(MockAudioContext).toHaveBeenCalledTimes(1);
+      // 2 回とも suspended 状態として mockResume が呼ばれる（インスタンスの state は変化しないモック）
+      expect(mockResume).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('webkitAudioContext フォールバック', () => {
+    it('window.AudioContext が undefined のとき webkitAudioContext を使用する', async () => {
+      const mockResume = jest.fn().mockResolvedValue(undefined);
+      const instance = { state: 'suspended', resume: mockResume };
+      const MockWebkitAudioContext = jest.fn(() => instance);
+
+      removeAudioContext();
+      Object.defineProperty(window, 'webkitAudioContext', {
+        writable: true,
+        configurable: true,
+        value: MockWebkitAudioContext,
+      });
+
+      const { result } = renderHook(() => useAudioContext());
+
+      await act(async () => {
+        await result.current.ensureUnlocked();
+      });
+
+      expect(MockWebkitAudioContext).toHaveBeenCalledTimes(1);
+      expect(mockResume).toHaveBeenCalledTimes(1);
+      expect(result.current.audioContext).not.toBeNull();
+    });
+  });
+
+  describe('AudioContext 不在環境', () => {
+    it('AudioContext が利用不可の環境でもクラッシュしない', async () => {
+      removeAudioContext();
+      const { result } = renderHook(() => useAudioContext());
+
+      await expect(
+        act(async () => {
+          await result.current.ensureUnlocked();
+        })
+      ).resolves.toBeUndefined();
+
+      expect(result.current.audioContext).toBeNull();
+    });
+
+    it('AudioContext 不在環境では getContext が null を返す', async () => {
+      removeAudioContext();
+      const { result } = renderHook(() => useAudioContext());
+
+      await act(async () => {
+        await result.current.ensureUnlocked();
+      });
+
+      expect(result.current.getContext()).toBeNull();
+    });
+  });
+
+  describe('getContext（同期参照）', () => {
+    it('ensureUnlocked 前は getContext が null を返す', () => {
+      setupMockAudioContext('suspended');
+      const { result } = renderHook(() => useAudioContext());
+      expect(result.current.getContext()).toBeNull();
+    });
+
+    it('ensureUnlocked 後は getContext が AudioContext インスタンスを返す', async () => {
+      setupMockAudioContext('suspended');
+      const { result } = renderHook(() => useAudioContext());
+
+      await act(async () => {
+        await result.current.ensureUnlocked();
+      });
+
+      expect(result.current.getContext()).not.toBeNull();
+    });
+
+    it('getContext と audioContext state は同じインスタンスを指す', async () => {
+      setupMockAudioContext('running');
+      const { result } = renderHook(() => useAudioContext());
+
+      await act(async () => {
+        await result.current.ensureUnlocked();
+      });
+
+      expect(result.current.getContext()).toBe(result.current.audioContext);
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/audio/useAudioQueue.test.ts
+++ b/services/livetalk/web/tests/unit/lib/audio/useAudioQueue.test.ts
@@ -1,0 +1,313 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAudioQueue } from '@/lib/audio/useAudioQueue';
+
+/** テスト用のダミー AudioBuffer を生成する */
+function makeDummyBuffer(id: number = 0): AudioBuffer {
+  return { id } as unknown as AudioBuffer;
+}
+
+describe('useAudioQueue', () => {
+  describe('初期状態', () => {
+    it('初期値は audioBuffer が null', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      expect(result.current.audioBuffer).toBeNull();
+    });
+
+    it('reset 直後に onDrained が発火しないこと（streamDone=false なので）', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(onDrained).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('enqueue', () => {
+    it('enqueue するとキューが空なので即 current（audioBuffer）になる', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf = makeDummyBuffer(1);
+
+      act(() => {
+        result.current.enqueue(buf);
+      });
+
+      expect(result.current.audioBuffer).toBe(buf);
+    });
+
+    it('再生中に enqueue するとキューに積まれ current は変わらない', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf1 = makeDummyBuffer(1);
+      const buf2 = makeDummyBuffer(2);
+
+      act(() => {
+        result.current.enqueue(buf1);
+      });
+      act(() => {
+        result.current.enqueue(buf2);
+      });
+
+      // current は最初に enqueue した buf1 のまま
+      expect(result.current.audioBuffer).toBe(buf1);
+    });
+  });
+
+  describe('handlePlaybackEnd', () => {
+    it('handlePlaybackEnd で次の buf に進む', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf1 = makeDummyBuffer(1);
+      const buf2 = makeDummyBuffer(2);
+
+      act(() => {
+        result.current.enqueue(buf1);
+        result.current.enqueue(buf2);
+      });
+
+      act(() => {
+        result.current.handlePlaybackEnd();
+      });
+
+      expect(result.current.audioBuffer).toBe(buf2);
+    });
+
+    it('キューが空のとき handlePlaybackEnd で audioBuffer が null になる', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf = makeDummyBuffer(1);
+
+      act(() => {
+        result.current.enqueue(buf);
+      });
+      act(() => {
+        result.current.handlePlaybackEnd();
+      });
+
+      expect(result.current.audioBuffer).toBeNull();
+    });
+  });
+
+  describe('handlePlaybackError', () => {
+    it('handlePlaybackError でも advance する（次の buf に進む）', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf1 = makeDummyBuffer(1);
+      const buf2 = makeDummyBuffer(2);
+
+      act(() => {
+        result.current.enqueue(buf1);
+        result.current.enqueue(buf2);
+      });
+      act(() => {
+        result.current.handlePlaybackError();
+      });
+
+      expect(result.current.audioBuffer).toBe(buf2);
+    });
+
+    it('キューが空のとき handlePlaybackError で audioBuffer が null になる', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf = makeDummyBuffer(1);
+
+      act(() => {
+        result.current.enqueue(buf);
+      });
+      act(() => {
+        result.current.handlePlaybackError();
+      });
+
+      expect(result.current.audioBuffer).toBeNull();
+    });
+  });
+
+  describe('markStreamDone と onDrained', () => {
+    it('markStreamDone 後にキュー空・current=null なら onDrained が発火する', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+
+      act(() => {
+        result.current.markStreamDone();
+      });
+
+      expect(onDrained).toHaveBeenCalledTimes(1);
+    });
+
+    it('再生中に markStreamDone しても onDrained は発火しない（current があるため）', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf = makeDummyBuffer(1);
+
+      act(() => {
+        result.current.enqueue(buf);
+        result.current.markStreamDone();
+      });
+
+      // current が buf なので drain しない
+      expect(onDrained).not.toHaveBeenCalled();
+    });
+
+    it('再生完了後に streamDone 済みなら onDrained が発火する', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf = makeDummyBuffer(1);
+
+      act(() => {
+        result.current.enqueue(buf);
+        result.current.markStreamDone();
+      });
+      act(() => {
+        result.current.handlePlaybackEnd();
+      });
+
+      expect(onDrained).toHaveBeenCalledTimes(1);
+    });
+
+    it('連続 enqueue → 全再生完了 → markStreamDone で onDrained 発火', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf1 = makeDummyBuffer(1);
+      const buf2 = makeDummyBuffer(2);
+
+      act(() => {
+        result.current.enqueue(buf1);
+        result.current.enqueue(buf2);
+      });
+      act(() => {
+        result.current.handlePlaybackEnd(); // buf1 → buf2
+      });
+      act(() => {
+        result.current.handlePlaybackEnd(); // buf2 → null
+      });
+      act(() => {
+        result.current.markStreamDone();
+      });
+
+      expect(onDrained).toHaveBeenCalledTimes(1);
+      expect(result.current.audioBuffer).toBeNull();
+    });
+
+    it('キューにまだバッファがある間は markStreamDone で onDrained が発火しない', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf1 = makeDummyBuffer(1);
+      const buf2 = makeDummyBuffer(2);
+
+      act(() => {
+        result.current.enqueue(buf1);
+        result.current.enqueue(buf2);
+        result.current.markStreamDone();
+      });
+
+      // current=buf1, queue=[buf2] → まだ drain しない
+      expect(onDrained).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reset', () => {
+    it('reset でキューと current と streamDone がクリアされる', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf = makeDummyBuffer(1);
+
+      act(() => {
+        result.current.enqueue(buf);
+        result.current.markStreamDone();
+      });
+      // markStreamDone で onDrained が 1 回発火したのでリセット
+      onDrained.mockClear();
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.audioBuffer).toBeNull();
+      // reset 後は streamDone=false なので onDrained は発火しない
+      expect(onDrained).not.toHaveBeenCalled();
+    });
+
+    it('reset 後に enqueue → markStreamDone で再び onDrained が発火する', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+
+      act(() => {
+        result.current.markStreamDone();
+      });
+      expect(onDrained).toHaveBeenCalledTimes(1);
+      onDrained.mockClear();
+
+      act(() => {
+        result.current.reset();
+      });
+
+      act(() => {
+        result.current.markStreamDone();
+      });
+
+      expect(onDrained).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onDrained 参照変更による誤発火防止', () => {
+    it('onDrained コールバックが毎レンダーで新しい参照になっても誤発火しない', () => {
+      let callCount = 0;
+      // rerenderで毎回新しい関数参照を渡す
+      const { result, rerender } = renderHook(
+        ({ cb }: { cb: () => void }) => useAudioQueue({ onDrained: cb }),
+        { initialProps: { cb: () => callCount++ } }
+      );
+
+      // コールバック参照を変えて rerender
+      rerender({ cb: () => callCount++ });
+      rerender({ cb: () => callCount++ });
+
+      // rerender だけでは onDrained は発火しない
+      expect(callCount).toBe(0);
+
+      // 正常なトリガーでのみ発火する
+      act(() => {
+        result.current.markStreamDone();
+      });
+      expect(callCount).toBe(1);
+    });
+  });
+
+  describe('順序保証', () => {
+    it('複数 enqueue したバッファが enqueue 順に再生される', () => {
+      const onDrained = jest.fn();
+      const { result } = renderHook(() => useAudioQueue({ onDrained }));
+      const buf1 = makeDummyBuffer(1);
+      const buf2 = makeDummyBuffer(2);
+      const buf3 = makeDummyBuffer(3);
+
+      act(() => {
+        result.current.enqueue(buf1);
+        result.current.enqueue(buf2);
+        result.current.enqueue(buf3);
+      });
+
+      // 再生順: buf1 → buf2 → buf3
+      expect(result.current.audioBuffer).toBe(buf1);
+
+      act(() => {
+        result.current.handlePlaybackEnd();
+      });
+      expect(result.current.audioBuffer).toBe(buf2);
+
+      act(() => {
+        result.current.handlePlaybackEnd();
+      });
+      expect(result.current.audioBuffer).toBe(buf3);
+
+      act(() => {
+        result.current.handlePlaybackEnd();
+      });
+      expect(result.current.audioBuffer).toBeNull();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useCharacterQuerySync.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useCharacterQuerySync.test.ts
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+import { useCharacterQuerySync } from '@/lib/home/useCharacterQuerySync';
+
+// useSearchParams をモック化
+const mockSearchParamsGet = jest.fn().mockReturnValue(null);
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(() => ({
+    get: mockSearchParamsGet,
+  })),
+}));
+
+// CharacterContext の useCharacter をモック化
+const mockSetCharacterId = jest.fn();
+jest.mock('@/lib/characters/CharacterContext', () => ({
+  useCharacter: jest.fn(() => ({
+    characterId: 'hiyori',
+    setCharacterId: mockSetCharacterId,
+  })),
+}));
+
+// hasCharacterProfile をモック化（hiyori と ageha は有効、other は無効）
+jest.mock('@/lib/characters/client-profiles', () => ({
+  hasCharacterProfile: jest.fn((id: string) => ['hiyori', 'ageha'].includes(id)),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+  mockSearchParamsGet.mockReturnValue(null);
+});
+
+describe('useCharacterQuerySync', () => {
+  describe('?character クエリがない場合', () => {
+    it('character クエリがないとき setCharacterId は呼ばれない', () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('有効な ?character クエリがある場合', () => {
+    it('?character=ageha のとき setCharacterId(ageha) が呼ばれる', () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'character') return 'ageha';
+        return null;
+      });
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).toHaveBeenCalledWith('ageha');
+    });
+
+    it('?character=hiyori のとき setCharacterId(hiyori) が呼ばれる', () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'character') return 'hiyori';
+        return null;
+      });
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).toHaveBeenCalledWith('hiyori');
+    });
+  });
+
+  describe('無効な ?character クエリがある場合', () => {
+    it('登録されていないキャラクター ID のとき setCharacterId は呼ばれない', () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'character') return 'unknown-character-xyz';
+        return null;
+      });
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).not.toHaveBeenCalled();
+    });
+
+    it('空文字のとき setCharacterId は呼ばれない', () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'character') return '';
+        return null;
+      });
+      renderHook(() => useCharacterQuerySync());
+      expect(mockSetCharacterId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('戻り値', () => {
+    it('戻り値は void（undefined）', () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      const { result } = renderHook(() => useCharacterQuerySync());
+      expect(result.current).toBeUndefined();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useChatStream.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useChatStream.test.ts
@@ -1,0 +1,760 @@
+// jsdom は TextEncoder / TextDecoder / ReadableStream を提供しない場合があるため補完
+import { TextEncoder, TextDecoder } from 'util';
+import { ReadableStream } from 'stream/web';
+Object.assign(global, { TextEncoder, TextDecoder, ReadableStream });
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { LifecycleState } from '@nagiyu/livetalk-core';
+import { useChatStream, type UseChatStreamDeps } from '@/lib/home/useChatStream';
+import type { ChatPhase } from '@/lib/home/types';
+
+// reportClientError をモック化（fetch 呼び出しを排除）
+jest.mock('@/lib/client-logger', () => ({
+  reportClientError: jest.fn(),
+}));
+
+import { reportClientError } from '@/lib/client-logger';
+const mockReportClientError = reportClientError as jest.Mock;
+
+// NDJSON 行を TextEncoder で ReadableStream に変換するヘルパー
+function makeNdjsonStream(lines: unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(JSON.stringify(line) + '\n'));
+      }
+      controller.close();
+    },
+  });
+}
+
+// deps のデフォルトスタブを生成するヘルパー
+// jest.fn() のインスタンスを UseChatStreamDeps の各フィールドにキャストして返す
+function makeDeps(overrides: Partial<UseChatStreamDeps> = {}): UseChatStreamDeps {
+  return {
+    characterId: 'hiyori',
+    setPhase: jest.fn() as unknown as Dispatch<SetStateAction<ChatPhase>>,
+    ensureUnlocked: jest.fn().mockResolvedValue(undefined) as () => Promise<void>,
+    getContext: jest.fn().mockReturnValue(null) as () => AudioContext | null,
+    enqueue: jest.fn() as (buffer: AudioBuffer) => void,
+    markStreamDone: jest.fn() as () => void,
+    resetAudioQueue: jest.fn() as () => void,
+    advanceOnError: jest.fn() as () => void,
+    consumeKnowledgeId: jest.fn().mockReturnValue(null) as (
+      currentCharacterId: string
+    ) => string | null,
+    clearFirstWordText: jest.fn() as () => void,
+    clearOnboardingText: jest.fn() as () => void,
+    setLifecycleState: jest.fn() as unknown as Dispatch<SetStateAction<LifecycleState>>,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useChatStream', () => {
+  describe('初期値', () => {
+    it('初期状態は userText / responseText / errorMessage が null、safetyOpen が false', () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, body: null, status: 500 });
+      const { result } = renderHook(() => useChatStream(makeDeps()));
+
+      expect(result.current.userText).toBeNull();
+      expect(result.current.responseText).toBeNull();
+      expect(result.current.errorMessage).toBeNull();
+      expect(result.current.safetyOpen).toBe(false);
+      expect(result.current.safetyResources).toEqual([]);
+    });
+  });
+
+  describe('closeSafety', () => {
+    it('closeSafety を呼ぶと safetyOpen が false になる', async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              JSON.stringify({
+                type: 'safety',
+                trigger: 'input_keyword',
+                resources: [{ title: 'サポート', url: 'https://example.com' }],
+              }) + '\n'
+            )
+          );
+          controller.close();
+        },
+      });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: stream, status: 200 });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(result.current.safetyOpen).toBe(true));
+
+      act(() => {
+        result.current.closeSafety();
+      });
+      expect(result.current.safetyOpen).toBe(false);
+    });
+  });
+
+  describe('handleSubmit: 状態リセット', () => {
+    it('送信時に setPhase("loading") が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.setPhase).toHaveBeenCalledWith('loading');
+    });
+
+    it('送信時に clearFirstWordText と clearOnboardingText が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.clearFirstWordText).toHaveBeenCalled();
+      expect(deps.clearOnboardingText).toHaveBeenCalled();
+    });
+
+    it('送信時に resetAudioQueue が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.resetAudioQueue).toHaveBeenCalled();
+    });
+
+    it('送信時に ensureUnlocked が先行して呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const callOrder: string[] = [];
+      const deps = makeDeps({
+        ensureUnlocked: jest.fn().mockImplementation(async () => {
+          callOrder.push('ensureUnlocked');
+        }),
+        setPhase: jest.fn().mockImplementation(() => {
+          callOrder.push('setPhase');
+        }) as Dispatch<SetStateAction<ChatPhase>>,
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      // ensureUnlocked は setPhase より先に呼ばれる
+      expect(callOrder[0]).toBe('ensureUnlocked');
+    });
+
+    it('送信時に userText が設定される', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('こんにちは');
+      });
+
+      expect(result.current.userText).toBe('こんにちは');
+    });
+  });
+
+  describe('handleSubmit: response.ok=false の場合', () => {
+    it('HTTP エラー時に errorMessage が設定され setPhase("idle") が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        body: null,
+        status: 500,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(result.current.errorMessage).toBe(
+        '応答の取得に失敗しました。時間を置いて再度お試しください。'
+      );
+      expect(deps.setPhase).toHaveBeenCalledWith('idle');
+    });
+
+    it('HTTP エラー時に reportClientError が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        body: null,
+        status: 500,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'error',
+        'チャット fetch 失敗',
+        'HTTP 500',
+        expect.objectContaining({ screen: 'chat' })
+      );
+    });
+  });
+
+  describe('handleSubmit: streaming フェーズ', () => {
+    it('ストリーム開始後に setPhase("streaming") が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.setPhase).toHaveBeenCalledWith('streaming');
+    });
+  });
+
+  describe('handleSubmit: text イベント', () => {
+    it('text イベントで responseText が追記される', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'text', delta: 'こんに' },
+          { type: 'text', delta: 'ちは' },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      // React の state 更新は関数形式で追記されるため最終的な値を確認
+      await waitFor(() => expect(result.current.responseText).toBe('こんにちは'));
+    });
+  });
+
+  describe('handleSubmit: sentence イベント', () => {
+    it('sentence イベントで AudioContext がある場合 decodeAudioData が呼ばれ enqueue される', async () => {
+      const mockDecodeAudioData = jest.fn().mockResolvedValue({} as AudioBuffer);
+      const mockAudioCtx = {
+        state: 'running' as AudioContextState,
+        decodeAudioData: mockDecodeAudioData,
+      };
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'sentence', index: 0, text: 'こんにちは', audio: 'AAAAAA==' },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        getContext: jest.fn().mockReturnValue(mockAudioCtx as unknown as AudioContext),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(mockDecodeAudioData).toHaveBeenCalledTimes(1));
+      expect(deps.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('AudioContext が null の場合 enqueue は呼ばれない（音声スキップ）', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'sentence', index: 0, text: 'こんにちは', audio: 'AAAAAA==' },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        getContext: jest.fn().mockReturnValue(null),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('decodeAudioData が失敗してもクラッシュせず reportClientError が呼ばれる', async () => {
+      const mockDecodeAudioData = jest.fn().mockRejectedValue(new Error('decode failure'));
+      const mockAudioCtx = {
+        state: 'running' as AudioContextState,
+        decodeAudioData: mockDecodeAudioData,
+      };
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'sentence', index: 0, text: 'こんにちは', audio: 'AAAAAA==' },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        getContext: jest.fn().mockReturnValue(mockAudioCtx as unknown as AudioContext),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(mockDecodeAudioData).toHaveBeenCalledTimes(1));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[LiveTalk] 音声 decode に失敗しました',
+        expect.any(Error)
+      );
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'warning',
+        '音声 decode 失敗',
+        'decode failure',
+        expect.objectContaining({ screen: 'chat', sentenceReceived: 1 })
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('handleSubmit: lifecycle イベント', () => {
+    it('lifecycle イベントで setLifecycleState が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'lifecycle', state: 'sleeping' }, { type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.setLifecycleState).toHaveBeenCalledWith('sleeping');
+    });
+  });
+
+  describe('handleSubmit: safety イベント', () => {
+    it('safety イベントで safetyOpen が true になり safetyResources が設定される', async () => {
+      const resources = [{ title: 'サポート', url: 'https://example.com' }];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'safety', trigger: 'input_keyword', resources },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(result.current.safetyOpen).toBe(true));
+      expect(result.current.safetyResources).toEqual(resources);
+    });
+
+    it('safety trigger=output_moderation かつ replacementText がある場合 responseText が上書きされる', async () => {
+      const resources = [{ title: 'サポート', url: 'https://example.com' }];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'text', delta: '元のテキスト' },
+          {
+            type: 'safety',
+            trigger: 'output_moderation',
+            resources,
+            replacementText: '代替テキスト',
+          },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(result.current.safetyOpen).toBe(true));
+      expect(result.current.responseText).toBe('代替テキスト');
+    });
+
+    it('safety trigger=input_keyword の場合 responseText は上書きされない', async () => {
+      const resources = [{ title: 'サポート', url: 'https://example.com' }];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([
+          { type: 'text', delta: '元のテキスト' },
+          { type: 'safety', trigger: 'input_keyword', resources },
+          { type: 'done' },
+        ]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      await waitFor(() => expect(result.current.safetyOpen).toBe(true));
+      // input_keyword は responseText を上書きしない
+      await waitFor(() => expect(result.current.responseText).toBe('元のテキスト'));
+    });
+  });
+
+  describe('handleSubmit: done イベント', () => {
+    it('done イベントで markStreamDone が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.markStreamDone).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleSubmit: error イベント', () => {
+    it('error イベントで errorMessage が設定され markStreamDone と reportClientError が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'error', message: 'サーバーエラーです' }]),
+        status: 200,
+      });
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(result.current.errorMessage).toBe('サーバーエラーです');
+      expect(deps.markStreamDone).toHaveBeenCalled();
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'error',
+        'チャット stream エラー',
+        'サーバーエラーです',
+        expect.objectContaining({ screen: 'chat', streamDone: true })
+      );
+    });
+  });
+
+  describe('handleSubmit: AbortError', () => {
+    it('AbortError は無視されエラーメッセージが設定されない', async () => {
+      const abortError = new Error('AbortError');
+      abortError.name = 'AbortError';
+      global.fetch = jest.fn().mockRejectedValue(abortError);
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(result.current.errorMessage).toBeNull();
+      expect(deps.setPhase).not.toHaveBeenCalledWith('idle');
+    });
+
+    it('2 回目の送信前に前回 AbortController が abort される（AbortError は無視）', async () => {
+      // 1 回目は即 AbortError を throw するようにして abort 確認を行う
+      // （void act は非同期漏れを起こすため使わず、2 回 fetch を呼ぶことで確認する）
+      let callCount = 0;
+      const abortErrors: DOMException[] = [];
+
+      global.fetch = jest.fn().mockImplementation((_url: string, options: RequestInit) => {
+        callCount++;
+        const signal = options?.signal;
+        if (callCount === 1) {
+          // 1 回目は done ストリームを返す
+          return Promise.resolve({
+            ok: true,
+            body: makeNdjsonStream([{ type: 'done' }]),
+            status: 200,
+          });
+        }
+        // 2 回目以降も done ストリームを返す
+        if (signal?.aborted) {
+          const err = new DOMException('Aborted', 'AbortError');
+          abortErrors.push(err);
+          return Promise.reject(err);
+        }
+        return Promise.resolve({
+          ok: true,
+          body: makeNdjsonStream([{ type: 'done' }]),
+          status: 200,
+        });
+      });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      // 1 回目送信
+      await act(async () => {
+        await result.current.handleSubmit('1回目');
+      });
+
+      // 2 回目送信（前回の abort controller が abort される）
+      await act(async () => {
+        await result.current.handleSubmit('2回目');
+      });
+
+      // 2 回の fetch が呼ばれたことを確認（前回 abort + 新リクエスト）
+      expect(callCount).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('handleSubmit: 通信エラー catch', () => {
+    it('fetch が例外を投げたとき errorMessage が設定され setPhase("idle") と reportClientError が呼ばれる', async () => {
+      const networkError = new Error('ネットワークエラー');
+      global.fetch = jest.fn().mockRejectedValue(networkError);
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(result.current.errorMessage).toBe(
+        'エラーが発生しました。時間を置いて再度お試しください。'
+      );
+      expect(deps.setPhase).toHaveBeenCalledWith('idle');
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'error',
+        'チャット通信エラー',
+        'ネットワークエラー',
+        expect.objectContaining({ screen: 'chat', stack: expect.any(String) })
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('handleSubmit: malformed 行スキップ', () => {
+    it('malformed JSON 行はスキップされクラッシュしない', async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          // 不正な JSON を含む NDJSON
+          controller.enqueue(encoder.encode('{"type":"text","delta":"こんにちは"}\n'));
+          controller.enqueue(encoder.encode('{invalid json}\n'));
+          controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+          controller.close();
+        },
+      });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: stream, status: 200 });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      // malformed 行はスキップ、done は処理される
+      expect(deps.markStreamDone).toHaveBeenCalled();
+      await waitFor(() => expect(result.current.responseText).toBe('こんにちは'));
+    });
+
+    it('空行はスキップされクラッシュしない', async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('\n\n'));
+          controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+          controller.close();
+        },
+      });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: stream, status: 200 });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      expect(deps.markStreamDone).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSubmit: knowledgeId の伝播', () => {
+    it('consumeKnowledgeId が knowledgeId を返す場合 chatBody に含まれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        consumeKnowledgeId: jest.fn().mockReturnValue('k-xyz'),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      const chatCall = (global.fetch as jest.Mock).mock.calls.find(
+        ([url]: [string]) => url === '/api/chat'
+      );
+      expect(chatCall).toBeDefined();
+      const chatBody = JSON.parse(chatCall[1].body as string);
+      expect(chatBody.knowledgeId).toBe('k-xyz');
+    });
+
+    it('consumeKnowledgeId が null を返す場合 chatBody に knowledgeId が含まれない', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        body: makeNdjsonStream([{ type: 'done' }]),
+        status: 200,
+      });
+      const deps = makeDeps({
+        consumeKnowledgeId: jest.fn().mockReturnValue(null),
+      });
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      const chatCall = (global.fetch as jest.Mock).mock.calls.find(
+        ([url]: [string]) => url === '/api/chat'
+      );
+      expect(chatCall).toBeDefined();
+      const chatBody = JSON.parse(chatCall[1].body as string);
+      expect(chatBody.knowledgeId).toBeUndefined();
+    });
+  });
+
+  describe('handleSubmit: ストリーム終端の残余行処理', () => {
+    it('改行で終わらない残余行でも最後のイベントが処理される', async () => {
+      const encoder = new TextEncoder();
+      // 最後の行に改行を付けない（残余行として lineBuffer に残る）
+      const stream = new ReadableStream({
+        start(controller) {
+          // done を改行なしで送信
+          controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' })));
+          controller.close();
+        },
+      });
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, body: stream, status: 200 });
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      await act(async () => {
+        await result.current.handleSubmit('テスト');
+      });
+
+      // 残余行の done も処理される
+      expect(deps.markStreamDone).toHaveBeenCalled();
+    });
+  });
+
+  describe('handlePlaybackError', () => {
+    it('handlePlaybackError で errorMessage が設定され advanceOnError と reportClientError が呼ばれる', () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, body: null, status: 500 });
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const deps = makeDeps();
+      const { result } = renderHook(() => useChatStream(deps));
+
+      act(() => {
+        result.current.handlePlaybackError(new Error('再生エラー'));
+      });
+
+      expect(result.current.errorMessage).toBe('音声再生中にエラーが発生しました。');
+      expect(deps.advanceOnError).toHaveBeenCalled();
+      expect(mockReportClientError).toHaveBeenCalledWith(
+        'warning',
+        '音声再生エラー',
+        '再生エラー',
+        expect.objectContaining({ screen: 'chat' })
+      );
+      expect(consoleSpy).toHaveBeenCalledWith('[LiveTalk] 音声再生エラー', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('関数参照の安定性', () => {
+    it('handleSubmit と handlePlaybackError は再レンダリングで参照が変わらない', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, body: null, status: 500 });
+      const deps = makeDeps();
+      const { result, rerender } = renderHook(() => useChatStream(deps));
+
+      const firstHandleSubmit = result.current.handleSubmit;
+      const firstHandlePlaybackError = result.current.handlePlaybackError;
+
+      rerender();
+
+      expect(result.current.handleSubmit).toBe(firstHandleSubmit);
+      expect(result.current.handlePlaybackError).toBe(firstHandlePlaybackError);
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useConsent.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useConsent.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useConsent } from '@/lib/home/useConsent';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useConsent', () => {
+  describe('初期値', () => {
+    it('初期状態は checking', () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: true }),
+      });
+      const { result } = renderHook(() => useConsent());
+      expect(result.current.consentPhase).toBe('checking');
+    });
+  });
+
+  describe('/api/consent 取得', () => {
+    it('consented: true のとき consentPhase が done になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: true }),
+      });
+      const { result } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('done'));
+    });
+
+    it('consented: false のとき consentPhase が required になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: false }),
+      });
+      const { result } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('required'));
+    });
+
+    it('取得失敗時は consentPhase が required になる', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+      const { result } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('required'));
+    });
+
+    it('/api/consent に fetch が呼ばれる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: true }),
+      });
+      renderHook(() => useConsent());
+      await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/api/consent'));
+    });
+  });
+
+  describe('markConsented', () => {
+    it('markConsented を呼ぶと consentPhase が done になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: false }),
+      });
+      const { result } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('required'));
+
+      act(() => {
+        result.current.markConsented();
+      });
+
+      expect(result.current.consentPhase).toBe('done');
+    });
+
+    it('markConsented は安定した関数参照を持つ', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ consented: true }),
+      });
+      const { result, rerender } = renderHook(() => useConsent());
+      await waitFor(() => expect(result.current.consentPhase).toBe('done'));
+
+      const firstRef = result.current.markConsented;
+      rerender();
+      expect(result.current.markConsented).toBe(firstRef);
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useFirstWord.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useFirstWord.test.ts
@@ -1,0 +1,407 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useFirstWord } from '@/lib/home/useFirstWord';
+
+// useSearchParams をモック化
+const mockSearchParamsGet = jest.fn().mockReturnValue(null);
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(() => ({
+    get: mockSearchParamsGet,
+  })),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+  mockSearchParamsGet.mockReturnValue(null);
+});
+
+describe('useFirstWord', () => {
+  describe('初期値', () => {
+    it('初期状態は firstWordText と prefillText が null', () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false });
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      expect(result.current.firstWordText).toBeNull();
+      expect(result.current.prefillText).toBeNull();
+    });
+  });
+
+  describe('first-word 取得', () => {
+    it('characterId 付きで /api/push/first-word を取得する', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({ ok: false });
+        }
+        return Promise.resolve({ ok: true });
+      });
+      renderHook(() => useFirstWord('hiyori'));
+
+      await waitFor(() => {
+        const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+        expect(calls.some((url) => url.includes('/api/push/first-word?characterId=hiyori'))).toBe(
+          true
+        );
+      });
+    });
+
+    it('ok: true かつデータあり → firstWordText が設定される', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: 'テスト第一声',
+                knowledgeId: 'k-xyz',
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('テスト第一声'));
+    });
+
+    it('ok: false のとき firstWordText は null のまま', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false });
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await act(async () => {});
+      expect(result.current.firstWordText).toBeNull();
+    });
+
+    it('取得成功時に /api/push/consumed が PATCH で呼ばれる', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: null,
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => {
+        const consumedCall = (global.fetch as jest.Mock).mock.calls.find(
+          ([url]: [string]) => url === '/api/push/consumed'
+        );
+        expect(consumedCall).toBeDefined();
+        expect(consumedCall[1].method).toBe('PATCH');
+        const body = JSON.parse(consumedCall[1].body as string);
+        expect(body.notifId).toBe('n1');
+      });
+    });
+
+    it('fetch 失敗時はクラッシュしない', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await act(async () => {});
+      expect(result.current.firstWordText).toBeNull();
+    });
+  });
+
+  describe('characterId が変わったとき', () => {
+    it('characterId が変わると再 fetch し前の firstWordText がクリアされる', async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          callCount++;
+          if (callCount === 1) {
+            return Promise.resolve({
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  notifId: 'n1',
+                  body: 'ひよりの声',
+                  knowledgeId: 'k1',
+                  characterId: 'hiyori',
+                }),
+            });
+          }
+          return Promise.resolve({ ok: false });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result, rerender } = renderHook(({ characterId }) => useFirstWord(characterId), {
+        initialProps: { characterId: 'hiyori' },
+      });
+
+      await waitFor(() => expect(result.current.firstWordText).toBe('ひよりの声'));
+
+      rerender({ characterId: 'ageha' });
+
+      // キャラ切替直後に null になる（effect の先頭でクリア）
+      expect(result.current.firstWordText).toBeNull();
+    });
+  });
+
+  describe('prefillText（from=push + suggestedReply）', () => {
+    it('from=push かつ suggestedReply あり → prefillText が設定される', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'from') return 'push';
+        return null;
+      });
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k1',
+                characterId: 'hiyori',
+                suggestedReply: 'TypeScriptについて教えて',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.prefillText).toBe('TypeScriptについて教えて'));
+    });
+
+    it('from=push でない場合は suggestedReply があっても prefillText が null のまま', async () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k1',
+                characterId: 'hiyori',
+                suggestedReply: '返信テキスト',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+      expect(result.current.prefillText).toBeNull();
+    });
+
+    it('from=push でも suggestedReply が null なら prefillText は null のまま', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'from') return 'push';
+        return null;
+      });
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k1',
+                characterId: 'hiyori',
+                suggestedReply: null,
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+      expect(result.current.prefillText).toBeNull();
+    });
+  });
+
+  describe('consumeKnowledgeId（クロス汚染防止ガード）', () => {
+    it('カレントキャラ == 通知元キャラのとき knowledgeId を返し ref をクリアする', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k-hiyori',
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      let knowledgeId: string | null = null;
+      act(() => {
+        knowledgeId = result.current.consumeKnowledgeId('hiyori');
+      });
+
+      // カレント == 通知元 → knowledgeId が返る
+      expect(knowledgeId).toBe('k-hiyori');
+    });
+
+    it('2 回目の consumeKnowledgeId は null を返す（ref がクリアされている）', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k-hiyori',
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      act(() => {
+        result.current.consumeKnowledgeId('hiyori');
+      });
+      let secondKnowledgeId: string | null = null;
+      act(() => {
+        secondKnowledgeId = result.current.consumeKnowledgeId('hiyori');
+      });
+
+      expect(secondKnowledgeId).toBeNull();
+    });
+
+    it('カレントキャラ != 通知元キャラのとき null を返す（クロス汚染防止）', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: 'k-ageha',
+                // 通知元は ageha だがカレントは hiyori でチェックする
+                characterId: 'ageha',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      let knowledgeId: string | null = null;
+      act(() => {
+        // カレントキャラとして 'hiyori' を渡す（通知元は 'ageha'）
+        knowledgeId = result.current.consumeKnowledgeId('hiyori');
+      });
+
+      // クロス汚染防止 → null
+      expect(knowledgeId).toBeNull();
+    });
+
+    it('knowledgeId が null の first-word でも consumeKnowledgeId は null を返す', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: null,
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      let knowledgeId: string | null = null;
+      act(() => {
+        knowledgeId = result.current.consumeKnowledgeId('hiyori');
+      });
+
+      expect(knowledgeId).toBeNull();
+    });
+  });
+
+  describe('clearFirstWordText', () => {
+    it('clearFirstWordText を呼ぶと firstWordText が null になる', async () => {
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.startsWith('/api/push/first-word')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                notifId: 'n1',
+                body: '第一声',
+                knowledgeId: null,
+                characterId: 'hiyori',
+              }),
+          });
+        }
+        if (url === '/api/push/consumed') {
+          return Promise.resolve({ ok: true });
+        }
+        return Promise.resolve({ ok: true });
+      });
+
+      const { result } = renderHook(() => useFirstWord('hiyori'));
+      await waitFor(() => expect(result.current.firstWordText).toBe('第一声'));
+
+      act(() => {
+        result.current.clearFirstWordText();
+      });
+
+      expect(result.current.firstWordText).toBeNull();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useLifecycle.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useLifecycle.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useLifecycle } from '@/lib/home/useLifecycle';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useLifecycle', () => {
+  describe('初期値', () => {
+    it('初期状態は lifecycleState が awake', () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      expect(result.current.lifecycleState).toBe('awake');
+    });
+  });
+
+  describe('/api/lifecycle 取得', () => {
+    it('characterId 付きで /api/lifecycle を取得する', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+      renderHook(() => useLifecycle('hiyori'));
+
+      await waitFor(() => {
+        const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+        expect(calls.some((url) => url.includes('/api/lifecycle?characterId=hiyori'))).toBe(true);
+      });
+    });
+
+    it('state: sleeping が返ったとき lifecycleState が sleeping になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'sleeping' }),
+      });
+
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await waitFor(() => expect(result.current.lifecycleState).toBe('sleeping'));
+    });
+
+    it('state: awake が返ったとき lifecycleState が awake になる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'sleeping' }),
+      });
+
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await waitFor(() => expect(result.current.lifecycleState).toBe('sleeping'));
+
+      // awake に戻る fetch
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+    });
+
+    it('fetch 失敗時は初期値 awake を維持する', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await act(async () => {});
+      expect(result.current.lifecycleState).toBe('awake');
+    });
+
+    it('不明な state 値が返ってきた場合は state を更新しない', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'unknown-state' }),
+      });
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await act(async () => {});
+      // 有効な state 以外は無視して初期値 awake のまま
+      expect(result.current.lifecycleState).toBe('awake');
+    });
+  });
+
+  describe('characterId が変わったとき', () => {
+    it('characterId が変わると再 fetch する', async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation(() => {
+        callCount++;
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ state: 'awake' }),
+        });
+      });
+
+      const { rerender } = renderHook(({ characterId }) => useLifecycle(characterId), {
+        initialProps: { characterId: 'hiyori' },
+      });
+      await waitFor(() => expect(callCount).toBe(1));
+
+      rerender({ characterId: 'ageha' });
+      await waitFor(() => expect(callCount).toBe(2));
+    });
+  });
+
+  describe('setLifecycleState（公開）', () => {
+    it('setLifecycleState を呼ぶと lifecycleState が更新される', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+
+      const { result } = renderHook(() => useLifecycle('hiyori'));
+      await waitFor(() => expect(result.current.lifecycleState).toBe('awake'));
+
+      act(() => {
+        result.current.setLifecycleState('sleeping');
+      });
+      expect(result.current.lifecycleState).toBe('sleeping');
+    });
+
+    it('setLifecycleState は安定した関数参照を持つ', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'awake' }),
+      });
+      const { result, rerender } = renderHook(() => useLifecycle('hiyori'));
+      await waitFor(() => expect(result.current.lifecycleState).toBe('awake'));
+
+      const firstRef = result.current.setLifecycleState;
+      rerender();
+      expect(result.current.setLifecycleState).toBe(firstRef);
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/useOnboarding.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/useOnboarding.test.ts
@@ -1,0 +1,213 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useOnboarding } from '@/lib/home/useOnboarding';
+
+// オンボーディング判定関数をモック
+jest.mock('@/lib/pwa/standalone', () => ({
+  isStandalone: jest.fn().mockReturnValue(false),
+  isPushSupported: jest.fn().mockReturnValue(false),
+  shouldShowInstallGuide: jest.fn().mockReturnValue(false),
+  shouldShowNotificationPermission: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('@/lib/pwa/messages', () => ({
+  PWA_MESSAGES: {
+    INSTALL_PROMPT: 'お家を作ってほしいな…',
+    NOTIFICATION_PROMPT: '来てくれてありがとう！',
+    NOTIFICATION_GRANTED: 'やった！',
+  },
+}));
+
+import {
+  isStandalone,
+  isPushSupported,
+  shouldShowInstallGuide,
+  shouldShowNotificationPermission,
+} from '@/lib/pwa/standalone';
+import { PWA_MESSAGES } from '@/lib/pwa/messages';
+
+afterEach(() => {
+  jest.clearAllMocks();
+  // モックを既定値（表示なし）に戻す
+  (isStandalone as jest.Mock).mockReturnValue(false);
+  (isPushSupported as jest.Mock).mockReturnValue(false);
+  (shouldShowInstallGuide as jest.Mock).mockReturnValue(false);
+  (shouldShowNotificationPermission as jest.Mock).mockReturnValue(false);
+});
+
+describe('useOnboarding', () => {
+  describe('初期値', () => {
+    it('初期状態は onboardingPhase が null, onboardingText が null', () => {
+      const { result } = renderHook(() => useOnboarding('checking'));
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBeNull();
+    });
+  });
+
+  describe('consentPhase が done のとき', () => {
+    it('スタンドアロンでなく shouldShowInstallGuide が true なら install フェーズになる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(false);
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('install'));
+      expect(result.current.onboardingText).toBe(PWA_MESSAGES.INSTALL_PROMPT);
+    });
+
+    it('スタンドアロン + push サポート + 通知未許可 + shouldShowNotificationPermission が true なら notification フェーズになる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      // window.Notification.permission を 'default' に設定
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'default' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('notification'));
+      expect(result.current.onboardingText).toBe(PWA_MESSAGES.NOTIFICATION_PROMPT);
+    });
+
+    it('通知が granted 済みなら notification フェーズにならない', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'granted' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      // consentPhase=done でも notification にならない
+      await act(async () => {});
+      expect(result.current.onboardingPhase).toBeNull();
+    });
+
+    it('すべての条件が false なら onboardingPhase は null のまま', async () => {
+      const { result } = renderHook(() => useOnboarding('done'));
+      await act(async () => {});
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBeNull();
+    });
+  });
+
+  describe('consentPhase が done でない場合', () => {
+    it('checking のときはオンボーディング判定が走らない', async () => {
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+      const { result } = renderHook(() => useOnboarding('checking'));
+      await act(async () => {});
+      expect(result.current.onboardingPhase).toBeNull();
+    });
+
+    it('required のときはオンボーディング判定が走らない', async () => {
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+      const { result } = renderHook(() => useOnboarding('required'));
+      await act(async () => {});
+      expect(result.current.onboardingPhase).toBeNull();
+    });
+  });
+
+  describe('ハンドラ', () => {
+    it('handleInstallSkip で onboardingPhase と onboardingText がクリアされる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(false);
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('install'));
+
+      act(() => {
+        result.current.handleInstallSkip();
+      });
+
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBeNull();
+    });
+
+    it('handleNotificationSkip で onboardingPhase と onboardingText がクリアされる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'default' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('notification'));
+
+      act(() => {
+        result.current.handleNotificationSkip();
+      });
+
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBeNull();
+    });
+
+    it('handleNotificationGranted で onboardingPhase がクリアされ NOTIFICATION_GRANTED テキストが設定される', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'default' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('notification'));
+
+      act(() => {
+        result.current.handleNotificationGranted();
+      });
+
+      expect(result.current.onboardingPhase).toBeNull();
+      expect(result.current.onboardingText).toBe(PWA_MESSAGES.NOTIFICATION_GRANTED);
+    });
+
+    it('handleNotificationGranted から 4 秒後に onboardingText が自動クリアされる', async () => {
+      jest.useFakeTimers();
+      (isStandalone as jest.Mock).mockReturnValue(true);
+      (isPushSupported as jest.Mock).mockReturnValue(true);
+      (shouldShowNotificationPermission as jest.Mock).mockReturnValue(true);
+      Object.defineProperty(window, 'Notification', {
+        writable: true,
+        configurable: true,
+        value: { permission: 'default' },
+      });
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingPhase).toBe('notification'));
+
+      act(() => {
+        result.current.handleNotificationGranted();
+      });
+      expect(result.current.onboardingText).toBe(PWA_MESSAGES.NOTIFICATION_GRANTED);
+
+      act(() => {
+        jest.advanceTimersByTime(4000);
+      });
+      expect(result.current.onboardingText).toBeNull();
+
+      jest.useRealTimers();
+    });
+
+    it('clearOnboardingText で onboardingText が null になる', async () => {
+      (isStandalone as jest.Mock).mockReturnValue(false);
+      (shouldShowInstallGuide as jest.Mock).mockReturnValue(true);
+
+      const { result } = renderHook(() => useOnboarding('done'));
+      await waitFor(() => expect(result.current.onboardingText).toBe(PWA_MESSAGES.INSTALL_PROMPT));
+
+      act(() => {
+        result.current.clearOnboardingText();
+      });
+
+      expect(result.current.onboardingText).toBeNull();
+      // onboardingPhase はそのまま
+      expect(result.current.onboardingPhase).toBe('install');
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/home/usePendingNotifications.test.ts
+++ b/services/livetalk/web/tests/unit/lib/home/usePendingNotifications.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePendingNotifications } from '@/lib/home/usePendingNotifications';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('usePendingNotifications', () => {
+  describe('初期値', () => {
+    it('初期状態は pendingNotifications が空配列', () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      const { result } = renderHook(() => usePendingNotifications());
+      expect(result.current.pendingNotifications).toEqual([]);
+    });
+  });
+
+  describe('/api/push/pending 取得', () => {
+    it('マウント時に /api/push/pending を取得する', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      renderHook(() => usePendingNotifications());
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/push/pending');
+      });
+    });
+
+    it('通知データがある場合は pendingNotifications が更新される', async () => {
+      const pendingData = [
+        { characterId: 'ageha', notifId: 'n1', body: 'アゲハより' },
+        { characterId: 'koharu', notifId: 'n2', body: '小春より' },
+      ];
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(pendingData),
+      });
+
+      const { result } = renderHook(() => usePendingNotifications());
+      await waitFor(() => expect(result.current.pendingNotifications).toHaveLength(2));
+      expect(result.current.pendingNotifications[0].characterId).toBe('ageha');
+      expect(result.current.pendingNotifications[1].characterId).toBe('koharu');
+    });
+
+    it('空配列のとき pendingNotifications が空のまま', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      const { result } = renderHook(() => usePendingNotifications());
+      await act(async () => {});
+      expect(result.current.pendingNotifications).toEqual([]);
+    });
+
+    it('ok: false のとき pendingNotifications が空のまま', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false });
+      const { result } = renderHook(() => usePendingNotifications());
+      await act(async () => {});
+      expect(result.current.pendingNotifications).toEqual([]);
+    });
+
+    it('fetch 失敗時はクラッシュせず pendingNotifications が空のまま', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+      const { result } = renderHook(() => usePendingNotifications());
+      await act(async () => {});
+      expect(result.current.pendingNotifications).toEqual([]);
+    });
+
+    it('マウント後の再レンダリングでは再 fetch しない', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      const { rerender } = renderHook(() => usePendingNotifications());
+      await act(async () => {});
+      rerender();
+      rerender();
+      // マウント時の 1 回のみ
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

リブトークのチャット画面フロントエンド（`services/livetalk/web`）の構造整理。肥大化していた `page.tsx`（601 行・useEffect 8 / useState 13 / useRef 7）のロジックを custom hook 群に分割し、音声キューを state machine 化、Live2D 内部 API の型穴を縮小した。**全 Phase 挙動不変のリファクタリング**。

`integration/3529-livetalk-frontend` 上で 4 つの Phase に分けて段階実装し、各 Phase を dev 環境で確認しながら積み上げた取りまとめ PR。

### Phase 構成（すべて merged 済み・CI グリーン）

| Phase | 内容 | PR |
|---|---|---|
| 1 | 音声基盤の hook 化。`audioQueueRef`/`isPlayingRef`/`streamDoneRef` の手動管理を `useReducer` の state machine（`useAudioQueue`）へ、AudioContext unlock を `useAudioContext` へ | #3567 |
| 2 | データ取得系 useEffect を `src/lib/home/` の 6 hook（consent / onboarding / first-word / pending / lifecycle / character-query-sync）へ分割。クロス汚染防止を `consumeKnowledgeId` に整理 | #3570 |
| 3 | チャット送信フロー（`handleSubmit` + NDJSON parse + イベント分岐 + 再生エラー）を `useChatStream` へ集約 | #3571 |
| 4 | `Live2DCanvas.tsx` の `as unknown as {...}` 内部 API キャストを公開型（`Cubism4InternalModel` 等）で置換し型穴を縮小 | #3572 |

### 主な成果

- **`page.tsx` 601 → 232 行**（約 6 割減）。hook 合成 + JSX の薄い構成に。
- 音声キューの状態遷移（enqueue → 再生 → drain）を hook 内の state machine に閉じ込め、追跡容易に。
- ビジネスロジックを `src/lib/audio/` `src/lib/home/` に分離（リポジトリ規約「UI とロジックの分離」に整合）。
- Live2D 内部 API を覆っていた広範な ad-hoc キャストを、本質的に必要な最小キャスト 2 箇所（リップシンク hijack の `currentAudio`・eventemitter3 の `on`/`off`）まで縮小。`coreModel.setParameterValueById` 等がライブラリ実型で型チェックされるように。

## 関連 Issue

Closes #3529

（親 Issue: #3521。本 PR は #3521 配下のサブ Issue #3529 の対応であり、#3521 は他サブ Issue 未了のため本 PR ではクローズしない。）

## 変更種別

- [x] リファクタリング

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](docs/development/architecture.md) を確認した
- [x] [開発方針](docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した（UI/ロジック分離・lib にロジック集約・パスエイリアス不使用）
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [x] 関連ドキュメントを更新した（構造リファクタのため `docs/` への追従要否を develop 反映後に判断）
- [ ] CI/CD 設定を追加・更新した（該当なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- 新規 hook 群の単体テストを `tests/unit/lib/audio/` `tests/unit/lib/home/` に追加（`renderHook` + fetch/stream モック）。
- 既存 `tests/unit/app/page.test.tsx`（handleSubmit・first-word consume・クロス汚染・prefill 等を UI 経由で検証する回帰テスト）を全 Phase で緑のまま維持。

検証（各 Phase でローカル + Fast CI）:
- `npm test`: 703 件全パス（68 スイート）
- カバレッジ: global 91.76% / branch 92.14% / func 83.2%（閾値 80% 超）、`src/lib/audio` `src/lib/home` は各 hook ほぼ 100%
- `tsc --noEmit`: 変更ファイル型エラー 0（既存ベースライン 34 件は本対応と無関係・develop と同数）
- `prettier --check` / `eslint`: クリーン
- Phase 3（最も込み入った送信フロー抽出）は fresh-eyes レビュー（別コンテキスト）を実施し挙動完全一致を確認

正味の差分: 21 ファイル、+3,326 / −468。

## レビューポイント

- 全 Phase を通じて**挙動不変**であること（既存 `page.test.tsx` の回帰テストが全 Phase 緑）。
- `useAudioQueue` の状態遷移が旧 ref 手動管理と等価であること（`isPlaying` ⇔ `current !== null`、drain → `onDrained`）。
- `useChatStream` の `setPhase` 依存注入（`useAudioQueue.onDrained` との循環依存回避）。
- `useFirstWord.consumeKnowledgeId` のクロス汚染防止ガードが旧実装と等価であること。

## 補足事項

各 Phase の詳細・設計判断は個別 PR（#3567 / #3570 / #3571 / #3572）を参照。develop 反映後、`docs/` への追従要否（設計判断として残すべき内容があるか）を判断する。


---
_Generated by [Claude Code](https://claude.ai/code/session_01FLhrr8dDji5yKVxmSuu7Ce)_