### PR TITLE
リブトーク core: LLM プロンプト・モデル定数の一元化リファクタ

### DIFF
--- a/services/livetalk/core/src/llm-client/index.ts
+++ b/services/livetalk/core/src/llm-client/index.ts
@@ -41,3 +41,7 @@ export {
   type CreateEmbeddingClientOptions,
   type ProviderSecretConfig,
 } from './factory.js';
+
+export { LLM_MODELS } from './models.js';
+
+export { buildSummarizePrompt } from './prompts/summarize.prompt.js';

--- a/services/livetalk/core/src/llm-client/models.ts
+++ b/services/livetalk/core/src/llm-client/models.ts
@@ -1,0 +1,25 @@
+/**
+ * LLM 用途別モデル定数（一元管理）。
+ *
+ * 各用途に使用するモデルをここで一元管理する。コスト方針：
+ * - conversation: `gpt-5`（会話の応答品質を優先）
+ * - summarize / classify / research: `gpt-5-mini`（コスト最適化。stock-tracker / quick-clip と同じ選択）
+ * - embedding: `text-embedding-3-small`（軽量・高速・低コスト）
+ *
+ * 各 Provider 実装はこの定数から導出した形で既定モデルを定義する。
+ *
+ * @see Issue #3248 "用途別モデル振り分けの仕組み"
+ * @see Issue #3530 "LLM プロンプト・モデル定数の一元化リファクタ"
+ */
+export const LLM_MODELS = {
+  /** 会話応答。応答品質を最優先するため高性能モデルを使用 */
+  conversation: 'gpt-5',
+  /** 会話圧縮要約。コスト最適化のため mini モデルを使用 */
+  summarize: 'gpt-5-mini',
+  /** 分類。コスト最適化のため mini モデルを使用 */
+  classify: 'gpt-5-mini',
+  /** Web リサーチ。コスト最適化のため mini モデルを使用 */
+  research: 'gpt-5-mini',
+  /** テキスト埋め込み（1536 次元）。軽量・高速・低コスト */
+  embedding: 'text-embedding-3-small',
+} as const;

--- a/services/livetalk/core/src/llm-client/openai-client.ts
+++ b/services/livetalk/core/src/llm-client/openai-client.ts
@@ -19,19 +19,24 @@ import type {
 } from './types.js';
 import { SummarizeResultSchema } from './schemas/summarize.schema.js';
 import { withLLMRetry } from '../lib/llm-retry.js';
+import { LLM_MODELS } from './models.js';
+import { buildSummarizePrompt } from './prompts/summarize.prompt.js';
 
 /**
  * OpenAI 実装の用途別既定モデル（GPT-5 系）。
+ *
+ * モデル名は {@link LLM_MODELS} から導出し、ここで重複定義しない。
  *
  * - conversation: `gpt-5`（会話の応答品質を優先）
  * - summarize / classify: `gpt-5-mini`（コスト最適化、stock-tracker / quick-clip と同じ選択）
  *
  * @see Issue #3248 "用途別モデル振り分けの仕組み"
+ * @see Issue #3530 "LLM プロンプト・モデル定数の一元化リファクタ"
  */
 export const OPENAI_DEFAULT_MODELS: PurposeModelMap = {
-  conversation: 'gpt-5',
-  summarize: 'gpt-5-mini',
-  classify: 'gpt-5-mini',
+  conversation: LLM_MODELS.conversation,
+  summarize: LLM_MODELS.summarize,
+  classify: LLM_MODELS.classify,
 };
 
 export const OPENAI_ERROR_MESSAGES = {
@@ -137,54 +142,7 @@ export class OpenAIClient implements ILLMClient {
   }
 
   public async summarize(input: SummarizeInput): Promise<SummarizeResult> {
-    const { existingSummary, newMessages, characterName, existingInterestCategories } = input;
-
-    const existingSection = existingSummary
-      ? `既存の要約：\n${existingSummary}`
-      : '既存の要約：なし';
-
-    const messagesSection = newMessages
-      .map((m) => `${m.role === 'user' ? 'ユーザー' : characterName}: ${m.text}`)
-      .join('\n');
-
-    const existingCategoriesSection =
-      existingInterestCategories && existingInterestCategories.length > 0
-        ? `既存の興味カテゴリ一覧（同義のものはこの表記を再利用すること）：\n${existingInterestCategories
-            .map((c) => `- ${c}`)
-            .join('\n')}`
-        : '既存の興味カテゴリ一覧：なし';
-
-    const prompt = `以下は ${characterName} とユーザーとの会話です。
-
-${existingSection}
-
-新しい会話：
-${messagesSection}
-
-${existingCategoriesSection}
-
-要約に含めないもの（汚染防止）：
-- キャラの口調・文体・口癖（例：「むにゃ」「うとうと」「〜だよね〜」等の語尾・修辞）
-- キャラ自身の状態（眠い、寝ぼけている、ご機嫌、等）
-- 寝ぼけ演出・時間帯演出に由来する一時的な表現
-
-要約に含めるもの：
-- ユーザーの嗜好・興味・話題
-- ユーザーとキャラの関係性の変化（親密度、過去のやりとりの文脈）
-- 会話で確定した事実・約束・予定
-
-interestCategories の抽出ルール：
-- 中粒度（趣味・嗜好レベル）で抽出する。良い例：「映画」「コーヒー」「ゲーム」「音楽」「読書」「猫」
-- 包含関係のあるカテゴリは親に集約する。悪い例：「映画スナック」（→「映画」へ）、「コーヒー・紅茶・カモミール」（→「飲み物」へ）、「オトモアイルー」（→「ゲーム」へ）
-- 既存カテゴリ一覧に同義カテゴリがあれば、必ず既存の表記をそのまま再利用する（例：既存に「コーヒー」があるのに新規で「コーヒー・飲み物」を作らない）
-- 1 会話あたり 5 件程度を目安に、ユーザーが明確に関心を示したものだけを抽出する
-
-mergedSummary（既存と新規をマージした最新要約、日本語）、
-newMemoryCandidates（新規記憶候補の配列、category と content を含む）、
-interestCategories（上記ルールに従って抽出したカテゴリ配列、category と weight を含む。weight は会話内の言及回数。なければ空配列）、
-bidirectionalityScore（ユーザーが ${characterName} の発話に反応・質問返しをした割合 0.0〜1.0。
-  キャラ発信の話題にユーザーが乗った場合は高く 0.7〜1.0、ユーザーが一方的に話し続けた場合は低く 0.0〜0.3）
-を返してください。`;
+    const prompt = buildSummarizePrompt(input);
 
     const raw = await this.chatStructured(
       [{ role: 'user', content: prompt }],
@@ -294,8 +252,8 @@ function toSummarizeResult(raw: z.infer<typeof SummarizeResultSchema>): Summariz
   };
 }
 
-/** OpenAI embedding API で使用するモデル。軽量・高速・低コスト。 */
-export const OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
+/** OpenAI embedding API で使用するモデル。{@link LLM_MODELS.embedding} から導出する。 */
+export const OPENAI_EMBEDDING_MODEL = LLM_MODELS.embedding;
 
 export const OPENAI_EMBEDDING_ERROR_MESSAGES = {
   EMPTY_API_KEY: 'OpenAI API キーが指定されていません',

--- a/services/livetalk/core/src/llm-client/prompts/summarize.prompt.ts
+++ b/services/livetalk/core/src/llm-client/prompts/summarize.prompt.ts
@@ -12,9 +12,7 @@ import type { SummarizeInput } from '../types.js';
 export function buildSummarizePrompt(input: SummarizeInput): string {
   const { existingSummary, newMessages, characterName, existingInterestCategories } = input;
 
-  const existingSection = existingSummary
-    ? `既存の要約：\n${existingSummary}`
-    : '既存の要約：なし';
+  const existingSection = existingSummary ? `既存の要約：\n${existingSummary}` : '既存の要約：なし';
 
   const messagesSection = newMessages
     .map((m) => `${m.role === 'user' ? 'ユーザー' : characterName}: ${m.text}`)

--- a/services/livetalk/core/src/llm-client/prompts/summarize.prompt.ts
+++ b/services/livetalk/core/src/llm-client/prompts/summarize.prompt.ts
@@ -1,0 +1,61 @@
+import type { SummarizeInput } from '../types.js';
+
+/**
+ * 会話圧縮要約用プロンプトを組み立てる純粋関数。
+ *
+ * `openai-client.ts` の `summarize()` から抽出したもので、プロンプト文言は完全に現状維持。
+ * テスト・再利用のために独立ファイルへ切り出している。
+ *
+ * @param input - 要約に必要な入力データ（SummarizeInput）
+ * @returns LLM に渡すプロンプト文字列
+ */
+export function buildSummarizePrompt(input: SummarizeInput): string {
+  const { existingSummary, newMessages, characterName, existingInterestCategories } = input;
+
+  const existingSection = existingSummary
+    ? `既存の要約：\n${existingSummary}`
+    : '既存の要約：なし';
+
+  const messagesSection = newMessages
+    .map((m) => `${m.role === 'user' ? 'ユーザー' : characterName}: ${m.text}`)
+    .join('\n');
+
+  const existingCategoriesSection =
+    existingInterestCategories && existingInterestCategories.length > 0
+      ? `既存の興味カテゴリ一覧（同義のものはこの表記を再利用すること）：\n${existingInterestCategories
+          .map((c) => `- ${c}`)
+          .join('\n')}`
+      : '既存の興味カテゴリ一覧：なし';
+
+  return `以下は ${characterName} とユーザーとの会話です。
+
+${existingSection}
+
+新しい会話：
+${messagesSection}
+
+${existingCategoriesSection}
+
+要約に含めないもの（汚染防止）：
+- キャラの口調・文体・口癖（例：「むにゃ」「うとうと」「〜だよね〜」等の語尾・修辞）
+- キャラ自身の状態（眠い、寝ぼけている、ご機嫌、等）
+- 寝ぼけ演出・時間帯演出に由来する一時的な表現
+
+要約に含めるもの：
+- ユーザーの嗜好・興味・話題
+- ユーザーとキャラの関係性の変化（親密度、過去のやりとりの文脈）
+- 会話で確定した事実・約束・予定
+
+interestCategories の抽出ルール：
+- 中粒度（趣味・嗜好レベル）で抽出する。良い例：「映画」「コーヒー」「ゲーム」「音楽」「読書」「猫」
+- 包含関係のあるカテゴリは親に集約する。悪い例：「映画スナック」（→「映画」へ）、「コーヒー・紅茶・カモミール」（→「飲み物」へ）、「オトモアイルー」（→「ゲーム」へ）
+- 既存カテゴリ一覧に同義カテゴリがあれば、必ず既存の表記をそのまま再利用する（例：既存に「コーヒー」があるのに新規で「コーヒー・飲み物」を作らない）
+- 1 会話あたり 5 件程度を目安に、ユーザーが明確に関心を示したものだけを抽出する
+
+mergedSummary（既存と新規をマージした最新要約、日本語）、
+newMemoryCandidates（新規記憶候補の配列、category と content を含む）、
+interestCategories（上記ルールに従って抽出したカテゴリ配列、category と weight を含む。weight は会話内の言及回数。なければ空配列）、
+bidirectionalityScore（ユーザーが ${characterName} の発話に反応・質問返しをした割合 0.0〜1.0。
+  キャラ発信の話題にユーザーが乗った場合は高く 0.7〜1.0、ユーザーが一方的に話し続けた場合は低く 0.0〜0.3）
+を返してください。`;
+}

--- a/services/livetalk/core/src/research/index.ts
+++ b/services/livetalk/core/src/research/index.ts
@@ -4,3 +4,4 @@ export {
   RESEARCH_ERROR_MESSAGES,
   type OpenAIResearchClientOptions,
 } from './openai-research-client.js';
+export { buildResearchPrompt } from './research.prompt.js';

--- a/services/livetalk/core/src/research/openai-research-client.ts
+++ b/services/livetalk/core/src/research/openai-research-client.ts
@@ -4,8 +4,10 @@ import { z } from 'zod';
 import type { CharacterDefinition } from '../characters/types.js';
 import type { IResearchClient, ResearchResult } from './types.js';
 import { withLLMRetry, withLLMTimeout } from '../lib/llm-retry.js';
+import { LLM_MODELS } from '../llm-client/models.js';
+import { buildResearchPrompt } from './research.prompt.js';
 
-const RESEARCH_MODEL = 'gpt-5-mini';
+const RESEARCH_MODEL = LLM_MODELS.research;
 const REQUEST_TIMEOUT_MS = 120_000;
 
 export const RESEARCH_ERROR_MESSAGES = {
@@ -58,7 +60,7 @@ export class OpenAIResearchClient implements IResearchClient {
               content: [
                 {
                   type: 'input_text',
-                  text: buildPrompt(query, character),
+                  text: buildResearchPrompt(query, character),
                 },
               ],
             },
@@ -77,19 +79,3 @@ export class OpenAIResearchClient implements IResearchClient {
   }
 }
 
-function buildPrompt(query: string, character: CharacterDefinition): string {
-  const likes = character.personality.preferences.likes.join('、');
-  return [
-    `あなたは「${character.displayName}」です。`,
-    `口調・性格：${character.personality.speechStyle}`,
-    `好きなもの：${likes}`,
-    '',
-    `「${query}」について必ず Web 検索し、${character.displayName} らしい視点で内容を要約してください。`,
-    '',
-    '返す項目（JSON）:',
-    '- topic: 検索したトピックの短い名詞句（5〜15 文字程度、例: 飲み物の新作、超かぐや姫）。説明文ではなく固有名詞や短い語句にすること',
-    '- summary: キャラクター目線の要約（200 文字以上）。topic の詳細説明はここに書く',
-    '- sourceUrls: 参照した URL のリスト（空の場合は空配列）',
-    `- rawComment: ${character.displayName} として一言コメント（50〜100 文字、上記の口調で）`,
-  ].join('\n');
-}

--- a/services/livetalk/core/src/research/openai-research-client.ts
+++ b/services/livetalk/core/src/research/openai-research-client.ts
@@ -78,4 +78,3 @@ export class OpenAIResearchClient implements IResearchClient {
     return response.output_parsed;
   }
 }
-

--- a/services/livetalk/core/src/research/research.prompt.ts
+++ b/services/livetalk/core/src/research/research.prompt.ts
@@ -1,0 +1,28 @@
+import type { CharacterDefinition } from '../characters/types.js';
+
+/**
+ * Web リサーチ用プロンプトを組み立てる純粋関数。
+ *
+ * `openai-research-client.ts` の末尾 `buildPrompt()` から抽出したもので、プロンプト文言は完全に現状維持。
+ * テスト・再利用のために独立ファイルへ切り出している。
+ *
+ * @param query - リサーチクエリ文字列
+ * @param character - キャラクター定義（口調・好みを反映するため）
+ * @returns LLM に渡すプロンプト文字列
+ */
+export function buildResearchPrompt(query: string, character: CharacterDefinition): string {
+  const likes = character.personality.preferences.likes.join('、');
+  return [
+    `あなたは「${character.displayName}」です。`,
+    `口調・性格：${character.personality.speechStyle}`,
+    `好きなもの：${likes}`,
+    '',
+    `「${query}」について必ず Web 検索し、${character.displayName} らしい視点で内容を要約してください。`,
+    '',
+    '返す項目（JSON）:',
+    '- topic: 検索したトピックの短い名詞句（5〜15 文字程度、例: 飲み物の新作、超かぐや姫）。説明文ではなく固有名詞や短い語句にすること',
+    '- summary: キャラクター目線の要約（200 文字以上）。topic の詳細説明はここに書く',
+    '- sourceUrls: 参照した URL のリスト（空の場合は空配列）',
+    `- rawComment: ${character.displayName} として一言コメント（50〜100 文字、上記の口調で）`,
+  ].join('\n');
+}

--- a/services/livetalk/core/tests/unit/llm-client/prompts/summarize.prompt.test.ts
+++ b/services/livetalk/core/tests/unit/llm-client/prompts/summarize.prompt.test.ts
@@ -1,0 +1,154 @@
+import { buildSummarizePrompt } from '../../../../src/llm-client/prompts/summarize.prompt.js';
+import type { SummarizeInput } from '../../../../src/llm-client/types.js';
+
+/** テスト用の基本入力 */
+const baseInput: SummarizeInput = {
+  existingSummary: undefined,
+  newMessages: [
+    { role: 'user', text: 'コーヒーが好きだよ' },
+    { role: 'assistant', text: 'そうなんだね！' },
+  ],
+  characterName: 'ひより',
+};
+
+describe('buildSummarizePrompt', () => {
+  describe('汚染防止セクション', () => {
+    it('「要約に含めないもの（汚染防止）」セクションが含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('要約に含めないもの（汚染防止）');
+    });
+
+    it('キャラの口調・口癖の除外指示が含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('キャラの口調・文体・口癖');
+    });
+
+    it('寝ぼけ演出スキップ指示（「むにゃ」「うとうと」の具体例）が含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('むにゃ');
+      expect(prompt).toContain('うとうと');
+    });
+
+    it('寝ぼけ演出・時間帯演出の除外指示が含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('寝ぼけ演出・時間帯演出に由来する一時的な表現');
+    });
+  });
+
+  describe('要約に含めるもの', () => {
+    it('ユーザーの嗜好・興味・話題の抽出指示が含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('要約に含めるもの');
+      expect(prompt).toContain('ユーザーの嗜好・興味・話題');
+    });
+
+    it('関係性の変化の記録指示が含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('ユーザーとキャラの関係性の変化');
+    });
+
+    it('確定した事実・約束・予定の記録指示が含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('会話で確定した事実・約束・予定');
+    });
+  });
+
+  describe('interestCategories 抽出ルール', () => {
+    it('interestCategories の抽出ルールセクションが含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('interestCategories の抽出ルール');
+    });
+
+    it('bidirectionalityScore の指示が含まれる', () => {
+      const prompt = buildSummarizePrompt(baseInput);
+      expect(prompt).toContain('bidirectionalityScore');
+    });
+  });
+
+  describe('characterName の埋め込み', () => {
+    it('characterName がプロンプト冒頭に埋め込まれる', () => {
+      const prompt = buildSummarizePrompt({ ...baseInput, characterName: '桃瀬ひより' });
+      expect(prompt).toContain('桃瀬ひより');
+    });
+
+    it('bidirectionalityScore の指示に characterName が含まれる', () => {
+      const prompt = buildSummarizePrompt({ ...baseInput, characterName: 'テストキャラ' });
+      expect(prompt).toContain('テストキャラ の発話に反応・質問返しをした割合');
+    });
+  });
+
+  describe('existingSummary の有無による分岐', () => {
+    it('existingSummary が undefined のとき「既存の要約：なし」が含まれる', () => {
+      const prompt = buildSummarizePrompt({ ...baseInput, existingSummary: undefined });
+      expect(prompt).toContain('既存の要約：なし');
+    });
+
+    it('existingSummary が空文字のとき「既存の要約：なし」が含まれる', () => {
+      const prompt = buildSummarizePrompt({ ...baseInput, existingSummary: '' });
+      expect(prompt).toContain('既存の要約：なし');
+    });
+
+    it('existingSummary が有るとき本文が含まれる', () => {
+      const prompt = buildSummarizePrompt({
+        ...baseInput,
+        existingSummary: '過去にコーヒーが好きと話した',
+      });
+      expect(prompt).toContain('既存の要約：\n過去にコーヒーが好きと話した');
+      expect(prompt).not.toContain('既存の要約：なし');
+    });
+  });
+
+  describe('existingInterestCategories の有無による分岐', () => {
+    it('existingInterestCategories が未指定のとき「既存の興味カテゴリ一覧：なし」が含まれる', () => {
+      const prompt = buildSummarizePrompt({ ...baseInput, existingInterestCategories: undefined });
+      expect(prompt).toContain('既存の興味カテゴリ一覧：なし');
+    });
+
+    it('existingInterestCategories が空配列のとき「既存の興味カテゴリ一覧：なし」が含まれる', () => {
+      const prompt = buildSummarizePrompt({ ...baseInput, existingInterestCategories: [] });
+      expect(prompt).toContain('既存の興味カテゴリ一覧：なし');
+    });
+
+    it('existingInterestCategories が有るとき箇条書きで含まれる', () => {
+      const prompt = buildSummarizePrompt({
+        ...baseInput,
+        existingInterestCategories: ['コーヒー', '映画'],
+      });
+      expect(prompt).toContain('- コーヒー');
+      expect(prompt).toContain('- 映画');
+      expect(prompt).toContain('既存の興味カテゴリ一覧（同義のものはこの表記を再利用すること）');
+    });
+  });
+
+  describe('newMessages の role 変換', () => {
+    it('role=user が「ユーザー」に変換される', () => {
+      const prompt = buildSummarizePrompt({
+        ...baseInput,
+        newMessages: [{ role: 'user', text: 'テストメッセージ' }],
+      });
+      expect(prompt).toContain('ユーザー: テストメッセージ');
+    });
+
+    it('role=assistant が characterName に変換される', () => {
+      const prompt = buildSummarizePrompt({
+        ...baseInput,
+        characterName: 'ひより',
+        newMessages: [{ role: 'assistant', text: 'よろしくね！' }],
+      });
+      expect(prompt).toContain('ひより: よろしくね！');
+    });
+
+    it('user と assistant が混在する場合、両方が正しく変換される', () => {
+      const prompt = buildSummarizePrompt({
+        ...baseInput,
+        characterName: 'ひより',
+        newMessages: [
+          { role: 'user', text: 'こんにちは' },
+          { role: 'assistant', text: 'こんにちは！' },
+        ],
+      });
+      expect(prompt).toContain('ユーザー: こんにちは');
+      expect(prompt).toContain('ひより: こんにちは！');
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/research/research.prompt.test.ts
+++ b/services/livetalk/core/tests/unit/research/research.prompt.test.ts
@@ -1,0 +1,103 @@
+import { buildResearchPrompt } from '../../../src/research/research.prompt.js';
+import type { CharacterDefinition } from '../../../src/characters/types.js';
+
+/** テスト用キャラクター定義 */
+const character: CharacterDefinition = {
+  id: 'hiyori',
+  displayName: '桃瀬ひより',
+  notificationName: 'ひより',
+  personality: {
+    basePrompt: '',
+    speechStyle: '優しく丁寧な口調',
+    preferences: {
+      likes: ['コーヒー', '読書', '猫'],
+      dislikes: [],
+    },
+  },
+  voiceConfig: { provider: 'voicevox' as const, speakerId: 14 },
+  license: { displayText: '', creditName: '' },
+};
+
+describe('buildResearchPrompt', () => {
+  describe('character.displayName の埋め込み', () => {
+    it('displayName がプロンプト冒頭（「あなたは〜です」）に含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain(`あなたは「${character.displayName}」です。`);
+    });
+
+    it('rawComment の指示に displayName が含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain(`${character.displayName} として一言コメント`);
+    });
+
+    it('Web 検索指示に displayName が含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain(`${character.displayName} らしい視点で内容を要約してください`);
+    });
+  });
+
+  describe('query の埋め込み', () => {
+    it('query 文字列がプロンプトに含まれる', () => {
+      const prompt = buildResearchPrompt('最新のコーヒートレンド', character);
+      expect(prompt).toContain('最新のコーヒートレンド');
+    });
+
+    it('別の query でも正しく埋め込まれる', () => {
+      const prompt = buildResearchPrompt('おすすめのアニメ', character);
+      expect(prompt).toContain('おすすめのアニメ');
+    });
+  });
+
+  describe('speechStyle の埋め込み', () => {
+    it('口調・性格の指示が含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain(`口調・性格：${character.personality.speechStyle}`);
+    });
+  });
+
+  describe('likes の埋め込み', () => {
+    it('好きなものが「、」で結合されて含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain('好きなもの：コーヒー、読書、猫');
+    });
+
+    it('likes が 1 件の場合も「、」なしで含まれる', () => {
+      const singleLikeCharacter: CharacterDefinition = {
+        ...character,
+        personality: {
+          ...character.personality,
+          preferences: { likes: ['映画'], dislikes: [] },
+        },
+      };
+      const prompt = buildResearchPrompt('映画', singleLikeCharacter);
+      expect(prompt).toContain('好きなもの：映画');
+    });
+  });
+
+  describe('返す項目（JSON）の指示', () => {
+    it('topic の指示が含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain('- topic:');
+    });
+
+    it('summary の指示が含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain('- summary:');
+    });
+
+    it('sourceUrls の指示が含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain('- sourceUrls:');
+    });
+
+    it('rawComment の指示が含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain('- rawComment:');
+    });
+
+    it('「返す項目（JSON）」の見出しが含まれる', () => {
+      const prompt = buildResearchPrompt('コーヒー', character);
+      expect(prompt).toContain('返す項目（JSON）:');
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

リブトーク (`services/livetalk/core`) の LLM 関連定義（プロンプト・モデル名）が core 内に分散していた問題を解消する **挙動不変のリファクタ**。プロンプト改善・モデル更新時の同時編集を減らし、ドメインルールをテスト可能にする。

- **モデル定数の一元化**: `src/llm-client/models.ts` に `LLM_MODELS`（conversation / summarize / classify / research / embedding）を新設。`OPENAI_DEFAULT_MODELS`・`OPENAI_EMBEDDING_MODEL`・`RESEARCH_MODEL` はすべてここから導出（公開 API は互換維持）。
- **summarize プロンプトの抽出**: client 実装に直書きされていた要約プロンプトを `src/llm-client/prompts/summarize.prompt.ts` の純粋関数 `buildSummarizePrompt()` へ抽出。
- **research プロンプトの抽出**: client 実装内の `buildPrompt()` を `src/research/research.prompt.ts` の `buildResearchPrompt()` へ抽出（レイヤー逆流を避けるため research モジュール内に配置）。
- **テスト追加**: 汚染防止・寝ぼけ演出スキップ等のドメインルールをユニットテストで検証可能化。

> プロンプト文言・モデル名・出力は完全に現状維持（挙動変更なし）。プロンプト内容自体の改善は本 Issue のスコープ外。

## 関連 Issue

Issue #3530（親 Issue #3521）

<!-- サブ Issue の自動クローズは運用上行わないため Closes は付与しない。dev 反映確認後に手動クローズ予定 -->

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（コードを読めば分かる機械的移動のため docs 追従は不要と判断）
- [ ] CI/CD 設定を追加・更新した（新規サービス・ライブラリの場合）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `tests/unit/llm-client/prompts/summarize.prompt.test.ts`: 汚染防止セクション・要約に含めるもの・interestCategories 抽出ルール・bidirectionalityScore 指示・characterName 埋め込み・existingSummary / existingInterestCategories の有無分岐・role 表記変換を検証。
- `tests/unit/research/research.prompt.test.ts`: displayName / query / speechStyle / likes の埋め込み、返す項目（topic / summary / sourceUrls / rawComment）の JSON 指示を検証。
- ローカル: `npm run build` 通過、`npm test` 81 スイート / 1259 テスト全通過、カバレッジ statements 93.14% / branches 82.30%（閾値 80% 達成）。

## レビューポイント

- 抽出したプロンプト文言が元実装と一字一句一致しているか（挙動不変が主目的）。
- `LLM_MODELS` からの各モデル定数の導出値が元の値（gpt-5 / gpt-5-mini / text-embedding-3-small）と一致しているか。
- research プロンプトを `llm-client/prompts/` ではなく `research` モジュール内に置いた判断（`CharacterDefinition` 依存によるレイヤー逆流回避）。

## 補足事項

- 親 Issue #3521 のサブ Issue。dev に資材が出ない軽量リファクタのため integration ブランチは切らず develop へ直接 Draft PR としている。


---
_Generated by [Claude Code](https://claude.ai/code/session_01DTQ8ryWKXe8K5Tu9vKs9v1)_