### PR TITLE
[Refactoring] コード共通化（VAPID 公開鍵取得・テストユーザー生成・quick-clip 型重複）

### DIFF
--- a/libs/browser/src/index.ts
+++ b/libs/browser/src/index.ts
@@ -12,5 +12,5 @@ export { readFromClipboard, writeToClipboard } from './clipboard';
 export { getItem, setItem, removeItem } from './localStorage';
 
 // Web Push utilities
-export { urlBase64ToUint8Array, subscribePush, PUSH_ERROR_MESSAGES } from './push';
+export { urlBase64ToUint8Array, subscribePush, fetchVapidPublicKey, PUSH_ERROR_MESSAGES } from './push';
 export type { SubscribePushOptions } from './push';

--- a/libs/browser/src/index.ts
+++ b/libs/browser/src/index.ts
@@ -12,5 +12,10 @@ export { readFromClipboard, writeToClipboard } from './clipboard';
 export { getItem, setItem, removeItem } from './localStorage';
 
 // Web Push utilities
-export { urlBase64ToUint8Array, subscribePush, fetchVapidPublicKey, PUSH_ERROR_MESSAGES } from './push';
+export {
+  urlBase64ToUint8Array,
+  subscribePush,
+  fetchVapidPublicKey,
+  PUSH_ERROR_MESSAGES,
+} from './push';
 export type { SubscribePushOptions } from './push';

--- a/libs/browser/src/push.ts
+++ b/libs/browser/src/push.ts
@@ -17,7 +17,30 @@ export function urlBase64ToUint8Array(base64String: string): Uint8Array {
 export const PUSH_ERROR_MESSAGES = {
   UNSUPPORTED: 'このブラウザはプッシュ通知に対応していません',
   PERMISSION_DENIED: '通知が拒否されました。ブラウザ設定から通知を許可してください',
+  VAPID_KEY_FETCH_FAILED: 'VAPID公開鍵の取得に失敗しました',
+  VAPID_KEY_EMPTY: 'VAPID公開鍵が空です',
 } as const;
+
+/**
+ * VAPID 公開鍵をサーバから取得する。
+ *
+ * @param endpoint - VAPID 公開鍵を返す API エンドポイント（省略時は `/api/push/vapid-public-key`）
+ * @returns VAPID 公開鍵文字列（base64url 形式）
+ * @throws 取得失敗時または空のキーを受け取った時
+ */
+export async function fetchVapidPublicKey(
+  endpoint: string = '/api/push/vapid-public-key'
+): Promise<string> {
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error(PUSH_ERROR_MESSAGES.VAPID_KEY_FETCH_FAILED);
+  }
+  const { publicKey } = (await response.json()) as { publicKey?: string };
+  if (!publicKey) {
+    throw new Error(PUSH_ERROR_MESSAGES.VAPID_KEY_EMPTY);
+  }
+  return publicKey;
+}
 
 export interface SubscribePushOptions {
   /**

--- a/libs/browser/tests/unit/push.test.ts
+++ b/libs/browser/tests/unit/push.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { urlBase64ToUint8Array, subscribePush, PUSH_ERROR_MESSAGES } from '../../src/push';
+import { urlBase64ToUint8Array, subscribePush, fetchVapidPublicKey, PUSH_ERROR_MESSAGES } from '../../src/push';
 
 describe('push utilities', () => {
   describe('urlBase64ToUint8Array', () => {
@@ -224,6 +224,63 @@ describe('push utilities', () => {
       const getKey = jest.fn().mockResolvedValue(VAPID_KEY);
       await subscribePush({ vapidPublicKey: getKey });
       expect(getKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchVapidPublicKey', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('正常系: 既定エンドポイントで公開鍵を取得できる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ publicKey: 'test-vapid-key' }),
+      } as Response);
+
+      const key = await fetchVapidPublicKey();
+      expect(key).toBe('test-vapid-key');
+      expect(global.fetch).toHaveBeenCalledWith('/api/push/vapid-public-key');
+    });
+
+    it('カスタムエンドポイントを指定できる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ publicKey: 'custom-key' }),
+      } as Response);
+
+      const key = await fetchVapidPublicKey('/api/notify/vapid-key');
+      expect(key).toBe('custom-key');
+      expect(global.fetch).toHaveBeenCalledWith('/api/notify/vapid-key');
+    });
+
+    it('レスポンスが !ok の場合は VAPID_KEY_FETCH_FAILED エラーを投げる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
+
+      await expect(fetchVapidPublicKey()).rejects.toThrow(PUSH_ERROR_MESSAGES.VAPID_KEY_FETCH_FAILED);
+    });
+
+    it('publicKey が空の場合は VAPID_KEY_EMPTY エラーを投げる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ publicKey: '' }),
+      } as Response);
+
+      await expect(fetchVapidPublicKey()).rejects.toThrow(PUSH_ERROR_MESSAGES.VAPID_KEY_EMPTY);
+    });
+
+    it('publicKey が undefined の場合は VAPID_KEY_EMPTY エラーを投げる', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+
+      await expect(fetchVapidPublicKey()).rejects.toThrow(PUSH_ERROR_MESSAGES.VAPID_KEY_EMPTY);
     });
   });
 });

--- a/libs/browser/tests/unit/push.test.ts
+++ b/libs/browser/tests/unit/push.test.ts
@@ -1,7 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { urlBase64ToUint8Array, subscribePush, fetchVapidPublicKey, PUSH_ERROR_MESSAGES } from '../../src/push';
+import {
+  urlBase64ToUint8Array,
+  subscribePush,
+  fetchVapidPublicKey,
+  PUSH_ERROR_MESSAGES,
+} from '../../src/push';
 
 describe('push utilities', () => {
   describe('urlBase64ToUint8Array', () => {
@@ -262,7 +267,9 @@ describe('push utilities', () => {
         json: async () => ({}),
       } as Response);
 
-      await expect(fetchVapidPublicKey()).rejects.toThrow(PUSH_ERROR_MESSAGES.VAPID_KEY_FETCH_FAILED);
+      await expect(fetchVapidPublicKey()).rejects.toThrow(
+        PUSH_ERROR_MESSAGES.VAPID_KEY_FETCH_FAILED
+      );
     });
 
     it('publicKey が空の場合は VAPID_KEY_EMPTY エラーを投げる', async () => {

--- a/libs/nextjs/src/index.ts
+++ b/libs/nextjs/src/index.ts
@@ -23,8 +23,12 @@ export type {
 } from './auth-config.js';
 export { createAuthMiddleware } from './middleware.js';
 export type { AuthMiddlewareRequest, CreateAuthMiddlewareOptions } from './middleware.js';
-export { createSessionGetter } from './session.js';
-export type { CreateSessionGetterOptions } from './session.js';
+export { createSessionGetter, resolveTestUser } from './session.js';
+export type {
+  CreateSessionGetterOptions,
+  ResolveTestUserOptions,
+  ResolvedTestUser,
+} from './session.js';
 
 // Repository module - Repository initialization helpers
 export { withRepository, withRepositories } from './repository.js';

--- a/libs/nextjs/src/session.ts
+++ b/libs/nextjs/src/session.ts
@@ -1,3 +1,41 @@
+/**
+ * テストユーザー解決オプション。
+ */
+export interface ResolveTestUserOptions {
+  /** ロールが未設定の場合に使用する既定ロール一覧。 */
+  defaultRoles?: string[];
+}
+
+/**
+ * テストユーザー情報。
+ */
+export interface ResolvedTestUser {
+  id: string;
+  email: string;
+  name: string;
+  image?: string;
+  roles: string[];
+}
+
+/**
+ * `process.env` からテストユーザー情報を解決する。
+ *
+ * 各環境変数が未設定の場合は既定値にフォールバックする。
+ * `TEST_USER_ROLES` は `,` 区切りで複数ロールを指定できる。
+ *
+ * @param options - 解決オプション（既定ロールなど）
+ * @returns 解決済みテストユーザー情報
+ */
+export function resolveTestUser(options?: ResolveTestUserOptions): ResolvedTestUser {
+  return {
+    id: process.env.TEST_USER_ID || 'test-user-id',
+    email: process.env.TEST_USER_EMAIL || 'test@example.com',
+    name: process.env.TEST_USER_NAME || 'Test User',
+    image: process.env.TEST_USER_IMAGE || undefined,
+    roles: process.env.TEST_USER_ROLES?.split(',') || options?.defaultRoles || [],
+  };
+}
+
 interface SessionWithOptionalUser {
   user?: unknown;
 }

--- a/libs/nextjs/tests/unit/session.test.ts
+++ b/libs/nextjs/tests/unit/session.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { createSessionGetter } from '../../src/session';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createSessionGetter, resolveTestUser } from '../../src/session';
 
 interface MockAuthSession {
   user?: {
@@ -9,6 +9,82 @@ interface MockAuthSession {
   };
   expires?: string;
 }
+
+describe('resolveTestUser', () => {
+  const ENV_KEYS = [
+    'TEST_USER_ID',
+    'TEST_USER_EMAIL',
+    'TEST_USER_NAME',
+    'TEST_USER_IMAGE',
+    'TEST_USER_ROLES',
+  ] as const;
+
+  // テスト後に環境変数を元に戻す
+  const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
+
+  beforeEach(() => {
+    ENV_KEYS.forEach((key) => {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    });
+  });
+
+  afterEach(() => {
+    ENV_KEYS.forEach((key) => {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    });
+  });
+
+  it('環境変数未設定の場合は既定値を返す', () => {
+    const user = resolveTestUser();
+    expect(user).toEqual({
+      id: 'test-user-id',
+      email: 'test@example.com',
+      name: 'Test User',
+      image: undefined,
+      roles: [],
+    });
+  });
+
+  it('defaultRoles が適用される', () => {
+    const user = resolveTestUser({ defaultRoles: ['admin'] });
+    expect(user.roles).toEqual(['admin']);
+  });
+
+  it('環境変数を設定した場合は上書きされる', () => {
+    process.env.TEST_USER_ID = 'env-user-id';
+    process.env.TEST_USER_EMAIL = 'env@example.com';
+    process.env.TEST_USER_NAME = 'Env User';
+    process.env.TEST_USER_IMAGE = 'https://example.com/avatar.png';
+
+    const user = resolveTestUser();
+    expect(user.id).toBe('env-user-id');
+    expect(user.email).toBe('env@example.com');
+    expect(user.name).toBe('Env User');
+    expect(user.image).toBe('https://example.com/avatar.png');
+  });
+
+  it('TEST_USER_ROLES をカンマ区切りで複数ロールに分割する', () => {
+    process.env.TEST_USER_ROLES = 'admin,viewer,editor';
+    const user = resolveTestUser();
+    expect(user.roles).toEqual(['admin', 'viewer', 'editor']);
+  });
+
+  it('TEST_USER_ROLES が設定されている場合は defaultRoles より優先される', () => {
+    process.env.TEST_USER_ROLES = 'custom-role';
+    const user = resolveTestUser({ defaultRoles: ['admin'] });
+    expect(user.roles).toEqual(['custom-role']);
+  });
+
+  it('TEST_USER_IMAGE が未設定の場合は undefined', () => {
+    const user = resolveTestUser();
+    expect(user.image).toBeUndefined();
+  });
+});
 
 describe('createSessionGetter', () => {
   beforeEach(() => {

--- a/services/admin/web/src/components/notify/NotifyButton.tsx
+++ b/services/admin/web/src/components/notify/NotifyButton.tsx
@@ -4,27 +4,14 @@ import { useState } from 'react';
 import { Alert } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import { usePushSubscription } from '@nagiyu/react';
+import { fetchVapidPublicKey } from '@nagiyu/browser';
 
 const ERROR_MESSAGES = {
-  VAPID_KEY_FETCH_FAILED: 'VAPID 公開鍵の取得に失敗しました',
-  VAPID_KEY_EMPTY: 'VAPID 公開鍵が空です',
   SUBSCRIPTION_REGISTER_FAILED: '通知購読の登録に失敗しました',
   UNKNOWN: '通知設定中にエラーが発生しました',
 } as const;
 
 const SUCCESS_MESSAGE = '通知を有効化しました';
-
-const fetchVapidPublicKey = async (): Promise<string> => {
-  const response = await fetch('/api/notify/vapid-key');
-  if (!response.ok) {
-    throw new Error(ERROR_MESSAGES.VAPID_KEY_FETCH_FAILED);
-  }
-  const { publicKey } = (await response.json()) as { publicKey?: string };
-  if (!publicKey) {
-    throw new Error(ERROR_MESSAGES.VAPID_KEY_EMPTY);
-  }
-  return publicKey;
-};
 
 const postSubscription = async (subscription: PushSubscription): Promise<void> => {
   const response = await fetch('/api/notify/subscribe', {
@@ -42,7 +29,7 @@ export default function NotifyButton() {
   const [isError, setIsError] = useState(false);
 
   const { loading, subscribe } = usePushSubscription({
-    getVapidPublicKey: fetchVapidPublicKey,
+    getVapidPublicKey: () => fetchVapidPublicKey('/api/notify/vapid-key'),
     swPath: '/sw-push.js',
     onSubscribed: postSubscription,
   });

--- a/services/admin/web/src/lib/auth/session.ts
+++ b/services/admin/web/src/lib/auth/session.ts
@@ -1,23 +1,20 @@
 import { auth } from '../../auth';
-import { createSessionGetter } from '@nagiyu/nextjs/session';
+import { createSessionGetter, resolveTestUser } from '@nagiyu/nextjs/session';
 import type { Session } from 'next-auth';
-
-const TEST_SESSION_DEFAULTS = {
-  USER_ID: 'test-user-id',
-  USER_EMAIL: 'test@example.com',
-  USER_NAME: 'Test User',
-} as const;
 
 export const getSession = createSessionGetter({
   auth: auth as () => Promise<Session | null>,
-  createTestSession: () => ({
-    user: {
-      id: process.env.TEST_USER_ID || TEST_SESSION_DEFAULTS.USER_ID,
-      email: process.env.TEST_USER_EMAIL || TEST_SESSION_DEFAULTS.USER_EMAIL,
-      name: process.env.TEST_USER_NAME || TEST_SESSION_DEFAULTS.USER_NAME,
-      image: process.env.TEST_USER_IMAGE || undefined,
-      roles: process.env.TEST_USER_ROLES?.split(',') || ['admin'],
-    },
-    expires: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-  }),
+  createTestSession: () => {
+    const u = resolveTestUser({ defaultRoles: ['admin'] });
+    return {
+      user: {
+        id: u.id,
+        email: u.email,
+        name: u.name,
+        image: u.image,
+        roles: u.roles,
+      },
+      expires: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    };
+  },
 });

--- a/services/admin/web/tests/unit/components/notify/NotifyButton.test.tsx
+++ b/services/admin/web/tests/unit/components/notify/NotifyButton.test.tsx
@@ -136,7 +136,7 @@ describe('NotifyButton', () => {
     render(<NotifyButton />);
     await userEvent.click(screen.getByRole('button', { name: '通知を有効にする' }));
 
-    expect(await screen.findByText('VAPID 公開鍵の取得に失敗しました')).toBeInTheDocument();
+    expect(await screen.findByText('VAPID公開鍵の取得に失敗しました')).toBeInTheDocument();
   });
 
   it('VAPID 公開鍵が空の場合はエラーメッセージを表示する', async () => {
@@ -165,7 +165,7 @@ describe('NotifyButton', () => {
     render(<NotifyButton />);
     await userEvent.click(screen.getByRole('button', { name: '通知を有効にする' }));
 
-    expect(await screen.findByText('VAPID 公開鍵が空です')).toBeInTheDocument();
+    expect(await screen.findByText('VAPID公開鍵が空です')).toBeInTheDocument();
   });
 
   it('購読登録 API 失敗時はエラーメッセージを表示する', async () => {

--- a/services/auth/web/src/lib/auth/session.ts
+++ b/services/auth/web/src/lib/auth/session.ts
@@ -1,17 +1,20 @@
 import { auth } from '@nagiyu/auth-core';
-import { createSessionGetter } from '@nagiyu/nextjs/session';
+import { createSessionGetter, resolveTestUser } from '@nagiyu/nextjs/session';
 import type { Session } from 'next-auth';
 
 export const getSession = createSessionGetter({
   auth: auth as () => Promise<Session | null>,
-  createTestSession: () => ({
-    user: {
-      id: 'test-user-id',
-      email: process.env.TEST_USER_EMAIL || 'test@example.com',
-      name: 'Test User',
-      image: undefined,
-      roles: process.env.TEST_USER_ROLES?.split(',') || ['admin'],
-    },
-    expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
-  }),
+  createTestSession: () => {
+    const u = resolveTestUser({ defaultRoles: ['admin'] });
+    return {
+      user: {
+        id: u.id,
+        email: u.email,
+        name: u.name,
+        image: u.image,
+        roles: u.roles,
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+  },
 });

--- a/services/auth/web/tests/unit/lib/auth/session.test.ts
+++ b/services/auth/web/tests/unit/lib/auth/session.test.ts
@@ -70,6 +70,18 @@ describe('getSession', () => {
     expect(session?.user?.roles).toEqual(['admin']);
   });
 
+  it('TEST_USER_ID / TEST_USER_NAME が設定されていれば反映する', async () => {
+    process.env.SKIP_AUTH_CHECK = 'true';
+    process.env.TEST_USER_ID = 'env-user-id';
+    process.env.TEST_USER_NAME = 'Env User';
+
+    const { getSession } = await import('../../../../src/lib/auth/session');
+    const session = await getSession();
+
+    expect(session?.user?.id).toBe('env-user-id');
+    expect(session?.user?.name).toBe('Env User');
+  });
+
   it('SKIP_AUTH_CHECK 未設定で auth が null を返すと null', async () => {
     delete process.env.SKIP_AUTH_CHECK;
     (mockedAuth as jest.Mock).mockResolvedValueOnce(null);

--- a/services/auth/web/tests/unit/lib/auth/session.test.ts
+++ b/services/auth/web/tests/unit/lib/auth/session.test.ts
@@ -5,6 +5,13 @@ jest.mock('@nagiyu/auth-core', () => ({
 }));
 
 jest.mock('@nagiyu/nextjs/session', () => ({
+  resolveTestUser: jest.fn((options?: { defaultRoles?: string[] }) => ({
+    id: process.env.TEST_USER_ID || 'test-user-id',
+    email: process.env.TEST_USER_EMAIL || 'test@example.com',
+    name: process.env.TEST_USER_NAME || 'Test User',
+    image: process.env.TEST_USER_IMAGE || undefined,
+    roles: process.env.TEST_USER_ROLES?.split(',') || options?.defaultRoles || [],
+  })),
   createSessionGetter: jest.fn(
     (config: {
       auth: () => Promise<unknown>;

--- a/services/livetalk/web/src/components/NotificationPermission.tsx
+++ b/services/livetalk/web/src/components/NotificationPermission.tsx
@@ -4,17 +4,9 @@ import { useCallback, useState } from 'react';
 import { Box, Paper, Typography } from '@mui/material';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import { Button } from '@nagiyu/ui';
-import { subscribePush } from '@nagiyu/browser';
+import { subscribePush, fetchVapidPublicKey } from '@nagiyu/browser';
 import { snoozeNotificationPermission } from '@/lib/pwa/standalone';
 import { PWA_MESSAGES } from '@/lib/pwa/messages';
-
-const fetchVapidPublicKey = async (): Promise<string> => {
-  const response = await fetch('/api/push/vapid-public-key');
-  if (!response.ok) throw new Error('VAPID 公開鍵の取得に失敗しました');
-  const { publicKey } = (await response.json()) as { publicKey?: string };
-  if (!publicKey) throw new Error('VAPID 公開鍵が空です');
-  return publicKey;
-};
 
 const postSubscription = async (subscription: PushSubscription): Promise<void> => {
   const response = await fetch('/api/push/subscribe', {

--- a/services/livetalk/web/src/components/NotificationToggle.tsx
+++ b/services/livetalk/web/src/components/NotificationToggle.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import { Button } from '@nagiyu/ui';
-import { subscribePush } from '@nagiyu/browser';
+import { subscribePush, fetchVapidPublicKey } from '@nagiyu/browser';
 import { getCharacterDisplay } from '@/lib/characters/client-profiles';
 
 /**
@@ -25,18 +25,6 @@ export const NOTIFICATION_TOGGLE_MESSAGES = {
   DENIED: 'ブラウザの設定から通知を許可してね',
   ERROR: '通知の設定に失敗しちゃった。あとでもう一度試してね',
 } as const;
-
-const fetchVapidPublicKey = async (): Promise<string> => {
-  const response = await fetch('/api/push/vapid-public-key');
-  if (!response.ok) {
-    throw new Error('VAPID 公開鍵の取得に失敗しました');
-  }
-  const { publicKey } = (await response.json()) as { publicKey?: string };
-  if (!publicKey) {
-    throw new Error('VAPID 公開鍵が空です');
-  }
-  return publicKey;
-};
 
 const postSubscription = async (subscription: PushSubscription): Promise<void> => {
   const response = await fetch('/api/push/subscribe', {

--- a/services/livetalk/web/src/lib/server/session.ts
+++ b/services/livetalk/web/src/lib/server/session.ts
@@ -1,5 +1,5 @@
 import { auth } from '@/auth';
-import { createSessionGetter } from '@nagiyu/nextjs';
+import { createSessionGetter, resolveTestUser } from '@nagiyu/nextjs';
 import type { Session } from '@nagiyu/common';
 import type { Session as NextAuthSession } from 'next-auth';
 
@@ -12,18 +12,21 @@ import type { Session as NextAuthSession } from 'next-auth';
  */
 const getSessionFromAuth = createSessionGetter({
   auth,
-  createTestSession: () => ({
-    user: {
-      userId: 'test-user-id',
-      googleId: 'test-google-id',
-      email: process.env.TEST_USER_EMAIL || 'test@example.com',
-      name: 'Test User',
-      roles: process.env.TEST_USER_ROLES?.split(',') || ['livetalk-user'],
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    },
-    expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
-  }),
+  createTestSession: () => {
+    const u = resolveTestUser({ defaultRoles: ['livetalk-user'] });
+    return {
+      user: {
+        userId: u.id,
+        googleId: 'test-google-id',
+        email: u.email,
+        name: u.name,
+        roles: u.roles,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+  },
   mapSession: (session: NextAuthSession): Session => ({
     user: {
       userId: session.user.id || '',

--- a/services/niconico-mylist-assistant/web/src/components/HomePageClient.tsx
+++ b/services/niconico-mylist-assistant/web/src/components/HomePageClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Container, Typography, Box } from '@mui/material';
 import { Button } from '@nagiyu/ui';
 import { usePushSubscription } from '@nagiyu/react';
+import { fetchVapidPublicKey } from '@nagiyu/browser';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import NotificationPermissionDialog from './NotificationPermissionButton';
 
@@ -13,18 +14,6 @@ interface HomePageClientProps {
   isAuthenticated: boolean;
   appUrl: string;
 }
-
-const fetchVapidPublicKey = async (): Promise<string> => {
-  const response = await fetch('/api/push/vapid-public-key');
-  if (!response.ok) {
-    throw new Error('VAPID公開鍵の取得に失敗しました');
-  }
-  const { publicKey } = (await response.json()) as { publicKey?: string };
-  if (!publicKey) {
-    throw new Error('VAPID公開鍵が空です');
-  }
-  return publicKey;
-};
 
 const postSubscription = async (subscription: PushSubscription): Promise<void> => {
   const response = await fetch('/api/push/subscribe', {

--- a/services/niconico-mylist-assistant/web/src/lib/auth/session.ts
+++ b/services/niconico-mylist-assistant/web/src/lib/auth/session.ts
@@ -1,5 +1,5 @@
 import { auth } from '../../auth';
-import { createSessionGetter } from '@nagiyu/nextjs/session';
+import { createSessionGetter, resolveTestUser } from '@nagiyu/nextjs/session';
 import type { Session } from 'next-auth';
 
 type NiconicoSession = {
@@ -15,13 +15,13 @@ type NiconicoSession = {
 const getSessionFromAuth = createSessionGetter<Session, NiconicoSession>({
   auth: auth as () => Promise<Session | null>,
   createTestSession: () => {
-    const testUserId = process.env.TEST_USER_ID || 'test-user-id';
+    const u = resolveTestUser({ defaultRoles: [] });
     return {
       user: {
-        userId: testUserId,
-        email: process.env.TEST_USER_EMAIL || 'test@example.com',
-        name: process.env.TEST_USER_NAME || 'Test User',
-        roles: process.env.TEST_USER_ROLES?.split(',') || [],
+        userId: u.id,
+        email: u.email,
+        name: u.name,
+        roles: u.roles,
       },
       expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     };

--- a/services/quick-clip/web/package.json
+++ b/services/quick-clip/web/package.json
@@ -26,6 +26,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1063.0",
     "@nagiyu/aws": "*",
     "@nagiyu/nextjs": "*",
+    "@nagiyu/quick-clip-core": "*",
     "@nagiyu/ui": "*"
   }
 }

--- a/services/quick-clip/web/src/types/quick-clip.ts
+++ b/services/quick-clip/web/src/types/quick-clip.ts
@@ -1,46 +1,16 @@
-export type JobStatus = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
-export type BatchStage = 'downloading' | 'analyzing' | 'clipping' | 'aggregating';
-
-export type HighlightStatus = 'accepted' | 'rejected' | 'unconfirmed';
-export type ClipStatus = 'PENDING' | 'GENERATING' | 'GENERATED' | 'FAILED';
-export type HighlightSource = 'motion' | 'volume' | 'emotion' | 'both';
-
-export type Job = {
-  jobId: string;
-  batchJobId?: string;
-  batchStage?: BatchStage;
-  originalFileName: string;
-  fileSize: number;
-  createdAt: number;
-  expiresAt: number;
-  errorMessage?: string;
-};
-
-export type Highlight = {
-  highlightId: string;
-  jobId: string;
-  order: number;
-  startSec: number;
-  endSec: number;
-  source: HighlightSource;
-  status: HighlightStatus;
-  clipStatus: ClipStatus;
-  expiresAt: number;
-};
-
-export type UpdateHighlightInput = {
-  startSec?: number;
-  endSec?: number;
-  status?: HighlightStatus;
-  clipStatus?: ClipStatus;
-};
-
-/** Whisper 文字起こしの1セグメント。 */
-export type TranscriptSegment = {
-  /** セグメント開始時刻（秒）。 */
-  start: number;
-  /** セグメント終了時刻（秒）。 */
-  end: number;
-  /** 書き起こしテキスト。 */
-  text: string;
-};
+/**
+ * quick-clip の型定義。
+ * コアパッケージ（@nagiyu/quick-clip-core）から re-export する。
+ * web 専用の型はこのファイルに追加する。
+ */
+export type {
+  JobStatus,
+  BatchStage,
+  HighlightStatus,
+  ClipStatus,
+  HighlightSource,
+  Job,
+  Highlight,
+  UpdateHighlightInput,
+  TranscriptSegment,
+} from '@nagiyu/quick-clip-core';

--- a/services/share-together/web/src/lib/auth/session.ts
+++ b/services/share-together/web/src/lib/auth/session.ts
@@ -1,21 +1,24 @@
 import { NextResponse } from 'next/server';
 import type { Session } from 'next-auth';
-import { createSessionGetter } from '@nagiyu/nextjs/session';
+import { createSessionGetter, resolveTestUser } from '@nagiyu/nextjs/session';
 import { auth } from '../../../auth';
 import { ERROR_MESSAGES } from '@/lib/constants/errors';
 
 const getSessionFromAuth = createSessionGetter({
   auth: auth as () => Promise<Session | null>,
-  createTestSession: () => ({
-    user: {
-      id: process.env.TEST_USER_ID || 'test-user-id',
-      email: process.env.TEST_USER_EMAIL || 'test@example.com',
-      name: process.env.TEST_USER_NAME || 'Test User',
-      image: undefined,
-      roles: [],
-    },
-    expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-  }),
+  createTestSession: () => {
+    const u = resolveTestUser({ defaultRoles: [] });
+    return {
+      user: {
+        id: u.id,
+        email: u.email,
+        name: u.name,
+        image: u.image,
+        roles: u.roles,
+      },
+      expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    };
+  },
 });
 
 export const getSession = getSessionFromAuth;

--- a/services/stock-tracker/web/components/AlertSettingsModal.tsx
+++ b/services/stock-tracker/web/components/AlertSettingsModal.tsx
@@ -15,7 +15,7 @@ import {
   Switch,
 } from '@mui/material';
 import { Button, ErrorAlert, Select } from '@nagiyu/ui';
-import { subscribePush } from '@nagiyu/browser';
+import { subscribePush, fetchVapidPublicKey } from '@nagiyu/browser';
 import { formatPrice } from '@nagiyu/common';
 import { useEnterSubmit } from '@nagiyu/react';
 import { calculateTargetPriceFromPercentage } from '../lib/percentage-helper';
@@ -58,18 +58,6 @@ const FREQUENCY_LABELS: Record<AlertFrequency, string> = {
 // パーセンテージ選択肢の定数配列（-20 ～ +20、5%刻み）
 const PERCENTAGE_OPTIONS = [-20, -15, -10, -5, 0, 5, 10, 15, 20] as const;
 const DEFAULT_CHART_TIMEFRAME: Timeframe = '60';
-
-const fetchVapidPublicKey = async (): Promise<string> => {
-  const response = await fetch('/api/push/vapid-public-key');
-  if (!response.ok) {
-    throw new Error('VAPID公開鍵の取得に失敗しました');
-  }
-  const { publicKey } = (await response.json()) as { publicKey?: string };
-  if (!publicKey) {
-    throw new Error('VAPID公開鍵が空です');
-  }
-  return publicKey;
-};
 
 // プロパティ型定義
 interface AlertSettingsModalProps {


### PR DESCRIPTION
## 変更の概要

#3258（日次リファクタリング・コード共通化調査）の候補出し結果のうち、確度の高い 3 件を実装した。横断調査で挙がった候補から「重複が実害で修正が明快なもの」に絞り、偶発的重複（別ドメインのジョブが偶然同じ `JobStatus` 文字列ユニオンを持つだけの codec-converter ↔ quick-clip 間など）は意図的に除外している。

1. **VAPID 公開鍵取得関数の共通化**
   - `libs/browser` に `fetchVapidPublicKey(endpoint?)` を追加（既定 `'/api/push/vapid-public-key'`、エラーメッセージは `PUSH_ERROR_MESSAGES` に定数化）。
   - admin / livetalk(2 ファイル) / niconico / stock-tracker の各 web コンポーネントに重複していたローカル実装（計 5 箇所）を共通関数に置き換え。admin のみエンドポイントが異なるため `fetchVapidPublicKey('/api/notify/vapid-key')` で指定。

2. **quick-clip の型重複解消**
   - `services/quick-clip/web/src/types/quick-clip.ts` が独自再定義していた型を `@nagiyu/quick-clip-core` からの type-only re-export に変更（web package.json に core 依存を追加）。
   - core 側に `analysisProgress?` が追加されていた `Job` 型の drift も解消（optional 追加のため後方互換）。

3. **テストユーザー生成の env 読み取り共通化**
   - `libs/nextjs` に `resolveTestUser(options?)` を追加し、`TEST_USER_*` 環境変数の既定値付き読み取りを一元化。
   - admin / auth / niconico / share-together / livetalk の各 session（`SKIP_AUTH_CHECK` 時のテストユーザー生成）で利用。フィールド形・既定ロール・expires 期間は各サービス固有のまま据え置き、既定挙動は不変。

## 関連 Issue

関連: #3258（このPRでは自動クローズしない）

## 変更種別

- [ ] 新規機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/CD 更新
- [ ] インフラ更新
- [ ] その他

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（コードで自明な共通化のため docs 追従不要と判断）
- [ ] CI/CD 設定を追加・更新した（該当なし）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `libs/browser`：`fetchVapidPublicKey` のテスト 5 ケース追加（成功 / カスタムエンドポイント / !ok / 空 publicKey / undefined publicKey）。push.ts 100% カバレッジ。
- `libs/nextjs`：`resolveTestUser` のテスト追加（既定値 / env 上書き / roles split / defaultRoles / image 未設定）。session.ts 100% カバレッジ。
- 各サービスのテスト追従：auth に `resolveTestUser` モックと env 反映の回帰テストを追加、admin の VAPID メッセージ文言 assert を共通定数に統一。
- 客観検証（オーケストレーター実施）の結果：
  - libs/browser 61 / libs/nextjs 89 / livetalk-web 703 / quick-clip-web 159 / share-together-web 220 / stock-tracker-web 273 / auth-web 27 / admin 16 すべて pass。
  - niconico-mylist-assistant-web は test スクリプト無し。core ビルド後の `src` 型検査はクリーン。

## レビューポイント

- **session 既定挙動の保存**：auth / livetalk は元々 `id` / `name` をハードコードしていたが、`resolveTestUser` 経由で `TEST_USER_ID` / `TEST_USER_NAME` を読むよう統一した（既定値は旧値と同一のため CI/テスト挙動は不変、`SKIP_AUTH_CHECK` 経路限定）。env 反映を許容する方針で合意済み。
- **admin の VAPID エラー文言**：旧「VAPID 公開鍵…」（全角スペースあり）→ 共通定数「VAPID公開鍵…」（スペースなし）に統一。他サービスと揃える方針で合意済み。
- **型 re-export**：`export type`（type-only）のため、core の実行時依存（AWS SDK / openai 等）は web バンドルに混入しない。

## 補足事項

- fresh-eyes レビュー（別コンテキストの Opus）で「妥当・クリティカルなし」と評価済み。
- 軽微な未対応（今回スコープ外）：`services/quick-clip/web/src/app/jobs/[jobId]/page.tsx` に残る `AnalysisProgress` ローカル定義の core 取り込み、`TEST_USER_ROLES=''`（空文字）時に `['']` となる端ケース。いずれも実害が小さいため別途判断とする。


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4aBEwfMhQCQPmM24tpa45)_