### PR TITLE
status 画面の 500 を修正: ECS タスクロールへ GSI index 権限を付与（Issue #3580）

### DIFF
--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -126,7 +126,15 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     // これにより ECS Service stack は DynamoDB stack の deploy 順序に縛られない。
     const dynamoTableName = getDynamoDBTableName('livetalk', environment);
     const dynamoTableArn = getDynamoDBTableArn(this.region, this.account, dynamoTableName);
-    const dynamoTable = dynamodb.Table.fromTableArn(this, 'ImportedDynamoTable', dynamoTableArn);
+    // GSI への Query 権限を grant に含めるため、インデックス情報付きでインポートする。
+    // `fromTableArn` だけだと hasIndex=false となり grantReadWriteData が `table/.../index/*`
+    // を付与せず、ECS タスクロールが GSI を Query できず AccessDenied になる。
+    // GSI1=Profile 列挙（#3527）/ GSI2=SafetyEvent 横断レビュー（ADR-2.22 / #3580）。
+    // status 画面の SafetyEvent 横断 Query（GSI2）で顕在化した（batch-stack と同じ対処）。
+    const dynamoTable = dynamodb.Table.fromTableAttributes(this, 'ImportedDynamoTable', {
+      tableArn: dynamoTableArn,
+      globalIndexes: ['GSI1', 'GSI2'],
+    });
 
     this.ecsTaskSecurityGroup = new ec2.SecurityGroup(this, 'EcsTaskSecurityGroup', {
       vpc,

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -238,6 +238,25 @@ describe('LiveTalkEcsServiceStack', () => {
     );
   });
 
+  it('Task Role の DynamoDB grant に GSI（index/*）への Query 権限が含まれる', () => {
+    // status 画面は GSI2（SafetyEvent 横断レビュー）を Query するため、IAM ポリシーの
+    // Resource にテーブル本体に加えて `table/.../index/*` が含まれている必要がある
+    // （ADR-2.22 / #3580）。fromTableArn のままだと index ARN が grant されず AccessDenied。
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(['dynamodb:Query']),
+            Resource: Match.arrayWith([
+              Match.stringLikeRegexp('table/nagiyu-livetalk-dynamodb-dev/index/\\*'),
+            ]),
+          }),
+        ]),
+      },
+    });
+  });
+
   it('prod 環境でも正しい命名で生成する', () => {
     const template = synth('prod');
     template.hasResourceProperties('AWS::ECS::Service', {


### PR DESCRIPTION
## 変更の概要

dev 環境で `/status`（SCR-009）が 500（`This page couldn't load` / digest `2332811570`）になっていた不具合を修正する。

**根本原因**: ECS タスクロールが GSI2 への `dynamodb:Query` 権限を持っておらず `AccessDeniedException` で落ちていた。CloudWatch（`/ecs/nagiyu-livetalk-task-dev`）に以下が出力されていた:

```
DatabaseError: ... TaskRole ... is not authorized to perform: dynamodb:Query
on resource: .../table/nagiyu-livetalk-dynamodb-dev/index/GSI2
because no identity-based policy allows the dynamodb:Query action
digest: '2332811570'  →  .next/server/app/(protected)/status/page.js
```

GSI2 自体は ACTIVE で存在していたが、`ecs-service-stack.ts` がテーブルを `dynamodb.Table.fromTableArn` でインポートしていたため `hasIndex=false` となり、`grantReadWriteData` が `table/.../index/*` を付与していなかった。Web サービスは従来 GSI を Query しなかったため潜在化しており、今回の GSI2 横断 Query（status 画面のセーフティ横断レビュー）で初めて顕在化した。

**修正**: `fromTableAttributes` + `globalIndexes: ['GSI1', 'GSI2']` でインポートし、grant に index ARN を含める。`batch-stack.ts`（#3527 で同じ対処済み）と同一パターン。

## 関連 Issue

Issue #3580 の管轄内（混入源が同じ＝GSI2 追加）のため新規 Issue は起票していない。作業ブランチ → integration の PR のため `Closes` は付けない。

## 変更種別

- [x] バグ修正
- [x] インフラ更新

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（task role の grant に `table/.../index/*` が含まれることを検証）
- [x] ローカルでテストが全て通ることを確認した（ecs-service-stack 22 テスト pass）
- [x] ビルドエラーがないことを確認した

## テスト内容

- `infra/livetalk/tests/unit/ecs-service-stack.test.js` に「Task Role の DynamoDB grant に GSI（index/*）への Query 権限が含まれる」テストを追加（修正前は AccessDenied 相当で fail する回帰テスト）。
- ecs-service-stack 22 テスト pass。

## レビューポイント

- `globalIndexes` は非空であれば grant が `/index/*` ワイルドカードを付与するため GSI1/GSI2 双方をカバーする。明示性のため両方を列挙している。
- prod も同経路で修正される。dev 反映後、`livetalk:admin` で `/status` のセーフティ横断レビューが表示されることを確認する。

## 補足事項

dev 検証中に発見したログ起点の修正。CloudWatch Logs（`/ecs/nagiyu-livetalk-task-dev`）でエラー digest `2332811570` を特定し原因を確定した。


---
_Generated by [Claude Code](https://claude.ai/code/session_01AkamMPGvpwRXEgRknxPEzD)_