### PR TITLE
セーフティ検出の横断レビュー（GSI2 + admin 画面）を develop へ反映（Closes #3580）

### DIFF
--- a/infra/livetalk/lib/dynamodb-stack.ts
+++ b/infra/livetalk/lib/dynamodb-stack.ts
@@ -13,6 +13,8 @@ export interface LiveTalkDynamoDbStackProps extends cdk.StackProps {
  * - 命名: 共通ヘルパー `getDynamoDBTableName('livetalk', env)` で決定
  * - PK / SK の 2 キー Single Table 構成。Profile 列挙のために GSI1 を追加した（#3527）。
  *   GSI1PK='PROFILE' の sparse GSI で Profile のみ索引化する。
+ *   SafetyEvent 横断レビューのために GSI2 を追加した（ADR-2.22 / #3580）。
+ *   GSI2PK='SAFETY' の sparse GSI で SafetyEvent のみ索引化し、メタデータを INCLUDE 射影する。
  *   （`docs/services/livetalk/architecture.md` §3「データモデル概要」参照）
  * - Message は TTL（属性名 `TTL`、Unix 秒）で 90 日後に自動削除
  * - Point-in-time Recovery 有効、AWS マネージドキーで at-rest 暗号化
@@ -57,6 +59,24 @@ export class LiveTalkDynamoDbStack extends cdk.Stack {
       partitionKey: { name: 'GSI1PK', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'GSI1SK', type: dynamodb.AttributeType.STRING },
       projectionType: dynamodb.ProjectionType.KEYS_ONLY,
+    });
+
+    // GSI2: SafetyEvent のみを sparse 索引化する横断レビュー用 GSI（ADR-2.22 / #3580）
+    // GSI2PK='SAFETY' の SafetyEvent アイテムのみが対象（sparse GSI）
+    // 射影は一覧表示に必要なメタデータのみ INCLUDE（InputText/ResponseText は PII のため除外）
+    this.table.addGlobalSecondaryIndex({
+      indexName: 'GSI2',
+      partitionKey: { name: 'GSI2PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI2SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.INCLUDE,
+      nonKeyAttributes: [
+        'UserID',
+        'EventID',
+        'CharacterID',
+        'Trigger',
+        'DetectedPattern',
+        'CreatedAt',
+      ],
     });
 
     cdk.Tags.of(this).add('Application', 'nagiyu');

--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -126,7 +126,15 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
     // これにより ECS Service stack は DynamoDB stack の deploy 順序に縛られない。
     const dynamoTableName = getDynamoDBTableName('livetalk', environment);
     const dynamoTableArn = getDynamoDBTableArn(this.region, this.account, dynamoTableName);
-    const dynamoTable = dynamodb.Table.fromTableArn(this, 'ImportedDynamoTable', dynamoTableArn);
+    // GSI への Query 権限を grant に含めるため、インデックス情報付きでインポートする。
+    // `fromTableArn` だけだと hasIndex=false となり grantReadWriteData が `table/.../index/*`
+    // を付与せず、ECS タスクロールが GSI を Query できず AccessDenied になる。
+    // GSI1=Profile 列挙（#3527）/ GSI2=SafetyEvent 横断レビュー（ADR-2.22 / #3580）。
+    // status 画面の SafetyEvent 横断 Query（GSI2）で顕在化した（batch-stack と同じ対処）。
+    const dynamoTable = dynamodb.Table.fromTableAttributes(this, 'ImportedDynamoTable', {
+      tableArn: dynamoTableArn,
+      globalIndexes: ['GSI1', 'GSI2'],
+    });
 
     this.ecsTaskSecurityGroup = new ec2.SecurityGroup(this, 'EcsTaskSecurityGroup', {
       vpc,

--- a/infra/livetalk/tests/unit/dynamodb-stack.test.js
+++ b/infra/livetalk/tests/unit/dynamodb-stack.test.js
@@ -23,7 +23,7 @@ describe('LiveTalkDynamoDbStack', () => {
     });
   });
 
-  it('PK / SK の 2 キー Single Table 構成に GSI1（Profile 列挙用 sparse GSI）を追加する', () => {
+  it('PK / SK の 2 キー Single Table 構成に GSI1（Profile 列挙用 sparse GSI）と GSI2（SafetyEvent 横断レビュー用 sparse GSI）を追加する', () => {
     const template = synth('dev');
     template.hasResourceProperties('AWS::DynamoDB::Table', {
       KeySchema: [
@@ -35,11 +35,13 @@ describe('LiveTalkDynamoDbStack', () => {
         { AttributeName: 'SK', AttributeType: 'S' },
         { AttributeName: 'GSI1PK', AttributeType: 'S' },
         { AttributeName: 'GSI1SK', AttributeType: 'S' },
+        { AttributeName: 'GSI2PK', AttributeType: 'S' },
+        { AttributeName: 'GSI2SK', AttributeType: 'S' },
       ]),
     });
     // GSI1: Profile 列挙用 sparse GSI（#3527）
     template.hasResourceProperties('AWS::DynamoDB::Table', {
-      GlobalSecondaryIndexes: [
+      GlobalSecondaryIndexes: Match.arrayWith([
         {
           IndexName: 'GSI1',
           KeySchema: [
@@ -48,7 +50,33 @@ describe('LiveTalkDynamoDbStack', () => {
           ],
           Projection: { ProjectionType: 'KEYS_ONLY' },
         },
-      ],
+      ]),
+    });
+  });
+
+  it('GSI2（SafetyEvent 横断レビュー用 sparse GSI）が INCLUDE 射影でメタデータ属性を含む', () => {
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      GlobalSecondaryIndexes: Match.arrayWith([
+        {
+          IndexName: 'GSI2',
+          KeySchema: [
+            { AttributeName: 'GSI2PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI2SK', KeyType: 'RANGE' },
+          ],
+          Projection: {
+            ProjectionType: 'INCLUDE',
+            NonKeyAttributes: Match.arrayWith([
+              'UserID',
+              'EventID',
+              'CharacterID',
+              'Trigger',
+              'DetectedPattern',
+              'CreatedAt',
+            ]),
+          },
+        },
+      ]),
     });
   });
 

--- a/infra/livetalk/tests/unit/ecs-service-stack.test.js
+++ b/infra/livetalk/tests/unit/ecs-service-stack.test.js
@@ -238,6 +238,25 @@ describe('LiveTalkEcsServiceStack', () => {
     );
   });
 
+  it('Task Role の DynamoDB grant に GSI（index/*）への Query 権限が含まれる', () => {
+    // status 画面は GSI2（SafetyEvent 横断レビュー）を Query するため、IAM ポリシーの
+    // Resource にテーブル本体に加えて `table/.../index/*` が含まれている必要がある
+    // （ADR-2.22 / #3580）。fromTableArn のままだと index ARN が grant されず AccessDenied。
+    const template = synth('dev');
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(['dynamodb:Query']),
+            Resource: Match.arrayWith([
+              Match.stringLikeRegexp('table/nagiyu-livetalk-dynamodb-dev/index/\\*'),
+            ]),
+          }),
+        ]),
+      },
+    });
+  });
+
   it('prod 環境でも正しい命名で生成する', () => {
     const template = synth('prod');
     template.hasResourceProperties('AWS::ECS::Service', {

--- a/services/livetalk/core/src/constants.ts
+++ b/services/livetalk/core/src/constants.ts
@@ -308,6 +308,14 @@ export const NOTIFY_CRITICAL_INTEREST_SHARE_THRESHOLD = 0.15;
  */
 export const NOTIFY_CRITICAL_EVENT_HORIZON_DAYS = 14;
 
+// ---- セーフティ横断レビュー（ADR-2.22 / Issue #3580）----
+
+/**
+ * admin ステータス画面のセーフティ横断レビューで取得するデフォルト件数。
+ * 最近の検出から降順で最大この件数を一覧表示する。
+ */
+export const SAFETY_REVIEW_DEFAULT_LIMIT = 50;
+
 // ---- チャット API 保護ガード（Issue #3528）----
 
 /**

--- a/services/livetalk/core/src/entities/safety-event.entity.ts
+++ b/services/livetalk/core/src/entities/safety-event.entity.ts
@@ -8,6 +8,10 @@
  * TTL なし（人間レビュー用途のため永続保持）。
  * PII（InputText）を含むため、将来的に KMS CMK による暗号化を検討すること。
  *
+ * GSI2: SafetyEvent のみを sparse 索引化する横断レビュー用 GSI（ADR-2.22 / #3580）
+ * - GSI2PK='SAFETY' の SafetyEvent アイテムのみが対象
+ * - 射影は INCLUDE（メタデータのみ。InputText / ResponseText は PII のため除外）
+ *
  * @see docs/services/livetalk/architecture.md §3「データモデル概要」
  */
 
@@ -18,6 +22,11 @@ export interface SafetyEventEntity {
   UserID: string;
   /** イベント ID（ULID、時系列ソート可能） */
   EventID: string;
+  /**
+   * 横断レビュー用キャラクター識別子（ADR-2.22 / #3580）。
+   * チャット文脈で記録。既存レコードには無いため optional。
+   */
+  CharacterID?: string;
   /** 発生源（入力キーワード検出 or 応答後 Moderation） */
   Trigger: SafetyTrigger;
   /** 検出パターンの説明（カテゴリ名 + 一致テキスト） */
@@ -43,6 +52,7 @@ export interface SafetyEventKey {
 
 /**
  * SafetyEvent 作成入力（`EventID` / `CreatedAt` / `UpdatedAt` はリポジトリ側で付与）。
+ * CharacterID は横断レビュー用に作成時に必須とする（ADR-2.22 / #3580）。
  */
 export type CreateSafetyEventInput = Omit<
   SafetyEventEntity,
@@ -50,4 +60,21 @@ export type CreateSafetyEventInput = Omit<
 > & {
   /** 明示的に ULID を指定したい場合のみ渡す（テスト用途） */
   EventID?: string;
+  /** 横断レビュー用キャラクター識別子（作成時必須） */
+  CharacterID: string;
 };
+
+/**
+ * 横断一覧用の射影サマリ型（ADR-2.22 / #3580）。
+ * GSI2 の INCLUDE 射影に含まれるメタデータのみを保持する。
+ * PII（InputText / ResponseText）は含まない。
+ */
+export interface SafetyEventSummary {
+  UserID: string;
+  EventID: string;
+  /** 横断レビュー用キャラクター識別子。既存レコードには無いため optional */
+  CharacterID?: string;
+  Trigger: SafetyTrigger;
+  DetectedPattern: string;
+  CreatedAt: number;
+}

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -131,6 +131,7 @@ export type {
   SafetyEventEntity,
   SafetyEventKey,
   CreateSafetyEventInput,
+  SafetyEventSummary,
 } from './entities/safety-event.entity.js';
 export type {
   ProfileEntity,
@@ -177,6 +178,9 @@ export {
   // GSI1: Profile 列挙用 sparse GSI（#3527）
   PROFILE_GSI_INDEX_NAME,
   buildProfileGSI1PK,
+  // GSI2: SafetyEvent 横断レビュー用 sparse GSI（ADR-2.22 / #3580）
+  SAFETY_EVENT_GSI_INDEX_NAME,
+  buildSafetyEventGSI2PK,
 } from './mappers/keys.js';
 
 // Repository interfaces
@@ -380,6 +384,8 @@ export {
   CHAT_RATE_LIMIT_PER_MINUTE,
   CHAT_RATE_LIMIT_PER_HOUR,
   CHAT_LOCK_TTL_MS,
+  // セーフティ横断レビュー（ADR-2.22 / Issue #3580）
+  SAFETY_REVIEW_DEFAULT_LIMIT,
 } from './constants.js';
 
 // チャット API 保護ガード（Issue #3528）

--- a/services/livetalk/core/src/mappers/keys.ts
+++ b/services/livetalk/core/src/mappers/keys.ts
@@ -7,10 +7,18 @@
  * GSI1: Profile 列挙用 sparse GSI（#3527）
  * - GSI1PK='PROFILE' の Profile アイテムのみを索引化する
  * - GSI1SK は生の UserID（USER# プレフィックスなし）
+ *
+ * GSI2: SafetyEvent のみを sparse 索引化する横断レビュー用 GSI（ADR-2.22 / #3580）
+ * - GSI2PK='SAFETY' の SafetyEvent アイテムのみを索引化する
+ * - GSI2SK は EventID（ULID、時系列ソート可能）をそのまま使用する
+ * - 射影は INCLUDE（メタデータのみ。InputText / ResponseText は PII のため除外）
  */
 
 /** Profile 列挙 GSI のインデックス名 */
 export const PROFILE_GSI_INDEX_NAME = 'GSI1';
+
+/** SafetyEvent 横断レビュー GSI のインデックス名（ADR-2.22 / #3580） */
+export const SAFETY_EVENT_GSI_INDEX_NAME = 'GSI2';
 
 /**
  * GSI1 のパーティションキー値を返す。
@@ -18,6 +26,15 @@ export const PROFILE_GSI_INDEX_NAME = 'GSI1';
  */
 export function buildProfileGSI1PK(): string {
   return 'PROFILE';
+}
+
+/**
+ * GSI2 のパーティションキー値を返す。
+ * SafetyEvent アイテムのみに付与する（sparse GSI）。
+ * GSI2SK は EventID（ULID）をそのまま使用するため専用ビルダーは不要。
+ */
+export function buildSafetyEventGSI2PK(): string {
+  return 'SAFETY';
 }
 
 export function buildUserPK(userId: string): string {

--- a/services/livetalk/core/src/mappers/safety-event.mapper.ts
+++ b/services/livetalk/core/src/mappers/safety-event.mapper.ts
@@ -4,9 +4,13 @@ import {
   type DynamoDBItem,
   type EntityMapper,
 } from '@nagiyu/aws';
-import type { SafetyEventEntity, SafetyEventKey } from '../entities/safety-event.entity.js';
+import type {
+  SafetyEventEntity,
+  SafetyEventKey,
+  SafetyEventSummary,
+} from '../entities/safety-event.entity.js';
 import type { SafetyTrigger } from '../safety/types.js';
-import { buildSafetyEventSK, buildUserPK } from './keys.js';
+import { buildSafetyEventGSI2PK, buildSafetyEventSK, buildUserPK } from './keys.js';
 
 export class SafetyEventMapper implements EntityMapper<SafetyEventEntity, SafetyEventKey> {
   public readonly entityType = 'SafetyEvent';
@@ -29,7 +33,15 @@ export class SafetyEventMapper implements EntityMapper<SafetyEventEntity, Safety
       ResponseText: entity.ResponseText,
       CreatedAt: entity.CreatedAt,
       UpdatedAt: entity.UpdatedAt,
+      // GSI2: SafetyEvent のみを sparse 索引化する横断レビュー用 GSI（ADR-2.22 / #3580）
+      // 全 SafetyEvent に必ず付与することで、GSI2 クエリで横断取得できるようにする
+      GSI2PK: buildSafetyEventGSI2PK(),
+      GSI2SK: entity.EventID,
     };
+
+    if (entity.CharacterID !== undefined) {
+      item.CharacterID = entity.CharacterID;
+    }
 
     if (entity.ModerationCategories !== undefined) {
       item.ModerationCategories = entity.ModerationCategories;
@@ -50,6 +62,10 @@ export class SafetyEventMapper implements EntityMapper<SafetyEventEntity, Safety
       UpdatedAt: validateTimestampField(item.UpdatedAt, 'UpdatedAt'),
     };
 
+    if (item.CharacterID !== undefined) {
+      entity.CharacterID = validateStringField(item.CharacterID, 'CharacterID');
+    }
+
     if (item.ModerationCategories !== undefined) {
       entity.ModerationCategories = validateStringField(
         item.ModerationCategories,
@@ -59,6 +75,26 @@ export class SafetyEventMapper implements EntityMapper<SafetyEventEntity, Safety
     }
 
     return entity;
+  }
+
+  /**
+   * DynamoDB アイテムを横断一覧用サマリ型に変換する（ADR-2.22 / #3580）。
+   * GSI2 の INCLUDE 射影から読み取るため、InputText / ResponseText は含まない。
+   */
+  public toSummary(item: DynamoDBItem): SafetyEventSummary {
+    const summary: SafetyEventSummary = {
+      UserID: validateStringField(item.UserID, 'UserID'),
+      EventID: validateStringField(item.EventID, 'EventID'),
+      Trigger: validateStringField(item.Trigger, 'Trigger') as SafetyTrigger,
+      DetectedPattern: validateStringField(item.DetectedPattern, 'DetectedPattern'),
+      CreatedAt: validateTimestampField(item.CreatedAt, 'CreatedAt'),
+    };
+
+    if (item.CharacterID !== undefined) {
+      summary.CharacterID = validateStringField(item.CharacterID, 'CharacterID');
+    }
+
+    return summary;
   }
 
   public buildKeys(key: SafetyEventKey): { pk: string; sk: string } {

--- a/services/livetalk/core/src/repositories/dynamodb-safety-event.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-safety-event.repository.ts
@@ -1,11 +1,18 @@
-import { GetCommand, PutCommand, type DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
 import { DatabaseError, EntityAlreadyExistsError, type DynamoDBItem } from '@nagiyu/aws';
 import type {
   CreateSafetyEventInput,
   SafetyEventEntity,
   SafetyEventKey,
+  SafetyEventSummary,
 } from '../entities/safety-event.entity.js';
 import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+import { SAFETY_EVENT_GSI_INDEX_NAME, buildSafetyEventGSI2PK } from '../mappers/keys.js';
 import { SafetyEventMapper } from '../mappers/safety-event.mapper.js';
 import type { SafetyEventRepository } from './safety-event.repository.interface.js';
 
@@ -72,6 +79,28 @@ export class DynamoDBSafetyEventRepository implements SafetyEventRepository {
       );
       if (!result.Item) return null;
       return this.mapper.toEntity(result.Item as unknown as DynamoDBItem);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new DatabaseError(message, error instanceof Error ? error : undefined);
+    }
+  }
+
+  public async listRecent(limit: number): Promise<SafetyEventSummary[]> {
+    try {
+      const result = await this.docClient.send(
+        new QueryCommand({
+          TableName: this.tableName,
+          IndexName: SAFETY_EVENT_GSI_INDEX_NAME,
+          KeyConditionExpression: '#gsi2pk = :pk',
+          ExpressionAttributeNames: { '#gsi2pk': 'GSI2PK' },
+          ExpressionAttributeValues: { ':pk': buildSafetyEventGSI2PK() },
+          ScanIndexForward: false, // 降順（最近の検出が先頭）
+          Limit: limit,
+        })
+      );
+      return (result.Items ?? []).map((item) =>
+        this.mapper.toSummary(item as unknown as DynamoDBItem)
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new DatabaseError(message, error instanceof Error ? error : undefined);

--- a/services/livetalk/core/src/repositories/in-memory-safety-event.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-safety-event.repository.ts
@@ -1,10 +1,12 @@
-import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemorySingleTableStore, type DynamoDBItem } from '@nagiyu/aws';
 import type {
   CreateSafetyEventInput,
   SafetyEventEntity,
   SafetyEventKey,
+  SafetyEventSummary,
 } from '../entities/safety-event.entity.js';
 import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+import { buildSafetyEventGSI2PK } from '../mappers/keys.js';
 import { SafetyEventMapper } from '../mappers/safety-event.mapper.js';
 import type { SafetyEventRepository } from './safety-event.repository.interface.js';
 
@@ -45,5 +47,26 @@ export class InMemorySafetyEventRepository implements SafetyEventRepository {
     const item = this.store.get(pk, sk);
     if (!item) return null;
     return this.mapper.toEntity(item);
+  }
+
+  public async listRecent(limit: number): Promise<SafetyEventSummary[]> {
+    // GSI2PK='SAFETY' のアイテムを全件取得してから GSI2SK（EventID / ULID）の降順でソートし、
+    // limit 件返す。queryByAttribute は既定 limit=100 でページングするため、cursor ループで
+    // 全件集約しないと「最近の検出」を取り落とす（in-memory-profile.repository の listAllUserIds と同パターン）。
+    const items: DynamoDBItem[] = [];
+    let cursor: string | undefined;
+    do {
+      const result = this.store.queryByAttribute(
+        { attributeName: 'GSI2PK', attributeValue: buildSafetyEventGSI2PK() },
+        cursor ? { cursor } : undefined
+      );
+      items.push(...result.items);
+      cursor = result.nextCursor;
+    } while (cursor !== undefined);
+
+    return items
+      .sort((a, b) => String(b.GSI2SK).localeCompare(String(a.GSI2SK)))
+      .slice(0, limit)
+      .map((item) => this.mapper.toSummary(item));
   }
 }

--- a/services/livetalk/core/src/repositories/safety-event.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/safety-event.repository.interface.ts
@@ -2,13 +2,14 @@ import type {
   CreateSafetyEventInput,
   SafetyEventEntity,
   SafetyEventKey,
+  SafetyEventSummary,
 } from '../entities/safety-event.entity.js';
 
 /**
  * SafetyEvent のリポジトリインターフェース（Phase 2d / Issue #3250）。
  *
  * MVP では作成と単件取得のみを公開する。
- * 管理者向けの一覧取得は将来的に管理画面と合わせて追加する。
+ * 管理者向けの横断一覧取得は ADR-2.22 / #3580 で追加した。
  */
 export interface SafetyEventRepository {
   /**
@@ -20,4 +21,13 @@ export interface SafetyEventRepository {
    * 単一 SafetyEvent を取得する（主にテスト用）。
    */
   getById(key: SafetyEventKey): Promise<SafetyEventEntity | null>;
+
+  /**
+   * GSI2 を Query し、検出時刻の降順で最近の SafetyEvent を横断取得する（ADR-2.22 / #3580）。
+   * 全件 Scan を避けるため sparse GSI（GSI2PK='SAFETY'）を使用する。
+   * 射影 INCLUDE のため PII（InputText / ResponseText）は含まない。
+   *
+   * @param limit 取得する最大件数
+   */
+  listRecent(limit: number): Promise<SafetyEventSummary[]>;
 }

--- a/services/livetalk/core/src/usecases/chat-usecase.ts
+++ b/services/livetalk/core/src/usecases/chat-usecase.ts
@@ -321,6 +321,7 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
       try {
         await safetyEventRepository.create({
           UserID: userId,
+          CharacterID: characterId,
           Trigger: 'input_keyword',
           DetectedPattern: detectedPattern,
           InputText: userText,
@@ -631,6 +632,7 @@ export async function* runChatUseCase(params: ChatUseCaseParams): AsyncGenerator
           try {
             await safetyEventRepository.create({
               UserID: userId,
+              CharacterID: characterId,
               Trigger: 'output_moderation',
               DetectedPattern: `Moderation flagged: ${flaggedCategories.join(', ')}`,
               InputText: userText,

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-safety-event.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-safety-event.repository.test.ts
@@ -1,5 +1,6 @@
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { DynamoDBSafetyEventRepository } from '../../../src/repositories/dynamodb-safety-event.repository.js';
+import type { SafetyEventSummary } from '../../../src/entities/safety-event.entity.js';
 
 const TABLE = 'nagiyu-livetalk-test';
 const FIXED_NOW = 1_700_000_000_000;
@@ -20,7 +21,31 @@ function makeRepo(mockSend: jest.Mock) {
   );
 }
 
+/** デフォルト引数（ulidFactory / nowMs）で生成するリポジトリ */
+function makeRepoDefault(mockSend: jest.Mock) {
+  return new DynamoDBSafetyEventRepository(makeDocClient(mockSend), TABLE);
+}
+
 describe('DynamoDBSafetyEventRepository', () => {
+  describe('デフォルト引数の動作', () => {
+    it('ulidFactory / nowMs をデフォルト値で生成できる', async () => {
+      // デフォルト引数（行 28）のブランチをカバーする
+      const mockSend = jest.fn().mockResolvedValue({});
+      const repo = makeRepoDefault(mockSend);
+      // create 呼び出しで EventID が ULID として自動生成される
+      const entity = await repo.create({
+        UserID: 'u-default',
+        CharacterID: 'hiyori',
+        Trigger: 'input_keyword',
+        DetectedPattern: 'test',
+        InputText: 'input',
+        ResponseText: 'response',
+      });
+      expect(entity.EventID).toBeTruthy();
+      expect(entity.CreatedAt).toBeGreaterThan(0);
+    });
+  });
+
   describe('create()', () => {
     it('PutCommand で DynamoDB に書き込み、エンティティを返す', async () => {
       const mockSend = jest.fn().mockResolvedValue({});
@@ -28,6 +53,7 @@ describe('DynamoDBSafetyEventRepository', () => {
 
       const entity = await repo.create({
         UserID: 'u1',
+        CharacterID: 'hiyori',
         Trigger: 'input_keyword',
         DetectedPattern: '[自殺念慮] 死にたい',
         InputText: '死にたい',
@@ -36,9 +62,18 @@ describe('DynamoDBSafetyEventRepository', () => {
 
       expect(mockSend).toHaveBeenCalledTimes(1);
       expect(entity.UserID).toBe('u1');
+      expect(entity.CharacterID).toBe('hiyori');
       expect(entity.EventID).toBe(FIXED_ULID);
       expect(entity.Trigger).toBe('input_keyword');
       expect(entity.CreatedAt).toBe(FIXED_NOW);
+
+      // sparse GSI2 属性が書き込まれていること（これが欠けると横断 Query が空になる）
+      const putItem = mockSend.mock.calls[0][0].input.Item;
+      expect(putItem.GSI2PK).toBe('SAFETY');
+      expect(putItem.GSI2SK).toBe(FIXED_ULID);
+      expect(putItem.CharacterID).toBe('hiyori');
+      // PII を含む属性はベーステーブルには保持されるが、後述の listRecent では射影されない
+      expect(putItem.InputText).toBe('死にたい');
     });
 
     it('明示的な EventID を使用する', async () => {
@@ -47,6 +82,7 @@ describe('DynamoDBSafetyEventRepository', () => {
 
       const entity = await repo.create({
         UserID: 'u1',
+        CharacterID: 'hiyori',
         Trigger: 'output_moderation',
         DetectedPattern: 'Moderation flagged',
         InputText: 'test',
@@ -67,6 +103,7 @@ describe('DynamoDBSafetyEventRepository', () => {
       await expect(
         repo.create({
           UserID: 'u1',
+          CharacterID: 'hiyori',
           Trigger: 'input_keyword',
           DetectedPattern: 'test',
           InputText: 'test',
@@ -83,6 +120,24 @@ describe('DynamoDBSafetyEventRepository', () => {
       await expect(
         repo.create({
           UserID: 'u1',
+          CharacterID: 'hiyori',
+          Trigger: 'input_keyword',
+          DetectedPattern: 'test',
+          InputText: 'test',
+          ResponseText: 'response',
+        })
+      ).rejects.toMatchObject({ name: 'DatabaseError' });
+    });
+
+    it('Error 以外の例外も DatabaseError に変換する', async () => {
+      // error instanceof Error が false のブランチ（行 64-65）
+      const mockSend = jest.fn().mockRejectedValue('文字列エラー');
+      const repo = makeRepo(mockSend);
+
+      await expect(
+        repo.create({
+          UserID: 'u1',
+          CharacterID: 'hiyori',
           Trigger: 'input_keyword',
           DetectedPattern: 'test',
           InputText: 'test',
@@ -101,6 +156,7 @@ describe('DynamoDBSafetyEventRepository', () => {
           Type: 'SafetyEvent',
           UserID: 'u1',
           EventID: 'TEST_ULID',
+          CharacterID: 'hiyori',
           Trigger: 'input_keyword',
           DetectedPattern: '[自殺念慮] 死にたい',
           InputText: '死にたい',
@@ -114,6 +170,7 @@ describe('DynamoDBSafetyEventRepository', () => {
       const result = await repo.getById({ userId: 'u1', eventId: 'TEST_ULID' });
       expect(result).not.toBeNull();
       expect(result?.EventID).toBe('TEST_ULID');
+      expect(result?.CharacterID).toBe('hiyori');
       expect(result?.Trigger).toBe('input_keyword');
     });
 
@@ -132,6 +189,101 @@ describe('DynamoDBSafetyEventRepository', () => {
       await expect(repo.getById({ userId: 'u1', eventId: 'x' })).rejects.toMatchObject({
         name: 'DatabaseError',
       });
+    });
+
+    it('Error 以外の例外も DatabaseError に変換する', async () => {
+      // error instanceof Error が false のブランチ（行 81-82）
+      const mockSend = jest.fn().mockRejectedValue(42);
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.getById({ userId: 'u1', eventId: 'x' })).rejects.toMatchObject({
+        name: 'DatabaseError',
+      });
+    });
+  });
+
+  describe('listRecent()', () => {
+    it('GSI2 クエリを ScanIndexForward=false で発行する', async () => {
+      const items: SafetyEventSummary[] = [
+        {
+          UserID: 'u1',
+          EventID: 'ULID2',
+          CharacterID: 'hiyori',
+          Trigger: 'input_keyword',
+          DetectedPattern: 'test',
+          CreatedAt: FIXED_NOW + 1000,
+        },
+        {
+          UserID: 'u2',
+          EventID: 'ULID1',
+          Trigger: 'output_moderation',
+          DetectedPattern: 'Moderation',
+          CreatedAt: FIXED_NOW,
+        },
+      ];
+
+      const mockSend = jest.fn().mockResolvedValue({
+        Items: items.map((s) => ({
+          GSI2PK: 'SAFETY',
+          GSI2SK: s.EventID,
+          UserID: s.UserID,
+          EventID: s.EventID,
+          ...(s.CharacterID !== undefined ? { CharacterID: s.CharacterID } : {}),
+          Trigger: s.Trigger,
+          DetectedPattern: s.DetectedPattern,
+          CreatedAt: s.CreatedAt,
+        })),
+      });
+      const repo = makeRepo(mockSend);
+
+      const result = await repo.listRecent(10);
+      expect(mockSend).toHaveBeenCalledTimes(1);
+
+      // QueryCommand の引数を検証
+      const call = mockSend.mock.calls[0][0];
+      expect(call.input.IndexName).toBe('GSI2');
+      expect(call.input.ScanIndexForward).toBe(false);
+      expect(call.input.Limit).toBe(10);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].EventID).toBe('ULID2');
+      expect(result[0].CharacterID).toBe('hiyori');
+      expect(result[1].EventID).toBe('ULID1');
+      // PII が含まれないことを確認
+      expect((result[0] as unknown as Record<string, unknown>).InputText).toBeUndefined();
+      expect((result[0] as unknown as Record<string, unknown>).ResponseText).toBeUndefined();
+    });
+
+    it('アイテムが 0 件の場合は空配列を返す', async () => {
+      const mockSend = jest.fn().mockResolvedValue({ Items: [] });
+      const repo = makeRepo(mockSend);
+
+      const result = await repo.listRecent(10);
+      expect(result).toEqual([]);
+    });
+
+    it('Items が undefined の場合も空配列を返す', async () => {
+      // result.Items ?? [] のフォールバックをテスト
+      const mockSend = jest.fn().mockResolvedValue({});
+      const repo = makeRepo(mockSend);
+
+      const result = await repo.listRecent(10);
+      expect(result).toEqual([]);
+    });
+
+    it('DynamoDB エラー → DatabaseError', async () => {
+      const mockSend = jest.fn().mockRejectedValue(new Error('GSI エラー'));
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.listRecent(10)).rejects.toMatchObject({ name: 'DatabaseError' });
+    });
+
+    it('Error 以外の例外も DatabaseError に変換する', async () => {
+      // error instanceof Error が false のブランチ
+      const mockSend = jest.fn().mockRejectedValue('文字列エラー');
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.listRecent(10)).rejects.toMatchObject({ name: 'DatabaseError' });
     });
   });
 });

--- a/services/livetalk/core/tests/unit/repositories/in-memory-safety-event.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-safety-event.repository.test.ts
@@ -24,12 +24,14 @@ describe('InMemorySafetyEventRepository', () => {
       const { repo, fixedNow } = makeRepo();
       const entity = await repo.create({
         UserID: 'u1',
+        CharacterID: 'hiyori',
         Trigger: 'input_keyword',
         DetectedPattern: '[自殺念慮] 死にたい',
         InputText: '死にたい',
         ResponseText: 'ねえ、今すごく心配しちゃった…',
       });
       expect(entity.UserID).toBe('u1');
+      expect(entity.CharacterID).toBe('hiyori');
       expect(entity.EventID).toBe('FIXED_ULID');
       expect(entity.Trigger).toBe('input_keyword');
       expect(entity.CreatedAt).toBe(fixedNow);
@@ -40,6 +42,7 @@ describe('InMemorySafetyEventRepository', () => {
       const { repo } = makeRepo();
       const entity = await repo.create({
         UserID: 'u1',
+        CharacterID: 'hiyori',
         Trigger: 'output_moderation',
         DetectedPattern: 'Moderation flagged: self-harm',
         InputText: 'test',
@@ -57,6 +60,7 @@ describe('InMemorySafetyEventRepository', () => {
       const { repo } = makeRepo();
       await repo.create({
         UserID: 'u1',
+        CharacterID: 'hiyori',
         Trigger: 'input_keyword',
         DetectedPattern: 'test',
         InputText: 'input',
@@ -65,12 +69,151 @@ describe('InMemorySafetyEventRepository', () => {
       const found = await repo.getById({ userId: 'u1', eventId: 'FIXED_ULID' });
       expect(found).not.toBeNull();
       expect(found?.EventID).toBe('FIXED_ULID');
+      expect(found?.CharacterID).toBe('hiyori');
     });
 
     it('存在しないイベントは null を返す', async () => {
       const { repo } = makeRepo();
       const found = await repo.getById({ userId: 'u1', eventId: 'nonexistent' });
       expect(found).toBeNull();
+    });
+  });
+
+  describe('listRecent()', () => {
+    it('複数件作成後、降順で返す', async () => {
+      // ULID はソートのため異なる値を使用する（後から作ったものが lexicographically 後になる）
+      const store = makeStore();
+      const nowBase = 1_700_000_000_000;
+      let callCount = 0;
+      const ulidFactory = () => `ULID${String.fromCharCode(65 + callCount++)}`;
+      const repo = new (
+        await import('../../../src/repositories/in-memory-safety-event.repository.js')
+      ).InMemorySafetyEventRepository(store, ulidFactory, () => nowBase);
+
+      // 3 件作成（ULID_A, ULID_B, ULID_C の順）
+      await repo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Trigger: 'input_keyword',
+        DetectedPattern: 'pattern1',
+        InputText: 'input1',
+        ResponseText: 'response1',
+      });
+      await repo.create({
+        UserID: 'u2',
+        CharacterID: 'hiyori',
+        Trigger: 'output_moderation',
+        DetectedPattern: 'pattern2',
+        InputText: 'input2',
+        ResponseText: 'response2',
+      });
+      await repo.create({
+        UserID: 'u3',
+        CharacterID: 'ageha',
+        Trigger: 'input_keyword',
+        DetectedPattern: 'pattern3',
+        InputText: 'input3',
+        ResponseText: 'response3',
+      });
+
+      const result = await repo.listRecent(10);
+      expect(result).toHaveLength(3);
+      // ULID_C > ULID_B > ULID_A の降順
+      expect(result[0].EventID).toBe('ULIDC');
+      expect(result[1].EventID).toBe('ULIDB');
+      expect(result[2].EventID).toBe('ULIDA');
+    });
+
+    it('limit が効く', async () => {
+      const store = makeStore();
+      let callCount = 0;
+      const ulidFactory = () => `ULID${String.fromCharCode(65 + callCount++)}`;
+      const repo = new (
+        await import('../../../src/repositories/in-memory-safety-event.repository.js')
+      ).InMemorySafetyEventRepository(store, ulidFactory, () => 1_700_000_000_000);
+
+      for (let i = 0; i < 5; i++) {
+        await repo.create({
+          UserID: `u${i}`,
+          CharacterID: 'hiyori',
+          Trigger: 'input_keyword',
+          DetectedPattern: `pattern${i}`,
+          InputText: `input${i}`,
+          ResponseText: `response${i}`,
+        });
+      }
+
+      const result = await repo.listRecent(3);
+      expect(result).toHaveLength(3);
+    });
+
+    it('CharacterID がサマリに含まれる', async () => {
+      const { repo } = makeRepo();
+      await repo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Trigger: 'input_keyword',
+        DetectedPattern: 'test',
+        InputText: 'input',
+        ResponseText: 'response',
+      });
+
+      const result = await repo.listRecent(10);
+      expect(result).toHaveLength(1);
+      expect(result[0].CharacterID).toBe('hiyori');
+    });
+
+    it('PII（InputText/ResponseText）はサマリに含まれない', async () => {
+      const { repo } = makeRepo();
+      await repo.create({
+        UserID: 'u1',
+        CharacterID: 'hiyori',
+        Trigger: 'input_keyword',
+        DetectedPattern: 'test',
+        InputText: 'これは PII データ',
+        ResponseText: 'これも PII データ',
+      });
+
+      const result = await repo.listRecent(10);
+      expect(result).toHaveLength(1);
+      expect((result[0] as unknown as Record<string, unknown>).InputText).toBeUndefined();
+      expect((result[0] as unknown as Record<string, unknown>).ResponseText).toBeUndefined();
+    });
+
+    it('0 件のとき空配列を返す', async () => {
+      const { repo } = makeRepo();
+      const result = await repo.listRecent(10);
+      expect(result).toEqual([]);
+    });
+
+    it('100 件超でも最近の検出を取り落とさない（queryByAttribute の既定 limit=100 回帰）', async () => {
+      // queryByAttribute は既定 limit=100 でページングするため、cursor ループで全件集約しないと
+      // 「先頭 100 件（挿入順=古い側）」だけを降順ソートしてしまい、最近の検出が欠落する。
+      const store = makeStore();
+      let callCount = 0;
+      // 連番をゼロ詰めし、後から作るほど lexicographically 大きい ULID にする
+      const ulidFactory = () => `ULID${String(callCount++).padStart(4, '0')}`;
+      const repo = new (
+        await import('../../../src/repositories/in-memory-safety-event.repository.js')
+      ).InMemorySafetyEventRepository(store, ulidFactory, () => 1_700_000_000_000);
+
+      const total = 150;
+      for (let i = 0; i < total; i++) {
+        await repo.create({
+          UserID: `u${i}`,
+          CharacterID: 'hiyori',
+          Trigger: 'input_keyword',
+          DetectedPattern: `pattern${i}`,
+          InputText: `input${i}`,
+          ResponseText: `response${i}`,
+        });
+      }
+
+      const result = await repo.listRecent(5);
+      expect(result).toHaveLength(5);
+      // 最後に作成した ULID0149 が先頭に来る（古い側 100 件で切り詰めていたら欠落する）
+      expect(result[0].EventID).toBe('ULID0149');
+      expect(result[4].EventID).toBe('ULID0145');
     });
   });
 });

--- a/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
+++ b/services/livetalk/core/tests/unit/usecases/chat-usecase.test.ts
@@ -124,6 +124,7 @@ function makeSafetyEventRepo(
         }) as SafetyEventEntity
     ),
     getById: jest.fn(async () => null),
+    listRecent: jest.fn(async () => []),
     ...overrides,
   };
 }

--- a/services/livetalk/web/src/app/(protected)/status/page.tsx
+++ b/services/livetalk/web/src/app/(protected)/status/page.tsx
@@ -16,6 +16,7 @@ import {
   NOTIFY_BACKOFF_BASE,
   NOTIFY_RECENT_SESSION_SAMPLE_N,
   NOTIFY_SESSION_GAP_MINUTES,
+  SAFETY_REVIEW_DEFAULT_LIMIT,
   resolveLifecycleState,
   shouldNotifyNow,
   extractSessionStartTimes,
@@ -24,6 +25,7 @@ import {
   computeIntensityFactor,
   type MessageEntity,
   type NotificationEventEntity,
+  type SafetyEventSummary,
 } from '@nagiyu/livetalk-core';
 import { getSession } from '@/lib/server/session';
 import {
@@ -33,6 +35,7 @@ import {
   getStudyTopicRepository,
   getMessageRepository,
 } from '@/lib/server/repositories';
+import { getSafetyEventRepository } from '@/lib/server/safety';
 import {
   hasCharacter,
   getRegisteredCharacterIds,
@@ -80,6 +83,12 @@ const REASON_LABELS: Record<string, string> = {
   no_content: 'コンテンツなし',
 };
 
+/** セーフティ検出の Trigger を日本語ラベルに変換する */
+const SAFETY_TRIGGER_LABELS: Record<string, string> = {
+  input_keyword: 'キーワード検出',
+  output_moderation: 'Moderation',
+};
+
 interface StatusPageProps {
   searchParams: Promise<{ characterId?: string }>;
 }
@@ -96,13 +105,15 @@ export default async function StatusPage({ searchParams }: StatusPageProps) {
   const userId = session.user.googleId;
   const now = new Date();
 
-  const [lifecycle, notificationEvents, allMessages, knowledge, studyPending] = await Promise.all([
-    getLifecycleRepository().get({ userId, characterId }),
-    getNotificationEventRepository().listByUser(userId, 10),
-    getMessageRepository().listSince(userId, characterId, 0),
-    getKnowledgeRepository().list(userId, characterId),
-    getStudyTopicRepository().listByStatus(userId, characterId, 'pending'),
-  ]);
+  const [lifecycle, notificationEvents, allMessages, knowledge, studyPending, recentSafetyEvents] =
+    await Promise.all([
+      getLifecycleRepository().get({ userId, characterId }),
+      getNotificationEventRepository().listByUser(userId, 10),
+      getMessageRepository().listSince(userId, characterId, 0),
+      getKnowledgeRepository().list(userId, characterId),
+      getStudyTopicRepository().listByStatus(userId, characterId, 'pending'),
+      getSafetyEventRepository().listRecent(SAFETY_REVIEW_DEFAULT_LIMIT),
+    ]);
 
   const bedtime = lifecycle?.Bedtime ?? LIFECYCLE_DEFAULT_BEDTIME;
   const wakeUpTime = lifecycle?.WakeUpTime ?? LIFECYCLE_DEFAULT_WAKE_UP_TIME;
@@ -261,6 +272,53 @@ export default async function StatusPage({ searchParams }: StatusPageProps) {
         decision ゲートを介さず即時送信します。dev 検証専用。
       </Typography>
       <StatusTestPush characterIds={registeredCharacterIds} displayNames={characterDisplayNames} />
+
+      <Divider sx={{ my: 1.5 }} />
+
+      {/* セーフティ横断レビュー（ADR-2.22 / Issue #3580） */}
+      <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+        セーフティ横断レビュー（直近 {SAFETY_REVIEW_DEFAULT_LIMIT} 件）
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1, fontSize: '0.75rem' }}>
+        全ユーザー横断で検出時刻の降順に一覧します。InputText / ResponseText は PII のため非表示。
+      </Typography>
+      {recentSafetyEvents.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          検出履歴なし
+        </Typography>
+      ) : (
+        <Box sx={{ mb: 1 }}>
+          {recentSafetyEvents.map((e: SafetyEventSummary) => {
+            const characterDisplay = e.CharacterID
+              ? (() => {
+                  try {
+                    return getCharacterDisplay(e.CharacterID).displayName;
+                  } catch {
+                    return e.CharacterID;
+                  }
+                })()
+              : '—';
+
+            return (
+              <Box
+                key={e.EventID}
+                sx={{ mb: 1, pl: 1, borderLeft: '2px solid', borderColor: 'divider' }}
+              >
+                <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                  {formatJst(e.CreatedAt)} | {SAFETY_TRIGGER_LABELS[e.Trigger] ?? e.Trigger} |
+                  キャラ: {characterDisplay}
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.75rem' }}>
+                  {e.DetectedPattern}
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.75rem' }}>
+                  ユーザー: {e.UserID}
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
     </Container>
   );
 }


### PR DESCRIPTION
## 変更の概要

セーフティ検出の横断レビュー（sparse GSI + admin 画面）を develop へ反映する。requirements 3.2 の「セーフティ検出ログを人間レビュー可能」を実態として満たすための実装（ADR-2.22）。`integration/3580-safety-review` で組み立て・dev 検証済み。

含まれる対応（integration ブランチ上の 2 PR）:

- **#3582 セーフティ横断レビュー実装**
  - sparse GSI（GSI2、`GSI2PK='SAFETY'` / `GSI2SK`=EventID）を SafetyEvent item にのみ付与し、INCLUDE 射影（PII の InputText/ResponseText は射影しない）で全ユーザー横断 Query を可能化
  - `SafetyEventRepository.listRecent(limit)` を追加（GSI2 を降順 Query / 射影サマリ型 `SafetyEventSummary` を返す）
  - `CharacterID` を SafetyEvent に追加（ADR-2.22 の「キャラ」射影。作成時必須・既存レコードは後方互換 optional）
  - admin ステータス画面（SCR-009）に「セーフティ横断レビュー」セクションを追加
  - CDK で GSI2 を増設
- **#3583 status 画面 500 の修正（dev 検証で発見）**
  - ECS タスクロールを `fromTableAttributes` + `globalIndexes` でインポートし、`grantReadWriteData` が `table/.../index/*` を付与するよう修正（GSI2 への `dynamodb:Query` AccessDenied で 500 になっていた）

dev 環境で `livetalk:admin` の `/status` に検出イベント（検出時刻・応答種別・キャラ表示名・検出パターン・ユーザー参照、PII 非表示）が降順表示されることを確認済み。

退会済みユーザーの SafetyEvent 匿名化（ADR-2.21）は別 Issue #3579 の領域。GSI2 は匿名化の有無に関わらず横断 Query できる。

## 関連 Issue

Closes #3580

（親の仕様検討 Issue #3532 は他の子 Issue が未完のため本 PR では閉じない）

## 変更種別

- [x] 新規機能
- [x] バグ修正
- [x] インフラ更新

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ 80% 以上。core/web/infra すべてグリーン）
- [ ] 関連ドキュメントを更新した（ADR-2.22/§3 は確定済み。射影属性の確定内容・ECS GSI grant の注意点の追従要否は develop 反映後に判断）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- core: safety-event 系の listRecent（降順・limit・100 件超回帰・CharacterID 含有・PII 非含有・0 件）、GSI2 属性書き込み検証
- infra: dynamodb-stack の GSI2（INCLUDE 射影）、ecs-service-stack の task role grant に `table/.../index/*` が含まれること
- Fast Verification（#3582 / #3583 とも全ジョブ green: lint/format/synth/build/docker/unit/E2E）

## レビューポイント

- GSI2 は sparse のため、デプロイ以降に検出されたイベントのみ一覧に載る（過去分はバックフィルしていない。ADR-2.22 の「最近の検出」用途として許容）。
- 射影は INCLUDE（メタデータのみ）。フル本文が必要な場合はベーステーブルの getById 経由。

## スクリーンショット（該当する場合）

dev の `/status` セーフティ横断レビューセクションに検出イベントが降順表示されることを確認済み（キャラは表示名解決、PII 非表示）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01AkamMPGvpwRXEgRknxPEzD)_