### PR TITLE
退会・データ削除: core 削除エンジン（Issue #3579 Phase 1）

### DIFF
--- a/services/livetalk/core/src/entities/account-deletion.entity.ts
+++ b/services/livetalk/core/src/entities/account-deletion.entity.ts
@@ -1,0 +1,15 @@
+/**
+ * アカウント削除結果型（退会・データ削除 / Issue #3579）。
+ *
+ * ADR-2.21 に従い、`PK = USER#<googleId>` 配下の全アイテムを削除するが、
+ * SafetyEvent（SK が `SAFETY#` で始まる）のみは匿名化して残す。
+ *
+ * @see docs/services/livetalk/architecture.md §2.21（ADR-2.21）
+ */
+
+export interface AccountDeletionResult {
+  /** 削除したアイテム数（SafetyEvent を除く全種別） */
+  deletedCount: number;
+  /** 匿名化した SafetyEvent の件数 */
+  anonymizedCount: number;
+}

--- a/services/livetalk/core/src/index.ts
+++ b/services/livetalk/core/src/index.ts
@@ -401,3 +401,12 @@ export {
   computeBucket,
   computeWindowTtlSec,
 } from './repositories/dynamodb-chat-guard.repository.js';
+
+// アカウント削除（退会・データ削除 / Issue #3579）
+export type { AccountDeletionResult } from './entities/account-deletion.entity.js';
+export type { AccountDeletionRepository } from './repositories/account-deletion.repository.interface.js';
+export {
+  DynamoDBAccountDeletionRepository,
+  ACCOUNT_DELETION_ERROR_MESSAGES,
+} from './repositories/dynamodb-account-deletion.repository.js';
+export { InMemoryAccountDeletionRepository } from './repositories/in-memory-account-deletion.repository.js';

--- a/services/livetalk/core/src/repositories/account-deletion.repository.interface.ts
+++ b/services/livetalk/core/src/repositories/account-deletion.repository.interface.ts
@@ -1,0 +1,24 @@
+/**
+ * アカウント削除リポジトリインターフェース（退会・データ削除 / Issue #3579）。
+ *
+ * ADR-2.21 の要件に従い、ユーザー PK 配下の全アイテムをハード削除し、
+ * SafetyEvent のみ匿名化して残す操作を提供する。
+ *
+ * @see docs/services/livetalk/architecture.md §2.21（ADR-2.21）
+ */
+
+import type { AccountDeletionResult } from '../entities/account-deletion.entity.js';
+
+export interface AccountDeletionRepository {
+  /**
+   * `PK = USER#<userId>` 配下の全アイテムを削除する。
+   *
+   * - SafetyEvent（SK が `SAFETY#` で始まる）は削除せず匿名化して残す。
+   * - 途中で失敗しても再実行で収束する（冪等）。
+   *
+   * @param userId - Google ID（`USER#` プレフィックスなし）
+   * @returns 削除件数・匿名化件数の集計結果
+   * @throws DatabaseError DynamoDB 操作が失敗した場合
+   */
+  deleteAccount(userId: string): Promise<AccountDeletionResult>;
+}

--- a/services/livetalk/core/src/repositories/dynamodb-account-deletion.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-account-deletion.repository.ts
@@ -19,11 +19,7 @@ import {
 import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
 import type { AccountDeletionResult } from '../entities/account-deletion.entity.js';
 import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
-import {
-  buildSafetyEventGSI2PK,
-  buildSafetyEventSKPrefix,
-  buildUserPK,
-} from '../mappers/keys.js';
+import { buildSafetyEventGSI2PK, buildSafetyEventSKPrefix, buildUserPK } from '../mappers/keys.js';
 import type { AccountDeletionRepository } from './account-deletion.repository.interface.js';
 
 /** エラーメッセージ定数 */
@@ -152,12 +148,13 @@ export class DynamoDBAccountDeletionRepository implements AccountDeletionReposit
     // 25 件ごとに分割してバッチ送信する
     for (let i = 0; i < items.length; i += BATCH_WRITE_MAX) {
       const chunk = items.slice(i, i + BATCH_WRITE_MAX);
-      let requestItems: Array<{ DeleteRequest: { Key: { PK: string; SK: string } } }> =
-        chunk.map((item) => ({
+      let requestItems: Array<{ DeleteRequest: { Key: { PK: string; SK: string } } }> = chunk.map(
+        (item) => ({
           DeleteRequest: {
             Key: { PK: String(item['PK']), SK: String(item['SK']) },
           },
-        }));
+        })
+      );
 
       let retries = 0;
       while (requestItems.length > 0) {
@@ -226,10 +223,7 @@ export class DynamoDBAccountDeletionRepository implements AccountDeletionReposit
    *
    * @returns 匿名化件数
    */
-  private async anonymizeSafetyEvents(
-    originalPk: string,
-    items: DynamoDBItem[]
-  ): Promise<number> {
+  private async anonymizeSafetyEvents(originalPk: string, items: DynamoDBItem[]): Promise<number> {
     if (items.length === 0) return 0;
 
     const now = this.nowMs();

--- a/services/livetalk/core/src/repositories/dynamodb-account-deletion.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-account-deletion.repository.ts
@@ -185,8 +185,11 @@ export class DynamoDBAccountDeletionRepository implements AccountDeletionReposit
         if (!unprocessed || unprocessed.length === 0) break;
 
         if (retries >= UNPROCESSED_MAX_RETRIES) {
-          // 最大リトライ後も残った件数は諦めてカウントしない
-          break;
+          // 不可逆な「データ削除」では未削除を残したまま成功扱いにしない。
+          // 残件があれば例外を投げ、呼び出し側で 500 を返して冪等再実行に委ねる。
+          throw new DatabaseError(
+            `${ACCOUNT_DELETION_ERROR_MESSAGES.バッチ削除失敗}: UnprocessedItems が最大リトライ回数（${UNPROCESSED_MAX_RETRIES}）後も残存しました（残 ${unprocessed.length} 件）`
+          );
         }
 
         // 指数バックオフ（50ms, 100ms, 200ms, 400ms）
@@ -212,8 +215,10 @@ export class DynamoDBAccountDeletionRepository implements AccountDeletionReposit
   /**
    * SafetyEvent アイテムを匿名化する。
    *
-   * この呼び出しで ULID を 1 つだけ発行し、全 SafetyEvent に同じ匿名トークンを付与する
-   * （同一ユーザーの検出をグルーピング可能にするため）。
+   * この呼び出しで ULID を 1 つだけ発行し、同一呼び出し内の全 SafetyEvent に同じ匿名トークンを
+   * 付与する（同一ユーザーの検出を可能な範囲でグルーピングするため）。トークンは不可逆なランダム値で、
+   * googleId に紐づかない（ADR-2.21「個人識別子を切り離す」を優先）。部分失敗後の再実行では
+   * 残件に別トークンが振られうる（グルーピングはベストエフォート）。
    *
    * 各アイテムは TransactWriteCommand で原子的に re-key する。
    * - Put: 新 PK（`USER#ANON#<ulid>`）に移動。UserID も匿名トークンに置換する。
@@ -242,8 +247,9 @@ export class DynamoDBAccountDeletionRepository implements AccountDeletionReposit
         UserID: anonToken,
         // GSI2 は維持する（匿名化後も横断 Query に残す）
         GSI2PK: buildSafetyEventGSI2PK(),
-        // GSI2SK は元の EventID を維持する
-        GSI2SK: item['GSI2SK'],
+        // GSI2SK は既存値を維持し、欠落時は EventID（= 定義上の GSI2SK 値）で補完する。
+        // #3580 以前の legacy item で GSI2SK が欠落していても確実に横断索引へ残す。
+        GSI2SK: item['GSI2SK'] ?? (item['EventID'] as string),
         UpdatedAt: now,
         AnonymizedAt: nowIso,
       };

--- a/services/livetalk/core/src/repositories/dynamodb-account-deletion.repository.ts
+++ b/services/livetalk/core/src/repositories/dynamodb-account-deletion.repository.ts
@@ -1,0 +1,282 @@
+/**
+ * アカウント削除リポジトリの DynamoDB 実装（退会・データ削除 / Issue #3579）。
+ *
+ * ADR-2.21 の要件:
+ * - `PK = USER#<userId>` 配下の全アイテムをページネーションで全件取得する。
+ * - SafetyEvent 以外: BatchWriteCommand（最大 25 件/バッチ）でハード削除する。
+ * - SafetyEvent: 匿名トークン（`ANON#<ulid>`）を 1 つ発行し、
+ *   TransactWriteCommand で 1 件ずつ原子的に re-key（旧 PK 削除 + 新 PK への Put）する。
+ *
+ * @see docs/services/livetalk/architecture.md §2.21（ADR-2.21）
+ */
+
+import {
+  BatchWriteCommand,
+  QueryCommand,
+  TransactWriteCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
+import { DatabaseError, type DynamoDBItem } from '@nagiyu/aws';
+import type { AccountDeletionResult } from '../entities/account-deletion.entity.js';
+import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+import {
+  buildSafetyEventGSI2PK,
+  buildSafetyEventSKPrefix,
+  buildUserPK,
+} from '../mappers/keys.js';
+import type { AccountDeletionRepository } from './account-deletion.repository.interface.js';
+
+/** エラーメッセージ定数 */
+export const ACCOUNT_DELETION_ERROR_MESSAGES = {
+  クエリ失敗: 'アカウント削除: ユーザーアイテムのクエリに失敗しました',
+  バッチ削除失敗: 'アカウント削除: バッチ削除に失敗しました',
+  再キー失敗: 'アカウント削除: SafetyEvent の匿名化（re-key）に失敗しました',
+} as const;
+
+/** BatchWriteCommand の最大アイテム数 */
+const BATCH_WRITE_MAX = 25;
+
+/** UnprocessedItems リトライの最大回数 */
+const UNPROCESSED_MAX_RETRIES = 4;
+
+/** UnprocessedItems リトライの初期待機時間（ms） */
+const UNPROCESSED_BASE_DELAY_MS = 50;
+
+/**
+ * 指定ミリ秒だけ待機するヘルパー。
+ * テストで差し替えやすいよう DI 可能にする。
+ */
+type SleepFn = (ms: number) => Promise<void>;
+const defaultSleep: SleepFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export class DynamoDBAccountDeletionRepository implements AccountDeletionRepository {
+  private readonly docClient: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly ulidFactory: UlidFactory;
+  private readonly nowMs: () => number;
+  private readonly sleep: SleepFn;
+
+  constructor(
+    docClient: DynamoDBDocumentClient,
+    tableName: string,
+    ulidFactory: UlidFactory = defaultUlidFactory,
+    nowMs: () => number = () => Date.now(),
+    sleep: SleepFn = defaultSleep
+  ) {
+    this.docClient = docClient;
+    this.tableName = tableName;
+    this.ulidFactory = ulidFactory;
+    this.nowMs = nowMs;
+    this.sleep = sleep;
+  }
+
+  public async deleteAccount(userId: string): Promise<AccountDeletionResult> {
+    const pk = buildUserPK(userId);
+    const safetyPrefix = buildSafetyEventSKPrefix();
+
+    // 1. PK 配下の全アイテムをページネーションで取得する
+    const allItems = await this.queryAll(pk);
+
+    // 2. SafetyEvent と それ以外に分割する
+    const safetyItems: DynamoDBItem[] = [];
+    const deleteItems: DynamoDBItem[] = [];
+
+    for (const item of allItems) {
+      const sk = String(item['SK'] ?? '');
+      if (sk.startsWith(safetyPrefix)) {
+        safetyItems.push(item);
+      } else {
+        deleteItems.push(item);
+      }
+    }
+
+    // 3. SafetyEvent 以外をバッチ削除する
+    const deletedCount = await this.batchDelete(deleteItems);
+
+    // 4. SafetyEvent を匿名化する（全イベントに同一トークンを付与）
+    const anonymizedCount = await this.anonymizeSafetyEvents(pk, safetyItems);
+
+    return { deletedCount, anonymizedCount };
+  }
+
+  /**
+   * PK 配下の全アイテムをページネーションで取得する。
+   * ExclusiveStartKey ループで全ページを集約する。
+   */
+  private async queryAll(pk: string): Promise<DynamoDBItem[]> {
+    const items: DynamoDBItem[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    for (;;) {
+      let result;
+      try {
+        result = await this.docClient.send(
+          new QueryCommand({
+            TableName: this.tableName,
+            KeyConditionExpression: '#pk = :pk',
+            ExpressionAttributeNames: { '#pk': 'PK' },
+            ExpressionAttributeValues: { ':pk': pk },
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(
+          `${ACCOUNT_DELETION_ERROR_MESSAGES.クエリ失敗}: ${message}`,
+          error instanceof Error ? error : undefined
+        );
+      }
+
+      for (const raw of result.Items ?? []) {
+        items.push(raw as unknown as DynamoDBItem);
+      }
+
+      if (!result.LastEvaluatedKey) break;
+      exclusiveStartKey = result.LastEvaluatedKey;
+    }
+
+    return items;
+  }
+
+  /**
+   * 対象アイテムを BatchWriteCommand で削除する。
+   * 25 件ごとにバッチを分割し、UnprocessedItems は指数バックオフでリトライする。
+   *
+   * @returns 削除件数（リトライ後の最終成功数）
+   */
+  private async batchDelete(items: DynamoDBItem[]): Promise<number> {
+    if (items.length === 0) return 0;
+
+    let deletedCount = 0;
+
+    // 25 件ごとに分割してバッチ送信する
+    for (let i = 0; i < items.length; i += BATCH_WRITE_MAX) {
+      const chunk = items.slice(i, i + BATCH_WRITE_MAX);
+      let requestItems: Array<{ DeleteRequest: { Key: { PK: string; SK: string } } }> =
+        chunk.map((item) => ({
+          DeleteRequest: {
+            Key: { PK: String(item['PK']), SK: String(item['SK']) },
+          },
+        }));
+
+      let retries = 0;
+      while (requestItems.length > 0) {
+        let result;
+        try {
+          result = await this.docClient.send(
+            new BatchWriteCommand({
+              RequestItems: {
+                [this.tableName]: requestItems,
+              },
+            })
+          );
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new DatabaseError(
+            `${ACCOUNT_DELETION_ERROR_MESSAGES.バッチ削除失敗}: ${message}`,
+            error instanceof Error ? error : undefined
+          );
+        }
+
+        const unprocessed = result.UnprocessedItems?.[this.tableName];
+        const processedCount = requestItems.length - (unprocessed?.length ?? 0);
+        deletedCount += processedCount;
+
+        if (!unprocessed || unprocessed.length === 0) break;
+
+        if (retries >= UNPROCESSED_MAX_RETRIES) {
+          // 最大リトライ後も残った件数は諦めてカウントしない
+          break;
+        }
+
+        // 指数バックオフ（50ms, 100ms, 200ms, 400ms）
+        await this.sleep(UNPROCESSED_BASE_DELAY_MS * Math.pow(2, retries));
+        retries++;
+
+        requestItems = unprocessed
+          .filter((r) => r.DeleteRequest !== undefined)
+          .map((r) => ({
+            DeleteRequest: {
+              Key: {
+                PK: String((r.DeleteRequest?.Key as Record<string, unknown>)?.['PK'] ?? ''),
+                SK: String((r.DeleteRequest?.Key as Record<string, unknown>)?.['SK'] ?? ''),
+              },
+            },
+          }));
+      }
+    }
+
+    return deletedCount;
+  }
+
+  /**
+   * SafetyEvent アイテムを匿名化する。
+   *
+   * この呼び出しで ULID を 1 つだけ発行し、全 SafetyEvent に同じ匿名トークンを付与する
+   * （同一ユーザーの検出をグルーピング可能にするため）。
+   *
+   * 各アイテムは TransactWriteCommand で原子的に re-key する。
+   * - Put: 新 PK（`USER#ANON#<ulid>`）に移動。UserID も匿名トークンに置換する。
+   * - Delete: 旧 PK（`USER#<userId>`）から削除する。
+   *
+   * @returns 匿名化件数
+   */
+  private async anonymizeSafetyEvents(
+    originalPk: string,
+    items: DynamoDBItem[]
+  ): Promise<number> {
+    if (items.length === 0) return 0;
+
+    const now = this.nowMs();
+    const anonToken = `ANON#${this.ulidFactory(now)}`;
+    const newPk = buildUserPK(anonToken);
+    const nowIso = new Date(now).toISOString();
+
+    let anonymizedCount = 0;
+
+    for (const item of items) {
+      const newItem: DynamoDBItem = {
+        ...item,
+        PK: newPk,
+        // UserID を匿名トークンに置換する（mapper が非空文字列でバリデートするため空にできない）
+        UserID: anonToken,
+        // GSI2 は維持する（匿名化後も横断 Query に残す）
+        GSI2PK: buildSafetyEventGSI2PK(),
+        // GSI2SK は元の EventID を維持する
+        GSI2SK: item['GSI2SK'],
+        UpdatedAt: now,
+        AnonymizedAt: nowIso,
+      };
+
+      try {
+        await this.docClient.send(
+          new TransactWriteCommand({
+            TransactItems: [
+              {
+                Put: {
+                  TableName: this.tableName,
+                  Item: newItem,
+                },
+              },
+              {
+                Delete: {
+                  TableName: this.tableName,
+                  Key: { PK: originalPk, SK: item['SK'] },
+                },
+              },
+            ],
+          })
+        );
+        anonymizedCount++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new DatabaseError(
+          `${ACCOUNT_DELETION_ERROR_MESSAGES.再キー失敗}: ${message}`,
+          error instanceof Error ? error : undefined
+        );
+      }
+    }
+
+    return anonymizedCount;
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-account-deletion.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-account-deletion.repository.ts
@@ -16,11 +16,7 @@
 import { InMemorySingleTableStore, type DynamoDBItem } from '@nagiyu/aws';
 import type { AccountDeletionResult } from '../entities/account-deletion.entity.js';
 import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
-import {
-  buildSafetyEventGSI2PK,
-  buildSafetyEventSKPrefix,
-  buildUserPK,
-} from '../mappers/keys.js';
+import { buildSafetyEventGSI2PK, buildSafetyEventSKPrefix, buildUserPK } from '../mappers/keys.js';
 import type { AccountDeletionRepository } from './account-deletion.repository.interface.js';
 
 export class InMemoryAccountDeletionRepository implements AccountDeletionRepository {
@@ -78,10 +74,7 @@ export class InMemoryAccountDeletionRepository implements AccountDeletionReposit
     let cursor: string | undefined;
 
     do {
-      const result = this.store.query(
-        { pk },
-        cursor ? { cursor } : undefined
-      );
+      const result = this.store.query({ pk }, cursor ? { cursor } : undefined);
       items.push(...result.items);
       cursor = result.nextCursor;
     } while (cursor !== undefined);

--- a/services/livetalk/core/src/repositories/in-memory-account-deletion.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-account-deletion.repository.ts
@@ -1,0 +1,131 @@
+/**
+ * アカウント削除リポジトリの InMemory 実装（退会・データ削除 / Issue #3579）。
+ *
+ * DynamoDB 実装と同一セマンティクスで動作する。
+ * USE_IN_MEMORY_DB の E2E / ユニットテスト環境で使用する。
+ *
+ * ADR-2.21 の要件:
+ * - `PK = USER#<userId>` 配下の全アイテムをカーソルで全件取得する。
+ * - SafetyEvent 以外: `store.delete(pk, sk)` でハード削除する。
+ * - SafetyEvent: 匿名トークン（`ANON#<ulid>`）を 1 つ発行し、
+ *   `store.put(新item)` + `store.delete(旧pk, 旧sk)` で re-key する。
+ *
+ * @see docs/services/livetalk/architecture.md §2.21（ADR-2.21）
+ */
+
+import { InMemorySingleTableStore, type DynamoDBItem } from '@nagiyu/aws';
+import type { AccountDeletionResult } from '../entities/account-deletion.entity.js';
+import { defaultUlidFactory, type UlidFactory } from '../lib/ulid.js';
+import {
+  buildSafetyEventGSI2PK,
+  buildSafetyEventSKPrefix,
+  buildUserPK,
+} from '../mappers/keys.js';
+import type { AccountDeletionRepository } from './account-deletion.repository.interface.js';
+
+export class InMemoryAccountDeletionRepository implements AccountDeletionRepository {
+  private readonly store: InMemorySingleTableStore;
+  private readonly ulidFactory: UlidFactory;
+  private readonly nowMs: () => number;
+
+  constructor(
+    store: InMemorySingleTableStore,
+    ulidFactory: UlidFactory = defaultUlidFactory,
+    nowMs: () => number = () => Date.now()
+  ) {
+    this.store = store;
+    this.ulidFactory = ulidFactory;
+    this.nowMs = nowMs;
+  }
+
+  public async deleteAccount(userId: string): Promise<AccountDeletionResult> {
+    const pk = buildUserPK(userId);
+    const safetyPrefix = buildSafetyEventSKPrefix();
+
+    // 1. PK 配下の全アイテムをカーソルループで全件取得する
+    const allItems = await this.queryAll(pk);
+
+    // 2. SafetyEvent と それ以外に分割する
+    const safetyItems: DynamoDBItem[] = [];
+    const deleteItems: DynamoDBItem[] = [];
+
+    for (const item of allItems) {
+      const sk = String(item['SK'] ?? '');
+      if (sk.startsWith(safetyPrefix)) {
+        safetyItems.push(item);
+      } else {
+        deleteItems.push(item);
+      }
+    }
+
+    // 3. SafetyEvent 以外をハード削除する
+    for (const item of deleteItems) {
+      this.store.delete(String(item['PK']), String(item['SK']));
+    }
+    const deletedCount = deleteItems.length;
+
+    // 4. SafetyEvent を匿名化する（全イベントに同一トークンを付与）
+    const anonymizedCount = this.anonymizeSafetyEvents(pk, safetyItems);
+
+    return { deletedCount, anonymizedCount };
+  }
+
+  /**
+   * PK 配下の全アイテムをカーソルループで取得する。
+   */
+  private async queryAll(pk: string): Promise<DynamoDBItem[]> {
+    const items: DynamoDBItem[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const result = this.store.query(
+        { pk },
+        cursor ? { cursor } : undefined
+      );
+      items.push(...result.items);
+      cursor = result.nextCursor;
+    } while (cursor !== undefined);
+
+    return items;
+  }
+
+  /**
+   * SafetyEvent アイテムを匿名化する。
+   *
+   * この呼び出しで ULID を 1 つだけ発行し、全 SafetyEvent に同じ匿名トークンを付与する
+   * （同一ユーザーの検出をグルーピング可能にするため）。
+   *
+   * 各アイテムは `store.put(新item)` + `store.delete(旧pk, 旧sk)` で re-key する。
+   *
+   * @returns 匿名化件数
+   */
+  private anonymizeSafetyEvents(originalPk: string, items: DynamoDBItem[]): number {
+    if (items.length === 0) return 0;
+
+    const now = this.nowMs();
+    const anonToken = `ANON#${this.ulidFactory(now)}`;
+    const newPk = buildUserPK(anonToken);
+    const nowIso = new Date(now).toISOString();
+
+    for (const item of items) {
+      const newItem: DynamoDBItem = {
+        ...item,
+        PK: newPk,
+        // UserID を匿名トークンに置換する（mapper が非空文字列でバリデートするため空にできない）
+        UserID: anonToken,
+        // GSI2 は維持する（匿名化後も横断 Query に残す）
+        GSI2PK: buildSafetyEventGSI2PK(),
+        // GSI2SK は元の EventID を維持する
+        GSI2SK: item['GSI2SK'],
+        UpdatedAt: now,
+        AnonymizedAt: nowIso,
+      };
+
+      // 原子的に re-key（InMemory は単スレッドなので順序保証される）
+      this.store.put(newItem);
+      this.store.delete(originalPk, String(item['SK']));
+    }
+
+    return items.length;
+  }
+}

--- a/services/livetalk/core/src/repositories/in-memory-account-deletion.repository.ts
+++ b/services/livetalk/core/src/repositories/in-memory-account-deletion.repository.ts
@@ -92,8 +92,10 @@ export class InMemoryAccountDeletionRepository implements AccountDeletionReposit
   /**
    * SafetyEvent アイテムを匿名化する。
    *
-   * この呼び出しで ULID を 1 つだけ発行し、全 SafetyEvent に同じ匿名トークンを付与する
-   * （同一ユーザーの検出をグルーピング可能にするため）。
+   * この呼び出しで ULID を 1 つだけ発行し、同一呼び出し内の全 SafetyEvent に同じ匿名トークンを
+   * 付与する（同一ユーザーの検出を可能な範囲でグルーピングするため）。トークンは不可逆なランダム値で、
+   * googleId に紐づかない（ADR-2.21「個人識別子を切り離す」を優先）。部分失敗後の再実行では
+   * 残件に別トークンが振られうる（グルーピングはベストエフォート）。
    *
    * 各アイテムは `store.put(新item)` + `store.delete(旧pk, 旧sk)` で re-key する。
    *
@@ -115,8 +117,9 @@ export class InMemoryAccountDeletionRepository implements AccountDeletionReposit
         UserID: anonToken,
         // GSI2 は維持する（匿名化後も横断 Query に残す）
         GSI2PK: buildSafetyEventGSI2PK(),
-        // GSI2SK は元の EventID を維持する
-        GSI2SK: item['GSI2SK'],
+        // GSI2SK は既存値を維持し、欠落時は EventID（= 定義上の GSI2SK 値）で補完する。
+        // #3580 以前の legacy item で GSI2SK が欠落していても確実に横断索引へ残す。
+        GSI2SK: item['GSI2SK'] ?? (item['EventID'] as string),
         UpdatedAt: now,
         AnonymizedAt: nowIso,
       };

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-account-deletion.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-account-deletion.repository.test.ts
@@ -1,0 +1,492 @@
+/**
+ * DynamoDBAccountDeletionRepository のユニットテスト（退会・データ削除 / Issue #3579）。
+ *
+ * DynamoDB クライアントをモックし、アカウント削除の全ロジックを検証する。
+ *
+ * テスト観点:
+ * (a) Query のページネーション（ExclusiveStartKey ループで全件取得する）
+ * (b) 非 SafetyEvent の BatchWrite 削除（25件/バッチ）
+ * (c) SafetyEvent の TransactWrite による re-key＋匿名化
+ *     - UserID が anonToken に置換される
+ *     - PK が `USER#ANON#…` に変わる
+ *     - GSI2PK / GSI2SK が維持される
+ *     - InputText / ResponseText / EventID が保持される
+ *     - AnonymizedAt が付与される
+ * (d) UnprocessedItems リトライ（指数バックオフ）
+ * (e) 何も無い PK での冪等（書き込み 0）
+ * (f) DatabaseError ラップ（クエリ失敗・バッチ削除失敗・re-key 失敗）
+ * (g) 結果カウント（deletedCount / anonymizedCount）
+ */
+
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import {
+  DynamoDBAccountDeletionRepository,
+  ACCOUNT_DELETION_ERROR_MESSAGES,
+} from '../../../src/repositories/dynamodb-account-deletion.repository.js';
+
+const TABLE = 'nagiyu-livetalk-test';
+const FIXED_NOW = 1_700_000_000_000;
+const FIXED_ULID = 'TESTULIDVALUE01234567890';
+const ANON_TOKEN = `ANON#${FIXED_ULID}`;
+const USER_ID = 'google-user-001';
+
+/** noopのsleep（テストでは待機しない） */
+const noopSleep = () => Promise.resolve();
+
+function makeDocClient(mockSend: jest.Mock) {
+  return { send: mockSend } as unknown as DynamoDBDocumentClient;
+}
+
+function makeRepo(
+  mockSend: jest.Mock,
+  opts?: { ulidFactory?: () => string; nowMs?: () => number }
+) {
+  return new DynamoDBAccountDeletionRepository(
+    makeDocClient(mockSend),
+    TABLE,
+    opts?.ulidFactory ?? (() => FIXED_ULID),
+    opts?.nowMs ?? (() => FIXED_NOW),
+    noopSleep
+  );
+}
+
+/** 典型的な非 SafetyEvent アイテム */
+function makeProfileItem(userId: string) {
+  return {
+    PK: `USER#${userId}`,
+    SK: 'PROFILE',
+    Type: 'Profile',
+    UserID: userId,
+    DisplayName: 'テストユーザー',
+    CreatedAt: FIXED_NOW,
+    UpdatedAt: FIXED_NOW,
+  };
+}
+
+/** 典型的な SafetyEvent アイテム */
+function makeSafetyItem(userId: string, eventId: string) {
+  return {
+    PK: `USER#${userId}`,
+    SK: `SAFETY#${eventId}`,
+    Type: 'SafetyEvent',
+    UserID: userId,
+    EventID: eventId,
+    CharacterID: 'hiyori',
+    Trigger: 'input_keyword',
+    DetectedPattern: '[自殺念慮] 死にたい',
+    InputText: '死にたい',
+    ResponseText: '心配してるよ',
+    GSI2PK: 'SAFETY',
+    GSI2SK: eventId,
+    CreatedAt: FIXED_NOW,
+    UpdatedAt: FIXED_NOW,
+  };
+}
+
+describe('DynamoDBAccountDeletionRepository', () => {
+  describe('デフォルト引数の動作', () => {
+    it('ulidFactory / nowMs / sleep をデフォルト値で生成できる', () => {
+      const mockSend = jest.fn();
+      const repo = new DynamoDBAccountDeletionRepository(makeDocClient(mockSend), TABLE);
+      expect(repo).toBeInstanceOf(DynamoDBAccountDeletionRepository);
+    });
+  });
+
+  describe('(e) 空の PK の冪等動作', () => {
+    it('アイテムが 0 件のとき書き込みなしで { deletedCount: 0, anonymizedCount: 0 } を返す', async () => {
+      const mockSend = jest
+        .fn()
+        // Query: 0件
+        .mockResolvedValueOnce({ Items: [] });
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result).toEqual({ deletedCount: 0, anonymizedCount: 0 });
+      // Query 1 回のみ（BatchWrite / TransactWrite は呼ばれない）
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('Items が undefined でも 0件として扱う', async () => {
+      const mockSend = jest.fn().mockResolvedValueOnce({});
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+      expect(result).toEqual({ deletedCount: 0, anonymizedCount: 0 });
+    });
+  });
+
+  describe('(a) Query のページネーション', () => {
+    it('LastEvaluatedKey がある場合に複数ページを取得する', async () => {
+      const profile = makeProfileItem(USER_ID);
+      const safetyItem = makeSafetyItem(USER_ID, 'EVT001');
+
+      const mockSend = jest
+        .fn()
+        // ページ 1: LastEvaluatedKey あり
+        .mockResolvedValueOnce({
+          Items: [profile],
+          LastEvaluatedKey: { PK: profile.PK, SK: profile.SK },
+        })
+        // ページ 2: LastEvaluatedKey なし（最終ページ）
+        .mockResolvedValueOnce({ Items: [safetyItem] })
+        // BatchWrite（profile 削除）
+        .mockResolvedValueOnce({ UnprocessedItems: {} })
+        // TransactWrite（SafetyEvent re-key）
+        .mockResolvedValueOnce({});
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      // Query が 2 回呼ばれていること
+      const queryCalls = mockSend.mock.calls.filter((call) =>
+        call[0]?.constructor?.name?.includes('QueryCommand')
+      );
+      expect(queryCalls.length).toBe(2);
+      // 2 回目のクエリに ExclusiveStartKey が設定されていること
+      expect(queryCalls[1][0].input.ExclusiveStartKey).toEqual({
+        PK: profile.PK,
+        SK: profile.SK,
+      });
+
+      expect(result.deletedCount).toBe(1);
+      expect(result.anonymizedCount).toBe(1);
+    });
+  });
+
+  describe('(b) 非 SafetyEvent の BatchWrite 削除', () => {
+    it('非 SafetyEvent アイテムを BatchWriteCommand で削除する', async () => {
+      const profile = makeProfileItem(USER_ID);
+
+      const mockSend = jest
+        .fn()
+        // Query
+        .mockResolvedValueOnce({ Items: [profile] })
+        // BatchWrite
+        .mockResolvedValueOnce({ UnprocessedItems: {} });
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.deletedCount).toBe(1);
+      expect(result.anonymizedCount).toBe(0);
+
+      // BatchWrite コマンドの内容を検証
+      const batchCall = mockSend.mock.calls[1];
+      const batchInput = batchCall[0].input;
+      expect(batchInput.RequestItems[TABLE]).toHaveLength(1);
+      expect(batchInput.RequestItems[TABLE][0].DeleteRequest.Key).toEqual({
+        PK: `USER#${USER_ID}`,
+        SK: 'PROFILE',
+      });
+    });
+
+    it('25件を超えるアイテムを複数バッチに分割して削除する', async () => {
+      // 26件の非SafetyEventアイテムを用意する
+      const items = Array.from({ length: 26 }, (_, i) => ({
+        PK: `USER#${USER_ID}`,
+        SK: `CHAR#hiyori#MSG#MSG${String(i).padStart(3, '0')}`,
+        Type: 'Message',
+        UserID: USER_ID,
+      }));
+
+      const mockSend = jest
+        .fn()
+        // Query（1ページ）
+        .mockResolvedValueOnce({ Items: items })
+        // BatchWrite 1回目（25件）
+        .mockResolvedValueOnce({ UnprocessedItems: {} })
+        // BatchWrite 2回目（1件）
+        .mockResolvedValueOnce({ UnprocessedItems: {} });
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.deletedCount).toBe(26);
+      // BatchWrite が 2 回呼ばれていること
+      const batchCalls = mockSend.mock.calls.slice(1);
+      expect(batchCalls.length).toBe(2);
+      expect(batchCalls[0][0].input.RequestItems[TABLE].length).toBe(25);
+      expect(batchCalls[1][0].input.RequestItems[TABLE].length).toBe(1);
+    });
+  });
+
+  describe('(c) SafetyEvent の TransactWrite による re-key＋匿名化', () => {
+    it('SafetyEvent を匿名化して re-key する', async () => {
+      const eventId = 'EVT001';
+      const safetyItem = makeSafetyItem(USER_ID, eventId);
+
+      const mockSend = jest
+        .fn()
+        // Query
+        .mockResolvedValueOnce({ Items: [safetyItem] })
+        // TransactWrite
+        .mockResolvedValueOnce({});
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.deletedCount).toBe(0);
+      expect(result.anonymizedCount).toBe(1);
+
+      // TransactWrite の内容を検証
+      const transactCall = mockSend.mock.calls[1];
+      const transactInput = transactCall[0].input;
+      const transactItems = transactInput.TransactItems;
+
+      expect(transactItems).toHaveLength(2);
+
+      // Put: 新 PK（USER#ANON#<ulid>）
+      const putItem = transactItems[0].Put.Item;
+      expect(putItem.PK).toBe(`USER#${ANON_TOKEN}`);
+      expect(putItem.SK).toBe(`SAFETY#${eventId}`);
+      expect(putItem.UserID).toBe(ANON_TOKEN);
+      // GSI2PK / GSI2SK が維持される
+      expect(putItem.GSI2PK).toBe('SAFETY');
+      expect(putItem.GSI2SK).toBe(eventId);
+      // InputText / ResponseText が保持される（証跡）
+      expect(putItem.InputText).toBe('死にたい');
+      expect(putItem.ResponseText).toBe('心配してるよ');
+      // EventID が保持される
+      expect(putItem.EventID).toBe(eventId);
+      // Type が維持される
+      expect(putItem.Type).toBe('SafetyEvent');
+      // AnonymizedAt が付与される
+      expect(putItem.AnonymizedAt).toBe(new Date(FIXED_NOW).toISOString());
+      // UpdatedAt が更新される
+      expect(putItem.UpdatedAt).toBe(FIXED_NOW);
+      // 元の googleId が含まれないこと
+      expect(putItem.PK).not.toContain(USER_ID);
+      expect(putItem.UserID).not.toBe(USER_ID);
+
+      // Delete: 旧 PK（USER#<userId>）
+      const deleteKey = transactItems[1].Delete.Key;
+      expect(deleteKey.PK).toBe(`USER#${USER_ID}`);
+      expect(deleteKey.SK).toBe(`SAFETY#${eventId}`);
+    });
+
+    it('複数の SafetyEvent に同じ匿名トークンを付与する', async () => {
+      const safetyItems = [
+        makeSafetyItem(USER_ID, 'EVT001'),
+        makeSafetyItem(USER_ID, 'EVT002'),
+        makeSafetyItem(USER_ID, 'EVT003'),
+      ];
+
+      const mockSend = jest
+        .fn()
+        // Query
+        .mockResolvedValueOnce({ Items: safetyItems })
+        // TransactWrite × 3
+        .mockResolvedValue({});
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.anonymizedCount).toBe(3);
+
+      // 全 TransactWrite で同じ匿名トークンを使用していること
+      const transactCalls = mockSend.mock.calls.slice(1);
+      expect(transactCalls.length).toBe(3);
+      const anonTokens = transactCalls.map(
+        (call) => call[0].input.TransactItems[0].Put.Item.UserID
+      );
+      // 全て同じトークン
+      expect(new Set(anonTokens).size).toBe(1);
+      expect(anonTokens[0]).toBe(ANON_TOKEN);
+    });
+
+    it('SafetyEvent の CharacterID が保持される', async () => {
+      const safetyItem = makeSafetyItem(USER_ID, 'EVT001');
+
+      const mockSend = jest
+        .fn()
+        .mockResolvedValueOnce({ Items: [safetyItem] })
+        .mockResolvedValueOnce({});
+
+      const repo = makeRepo(mockSend);
+      await repo.deleteAccount(USER_ID);
+
+      const putItem = mockSend.mock.calls[1][0].input.TransactItems[0].Put.Item;
+      expect(putItem.CharacterID).toBe('hiyori');
+    });
+  });
+
+  describe('(d) UnprocessedItems リトライ', () => {
+    it('UnprocessedItems が返った場合にリトライして削除する', async () => {
+      const profile = makeProfileItem(USER_ID);
+
+      const deleteRequest = {
+        DeleteRequest: { Key: { PK: profile.PK, SK: profile.SK } },
+      };
+
+      const mockSend = jest
+        .fn()
+        // Query
+        .mockResolvedValueOnce({ Items: [profile] })
+        // BatchWrite 1回目: UnprocessedItems あり
+        .mockResolvedValueOnce({
+          UnprocessedItems: { [TABLE]: [deleteRequest] },
+        })
+        // BatchWrite 2回目（リトライ）: 成功
+        .mockResolvedValueOnce({ UnprocessedItems: {} });
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      // Query 1 回 + BatchWrite 2 回
+      expect(mockSend).toHaveBeenCalledTimes(3);
+      // 最初の BatchWrite で 0 件処理（全て Unprocessed）、リトライで 1 件処理
+      expect(result.deletedCount).toBe(1);
+    });
+
+    it('最大リトライ（4回）を超えた場合は残りをカウントしない', async () => {
+      const profile = makeProfileItem(USER_ID);
+
+      const deleteRequest = {
+        DeleteRequest: { Key: { PK: profile.PK, SK: profile.SK } },
+      };
+
+      const mockSend = jest
+        .fn()
+        // Query
+        .mockResolvedValueOnce({ Items: [profile] })
+        // BatchWrite 1回目〜5回目（最大リトライ超過）: 全て Unprocessed
+        .mockResolvedValue({ UnprocessedItems: { [TABLE]: [deleteRequest] } });
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      // Query 1 回 + BatchWrite（1 + 4 リトライ）= 6 回
+      expect(mockSend).toHaveBeenCalledTimes(6);
+      // 全て Unprocessed のため deletedCount = 0
+      expect(result.deletedCount).toBe(0);
+    });
+  });
+
+  describe('(f) DatabaseError ラップ', () => {
+    it('Query 失敗 → DatabaseError（クエリ失敗メッセージ）', async () => {
+      const mockSend = jest.fn().mockRejectedValue(new Error('DB down'));
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.deleteAccount(USER_ID)).rejects.toMatchObject({
+        name: 'DatabaseError',
+        message: expect.stringContaining(ACCOUNT_DELETION_ERROR_MESSAGES.クエリ失敗),
+      });
+    });
+
+    it('Query 失敗: Error 以外の例外も DatabaseError に変換する', async () => {
+      const mockSend = jest.fn().mockRejectedValue('文字列エラー');
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.deleteAccount(USER_ID)).rejects.toMatchObject({
+        name: 'DatabaseError',
+      });
+    });
+
+    it('BatchWrite 失敗 → DatabaseError（バッチ削除失敗メッセージ）', async () => {
+      const profile = makeProfileItem(USER_ID);
+
+      const mockSend = jest
+        .fn()
+        // Query: 成功
+        .mockResolvedValueOnce({ Items: [profile] })
+        // BatchWrite: 失敗
+        .mockRejectedValueOnce(new Error('BatchWrite failed'));
+
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.deleteAccount(USER_ID)).rejects.toMatchObject({
+        name: 'DatabaseError',
+        message: expect.stringContaining(ACCOUNT_DELETION_ERROR_MESSAGES.バッチ削除失敗),
+      });
+    });
+
+    it('BatchWrite 失敗: Error 以外の例外も DatabaseError に変換する', async () => {
+      const profile = makeProfileItem(USER_ID);
+
+      const mockSend = jest
+        .fn()
+        .mockResolvedValueOnce({ Items: [profile] })
+        .mockRejectedValueOnce(42);
+
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.deleteAccount(USER_ID)).rejects.toMatchObject({
+        name: 'DatabaseError',
+      });
+    });
+
+    it('TransactWrite 失敗 → DatabaseError（再キー失敗メッセージ）', async () => {
+      const safetyItem = makeSafetyItem(USER_ID, 'EVT001');
+
+      const mockSend = jest
+        .fn()
+        // Query: 成功
+        .mockResolvedValueOnce({ Items: [safetyItem] })
+        // TransactWrite: 失敗
+        .mockRejectedValueOnce(new Error('TransactWrite failed'));
+
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.deleteAccount(USER_ID)).rejects.toMatchObject({
+        name: 'DatabaseError',
+        message: expect.stringContaining(ACCOUNT_DELETION_ERROR_MESSAGES.再キー失敗),
+      });
+    });
+
+    it('TransactWrite 失敗: Error 以外の例外も DatabaseError に変換する', async () => {
+      const safetyItem = makeSafetyItem(USER_ID, 'EVT001');
+
+      const mockSend = jest
+        .fn()
+        .mockResolvedValueOnce({ Items: [safetyItem] })
+        .mockRejectedValueOnce('non-error');
+
+      const repo = makeRepo(mockSend);
+
+      await expect(repo.deleteAccount(USER_ID)).rejects.toMatchObject({
+        name: 'DatabaseError',
+      });
+    });
+  });
+
+  describe('(g) 結果カウント', () => {
+    it('混在アイテムの削除・匿名化カウントが正しい', async () => {
+      const items = [
+        makeProfileItem(USER_ID),
+        { PK: `USER#${USER_ID}`, SK: 'CHAR#hiyori#MSG#001', Type: 'Message', UserID: USER_ID },
+        makeSafetyItem(USER_ID, 'EVT001'),
+        makeSafetyItem(USER_ID, 'EVT002'),
+      ];
+
+      const mockSend = jest
+        .fn()
+        // Query
+        .mockResolvedValueOnce({ Items: items })
+        // BatchWrite（2件の非SafetyEvent）
+        .mockResolvedValueOnce({ UnprocessedItems: {} })
+        // TransactWrite × 2（SafetyEvent）
+        .mockResolvedValue({});
+
+      const repo = makeRepo(mockSend);
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.deletedCount).toBe(2);
+      expect(result.anonymizedCount).toBe(2);
+    });
+  });
+
+  describe('Query の KeyConditionExpression 検証', () => {
+    it('KeyConditionExpression に #pk = :pk を使用する', async () => {
+      const mockSend = jest.fn().mockResolvedValueOnce({ Items: [] });
+      const repo = makeRepo(mockSend);
+
+      await repo.deleteAccount(USER_ID);
+
+      const queryInput = mockSend.mock.calls[0][0].input;
+      expect(queryInput.KeyConditionExpression).toBe('#pk = :pk');
+      expect(queryInput.ExpressionAttributeNames).toEqual({ '#pk': 'PK' });
+      expect(queryInput.ExpressionAttributeValues).toEqual({ ':pk': `USER#${USER_ID}` });
+      expect(queryInput.TableName).toBe(TABLE);
+    });
+  });
+});

--- a/services/livetalk/core/tests/unit/repositories/dynamodb-account-deletion.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/dynamodb-account-deletion.repository.test.ts
@@ -308,6 +308,27 @@ describe('DynamoDBAccountDeletionRepository', () => {
       const putItem = mockSend.mock.calls[1][0].input.TransactItems[0].Put.Item;
       expect(putItem.CharacterID).toBe('hiyori');
     });
+
+    it('GSI2SK 欠落の legacy SafetyEvent でも EventID で GSI2SK を補完する', async () => {
+      const eventId = 'EVT_LEGACY';
+      // #3580 以前に作られ GSI2PK / GSI2SK を持たない legacy item
+      const legacyItem = makeSafetyItem(USER_ID, eventId);
+      delete (legacyItem as Record<string, unknown>).GSI2PK;
+      delete (legacyItem as Record<string, unknown>).GSI2SK;
+
+      const mockSend = jest
+        .fn()
+        .mockResolvedValueOnce({ Items: [legacyItem] })
+        .mockResolvedValueOnce({});
+
+      const repo = makeRepo(mockSend);
+      await repo.deleteAccount(USER_ID);
+
+      const putItem = mockSend.mock.calls[1][0].input.TransactItems[0].Put.Item;
+      // GSI2PK は付与、GSI2SK は EventID で補完され横断索引に確実に残る
+      expect(putItem.GSI2PK).toBe('SAFETY');
+      expect(putItem.GSI2SK).toBe(eventId);
+    });
   });
 
   describe('(d) UnprocessedItems リトライ', () => {
@@ -338,7 +359,7 @@ describe('DynamoDBAccountDeletionRepository', () => {
       expect(result.deletedCount).toBe(1);
     });
 
-    it('最大リトライ（4回）を超えた場合は残りをカウントしない', async () => {
+    it('最大リトライ（4回）を超えても残存する場合は DatabaseError を投げる', async () => {
       const profile = makeProfileItem(USER_ID);
 
       const deleteRequest = {
@@ -353,12 +374,15 @@ describe('DynamoDBAccountDeletionRepository', () => {
         .mockResolvedValue({ UnprocessedItems: { [TABLE]: [deleteRequest] } });
 
       const repo = makeRepo(mockSend);
-      const result = await repo.deleteAccount(USER_ID);
+
+      // 不可逆な削除では未削除を残したまま成功扱いにせず例外を投げる
+      await expect(repo.deleteAccount(USER_ID)).rejects.toMatchObject({
+        name: 'DatabaseError',
+        message: expect.stringContaining(ACCOUNT_DELETION_ERROR_MESSAGES.バッチ削除失敗),
+      });
 
       // Query 1 回 + BatchWrite（1 + 4 リトライ）= 6 回
       expect(mockSend).toHaveBeenCalledTimes(6);
-      // 全て Unprocessed のため deletedCount = 0
-      expect(result.deletedCount).toBe(0);
     });
   });
 

--- a/services/livetalk/core/tests/unit/repositories/in-memory-account-deletion.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-account-deletion.repository.test.ts
@@ -87,9 +87,7 @@ function seedSafetyEvent(
     GSI2SK: eventId,
     CreatedAt: FIXED_NOW,
     UpdatedAt: FIXED_NOW,
-    ...(opts?.moderationCategories
-      ? { ModerationCategories: opts.moderationCategories }
-      : {}),
+    ...(opts?.moderationCategories ? { ModerationCategories: opts.moderationCategories } : {}),
   });
 }
 

--- a/services/livetalk/core/tests/unit/repositories/in-memory-account-deletion.repository.test.ts
+++ b/services/livetalk/core/tests/unit/repositories/in-memory-account-deletion.repository.test.ts
@@ -1,0 +1,386 @@
+/**
+ * InMemoryAccountDeletionRepository のユニットテスト（退会・データ削除 / Issue #3579）。
+ *
+ * ユーザーの混在アイテム（Profile / Message / Memory / Note 等）と SafetyEvent を seed し、
+ * deleteAccount 後の状態が仕様通りかを検証する。
+ *
+ * テスト観点:
+ * - 非 SafetyEvent（Profile / Message 等）が削除される
+ * - SafetyEvent が `USER#ANON#…` PK へ移動される
+ * - 移動後の SafetyEvent に同一匿名トークンが付与される
+ * - UserID が匿名トークンに置換される（googleId を含まない）
+ * - InputText / ResponseText / EventID / CharacterID が保持される（証跡）
+ * - GSI2PK が維持される（横断 Query に残る）
+ * - GSI2SK（EventID）が維持される
+ * - AnonymizedAt / UpdatedAt が付与される
+ * - 複数 SafetyEvent に同一匿名トークンが付与される
+ * - deletedCount / anonymizedCount のカウント
+ * - 空 PK での冪等（0件）
+ * - SafetyEvent のみの場合（バッチ削除が呼ばれない）
+ * - 100件超でもカーソルループで全件処理する
+ */
+
+import { InMemorySingleTableStore } from '@nagiyu/aws';
+import { InMemoryAccountDeletionRepository } from '../../../src/repositories/in-memory-account-deletion.repository.js';
+
+const FIXED_NOW = 1_700_000_000_000;
+const FIXED_ULID = 'TESTULIDVALUE01234567890';
+const ANON_TOKEN = `ANON#${FIXED_ULID}`;
+const USER_ID = 'google-user-001';
+const USER_PK = `USER#${USER_ID}`;
+
+function makeRepo(store = new InMemorySingleTableStore()) {
+  const repo = new InMemoryAccountDeletionRepository(
+    store,
+    () => FIXED_ULID,
+    () => FIXED_NOW
+  );
+  return { repo, store };
+}
+
+/** 典型的な Profile アイテム（非 SafetyEvent） */
+function seedProfile(store: InMemorySingleTableStore, userId: string) {
+  store.put({
+    PK: `USER#${userId}`,
+    SK: 'PROFILE',
+    Type: 'Profile',
+    UserID: userId,
+    DisplayName: 'テストユーザー',
+    CreatedAt: FIXED_NOW,
+    UpdatedAt: FIXED_NOW,
+  });
+}
+
+/** 典型的な Message アイテム（非 SafetyEvent） */
+function seedMessage(store: InMemorySingleTableStore, userId: string, msgId: string) {
+  store.put({
+    PK: `USER#${userId}`,
+    SK: `CHAR#hiyori#MSG#${msgId}`,
+    Type: 'Message',
+    UserID: userId,
+    MessageID: msgId,
+    Text: 'テストメッセージ',
+    CreatedAt: FIXED_NOW,
+    UpdatedAt: FIXED_NOW,
+  });
+}
+
+/** SafetyEvent アイテム */
+function seedSafetyEvent(
+  store: InMemorySingleTableStore,
+  userId: string,
+  eventId: string,
+  opts?: { characterId?: string; moderationCategories?: string }
+) {
+  store.put({
+    PK: `USER#${userId}`,
+    SK: `SAFETY#${eventId}`,
+    Type: 'SafetyEvent',
+    UserID: userId,
+    EventID: eventId,
+    CharacterID: opts?.characterId ?? 'hiyori',
+    Trigger: 'input_keyword',
+    DetectedPattern: '[自殺念慮] 死にたい',
+    InputText: '死にたい',
+    ResponseText: '心配してるよ',
+    GSI2PK: 'SAFETY',
+    GSI2SK: eventId,
+    CreatedAt: FIXED_NOW,
+    UpdatedAt: FIXED_NOW,
+    ...(opts?.moderationCategories
+      ? { ModerationCategories: opts.moderationCategories }
+      : {}),
+  });
+}
+
+describe('InMemoryAccountDeletionRepository', () => {
+  describe('空の PK の冪等動作', () => {
+    it('アイテムが 0 件のとき { deletedCount: 0, anonymizedCount: 0 } を返す', async () => {
+      const { repo } = makeRepo();
+      const result = await repo.deleteAccount(USER_ID);
+      expect(result).toEqual({ deletedCount: 0, anonymizedCount: 0 });
+    });
+  });
+
+  describe('非 SafetyEvent の削除', () => {
+    it('Profile と Message が削除される', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedProfile(store, USER_ID);
+      seedMessage(store, USER_ID, 'MSG001');
+
+      expect(store.get(USER_PK, 'PROFILE')).toBeDefined();
+      expect(store.get(USER_PK, 'CHAR#hiyori#MSG#MSG001')).toBeDefined();
+
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.deletedCount).toBe(2);
+      expect(result.anonymizedCount).toBe(0);
+      // 削除されていること
+      expect(store.get(USER_PK, 'PROFILE')).toBeUndefined();
+      expect(store.get(USER_PK, 'CHAR#hiyori#MSG#MSG001')).toBeUndefined();
+    });
+
+    it('SafetyEvent のみの場合（非SafetyEvent の削除は 0件）', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.deletedCount).toBe(0);
+      expect(result.anonymizedCount).toBe(1);
+      // 元の PK に SafetyEvent が残っていないこと
+      expect(store.get(USER_PK, 'SAFETY#EVT001')).toBeUndefined();
+      // 匿名化された新 PK に移動していること
+      const newPk = `USER#${ANON_TOKEN}`;
+      expect(store.get(newPk, 'SAFETY#EVT001')).toBeDefined();
+    });
+  });
+
+  describe('SafetyEvent の匿名化と re-key', () => {
+    it('SafetyEvent が USER#ANON#<ulid> PK へ移動する', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem).toBeDefined();
+      expect(movedItem!.PK).toBe(newPk);
+      expect(movedItem!.SK).toBe('SAFETY#EVT001');
+    });
+
+    it('UserID が匿名トークンに置換される（googleId を含まない）', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem!.UserID).toBe(ANON_TOKEN);
+      expect(String(movedItem!.UserID)).not.toContain(USER_ID);
+    });
+
+    it('InputText / ResponseText / EventID が保持される（証跡）', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem!.InputText).toBe('死にたい');
+      expect(movedItem!.ResponseText).toBe('心配してるよ');
+      expect(movedItem!.EventID).toBe('EVT001');
+    });
+
+    it('CharacterID が保持される', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001', { characterId: 'ageha' });
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem!.CharacterID).toBe('ageha');
+    });
+
+    it('ModerationCategories が保持される', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001', {
+        moderationCategories: '{"self-harm": true}',
+      });
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem!.ModerationCategories).toBe('{"self-harm": true}');
+    });
+
+    it('GSI2PK が維持される（横断 Query に残る）', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem!.GSI2PK).toBe('SAFETY');
+    });
+
+    it('GSI2SK（EventID）が維持される', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem!.GSI2SK).toBe('EVT001');
+    });
+
+    it('AnonymizedAt と UpdatedAt が付与される', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem!.AnonymizedAt).toBe(new Date(FIXED_NOW).toISOString());
+      expect(movedItem!.UpdatedAt).toBe(FIXED_NOW);
+    });
+
+    it('Type が SafetyEvent のまま維持される', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const movedItem = store.get(newPk, 'SAFETY#EVT001');
+      expect(movedItem!.Type).toBe('SafetyEvent');
+    });
+
+    it('複数の SafetyEvent に同じ匿名トークンが付与される', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+      seedSafetyEvent(store, USER_ID, 'EVT002');
+      seedSafetyEvent(store, USER_ID, 'EVT003');
+
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.anonymizedCount).toBe(3);
+
+      const newPk = `USER#${ANON_TOKEN}`;
+      const item1 = store.get(newPk, 'SAFETY#EVT001');
+      const item2 = store.get(newPk, 'SAFETY#EVT002');
+      const item3 = store.get(newPk, 'SAFETY#EVT003');
+
+      expect(item1).toBeDefined();
+      expect(item2).toBeDefined();
+      expect(item3).toBeDefined();
+      // 全て同じ匿名トークン
+      expect(item1!.UserID).toBe(ANON_TOKEN);
+      expect(item2!.UserID).toBe(ANON_TOKEN);
+      expect(item3!.UserID).toBe(ANON_TOKEN);
+    });
+
+    it('元の PK から SafetyEvent が削除される', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      // 元の PK にアイテムが残っていないこと
+      expect(store.get(USER_PK, 'SAFETY#EVT001')).toBeUndefined();
+    });
+  });
+
+  describe('混在アイテムの統合テスト', () => {
+    it('Profile + Message + SafetyEvent × 2 の混在シナリオ', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      seedProfile(store, USER_ID);
+      seedMessage(store, USER_ID, 'MSG001');
+      seedMessage(store, USER_ID, 'MSG002');
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+      seedSafetyEvent(store, USER_ID, 'EVT002');
+
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.deletedCount).toBe(3); // Profile + Message × 2
+      expect(result.anonymizedCount).toBe(2); // SafetyEvent × 2
+
+      // 非 SafetyEvent が削除されていること
+      expect(store.get(USER_PK, 'PROFILE')).toBeUndefined();
+      expect(store.get(USER_PK, 'CHAR#hiyori#MSG#MSG001')).toBeUndefined();
+      expect(store.get(USER_PK, 'CHAR#hiyori#MSG#MSG002')).toBeUndefined();
+
+      // SafetyEvent が新 PK に移動していること
+      const newPk = `USER#${ANON_TOKEN}`;
+      expect(store.get(newPk, 'SAFETY#EVT001')).toBeDefined();
+      expect(store.get(newPk, 'SAFETY#EVT002')).toBeDefined();
+    });
+
+    it('別ユーザーのデータは影響を受けない', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      // 対象ユーザー
+      seedProfile(store, USER_ID);
+      seedSafetyEvent(store, USER_ID, 'EVT001');
+
+      // 別ユーザー
+      const otherUserId = 'google-other-user';
+      seedProfile(store, otherUserId);
+      seedSafetyEvent(store, otherUserId, 'OTHER_EVT001');
+
+      await repo.deleteAccount(USER_ID);
+
+      // 別ユーザーのデータが残っていること
+      const otherPk = `USER#${otherUserId}`;
+      expect(store.get(otherPk, 'PROFILE')).toBeDefined();
+      expect(store.get(otherPk, 'SAFETY#OTHER_EVT001')).toBeDefined();
+    });
+  });
+
+  describe('カーソルループ（100件超）', () => {
+    it('100件超の非 SafetyEvent を全件削除する', async () => {
+      const store = new InMemorySingleTableStore();
+      const { repo } = makeRepo(store);
+
+      // 110件の Message アイテムを seed する
+      const total = 110;
+      for (let i = 0; i < total; i++) {
+        store.put({
+          PK: USER_PK,
+          SK: `CHAR#hiyori#MSG#${String(i).padStart(4, '0')}`,
+          Type: 'Message',
+          UserID: USER_ID,
+          CreatedAt: FIXED_NOW,
+          UpdatedAt: FIXED_NOW,
+        });
+      }
+
+      // 初期状態の確認
+      expect(store.size()).toBe(total);
+
+      const result = await repo.deleteAccount(USER_ID);
+
+      expect(result.deletedCount).toBe(total);
+      expect(result.anonymizedCount).toBe(0);
+      // 全件削除されていること
+      expect(store.size()).toBe(0);
+    });
+  });
+});

--- a/services/livetalk/web/src/lib/server/repositories.ts
+++ b/services/livetalk/web/src/lib/server/repositories.ts
@@ -14,6 +14,7 @@ import {
   getTableName,
 } from '@nagiyu/aws';
 import type {
+  AccountDeletionRepository,
   CharacterStateRepository,
   ChatGuardRepository,
   InterestRepository,
@@ -29,6 +30,7 @@ import type {
   StudyTopicRepository,
 } from '@nagiyu/livetalk-core';
 import {
+  DynamoDBAccountDeletionRepository,
   DynamoDBChatGuardRepository,
   DynamoDBCharacterStateRepository,
   DynamoDBInterestRepository,
@@ -42,6 +44,7 @@ import {
   DynamoDBProfileRepository,
   DynamoDBPushSubscriptionRepository,
   DynamoDBStudyTopicRepository,
+  InMemoryAccountDeletionRepository,
   InMemoryChatGuardRepository,
   InMemoryCharacterStateRepository,
   InMemoryInterestRepository,
@@ -59,6 +62,7 @@ import {
 
 const registry = registerDynamoRepositories<
   {
+    accountDeletion: AccountDeletionRepository;
     memory: MemoryRepository;
     memorySummary: MemorySummaryRepository;
     message: MessageRepository;
@@ -75,6 +79,11 @@ const registry = registerDynamoRepositories<
   InMemorySingleTableStore
 >(
   {
+    accountDeletion: {
+      createInMemoryRepository: (store) => new InMemoryAccountDeletionRepository(store),
+      createDynamoDBRepository: ({ docClient, tableName }) =>
+        new DynamoDBAccountDeletionRepository(docClient, tableName),
+    },
     memory: {
       createInMemoryRepository: (store) => new InMemoryMemoryRepository(store),
       createDynamoDBRepository: ({ docClient, tableName }) =>
@@ -141,6 +150,10 @@ const registry = registerDynamoRepositories<
     createSharedStore: () => new InMemorySingleTableStore(),
   }
 );
+
+export function getAccountDeletionRepository(): AccountDeletionRepository {
+  return registry.accountDeletion.createRepository();
+}
 
 export function getMemoryRepository(): MemoryRepository {
   return registry.memory.createRepository();


### PR DESCRIPTION
## 変更の概要

livetalk「退会・データ削除」（忘れてもらう権利 / Issue #3579）の **Phase 1: core 削除エンジン**を実装。

`@nagiyu/livetalk-core` に `AccountDeletionRepository` を追加し、`deleteAccount(userId)` で以下を行う（ADR-2.21）:

- `PK=USER#<googleId>` 配下の全 item をページネーションで取得（生 item レベルで扱い、将来の item 種別追加にも自動追従）
- **SafetyEvent（SK が `SAFETY#` で始まる）以外**を `BatchWriteItem`（25件/バッチ、UnprocessedItems を指数バックオフでリトライ）で即時ハード削除
- **SafetyEvent のみ匿名化して残す**：退会1回につき不可逆なランダム匿名トークン `ANON#<ulid>` を1つ発行し、各イベントを `TransactWrite([Put 新, Delete 旧])` で原子的に re-key
  - `PK` → `USER#ANON#<ulid>`、`UserID` → 匿名トークン（googleId を PK・属性双方から除去）
  - `InputText`/`ResponseText` は開発者防御の証跡として保持（ADR-2.21）
  - `GSI2PK='SAFETY'`/`GSI2SK=EventID` を維持し、匿名化後も #3580 の横断レビュー（admin 画面）に残す
- 冪等：途中失敗しても再実行で収束（移動済み SafetyEvent は旧 PK に居ないため二重移動しない）

DynamoDB 実装と InMemory 実装（`USE_IN_MEMORY_DB` の E2E 用）を同一セマンティクスで提供し、web 層の repository factory に配線（`getAccountDeletionRepository()`）。**インフラ変更なし**（GSI2 は #3580 で導入済み）。

## 関連 Issue

Issue #3579（Phase 1）。※ 作業ブランチ → integration の PR のため `Closes` は付けない。

## 変更種別

- [x] 新規機能

## 実装チェックリスト

- [x] コーディング規約に従って実装した（エラーメッセージ日本語+定数化 / libs 相対 ESM import / strict）
- [x] テストを追加・更新した（カバレッジ80%以上）
- [x] ローカルでテストが全て通ることを確認した（core: 83 suites / 1310 tests PASS、typecheck・build PASS）
- [x] ビルドエラーがないことを確認した

## テスト内容

- DynamoDB 実装（22+1 件）: Query ページネーション / 25件超のバッチ分割 / re-key＋匿名化（UserID 置換・PK 再キー・GSI2 維持・本文保持・AnonymizedAt 付与・googleId 非含有）/ 同一トークン共有 / UnprocessedItems リトライ / **リトライ上限残存で DatabaseError** / **GSI2SK 欠落 legacy item の EventID 補完** / 空 PK 冪等 / DatabaseError ラップ
- InMemory 実装（14 件）: 100件超カーソルループ / 別ユーザー非干渉 / 各保持属性検証 / カウント検証

## レビューポイント

- fresh-eyes レビュー（Opus）を実施済み。指摘対応として、(1) BatchWrite リトライ上限後に残件があれば**例外を投げる**（不可逆削除で未削除を成功扱いにしない）、(2) GSI2SK 欠落の legacy item は **EventID で補完**して横断索引から脱落させない、(3) 匿名トークンは**プライバシー優先のランダム値**（決定論導出＝擬似匿名化は採らない）とし、グルーピングは同一呼び出し内ベストエフォートである旨をコメント明確化。
- 匿名化レコードが admin 横断レビュー（#3580）に正しく出るかは Phase 2/3 完了後に dev で end-to-end 検証予定。

## 補足事項

後続: Phase 2（`DELETE /api/account`）→ Phase 3（SCR-011 UI）。本 PR は integration/3579-account-deletion 向け。


---
_Generated by [Claude Code](https://claude.ai/code/session_01E9P47aRt2xHqpYGFKxW4wo)_