### PR TITLE
退会・データ削除: DELETE /api/account（Issue #3579 Phase 2）

### DIFF
--- a/services/livetalk/web/src/app/api/account/constants.ts
+++ b/services/livetalk/web/src/app/api/account/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * アカウント API（`/api/account`）のエラーメッセージ定数（日本語）。
+ */
+export const ACCOUNT_ERROR_MESSAGES = {
+  DELETE_FAILED: 'アカウントの削除に失敗しました',
+} as const;

--- a/services/livetalk/web/src/app/api/account/route.ts
+++ b/services/livetalk/web/src/app/api/account/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { withAuth } from '@nagiyu/nextjs';
+import { getSession } from '@/lib/server/session';
+import { getAccountDeletionRepository } from '@/lib/server/repositories';
+import { ACCOUNT_ERROR_MESSAGES } from './constants';
+
+/**
+ * DELETE /api/account
+ *
+ * 退会処理。セッションユーザー自身の livetalk データを即時ハード削除する。
+ * SafetyEvent（自傷検出ログ）のみ匿名化して保持する（ADR-2.21）。
+ *
+ * - リクエストボディは不要（本人確認は Phase 3 の UI で担保）。
+ * - userId はセッションから取得するため、本人以外のデータは削除されない。
+ * - レスポンスには削除件数・匿名化件数を含めない（SafetyEvent の存在を本人に示すのは不適切）。
+ */
+export const DELETE = withAuth(getSession, 'livetalk:chat', async (session) => {
+  const userId = session.user.googleId;
+
+  try {
+    const result = await getAccountDeletionRepository().deleteAccount(userId);
+    console.log('[DELETE /api/account] アカウントを削除しました', {
+      deletedCount: result.deletedCount,
+      anonymizedCount: result.anonymizedCount,
+    });
+    return NextResponse.json({ deleted: true });
+  } catch (error) {
+    console.error('[DELETE /api/account] アカウントの削除に失敗しました', error);
+    return NextResponse.json(
+      { error: 'DELETE_FAILED', message: ACCOUNT_ERROR_MESSAGES.DELETE_FAILED },
+      { status: 500 }
+    );
+  }
+});

--- a/services/livetalk/web/tests/unit/app/api/account/route.test.ts
+++ b/services/livetalk/web/tests/unit/app/api/account/route.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+import { DELETE } from '@/app/api/account/route';
+import { getSession } from '@/lib/server/session';
+import { getAccountDeletionRepository } from '@/lib/server/repositories';
+import type { AccountDeletionRepository } from '@nagiyu/livetalk-core';
+import { ACCOUNT_ERROR_MESSAGES } from '@/app/api/account/constants';
+
+jest.mock('@/lib/server/session', () => ({ getSession: jest.fn() }));
+jest.mock('@/lib/server/repositories', () => ({ getAccountDeletionRepository: jest.fn() }));
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetRepo = getAccountDeletionRepository as jest.MockedFunction<
+  typeof getAccountDeletionRepository
+>;
+
+const session = {
+  user: {
+    userId: 'u1',
+    googleId: 'g1',
+    email: 'u@example.com',
+    name: 'テストユーザー',
+    roles: ['livetalk-user'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  expires: new Date(Date.now() + 60_000).toISOString(),
+};
+
+const makeRepo = (over: Partial<AccountDeletionRepository> = {}): AccountDeletionRepository =>
+  ({
+    deleteAccount: jest.fn(async () => ({ deletedCount: 5, anonymizedCount: 1 })),
+    ...over,
+  }) as unknown as AccountDeletionRepository;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DELETE /api/account', () => {
+  it('未認証は 401 を返す', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await DELETE(new Request('http://localhost'));
+    expect(res.status).toBe(401);
+  });
+
+  it('正常系: 200 かつ { deleted: true } を返す', async () => {
+    mockGetSession.mockResolvedValueOnce(session);
+    const repo = makeRepo();
+    mockGetRepo.mockReturnValue(repo);
+
+    const res = await DELETE(new Request('http://localhost'));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ deleted: true });
+  });
+
+  it('正常系: deleteAccount が session.user.googleId で呼ばれる', async () => {
+    mockGetSession.mockResolvedValueOnce(session);
+    const repo = makeRepo();
+    mockGetRepo.mockReturnValue(repo);
+
+    await DELETE(new Request('http://localhost'));
+
+    expect(repo.deleteAccount).toHaveBeenCalledWith('g1');
+    expect(repo.deleteAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('正常系: レスポンスに anonymizedCount / deletedCount を含まない', async () => {
+    mockGetSession.mockResolvedValueOnce(session);
+    mockGetRepo.mockReturnValue(makeRepo());
+
+    const res = await DELETE(new Request('http://localhost'));
+    const json = await res.json();
+
+    expect(json).not.toHaveProperty('anonymizedCount');
+    expect(json).not.toHaveProperty('deletedCount');
+  });
+
+  it('deleteAccount が throw した場合は 500 かつエラーレスポンスを返す', async () => {
+    mockGetSession.mockResolvedValueOnce(session);
+    const repo = makeRepo({
+      deleteAccount: jest.fn(async () => {
+        throw new Error('DynamoDB エラー');
+      }),
+    });
+    mockGetRepo.mockReturnValue(repo);
+
+    const res = await DELETE(new Request('http://localhost'));
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json).toEqual({
+      error: 'DELETE_FAILED',
+      message: ACCOUNT_ERROR_MESSAGES.DELETE_FAILED,
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

livetalk「退会・データ削除」（Issue #3579）の **Phase 2: 退会 API**。

`DELETE /api/account` を追加。Phase 1 の core 削除エンジン（`getAccountDeletionRepository().deleteAccount(userId)`）を呼び出す薄い API 層:

- `withAuth(getSession, 'livetalk:chat')` で本人のみ。**userId はセッション（`session.user.googleId`）から取得**するため、呼び出せても本人のデータしか削除されない。
- 成功時は `{ deleted: true }` のみ返す。**削除件数・匿名化件数（= SafetyEvent 件数）はレスポンスに含めない**（自傷検出ログの存在を本人に示すのは不適切）。件数はサーバ側の運用ログにのみ出力（PII・userId は出さない）。
- 失敗時は 500 ＋ 日本語定数メッセージ（`ACCOUNT_ERROR_MESSAGES.DELETE_FAILED`）。
- リクエストボディは不要（誤操作防止の確認は Phase 3 の UI で担保）。

## 関連 Issue

Issue #3579（Phase 2）。※ 作業ブランチ → integration の PR のため `Closes` は付けない。

## 変更種別

- [x] 新規機能

## 実装チェックリスト

- [x] コーディング規約に従って実装した（エラーメッセージ日本語+定数化 / withAuth パターン踏襲）
- [x] テストを追加・更新した（401 / 正常系 `{ deleted: true }`・googleId で呼ばれる・counts 非露出 / 500）
- [x] ローカルでテストが全て通ることを確認した（web: 69 suites / 708 tests PASS、account 5 件、eslint・prettier clean）
- [x] ビルドエラーがないことを確認した

## テスト内容

- 未認証（session=null）→ 401
- 正常系 → 200 `{ deleted: true }`、`deleteAccount(session.user.googleId)` が呼ばれること、レスポンスに `deletedCount`/`anonymizedCount` が**含まれない**こと
- `deleteAccount` が throw → 500 `{ error: 'DELETE_FAILED', message }`

## レビューポイント

- レスポンスから件数を意図的に除外している点（プライバシー配慮）。
- 確認 UI は後続 Phase 3（SCR-011）。本 API 単体では確認なしで削除を実行する（本人のセッション必須・自分のデータ限定なので安全）。

## 補足事項

後続: Phase 3（SCR-011 退会モーダル UI）。本 PR は integration/3579-account-deletion 向け。


---
_Generated by [Claude Code](https://claude.ai/code/session_01E9P47aRt2xHqpYGFKxW4wo)_