### PR TITLE
chore: 依存バージョンの不整合を統一（Issue #3463 Priority 2）

### DIFF
--- a/infra/common/package.json
+++ b/infra/common/package.json
@@ -26,6 +26,6 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.9.1"
+    "@types/node": "^24"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,8 +123,25 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.9.1"
+        "@types/node": "^24"
       }
+    },
+    "infra/common/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "infra/common/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "infra/livetalk": {
       "name": "@nagiyu/infra-livetalk",
@@ -150,16 +167,6 @@
         "aws-cdk-lib": "^2.258.0",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21"
-      }
-    },
-    "infra/node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "infra/node_modules/source-map": {
@@ -19028,13 +19035,6 @@
         "node": ">=20.18.1"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -20034,7 +20034,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "jest": "^30.4.2",
+        "jest": "^30.3.0",
         "ts-jest": "^29.4.11"
       }
     },
@@ -20053,7 +20053,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "jest": "^30.4.2",
+        "jest": "^30.3.0",
         "ts-jest": "^29.4.11"
       }
     },
@@ -20070,7 +20070,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "jest-environment-jsdom": "^30.4.1",
+        "jest-environment-jsdom": "^30.3.0",
         "pixi-live2d-display-lipsyncpatch": "0.5.0-ls-8",
         "pixi.js": "^7.4.3",
         "react-markdown": "^10.1.0",
@@ -20197,6 +20197,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1063.0",
         "@nagiyu/aws": "*",
         "@nagiyu/nextjs": "*",
+        "@nagiyu/quick-clip-core": "*",
         "@nagiyu/ui": "*"
       }
     },

--- a/services/livetalk/batch/package.json
+++ b/services/livetalk/batch/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "jest": "^30.4.2",
+    "jest": "^30.3.0",
     "ts-jest": "^29.4.11"
   }
 }

--- a/services/livetalk/core/package.json
+++ b/services/livetalk/core/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "jest": "^30.4.2",
+    "jest": "^30.3.0",
     "ts-jest": "^29.4.11"
   }
 }

--- a/services/livetalk/web/package.json
+++ b/services/livetalk/web/package.json
@@ -27,7 +27,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "jest-environment-jsdom": "^30.4.1",
+    "jest-environment-jsdom": "^30.3.0",
     "pixi-live2d-display-lipsyncpatch": "0.5.0-ls-8",
     "pixi.js": "^7.4.3",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## 変更の概要

Issue #3463（週次 npm 管理レポート 2026-W23）の **Priority 2: バージョン不整合** のうち、現時点で実在する不整合を統一する。宣言レンジの統一のみで、`@types/node` 以外は実インストール版に変更はない。

- `infra/common`: `@types/node` を `^25.9.1` → `^24` に統一（root 基準。唯一 `^25` に drift していた外れ値を解消。インストール版は major 24 に一本化）
- `services/livetalk/batch`・`services/livetalk/core`: `jest` を `^30.4.2` → `^30.3.0` に統一（root 基準）
- `services/livetalk/web`: `jest-environment-jsdom` を `^30.4.1` → `^30.3.0` に統一（root 基準）

レポートが挙げていた `ts-jest`（`^29.4.9`↔`^29.4.11`）と `@types/jest` は、レポート生成（6/8）以降に develop 側で既に統一済みのため対象外。

## 関連 Issue

Issue #3463（親 Issue は全 Priority の対応見届け後にクローズ。本 PR では自動クローズしない）

## 変更種別

- [x] その他（依存バージョンの不整合統一 / 保守）

## 実装前チェックリスト

- [x] [コーディング規約・べからず集](../docs/development/rules.md) を確認した
- [x] [アーキテクチャガイドライン](../docs/development/architecture.md) を確認した
- [x] [開発方針](../docs/README.md) を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [ ] テストを追加・更新した（バージョンレンジ統一のみのためテスト追加なし）
- [ ] 関連ドキュメントを更新した（コードから読み取れる情報のため不要）
- [ ] CI/CD 設定を追加・更新した（不要）
- [x] ローカルでテストが全て通ることを確認した（後述）
- [x] ビルドエラーがないことを確認した

## テスト内容

- `npm install` で lockfile が整合（差分は package-lock.json 43 行のみ）
- `npm ls @types/node --all`: ツリー上の `@types/node` が major 24 に一本化（`@types/node@25` の残存ゼロ）
- `npm run build -w @nagiyu/infra-common`（tsc）成功 ← `@types/node` を 25→24 にした唯一の解決変更の検証
- `jest` / `jest-environment-jsdom` は宣言レンジ統一のみで実インストール版（30.4.x）に変更なし → テスト挙動は不変

## レビューポイント

- `@types/node` を root 基準の `^24` に寄せた点（`infra/common` のみ `^25` に drift していたため。逆方向＝全体を `^25` に上げる選択もあったが、root と多数のワークスペースが `^24` を継承しており churn 最小の方向を採用）
- lockfile は最小差分に留めるため `npm dedupe`（広域の重複解消）は適用していない（root 24.13.1 / infra/common 24.13.2 の patch 共存は許容範囲）

## 補足事項

本 PR は Issue #3463 の **Priority 2 のみ**。**Priority 1（セキュリティ）は本 PR の対象外**で、判断を Issue にコメント済み（要約: 実測で High 10 + Moderate 4 だが全て esbuild/storybook/vite・next の transitive で、非破壊修正が存在せず npm の提案は破壊的ダウングレードのみ。dev/ビルドツール経由で本番ランタイム非該当のため今回は見送り）。Priority 3 は develop に概ね吸収済みのため対象外。


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9XMXn1RW3wE4vagTA4BNZ)_