### PR TITLE
退会・データ削除: 退会モーダル UI（SCR-011 / Issue #3579 Phase 3）

### DIFF
--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -10,6 +10,7 @@ import ResponseDisplay from '@/components/ResponseDisplay';
 import CharacterCanvas from '@/components/CharacterCanvas';
 import ConsentModal from '@/components/ConsentModal';
 import SafetyModal from '@/components/SafetyModal';
+import AccountDeletionModal from '@/components/AccountDeletionModal';
 import NotificationToggle from '@/components/NotificationToggle';
 import InstallGuide from '@/components/InstallGuide';
 import NotificationPermission from '@/components/NotificationPermission';
@@ -25,6 +26,7 @@ import { usePendingNotifications } from '@/lib/home/usePendingNotifications';
 import { useLifecycle } from '@/lib/home/useLifecycle';
 import { useCharacterQuerySync } from '@/lib/home/useCharacterQuerySync';
 import { useChatStream } from '@/lib/home/useChatStream';
+import { useAccountDeletion } from '@/lib/account/useAccountDeletion';
 import type { ChatPhase } from '@/lib/home/types';
 
 /**
@@ -71,6 +73,10 @@ function HomePageInner() {
 
   // 同意状態管理 hook
   const { consentPhase, markConsented } = useConsent();
+
+  // 退会・データ削除 hook
+  const { loading: deletionLoading, error: deletionError, requestDeletion } = useAccountDeletion();
+  const [deletionModalOpen, setDeletionModalOpen] = useState(false);
 
   // オンボーディング管理 hook（consentPhase 依存）
   const {
@@ -124,6 +130,13 @@ function HomePageInner() {
     <>
       <ConsentModal open={consentPhase === 'required'} onConsented={markConsented} />
       <SafetyModal open={safetyOpen} resources={safetyResources} onClose={closeSafety} />
+      <AccountDeletionModal
+        open={deletionModalOpen}
+        loading={deletionLoading}
+        error={deletionError}
+        onConfirm={requestDeletion}
+        onCancel={() => setDeletionModalOpen(false)}
+      />
       <Container
         maxWidth="sm"
         sx={{
@@ -210,6 +223,16 @@ function HomePageInner() {
             <Link href="/memory">私が覚えていること</Link>
             <Link href="/notes">ノート</Link>
             {isAdmin && <Link href="/status">ステータス</Link>}
+            {/* 利用規約・プライバシー導線の近くに退会入口を配置する（SCR-011） */}
+            <Link asChild>
+              <button
+                type="button"
+                onClick={() => setDeletionModalOpen(true)}
+                data-testid="open-deletion-modal"
+              >
+                退会・データ削除
+              </button>
+            </Link>
           </Box>
           <NotificationToggle />
         </Stack>

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Suspense, useCallback, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { Box, Container, Stack, Typography } from '@mui/material';
 import { Link } from '@nagiyu/ui';
@@ -75,8 +75,19 @@ function HomePageInner() {
   const { consentPhase, markConsented } = useConsent();
 
   // 退会・データ削除 hook
-  const { loading: deletionLoading, error: deletionError, requestDeletion } = useAccountDeletion();
+  const {
+    loading: deletionLoading,
+    error: deletionError,
+    requestDeletion,
+    clearError: clearDeletionError,
+  } = useAccountDeletion();
   const [deletionModalOpen, setDeletionModalOpen] = useState(false);
+
+  // 退会モーダルを開く（前回の残留エラーをクリアしてから開く）
+  const openDeletionModal = useCallback(() => {
+    clearDeletionError();
+    setDeletionModalOpen(true);
+  }, [clearDeletionError]);
 
   // オンボーディング管理 hook（consentPhase 依存）
   const {
@@ -223,13 +234,10 @@ function HomePageInner() {
             <Link href="/memory">私が覚えていること</Link>
             <Link href="/notes">ノート</Link>
             {isAdmin && <Link href="/status">ステータス</Link>}
-            {/* 利用規約・プライバシー導線の近くに退会入口を配置する（SCR-011） */}
+            {/* チャット画面フッターの補助リンク群に退会入口を配置する。
+                利用規約・プライバシーポリシー導線は下部の ServiceLayout 共有フッターに表示される（SCR-011）。 */}
             <Link asChild>
-              <button
-                type="button"
-                onClick={() => setDeletionModalOpen(true)}
-                data-testid="open-deletion-modal"
-              >
+              <button type="button" onClick={openDeletionModal} data-testid="open-deletion-modal">
                 退会・データ削除
               </button>
             </Link>

--- a/services/livetalk/web/src/components/AccountDeletionModal.tsx
+++ b/services/livetalk/web/src/components/AccountDeletionModal.tsx
@@ -49,8 +49,14 @@ export default function AccountDeletionModal({
   };
 
   return (
-    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
-      <DialogTitle>退会・データ削除</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={handleCancel}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="account-deletion-modal-title"
+    >
+      <DialogTitle id="account-deletion-modal-title">退会・データ削除</DialogTitle>
       <DialogContent>
         <DialogContentText sx={{ mb: 2 }}>
           退会すると、以下のデータがすべて削除されます。この操作は取り消せません。
@@ -70,7 +76,6 @@ export default function AccountDeletionModal({
           checked={confirmed}
           onChange={(e) => setConfirmed(e.target.checked)}
           disabled={loading}
-          data-testid="deletion-confirm-checkbox"
           label="削除範囲を理解し、復元できないことに同意します"
         />
         {error && (

--- a/services/livetalk/web/src/components/AccountDeletionModal.tsx
+++ b/services/livetalk/web/src/components/AccountDeletionModal.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Alert,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+import { Button, Checkbox } from '@nagiyu/ui';
+
+export interface AccountDeletionModalProps {
+  /** モーダルの開閉状態 */
+  open: boolean;
+  /** 退会処理中かどうか（ローディング状態） */
+  loading: boolean;
+  /** エラーメッセージ（null の場合は非表示） */
+  error: string | null;
+  /** 退会ボタンを押したときのコールバック */
+  onConfirm: () => void;
+  /** キャンセルボタンを押したときのコールバック */
+  onCancel: () => void;
+}
+
+/**
+ * 退会・データ削除の確認モーダル（presentational コンポーネント）。
+ *
+ * - 削除範囲の説明を明示する
+ * - セーフティログの匿名化保持について注記する
+ * - 確認チェックボックスにチェックするまで退会ボタンを無効化する
+ * - loading 中は退会・キャンセル両ボタンを disabled にする
+ */
+export default function AccountDeletionModal({
+  open,
+  loading,
+  error,
+  onConfirm,
+  onCancel,
+}: AccountDeletionModalProps) {
+  const [confirmed, setConfirmed] = useState(false);
+
+  const handleCancel = () => {
+    // モーダルを閉じる際にチェック状態をリセットする
+    setConfirmed(false);
+    onCancel();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>退会・データ削除</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>
+          退会すると、以下のデータがすべて削除されます。この操作は取り消せません。
+        </DialogContentText>
+        <Typography variant="body2" component="ul" sx={{ mb: 2, pl: 2 }}>
+          <li>会話履歴</li>
+          <li>記憶データ</li>
+          <li>親密度</li>
+          <li>ノート</li>
+          <li>その他すべての個人データ</li>
+        </Typography>
+        <Alert severity="info" data-testid="safety-log-notice" sx={{ mb: 2 }}>
+          安全のため、自傷・自殺に関する検出ログのみ、匿名化したうえで一定期間保持します。
+          保持期間が過ぎた後は自動的に削除されます。
+        </Alert>
+        <Checkbox
+          checked={confirmed}
+          onChange={(e) => setConfirmed(e.target.checked)}
+          disabled={loading}
+          data-testid="deletion-confirm-checkbox"
+          label="削除範囲を理解し、復元できないことに同意します"
+        />
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }} role="alert" data-testid="deletion-error">
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="ghost"
+          color="neutral"
+          onClick={handleCancel}
+          disabled={loading}
+          data-testid="deletion-cancel"
+        >
+          キャンセル
+        </Button>
+        <Button
+          variant="solid"
+          color="danger"
+          onClick={onConfirm}
+          loading={loading}
+          disabled={!confirmed || loading}
+          data-testid="deletion-confirm"
+        >
+          退会・削除する
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/services/livetalk/web/src/lib/account/api-client.ts
+++ b/services/livetalk/web/src/lib/account/api-client.ts
@@ -1,0 +1,19 @@
+/**
+ * アカウント UI から `/api/account` を呼ぶための fetch ラッパ。
+ *
+ * コンポーネントから fetch を直接呼ばず、ここに集約してテスト可能にする
+ * （カバレッジ計測対象は `src/lib/**` のみ）。
+ */
+
+export const ACCOUNT_API_ERROR_MESSAGES = {
+  DELETE_FAILED: '退会処理に失敗しました。時間を置いて再度お試しください。',
+} as const;
+
+/**
+ * アカウントを削除する（退会処理）。
+ * 成功時は void を返し、失敗時は DELETE_FAILED エラーを throw する。
+ */
+export async function deleteAccount(): Promise<void> {
+  const res = await fetch('/api/account', { method: 'DELETE' });
+  if (!res.ok) throw new Error(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED);
+}

--- a/services/livetalk/web/src/lib/account/useAccountDeletion.ts
+++ b/services/livetalk/web/src/lib/account/useAccountDeletion.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { signOut } from 'next-auth/react';
+import { deleteAccount } from './api-client';
+
+/**
+ * useAccountDeletion の戻り値型。
+ */
+export interface UseAccountDeletionResult {
+  /** 削除処理中かどうか */
+  loading: boolean;
+  /** 削除処理のエラーメッセージ（失敗時のみ非 null） */
+  error: string | null;
+  /** 退会処理を実行する。成功時は signOut してトップへリダイレクトする。 */
+  requestDeletion: () => Promise<void>;
+}
+
+/**
+ * アカウント削除（退会）ロジックを管理するカスタム hook。
+ *
+ * - `DELETE /api/account` を呼び出してデータを削除する
+ * - 成功時は next-auth の signOut でセッションを破棄してトップ（/）へリダイレクトする
+ * - 失敗時はエラーメッセージをセットし、モーダルは開いたままにする
+ */
+export function useAccountDeletion(): UseAccountDeletionResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestDeletion = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await deleteAccount();
+      await signOut({ redirectTo: '/' });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '退会処理に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { loading, error, requestDeletion };
+}

--- a/services/livetalk/web/src/lib/account/useAccountDeletion.ts
+++ b/services/livetalk/web/src/lib/account/useAccountDeletion.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import { signOut } from 'next-auth/react';
-import { deleteAccount } from './api-client';
+import { ACCOUNT_API_ERROR_MESSAGES, deleteAccount } from './api-client';
 
 /**
  * useAccountDeletion の戻り値型。
@@ -14,6 +14,8 @@ export interface UseAccountDeletionResult {
   error: string | null;
   /** 退会処理を実行する。成功時は signOut してトップへリダイレクトする。 */
   requestDeletion: () => Promise<void>;
+  /** エラー状態をクリアする（モーダルの開閉時に残留エラーを消すために使う）。 */
+  clearError: () => void;
 }
 
 /**
@@ -34,11 +36,13 @@ export function useAccountDeletion(): UseAccountDeletionResult {
       await deleteAccount();
       await signOut({ redirectTo: '/' });
     } catch (e) {
-      setError(e instanceof Error ? e.message : '退会処理に失敗しました。');
+      setError(e instanceof Error ? e.message : ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED);
     } finally {
       setLoading(false);
     }
   }, []);
 
-  return { loading, error, requestDeletion };
+  const clearError = useCallback(() => setError(null), []);
+
+  return { loading, error, requestDeletion, clearError };
 }

--- a/services/livetalk/web/tests/unit/components/AccountDeletionModal.test.tsx
+++ b/services/livetalk/web/tests/unit/components/AccountDeletionModal.test.tsx
@@ -1,0 +1,240 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import AccountDeletionModal from '@/components/AccountDeletionModal';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AccountDeletionModal', () => {
+  describe('open=false のとき', () => {
+    it('モーダルが表示されない', () => {
+      render(
+        <AccountDeletionModal
+          open={false}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('open=true のとき', () => {
+    it('削除範囲の説明が表示される', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      // 削除が不可逆であることの説明
+      expect(screen.getByText(/取り消せません/)).toBeInTheDocument();
+    });
+
+    it('削除対象データ（会話・記憶・親密度・ノート等）が表示される', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      expect(screen.getByText(/会話履歴/)).toBeInTheDocument();
+      expect(screen.getByText(/記憶データ/)).toBeInTheDocument();
+      expect(screen.getByText(/親密度/)).toBeInTheDocument();
+      expect(screen.getByText(/ノート/)).toBeInTheDocument();
+    });
+
+    it('セーフティログの匿名化保持の注記が表示される', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      const notice = screen.getByTestId('safety-log-notice');
+      expect(notice).toBeInTheDocument();
+      expect(notice).toHaveTextContent(/匿名化/);
+    });
+
+    it('確認チェックボックスが表示される', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      // Checkbox の input 要素を role で取得する（data-testid は CheckboxProps 未対応）
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+
+    it('チェック前は退会ボタンが disabled', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      const confirmButton = screen.getByTestId('deletion-confirm');
+      expect(confirmButton).toBeDisabled();
+    });
+
+    it('チェックボックスにチェックすると退会ボタンが有効化される', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      // Checkbox の input 要素を role で取得する
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+      expect(screen.getByTestId('deletion-confirm')).not.toBeDisabled();
+    });
+
+    it('チェック後に退会ボタンをクリックすると onConfirm が呼ばれる', () => {
+      const onConfirm = jest.fn();
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={onConfirm}
+          onCancel={jest.fn()}
+        />
+      );
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+      fireEvent.click(screen.getByTestId('deletion-confirm'));
+      expect(onConfirm).toHaveBeenCalled();
+    });
+
+    it('キャンセルボタンをクリックすると onCancel が呼ばれる', () => {
+      const onCancel = jest.fn();
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={onCancel}
+        />
+      );
+      fireEvent.click(screen.getByTestId('deletion-cancel'));
+      expect(onCancel).toHaveBeenCalled();
+    });
+
+    it('キャンセルするとチェック状態がリセットされる', () => {
+      const onCancel = jest.fn();
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={onCancel}
+        />
+      );
+      // チェックを入れると退会ボタンが有効化される
+      fireEvent.click(screen.getByRole('checkbox'));
+      expect(screen.getByTestId('deletion-confirm')).not.toBeDisabled();
+
+      // キャンセルする
+      fireEvent.click(screen.getByTestId('deletion-cancel'));
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('loading=true のとき', () => {
+    it('チェックボックスが disabled になる', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={true}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      // Checkbox の input 要素を role で取得する
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeDisabled();
+    });
+
+    it('退会ボタンが disabled になる', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={true}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      expect(screen.getByTestId('deletion-confirm')).toBeDisabled();
+    });
+
+    it('キャンセルボタンが disabled になる', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={true}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      expect(screen.getByTestId('deletion-cancel')).toBeDisabled();
+    });
+  });
+
+  describe('error が非 null のとき', () => {
+    it('エラーメッセージが表示される', () => {
+      const errorMessage = '退会処理に失敗しました。時間を置いて再度お試しください。';
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={errorMessage}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      const errorEl = screen.getByTestId('deletion-error');
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveTextContent(errorMessage);
+    });
+
+    it('error が null のときエラー表示がない', () => {
+      render(
+        <AccountDeletionModal
+          open={true}
+          loading={false}
+          error={null}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      );
+      expect(screen.queryByTestId('deletion-error')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/account/api-client.test.ts
+++ b/services/livetalk/web/tests/unit/lib/account/api-client.test.ts
@@ -1,0 +1,41 @@
+import { deleteAccount, ACCOUNT_API_ERROR_MESSAGES } from '@/lib/account/api-client';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('deleteAccount', () => {
+  it('DELETE /api/account を呼び出す', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+    await deleteAccount();
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/account', { method: 'DELETE' });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('res.ok が true のとき void を返す（例外を throw しない）', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+    await expect(deleteAccount()).resolves.toBeUndefined();
+  });
+
+  it('res.ok が false のとき DELETE_FAILED エラーを throw する', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(deleteAccount()).rejects.toThrow(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED);
+  });
+
+  it('ネットワークエラーのとき例外が伝播する', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('ネットワークエラー'));
+
+    await expect(deleteAccount()).rejects.toThrow('ネットワークエラー');
+  });
+});
+
+describe('ACCOUNT_API_ERROR_MESSAGES', () => {
+  it('DELETE_FAILED が日本語メッセージを持つ', () => {
+    expect(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED).toBeTruthy();
+    expect(typeof ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED).toBe('string');
+  });
+});

--- a/services/livetalk/web/tests/unit/lib/account/useAccountDeletion.test.ts
+++ b/services/livetalk/web/tests/unit/lib/account/useAccountDeletion.test.ts
@@ -142,7 +142,25 @@ describe('useAccountDeletion', () => {
         await result.current.requestDeletion();
       });
 
-      expect(result.current.error).toBe('退会処理に失敗しました。');
+      expect(result.current.error).toBe(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED);
+    });
+  });
+
+  describe('clearError', () => {
+    it('セットされた error を null に戻す', async () => {
+      mockDeleteAccount.mockRejectedValue(new Error(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED));
+
+      const { result } = renderHook(() => useAccountDeletion());
+
+      await act(async () => {
+        await result.current.requestDeletion();
+      });
+      expect(result.current.error).toBe(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED);
+
+      act(() => {
+        result.current.clearError();
+      });
+      expect(result.current.error).toBeNull();
     });
   });
 

--- a/services/livetalk/web/tests/unit/lib/account/useAccountDeletion.test.ts
+++ b/services/livetalk/web/tests/unit/lib/account/useAccountDeletion.test.ts
@@ -1,0 +1,160 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAccountDeletion } from '@/lib/account/useAccountDeletion';
+import { ACCOUNT_API_ERROR_MESSAGES } from '@/lib/account/api-client';
+
+jest.mock('next-auth/react', () => ({
+  signOut: jest.fn(),
+}));
+
+jest.mock('@/lib/account/api-client', () => ({
+  ...jest.requireActual('@/lib/account/api-client'),
+  deleteAccount: jest.fn(),
+}));
+
+// モックの参照を取得するため import する
+import { signOut } from 'next-auth/react';
+import { deleteAccount } from '@/lib/account/api-client';
+
+// signOut はオーバーロードがあるため jest.fn() でキャストする
+const mockSignOut = signOut as jest.Mock;
+const mockDeleteAccount = deleteAccount as jest.MockedFunction<typeof deleteAccount>;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useAccountDeletion', () => {
+  describe('初期値', () => {
+    it('loading の初期値は false', () => {
+      const { result } = renderHook(() => useAccountDeletion());
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('error の初期値は null', () => {
+      const { result } = renderHook(() => useAccountDeletion());
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('requestDeletion 成功', () => {
+    it('成功時は signOut が redirectTo: "/" で呼ばれる', async () => {
+      mockDeleteAccount.mockResolvedValue(undefined);
+      mockSignOut.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useAccountDeletion());
+
+      await act(async () => {
+        await result.current.requestDeletion();
+      });
+
+      expect(mockSignOut).toHaveBeenCalledWith({ redirectTo: '/' });
+    });
+
+    it('成功時は error が null のまま', async () => {
+      mockDeleteAccount.mockResolvedValue(undefined);
+      mockSignOut.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useAccountDeletion());
+
+      await act(async () => {
+        await result.current.requestDeletion();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+
+    it('処理中は loading が true になり、完了後に false に戻る', async () => {
+      let resolveDeletion!: () => void;
+      mockDeleteAccount.mockReturnValue(
+        new Promise<void>((res) => {
+          resolveDeletion = res;
+        })
+      );
+      mockSignOut.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useAccountDeletion());
+
+      // 処理開始
+      let promise!: Promise<void>;
+      act(() => {
+        promise = result.current.requestDeletion();
+      });
+
+      // loading が true になるまで待つ
+      await waitFor(() => expect(result.current.loading).toBe(true));
+
+      // 処理完了
+      act(() => {
+        resolveDeletion();
+      });
+
+      await act(async () => {
+        await promise;
+      });
+
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe('requestDeletion 失敗', () => {
+    it('deleteAccount が失敗したとき error にメッセージがセットされる', async () => {
+      mockDeleteAccount.mockRejectedValue(new Error(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED));
+
+      const { result } = renderHook(() => useAccountDeletion());
+
+      await act(async () => {
+        await result.current.requestDeletion();
+      });
+
+      expect(result.current.error).toBe(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED);
+    });
+
+    it('deleteAccount が失敗したとき signOut は呼ばれない', async () => {
+      mockDeleteAccount.mockRejectedValue(new Error(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED));
+
+      const { result } = renderHook(() => useAccountDeletion());
+
+      await act(async () => {
+        await result.current.requestDeletion();
+      });
+
+      expect(mockSignOut).not.toHaveBeenCalled();
+    });
+
+    it('失敗後は loading が false に戻る', async () => {
+      mockDeleteAccount.mockRejectedValue(new Error(ACCOUNT_API_ERROR_MESSAGES.DELETE_FAILED));
+
+      const { result } = renderHook(() => useAccountDeletion());
+
+      await act(async () => {
+        await result.current.requestDeletion();
+      });
+
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('Error インスタンスでない例外のとき汎用メッセージがセットされる', async () => {
+      mockDeleteAccount.mockRejectedValue('文字列エラー');
+
+      const { result } = renderHook(() => useAccountDeletion());
+
+      await act(async () => {
+        await result.current.requestDeletion();
+      });
+
+      expect(result.current.error).toBe('退会処理に失敗しました。');
+    });
+  });
+
+  describe('requestDeletion の安定性', () => {
+    it('requestDeletion は安定した関数参照を持つ', () => {
+      mockDeleteAccount.mockResolvedValue(undefined);
+      mockSignOut.mockResolvedValue(undefined);
+
+      const { result, rerender } = renderHook(() => useAccountDeletion());
+      const firstRef = result.current.requestDeletion;
+      rerender();
+      expect(result.current.requestDeletion).toBe(firstRef);
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

livetalk「退会・データ削除」（Issue #3579）の **Phase 3: 退会モーダル UI（SCR-011）**。これで API〜UI まで揃い、機能の仕上げになります。

SCR-011 の方針（独立した設定画面を持たず、チャット画面フッターから開くモーダル）どおりに実装:

- **`src/components/AccountDeletionModal.tsx`**（presentational）：削除範囲の説明（会話/記憶/親密度/ノート等）・**セーフティログ匿名化保持の注記**・**確認チェックボックス**（チェックするまで退会ボタン無効）・退会ボタン（`solid`/`danger`、loading 対応）・キャンセル・エラー表示。`@mui/material` Dialog 系＋`@nagiyu/ui` Button/Checkbox。
- **`src/lib/account/api-client.ts`**：`deleteAccount()` fetch ラッパ＋エラーメッセージ定数。
- **`src/lib/account/useAccountDeletion.ts`**：削除実行＋成功時 `signOut({ redirectTo: '/' })` を hook に集約（UI 層から fetch/signOut を直接叩かない分離）。
- **`src/app/page.tsx`**：チャット画面フッターの補助リンク群に「退会・データ削除」入口を追加しモーダルを配線（法務導線は下部の共有 `ServiceLayout` フッターに表示。共有 `libs/ui/Footer` は変更しない）。

## 関連 Issue

Issue #3579（Phase 3）。※ 作業ブランチ → integration の PR のため `Closes` は付けない。

## 変更種別

- [x] 新規機能

## 実装チェックリスト

- [x] コーディング規約に従って実装した（UI/ロジック分離 / エラーメッセージ日本語+定数化）
- [x] テストを追加・更新した（`lib/account` カバレッジ 100%、全体 80% 超）
- [x] ローカルでテストが全て通ることを確認した（web: 72 suites / 739 tests、eslint・prettier clean）
- [x] ビルドエラーがないことを確認した

## テスト内容

- `AccountDeletionModal`：open=false で非表示／削除範囲・セーフティ匿名化注記の表示／チェック前は退会ボタン無効・チェックで有効化／onConfirm・onCancel／loading 中の無効化／error 表示
- `api-client`：`/api/account` を DELETE で叩く／失敗で `DELETE_FAILED` throw
- `useAccountDeletion`：成功で `signOut({ redirectTo: '/' })`／失敗で error セット・signOut 非呼び出し／loading 遷移／`clearError`

## レビューポイント

- fresh-eyes レビュー（Opus）実施済み。クリティカルなし。対応として、(1) **失敗→閉じる→再オープン時のエラー残留**を解消（`clearError` を追加し開く際にクリア）、(2) 導線コメントを実態（法務導線は ServiceLayout 共有フッター）に合わせて修正、(3) Dialog に `aria-labelledby` 追加、(4) 効かない dead prop（Checkbox の data-testid）削除、(5) フォールバックエラーメッセージを定数化。
- 確認方式は**チェックボックス**（不可逆操作だが、退会導線の位置づけと既存 ConsentModal の作法に合わせた選択）。

## スクリーンショット（該当する場合）

UI 変更あり（退会モーダル）。dev 反映後に動作確認予定。

## 補足事項

Phase 1（core 削除エンジン）・Phase 2（`DELETE /api/account`）は integration にマージ済み。本 PR で SCR-011 まで揃う。integration → develop の段階で dev 環境にて「退会 → データ削除 → 匿名化 SafetyEvent が admin 横断レビュー（#3580）に表示」の end-to-end 確認を行う想定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01E9P47aRt2xHqpYGFKxW4wo)_