### PR TITLE
認証フロー改善 Phase 1: livetalk のサインアウト導線を auth サービスに集約

### DIFF
--- a/infra/livetalk/lib/ecs-service-stack.ts
+++ b/infra/livetalk/lib/ecs-service-stack.ts
@@ -267,6 +267,10 @@ export class LiveTalkEcsServiceStack extends cdk.Stack {
         NEXT_PUBLIC_AUTH_URL: authUrl,
         // 自サービスのベース URL（callbackUrl 生成用）
         APP_URL: appUrl,
+        // NextAuth v5 が内部ホスト名（ip-10-x-x-x.ec2.internal）へフォールバックしないよう
+        // 公開 URL を明示する。未設定時は ECS コンテナの内部ホスト名が AUTH_URL に使われ、
+        // サインイン・セッション検証のリダイレクトが ERR_NAME_NOT_RESOLVED で失敗する原因となる。
+        AUTH_URL: appUrl,
         // VOICEVOX エンジンの接続先（同 Task 内 localhost）
         VOICEVOX_URL: 'http://localhost:50021',
         // DynamoDB Single Table 名（Phase 2a で導入）。

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -45,3 +45,6 @@ export { privacyPolicySections } from './data/privacyPolicyData';
 export type { PolicySection, PolicyContent, PolicySubContent } from './data/privacyPolicyData';
 export { termSections } from './data/termsOfServiceData';
 export type { TermSection, TermContent } from './data/termsOfServiceData';
+
+// Export utils
+export { buildSignOutUrl } from './utils/auth';

--- a/libs/ui/src/utils/auth.ts
+++ b/libs/ui/src/utils/auth.ts
@@ -1,0 +1,29 @@
+/**
+ * 認証関連のユーティリティ関数
+ *
+ * auth サービスへの URL 構築など、サービス横断で共通利用する純粋関数を集める。
+ * libs 内のため、パスエイリアス（@/）は使用せず相対 import のみを使用する。
+ */
+
+/**
+ * auth サービスのサインアウト URL を生成する。
+ *
+ * サインアウト処理は Cookie 発行元である auth サービスに集約する方針のため、
+ * 各 consumer サービスは自前で NextAuth の signout POST を受けず、
+ * この関数で生成した URL へリダイレクトする。
+ *
+ * @param authUrl - auth サービスのベース URL（例: "https://auth.nagiyu.com"）
+ * @param callbackUrl - サインアウト後のリダイレクト先 URL（省略時は付与しない）
+ * @returns auth サービスの signout エンドポイント URL
+ */
+export function buildSignOutUrl(authUrl: string, callbackUrl?: string): string {
+  // 末尾スラッシュを正規化して二重スラッシュを防ぐ
+  const base = authUrl.replace(/\/+$/, '');
+  const endpoint = `${base}/api/auth/signout`;
+
+  if (callbackUrl === undefined || callbackUrl === '') {
+    return endpoint;
+  }
+
+  return `${endpoint}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+}

--- a/libs/ui/tests/unit/utils/auth.test.ts
+++ b/libs/ui/tests/unit/utils/auth.test.ts
@@ -68,7 +68,10 @@ describe('buildSignOutUrl', () => {
 
   describe('開発環境 URL の対応', () => {
     it('dev 環境のサブドメインでも正しく URL を生成する', () => {
-      const result = buildSignOutUrl('https://dev-auth.nagiyu.com', 'https://dev-live-talk.nagiyu.com');
+      const result = buildSignOutUrl(
+        'https://dev-auth.nagiyu.com',
+        'https://dev-live-talk.nagiyu.com'
+      );
       expect(result).toBe(
         'https://dev-auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Fdev-live-talk.nagiyu.com'
       );

--- a/libs/ui/tests/unit/utils/auth.test.ts
+++ b/libs/ui/tests/unit/utils/auth.test.ts
@@ -1,0 +1,82 @@
+import { buildSignOutUrl } from '../../../src/utils/auth';
+
+describe('buildSignOutUrl', () => {
+  describe('callbackUrl なし', () => {
+    it('基本的な authUrl からサインアウト URL を生成する', () => {
+      const result = buildSignOutUrl('https://auth.nagiyu.com');
+      expect(result).toBe('https://auth.nagiyu.com/api/auth/signout');
+    });
+
+    it('callbackUrl が undefined の場合クエリパラメータを付与しない', () => {
+      const result = buildSignOutUrl('https://auth.nagiyu.com', undefined);
+      expect(result).toBe('https://auth.nagiyu.com/api/auth/signout');
+    });
+
+    it('callbackUrl が空文字の場合クエリパラメータを付与しない', () => {
+      const result = buildSignOutUrl('https://auth.nagiyu.com', '');
+      expect(result).toBe('https://auth.nagiyu.com/api/auth/signout');
+    });
+  });
+
+  describe('callbackUrl あり', () => {
+    it('callbackUrl を encodeURIComponent してクエリパラメータに付与する', () => {
+      const result = buildSignOutUrl('https://auth.nagiyu.com', 'https://live-talk.nagiyu.com');
+      expect(result).toBe(
+        'https://auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com'
+      );
+    });
+
+    it('callbackUrl にパスが含まれる場合も正しく encode する', () => {
+      const result = buildSignOutUrl(
+        'https://auth.nagiyu.com',
+        'https://live-talk.nagiyu.com/notes'
+      );
+      expect(result).toBe(
+        'https://auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com%2Fnotes'
+      );
+    });
+
+    it('callbackUrl に特殊文字が含まれる場合も正しく encode する', () => {
+      const result = buildSignOutUrl(
+        'https://auth.nagiyu.com',
+        'https://example.com/page?foo=bar&baz=qux'
+      );
+      expect(result).toBe(
+        'https://auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Fexample.com%2Fpage%3Ffoo%3Dbar%26baz%3Dqux'
+      );
+    });
+  });
+
+  describe('authUrl の末尾スラッシュ正規化', () => {
+    it('authUrl の末尾スラッシュを除去して二重スラッシュを防ぐ', () => {
+      const result = buildSignOutUrl('https://auth.nagiyu.com/');
+      expect(result).toBe('https://auth.nagiyu.com/api/auth/signout');
+    });
+
+    it('authUrl の複数の末尾スラッシュも除去する', () => {
+      const result = buildSignOutUrl('https://auth.nagiyu.com///');
+      expect(result).toBe('https://auth.nagiyu.com/api/auth/signout');
+    });
+
+    it('末尾スラッシュ正規化後も callbackUrl を正しく付与する', () => {
+      const result = buildSignOutUrl('https://auth.nagiyu.com/', 'https://live-talk.nagiyu.com');
+      expect(result).toBe(
+        'https://auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com'
+      );
+    });
+  });
+
+  describe('開発環境 URL の対応', () => {
+    it('dev 環境のサブドメインでも正しく URL を生成する', () => {
+      const result = buildSignOutUrl('https://dev-auth.nagiyu.com', 'https://dev-live-talk.nagiyu.com');
+      expect(result).toBe(
+        'https://dev-auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Fdev-live-talk.nagiyu.com'
+      );
+    });
+
+    it('authUrl が空文字の場合でも例外を投げずに処理する（未設定フォールバック対応）', () => {
+      const result = buildSignOutUrl('');
+      expect(result).toBe('/api/auth/signout');
+    });
+  });
+});

--- a/services/livetalk/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/services/livetalk/web/src/app/api/auth/[...nextauth]/route.ts
@@ -32,5 +32,10 @@ async function GET(req: NextRequest) {
   return handlers.GET(req);
 }
 
+// サインアウト処理は Cookie 発行元の auth サービスに集約する方針のため、
+// consumer である livetalk はローカルで signout POST を受け付けない。
+// POST を export しないことで /api/auth/signout への直接 POST を無効化し、
+// 内部ホスト名（ip-10-x-x-x.ec2.internal）へのリダイレクトによる
+// ERR_NAME_NOT_RESOLVED を防ぐ。
+// サインアウトは buildSignOutUrl() で生成した auth サービスの URL へ遷移させる。
 export { GET };
-export const POST = handlers.POST;

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useCallback, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { Box, Container, Stack, Typography } from '@mui/material';
-import { Link } from '@nagiyu/ui';
+import { Link, buildSignOutUrl } from '@nagiyu/ui';
 import { hasPermission } from '@nagiyu/common';
 import ChatInput from '@/components/ChatInput';
 import ResponseDisplay from '@/components/ResponseDisplay';
@@ -239,6 +239,26 @@ function HomePageInner() {
             <Link asChild>
               <button type="button" onClick={openDeletionModal} data-testid="open-deletion-modal">
                 退会・データ削除
+              </button>
+            </Link>
+            {/* サインアウト導線。
+                サインアウト処理は Cookie 発行元の auth サービスに集約する方針のため、
+                自サービスの NextAuth signout POST ではなく auth サービスへリダイレクトする。
+                callbackUrl に自サービスの origin を渡し、サインアウト後に戻れるようにする。 */}
+            <Link asChild>
+              <button
+                type="button"
+                onClick={() =>
+                  window.location.assign(
+                    buildSignOutUrl(
+                      process.env.NEXT_PUBLIC_AUTH_URL ?? '',
+                      window.location.origin
+                    )
+                  )
+                }
+                data-testid="sign-out-button"
+              >
+                サインアウト
               </button>
             </Link>
           </Box>

--- a/services/livetalk/web/src/app/page.tsx
+++ b/services/livetalk/web/src/app/page.tsx
@@ -250,10 +250,7 @@ function HomePageInner() {
                 type="button"
                 onClick={() =>
                   window.location.assign(
-                    buildSignOutUrl(
-                      process.env.NEXT_PUBLIC_AUTH_URL ?? '',
-                      window.location.origin
-                    )
+                    buildSignOutUrl(process.env.NEXT_PUBLIC_AUTH_URL ?? '', window.location.origin)
                   )
                 }
                 data-testid="sign-out-button"


### PR DESCRIPTION
## 変更の概要

親 Issue #3593（プラットフォーム認証: サインアウト導線の欠如とロール伝播の課題）の Phase 1。リブトークでロール付与後にサインアウト→再ログインが必要だが導線が無く、`/api/auth/signout` を直叩きすると ECS タスクの内部ホスト名へリダイレクトされ `ERR_NAME_NOT_RESOLVED` で失敗していた。本 PR でサインアウトを auth サービスに集約し、redirect バグを構造的に防ぐ。

- `@nagiyu/ui` に `buildSignOutUrl(authUrl, callbackUrl?)` を追加（auth サービスの signout URL を生成する純粋関数）
- livetalk トップページのフッターに「サインアウト」導線を追加。クリックで auth サービスの signout へ遷移し、`callbackUrl` に自サービスの origin を渡す
- livetalk の NextAuth POST ハンドラ露出を撤去（GET の `/api/auth/session` 用途は維持）。ローカルへの直接 signout POST を無効化し、内部ホスト名へのリダイレクトを防ぐ
- infra: livetalk ECS タスクに `AUTH_URL`（自サービスの公開 URL）を明示。NextAuth v5 が内部ホスト名へフォールバックしない防御

## 関連 Issue

親 Issue: #3593（作業ブランチ → integration のため `Closes #` は付けない）

## 変更種別

- [x] バグ修正
- [x] 新規機能
- [x] インフラ更新

## 実装前チェックリスト

- [x] コーディング規約・べからず集を確認した
- [x] アーキテクチャガイドラインを確認した
- [x] 開発方針を確認した

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（テストカバレッジ80%以上を確保）
- [ ] 関連ドキュメントを更新した（Phase 完了後に追従判断）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラーがないことを確認した

## テスト内容

- `buildSignOutUrl` のユニットテスト 11 件（callbackUrl あり/なし・末尾スラッシュ正規化・encodeURIComponent・空文字フォールバック）
- `libs/ui` 全 352 件グリーン（branches 92.95% / lines 95.95%、閾値超え）
- livetalk web `page.test.tsx` 21 件グリーン（サインアウトボタン追加で既存テスト非破壊を確認）
- 共通ライブラリを依存順にビルド成功、変更ファイルの `tsc --noEmit` に新規エラーなし

## レビューポイント

- サインアウトを auth サービスへ集約する方針（`docs/development/authentication.md` 問題1：consumer は NextAuth ルートハンドラを置かない方針）と整合。GET（session）のみ残し POST を撤去した点
- `AUTH_URL: appUrl`（自サービス URL）を ECS に明示した点。先行対応 #3579（退会後のブラウザ側遷移）と同根の内部ホスト redirect 対策で方針が一致
- `buildSignOutUrl` は `authUrl` を引数で受ける設計（client での `NEXT_PUBLIC_AUTH_URL` inline をサービス側に閉じ、ヘルパーをテスト可能に保つため）

## スクリーンショット

UI 変更（フッターに「サインアウト」リンク追加）あり。dev 反映後に実機確認予定。

https://claude.ai/code/session_015mjPyhPKqKqiW1MjZGJqk3

---
_Generated by [Claude Code](https://claude.ai/code/session_015mjPyhPKqKqiW1MjZGJqk3)_