### PR TITLE
認証フロー改善 Phase 2: サインアウト導線を auth サービスへ集約（stock-tracker / share-together / admin）

### DIFF
--- a/services/admin/web/src/app/(protected)/dashboard/page.tsx
+++ b/services/admin/web/src/app/(protected)/dashboard/page.tsx
@@ -89,8 +89,19 @@ export default async function DashboardPage() {
       )}
 
       {/* ログアウトボタン */}
+      {/* callbackUrl を付与してサインアウト後に admin へ戻れるようにする。
+          server component のため @nagiyu/ui の barrel import を避け、インライン展開を採用。
+          APP_URL が未設定の場合は callbackUrl を付与しないフォールバック。 */}
       <Button asChild variant="outline" color="primary">
-        <a href={`${process.env.NEXT_PUBLIC_AUTH_URL || ''}/api/auth/signout`}>ログアウト</a>
+        <a
+          href={
+            process.env.APP_URL
+              ? `${process.env.NEXT_PUBLIC_AUTH_URL || ''}/api/auth/signout?callbackUrl=${encodeURIComponent(process.env.APP_URL)}`
+              : `${process.env.NEXT_PUBLIC_AUTH_URL || ''}/api/auth/signout`
+          }
+        >
+          ログアウト
+        </a>
       </Button>
     </Box>
   );

--- a/services/share-together/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/services/share-together/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,9 @@
 import { handlers } from '../../../../../auth';
 
-export const { GET, POST } = handlers;
+// サインアウト処理は Cookie 発行元の auth サービスに集約する方針のため、
+// consumer である share-together はローカルで signout POST を受け付けない。
+// POST を export しないことで /api/auth/signout への直接 POST を無効化し、
+// 内部ホスト名（ip-10-x-x-x.ec2.internal）へのリダイレクトによる
+// ERR_NAME_NOT_RESOLVED を防ぐ。
+// GET は /api/auth/session の取得に使用するため維持する。
+export const { GET } = handlers;

--- a/services/share-together/web/tests/unit/app/api/auth/[...nextauth]/route.test.ts
+++ b/services/share-together/web/tests/unit/app/api/auth/[...nextauth]/route.test.ts
@@ -18,11 +18,16 @@ jest.mock('next-auth', () => ({
   })),
 }));
 
-import { GET, POST } from '@/app/api/auth/[...nextauth]/route';
+import { GET } from '@/app/api/auth/[...nextauth]/route';
 
 describe('/api/auth/[...nextauth] route', () => {
-  it('NextAuth handlers を GET/POST に公開する', () => {
+  it('NextAuth GET handler を公開する', () => {
     expect(GET).toBe(mockGet);
-    expect(POST).toBe(mockPost);
+  });
+
+  it('POST は export しない（auth サービスへのサインアウト集約方針）', async () => {
+    // POST を動的 import で確認し、export されていないことを検証する
+    const routeModule = await import('@/app/api/auth/[...nextauth]/route');
+    expect((routeModule as Record<string, unknown>)['POST']).toBeUndefined();
   });
 });

--- a/services/stock-tracker/web/app/api/auth/[...nextauth]/route.ts
+++ b/services/stock-tracker/web/app/api/auth/[...nextauth]/route.ts
@@ -16,5 +16,10 @@ async function GET(req: NextRequest) {
   return handlers.GET(req);
 }
 
+// サインアウト処理は Cookie 発行元の auth サービスに集約する方針のため、
+// consumer である stock-tracker はローカルで signout POST を受け付けない。
+// POST を export しないことで /api/auth/signout への直接 POST を無効化し、
+// 内部ホスト名（ip-10-x-x-x.ec2.internal）へのリダイレクトによる
+// ERR_NAME_NOT_RESOLVED を防ぐ。
+// サインアウトは buildSignOutUrl() で生成した auth サービスの URL へ遷移させる。
 export { GET };
-export const POST = handlers.POST;

--- a/services/stock-tracker/web/components/ThemeRegistry.tsx
+++ b/services/stock-tracker/web/components/ThemeRegistry.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import * as React from 'react';
-import { SessionProvider, useSession, signOut } from 'next-auth/react';
-import { ErrorBoundary, ServiceLayout, type NavigationItem } from '@nagiyu/ui';
+import { SessionProvider, useSession } from 'next-auth/react';
+import { ErrorBoundary, ServiceLayout, buildSignOutUrl, type NavigationItem } from '@nagiyu/ui';
 import { SnackbarProvider } from './SnackbarProvider';
 import { hasPermission } from '@nagiyu/common';
 
@@ -61,7 +61,12 @@ function ThemeRegistryContent({ children, version = '1.0.0' }: ThemeRegistryProp
     : undefined;
 
   // ログアウトハンドラー
-  const handleLogout = () => signOut();
+  // サインアウトは Cookie 発行元の auth サービスに集約する方針のため、
+  // buildSignOutUrl で生成した auth サービスの URL へ遷移させる。
+  const handleLogout = () =>
+    window.location.assign(
+      buildSignOutUrl(process.env.NEXT_PUBLIC_AUTH_URL ?? '', window.location.origin)
+    );
 
   return (
     <ErrorBoundary>

--- a/services/stock-tracker/web/tests/unit/components/theme-registry-navigation.test.ts
+++ b/services/stock-tracker/web/tests/unit/components/theme-registry-navigation.test.ts
@@ -1,3 +1,4 @@
+/** @jest-environment jsdom */
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import ThemeRegistry from '../../../components/ThemeRegistry';
@@ -6,14 +7,36 @@ import { useSession } from 'next-auth/react';
 jest.mock('next-auth/react', () => {
   return {
     useSession: jest.fn(),
-    signOut: jest.fn(),
     SessionProvider: ({ children }: { children: React.ReactNode }) =>
       React.createElement(React.Fragment, null, children),
   };
 });
 
+// ログアウトハンドラーを ServiceLayout の onLogout として受け取るため、
+// headerProps ごと記録して後から検証できるようにする
+let capturedOnLogout: (() => void) | undefined;
+
+// jest.mock のファクトリはホイスティングされるため、ファクトリ内で jest.fn() を定義し
+// モジュールスコープに再代入する形でテストから参照できるようにする
+// （ファクトリ外の変数をファクトリ内で参照すると TDZ エラーになる）
+let mockBuildSignOutUrl: jest.Mock;
+
 jest.mock('@nagiyu/ui', () => {
+  // buildSignOutUrl は純粋関数のため実装をそのまま模倣し、呼び出しを記録する
+  const fn = jest.fn((authUrl: string, callbackUrl?: string) => {
+    const base = authUrl.replace(/\/+$/, '');
+    const endpoint = `${base}/api/auth/signout`;
+    if (callbackUrl === undefined || callbackUrl === '') {
+      return endpoint;
+    }
+    return `${endpoint}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  });
+  // ファクトリ外のモジュールスコープ変数に代入して beforeEach 等からアクセスできるようにする
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).__mockBuildSignOutUrl = fn;
+
   return {
+    buildSignOutUrl: fn,
     ErrorBoundary: ({ children }: { children: React.ReactNode }) =>
       React.createElement(React.Fragment, null, children),
     ServiceLayout: ({
@@ -21,9 +44,10 @@ jest.mock('@nagiyu/ui', () => {
       headerProps,
     }: {
       children: React.ReactNode;
-      headerProps?: { navigationItems?: unknown };
-    }) =>
-      React.createElement(
+      headerProps?: { navigationItems?: unknown; onLogout?: () => void };
+    }) => {
+      capturedOnLogout = headerProps?.onLogout;
+      return React.createElement(
         React.Fragment,
         null,
         React.createElement(
@@ -32,7 +56,8 @@ jest.mock('@nagiyu/ui', () => {
           JSON.stringify(headerProps?.navigationItems)
         ),
         children
-      ),
+      );
+    },
   };
 });
 
@@ -41,6 +66,12 @@ jest.mock('../../../components/SnackbarProvider', () => {
     SnackbarProvider: ({ children }: { children: React.ReactNode }) =>
       React.createElement(React.Fragment, null, children),
   };
+});
+
+beforeAll(() => {
+  // jest.mock ファクトリ実行後に globalThis 経由でモック関数を取得する
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockBuildSignOutUrl = (globalThis as any).__mockBuildSignOutUrl;
 });
 
 describe('ThemeRegistry navigationItems', () => {
@@ -54,6 +85,8 @@ describe('ThemeRegistry navigationItems', () => {
   };
 
   beforeEach(() => {
+    capturedOnLogout = undefined;
+    mockBuildSignOutUrl.mockClear();
     mockedUseSession.mockReturnValue({
       data: null,
       status: 'unauthenticated',
@@ -101,5 +134,41 @@ describe('ThemeRegistry navigationItems', () => {
     );
     const navigationItems = getNavigationItems(html);
     expect(navigationItems).not.toContainEqual({ label: 'サマリー', href: '/summaries' });
+  });
+});
+
+describe('ThemeRegistry ログアウトハンドラー', () => {
+  const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>;
+
+  beforeEach(() => {
+    capturedOnLogout = undefined;
+    mockBuildSignOutUrl.mockClear();
+    mockedUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: jest.fn(),
+    });
+  });
+
+  it('ログアウト時に buildSignOutUrl が auth URL と現在の origin を引数に呼ばれる', () => {
+    // jsdom では window.location の assign / origin は non-configurable のため
+    // Object.defineProperty や jest.spyOn でモックできない。
+    // ここでは ThemeRegistry が buildSignOutUrl を正しい引数（AUTH_URL, window.location.origin）で
+    // 呼び出すことをテストし、ナビゲーション副作用（assign の呼び出し）は検証スコープ外とする。
+    // （assign 呼び出し自体は jest-environment-jsdom で "Not implemented: navigation" の
+    //   コンソールエラーになるが、テストの合否には影響しない。）
+    process.env.NEXT_PUBLIC_AUTH_URL = 'http://localhost:3001';
+
+    renderToStaticMarkup(
+      React.createElement(ThemeRegistry, null, React.createElement('div', null, 'child'))
+    );
+
+    expect(capturedOnLogout).toBeDefined();
+
+    // jsdom のデフォルト origin は 'http://localhost'
+    // capturedOnLogout() を呼ぶと assign が実行されるが jsdom が警告を出すのみで失敗しない
+    expect(() => capturedOnLogout!()).not.toThrow();
+
+    expect(mockBuildSignOutUrl).toHaveBeenCalledWith('http://localhost:3001', 'http://localhost');
   });
 });


### PR DESCRIPTION
## 変更の概要

親 Issue #3593 の Phase 2。Phase 1（#3596）で導入した `buildSignOutUrl` を使い、ログアウト導線を持つ他サービスを「サインアウトは auth サービスへ集約」の同一パターンに揃える。**本 PR は #3596 の上に stack している**（base = Phase 1 ブランチ）。

- **stock-tracker**: Header のログアウトを `signOut()`（next-auth/react のローカル POST）から `buildSignOutUrl` 経由の auth サービス遷移へ変更。ローカル NextAuth POST ハンドラ露出を撤去（GET の session 用途は維持）
- **share-together**: 休眠していたローカル NextAuth POST ハンドラ露出を撤去（GET は維持）。ユーザー向けログアウト導線は元々無いため UI 変更なし
- **admin**: 既に auth へ集約済みのログアウトリンクに `callbackUrl`（`APP_URL`）を付与し、サインアウト後に admin へ戻れるようにした（server component のため `buildSignOutUrl` のロジックをインライン展開）

## 関連 Issue

親 Issue: #3593（作業ブランチ → integration のため `Closes #` は付けない）

## 変更種別

- [x] バグ修正
- [x] リファクタリング

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ閾値維持）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラー・フォーマットエラーがないことを確認した

## テスト内容

- stock-tracker `theme-registry-navigation.test.ts` 3 件グリーン（`buildSignOutUrl` の呼び出し引数を検証する形に更新。jsdom の navigation 非サポートにより `window.location.assign` 自体のアサートは引数検証で代替）
- share-together `api/auth/[...nextauth]/route.test.ts` 2 件グリーン（POST が export されないことを検証）
- admin 全 16 件グリーン（ログアウトリンクが `/api/auth/signout` を含むことを維持）
- 変更ファイルの prettier 整形済み

## レビューポイント

- 各 consumer の方針統一: 「サインアウトは auth へ集約・ローカル signout POST は受けない・GET（session）のみ維持」（`docs/development/authentication.md` 問題1 と整合）
- admin はインライン展開を採用（server component から `@nagiyu/ui` の client barrel を import するのを避けるため）
- niconico-mylist-assistant はローカル route handler もログアウト導線も無いため対象外
- stock-tracker / share-together の infra `AUTH_URL` は既設定で内部ホスト crash しないため本 PR では変更していない

## スクリーンショット

stock-tracker のログアウト挙動変更（遷移先が auth サービスの signout に変わる）。dev 反映後に実機確認予定。

https://claude.ai/code/session_015mjPyhPKqKqiW1MjZGJqk3

---
_Generated by [Claude Code](https://claude.ai/code/session_015mjPyhPKqKqiW1MjZGJqk3)_