### PR TITLE
認証フロー改善 Phase 3: auth 側ロール TTL リフレッシュと /refresh、オープンリダイレクト是正

### DIFF
--- a/libs/common/src/auth/index.ts
+++ b/libs/common/src/auth/index.ts
@@ -8,3 +8,4 @@ export * from './types.js';
 export * from './roles.js';
 export * from './permissions.js';
 export * from './auth-error.js';
+export * from './redirect.js';

--- a/libs/common/src/auth/redirect.ts
+++ b/libs/common/src/auth/redirect.ts
@@ -1,0 +1,49 @@
+/**
+ * リダイレクト先 URL の許可判定（オープンリダイレクト対策）
+ *
+ * 認証フローでは、外部から渡される callbackUrl / リダイレクト URL を
+ * 検証せずに遷移先へ用いるとオープンリダイレクトになる。
+ * 文字列の前方一致（例: `url.startsWith(baseUrl)` や
+ * `/^https?:\/\/[^/]*\.nagiyu\.com/`）は
+ * `https://auth.nagiyu.com.evil.com` のようにホスト名の途中に
+ * 許可ドメインを含む URL を誤って許可してしまうため使用しない。
+ *
+ * 本モジュールはフレームワーク非依存・外部依存なしのため、
+ * サーバー／クライアント双方から安全に利用できる。
+ */
+
+/**
+ * リダイレクト先 URL がプラットフォーム内（同一オリジン、または
+ * `nagiyu.com` 本体・そのサブドメイン）かを判定する。
+ *
+ * - URL としてパースできない（相対パス等）→ false
+ * - http / https 以外（javascript:, data: 等）→ false
+ * - baseUrl と同一オリジン → true
+ * - ホスト名が `nagiyu.com` 完全一致、または `.nagiyu.com` 末尾一致 → true
+ *
+ * @param rawUrl - 検証対象の URL 文字列
+ * @param baseUrl - 自サービスのベース URL（同一オリジン判定に使用）
+ * @returns 許可される場合 true
+ */
+export function isAllowedNagiyuRedirectUrl(rawUrl: string, baseUrl: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return false;
+  }
+
+  try {
+    if (parsed.origin === new URL(baseUrl).origin) {
+      return true;
+    }
+  } catch {
+    // baseUrl 自体が不正な場合はホスト名判定に委ねる
+  }
+
+  return parsed.hostname === 'nagiyu.com' || parsed.hostname.endsWith('.nagiyu.com');
+}

--- a/libs/common/tests/unit/auth/redirect.test.ts
+++ b/libs/common/tests/unit/auth/redirect.test.ts
@@ -1,0 +1,68 @@
+/**
+ * isAllowedNagiyuRedirectUrl のユニットテスト
+ *
+ * オープンリダイレクト対策として、ホスト名の途中に許可ドメインを含む
+ * 攻撃 URL を拒否することを重点的に検証する。
+ */
+
+import { isAllowedNagiyuRedirectUrl } from '../../../src/auth/redirect';
+
+const BASE_URL = 'https://auth.nagiyu.com';
+
+describe('isAllowedNagiyuRedirectUrl', () => {
+  describe('許可されるケース', () => {
+    it('同一オリジン（baseUrl 同一 origin のパス付き）は許可', () => {
+      expect(isAllowedNagiyuRedirectUrl(`${BASE_URL}/dashboard`, BASE_URL)).toBe(true);
+    });
+
+    it('サブドメイン *.nagiyu.com は許可', () => {
+      expect(isAllowedNagiyuRedirectUrl('https://admin.nagiyu.com/', BASE_URL)).toBe(true);
+    });
+
+    it('dev-*.nagiyu.com は許可', () => {
+      expect(isAllowedNagiyuRedirectUrl('https://dev-stock-tracker.nagiyu.com/x', BASE_URL)).toBe(
+        true
+      );
+    });
+
+    it('apex ドメイン nagiyu.com は許可', () => {
+      expect(isAllowedNagiyuRedirectUrl('https://nagiyu.com/', BASE_URL)).toBe(true);
+    });
+
+    it('http スキームの *.nagiyu.com も許可', () => {
+      expect(isAllowedNagiyuRedirectUrl('http://admin.nagiyu.com/', BASE_URL)).toBe(true);
+    });
+  });
+
+  describe('拒否されるケース（オープンリダイレクト対策）', () => {
+    it('ホスト途中に nagiyu.com を含む別ドメインは拒否', () => {
+      expect(isAllowedNagiyuRedirectUrl('https://auth.nagiyu.com.evil.com/phish', BASE_URL)).toBe(
+        false
+      );
+    });
+
+    it('nagiyu.com.attacker.com は拒否', () => {
+      expect(isAllowedNagiyuRedirectUrl('https://nagiyu.com.attacker.com/', BASE_URL)).toBe(false);
+    });
+
+    it('末尾に別 TLD が続く nagiyu.como は拒否', () => {
+      expect(isAllowedNagiyuRedirectUrl('https://x.nagiyu.como/', BASE_URL)).toBe(false);
+    });
+
+    it('全く別ドメインは拒否', () => {
+      expect(isAllowedNagiyuRedirectUrl('https://evil.example.com/', BASE_URL)).toBe(false);
+    });
+
+    it('javascript: スキームは拒否', () => {
+      expect(isAllowedNagiyuRedirectUrl('javascript:alert(1)', BASE_URL)).toBe(false);
+    });
+
+    it('data: スキームは拒否', () => {
+      expect(isAllowedNagiyuRedirectUrl('data:text/html,<h1>x</h1>', BASE_URL)).toBe(false);
+    });
+
+    it('相対パスは拒否（絶対 URL としてパース不能）', () => {
+      expect(isAllowedNagiyuRedirectUrl('/relative/path', BASE_URL)).toBe(false);
+    });
+  });
+});

--- a/libs/nextjs/src/types/next-auth.d.ts
+++ b/libs/nextjs/src/types/next-auth.d.ts
@@ -28,5 +28,7 @@ declare module 'next-auth/jwt' {
     name?: string;
     picture?: string;
     roles?: string[];
+    /** ロールを最後に DB から取得した epoch ms */
+    rolesRefreshedAt?: number;
   }
 }

--- a/services/auth/core/src/auth/auth.ts
+++ b/services/auth/core/src/auth/auth.ts
@@ -2,7 +2,7 @@ import NextAuth, { type NextAuthConfig } from 'next-auth';
 import Google from 'next-auth/providers/google';
 import { createAuthConfig } from '@nagiyu/nextjs';
 import { reportErrorEvent } from '@nagiyu/aws';
-import { toErrorMessage } from '@nagiyu/common';
+import { toErrorMessage, isAllowedNagiyuRedirectUrl } from '@nagiyu/common';
 import { createUserRepository } from '../repositories/factory';
 
 // エラーメッセージ定数
@@ -70,6 +70,11 @@ const sharedAuthConfig = createAuthConfig({
           if (dbUser) {
             token.roles = dbUser.roles ?? [];
             token.userId = dbUser.userId;
+          } else {
+            // ユーザーが DB に存在しない（退会・削除済み等）→ ロールを剥奪する。
+            // DB エラーは getUserByGoogleId が throw し下の catch で旧ロールを維持するため、
+            // ここに来る null は「ユーザー不在」を一意に意味する。
+            token.roles = [];
           }
           token.rolesRefreshedAt = Date.now();
         } catch (error) {
@@ -110,12 +115,9 @@ export const authConfig: NextAuthConfig = {
   callbacks: {
     ...sharedCallbacks,
     async redirect({ url, baseUrl }) {
-      // 同じドメインへのリダイレクトを許可
-      if (url.startsWith(baseUrl)) {
-        return url;
-      }
-      // プラットフォーム内のサービス (*.nagiyu.com) へのリダイレクトを許可
-      if (url.match(/^https?:\/\/[^/]*\.nagiyu\.com/)) {
+      // 同一オリジン または *.nagiyu.com のみ許可（オープンリダイレクト対策）。
+      // 判定は @nagiyu/common の共通バリデータに委譲する。
+      if (isAllowedNagiyuRedirectUrl(url, baseUrl)) {
         return url;
       }
       // 外部 URL は拒否して baseUrl にフォールバック

--- a/services/auth/core/src/auth/auth.ts
+++ b/services/auth/core/src/auth/auth.ts
@@ -13,7 +13,13 @@ const ERROR_MESSAGES = {
     'Google OAuth クライアントシークレットが設定されていません。環境変数 GOOGLE_CLIENT_SECRET を設定してください。',
   MISSING_USER_EMAIL: 'Google OAuth ユーザー情報に email が含まれていません。',
   MISSING_USER_NAME: 'Google OAuth ユーザー情報に name が含まれていません。',
+  ROLES_REFRESH_FAILED: 'jwt コールバック: DB からのロール再取得に失敗しました。',
 } as const;
+
+/**
+ * auth ドメインのセッション読み取り時に最大この間隔で DynamoDB を再取得する（5 分）
+ */
+const ROLES_REFRESH_TTL_MS = 5 * 60 * 1000;
 
 // 環境変数の検証（ビルド時以外のみ）
 // Next.js のビルド時は環境変数が未設定でも許容する
@@ -33,8 +39,9 @@ if (
 // UserRepository は Next.js のビルド時に初期化されないよう、コールバック内で都度取得する。
 // registry 側でシングルトン化されるため複数回呼び出しても同一インスタンスが返る。
 const sharedAuthConfig = createAuthConfig({
-  jwt: async ({ token, user, account }) => {
+  jwt: async ({ token, user, account, trigger }) => {
     if (account && user) {
+      // ログイン時: Google アカウント情報をトークンに焼き込む
       token.googleId = account.providerAccountId;
       token.email = user.email;
       token.name = user.name;
@@ -44,9 +51,40 @@ const sharedAuthConfig = createAuthConfig({
       const dbUser = await userRepository.getUserByGoogleId(account.providerAccountId);
       token.userId = dbUser?.userId;
       token.roles = dbUser?.roles || [];
+      token.rolesRefreshedAt = Date.now();
 
       if (dbUser) {
         await userRepository.updateLastLogin(dbUser.userId);
+      }
+    } else if (token.googleId) {
+      // ログイン以外の呼び出し: TTL ゲートまたは明示的な update トリガーでロールを再取得する
+      // token は Record<string, unknown> と交差するため、カスタムフィールドは型アサーションが必要
+      const rolesRefreshedAt = (token.rolesRefreshedAt as number | undefined) ?? 0;
+      const shouldRefresh =
+        trigger === 'update' || Date.now() - rolesRefreshedAt > ROLES_REFRESH_TTL_MS;
+
+      if (shouldRefresh) {
+        try {
+          const userRepository = createUserRepository();
+          const dbUser = await userRepository.getUserByGoogleId(token.googleId as string);
+          if (dbUser) {
+            token.roles = dbUser.roles ?? [];
+            token.userId = dbUser.userId;
+          }
+          token.rolesRefreshedAt = Date.now();
+        } catch (error) {
+          await reportErrorEvent({
+            serviceId: 'auth',
+            severity: 'error',
+            title: 'jwt コールバック: DB からのロール再取得に失敗しました',
+            message: ERROR_MESSAGES.ROLES_REFRESH_FAILED,
+            context: {
+              step: 'rolesRefresh',
+              errorStack: error instanceof Error ? error.stack : undefined,
+            },
+          });
+          // DB エラー時はセッションを壊さず既存トークンをそのまま返す
+        }
       }
     }
     return token;

--- a/services/auth/core/tests/unit/auth/jwt-roles-refresh.test.ts
+++ b/services/auth/core/tests/unit/auth/jwt-roles-refresh.test.ts
@@ -219,7 +219,7 @@ describe('jwt コールバック - rolesRefreshedAt', () => {
   });
 
   describe('DB ユーザーが見つからない場合', () => {
-    it('dbUser が null でも rolesRefreshedAt だけ更新し例外を投げない', async () => {
+    it('dbUser が null のとき roles を空にする（退会・削除済みユーザーの権限剥奪）', async () => {
       const oldTimestamp = Date.now() - TTL_MS - 1000;
       mockGetUserByGoogleId.mockResolvedValueOnce(null);
 
@@ -236,8 +236,10 @@ describe('jwt コールバック - rolesRefreshedAt', () => {
       };
       const result = await capturedCallbacks.jwt!({ token });
 
-      // 既存 roles は変わらない
-      expect(result.roles).toEqual(['existing-role']);
+      // ユーザーが DB に存在しない（= 退会・削除済み）ため roles を剥奪する。
+      // DB エラーは throw され別の catch で旧 roles 維持となるため、
+      // ここに来る null は「ユーザー不在」を一意に意味する。
+      expect(result.roles).toEqual([]);
       // rolesRefreshedAt は更新される（次回の無駄な再取得を防ぐ）
       expect(result.rolesRefreshedAt as number).toBeGreaterThan(oldTimestamp);
       // 例外なし
@@ -261,15 +263,10 @@ describe('jwt コールバック - rolesRefreshedAt', () => {
         rolesRefreshedAt: oldTimestamp,
       };
 
-      await expect(capturedCallbacks.jwt!({ token })).resolves.not.toThrow();
+      // DB エラー（getUserByGoogleId が throw）時は catch で握りつぶし、
+      // 既存 token（roles 含む）をそのまま返す。null 不在時の roles 剥奪とは区別される。
+      const result = await capturedCallbacks.jwt!({ token });
 
-      const result = await capturedCallbacks.jwt!({
-        token: { ...token },
-        // 2 回目は createUserRepository を再設定する必要があるため、
-        // 上記 resolves で検証済みのため、別途エラーなく返却されたことのみ確認する
-      });
-
-      // googleId がなければ再取得ロジックに入らない（token をそのまま返す）
       expect(result).toMatchObject({ googleId: 'google-err', roles: ['safe-role'] });
     });
 

--- a/services/auth/core/tests/unit/auth/jwt-roles-refresh.test.ts
+++ b/services/auth/core/tests/unit/auth/jwt-roles-refresh.test.ts
@@ -1,0 +1,334 @@
+/**
+ * jwt コールバックのロール再取得（TTL ゲート・強制リフレッシュ）テスト
+ *
+ * テスト対象:
+ *   - ログイン時に rolesRefreshedAt が設定される
+ *   - rolesRefreshedAt が TTL より古い → getUserByGoogleId が呼ばれ roles が更新される
+ *   - trigger === 'update' → TTL に関わらず強制再取得される
+ *   - rolesRefreshedAt が新しい（TTL 内）かつ trigger なし → 再取得されない
+ *   - DB エラー時に例外を投げず token をそのまま返す
+ */
+
+import { reportErrorEvent } from '@nagiyu/aws';
+
+type AnyAsyncFn = (...args: unknown[]) => Promise<Record<string, unknown>>;
+
+const capturedCallbacks: { jwt?: AnyAsyncFn } = {};
+const mockGetUserByGoogleId = jest.fn();
+const mockUpdateLastLogin = jest.fn();
+
+jest.mock('@nagiyu/aws', () => ({
+  reportErrorEvent: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@nagiyu/nextjs', () => ({
+  createAuthConfig: jest.fn().mockImplementation(({ jwt }: { jwt: AnyAsyncFn }) => {
+    capturedCallbacks.jwt = jwt;
+    return { callbacks: {} };
+  }),
+}));
+
+jest.mock('next-auth', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({
+    handlers: {},
+    auth: jest.fn(),
+    signIn: jest.fn(),
+    signOut: jest.fn(),
+  }),
+}));
+
+jest.mock('next-auth/providers/google', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../../src/repositories/factory', () => ({
+  createUserRepository: jest.fn().mockReturnValue({
+    getUserByGoogleId: mockGetUserByGoogleId,
+    updateLastLogin: mockUpdateLastLogin,
+    upsertUser: jest.fn().mockResolvedValue({ userId: 'user-123' }),
+  }),
+}));
+
+/** 5 分（TTL）= 300_000 ms */
+const TTL_MS = 5 * 60 * 1000;
+
+describe('jwt コールバック - rolesRefreshedAt', () => {
+  beforeAll(async () => {
+    await import('../../../src/auth/auth');
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (reportErrorEvent as jest.Mock).mockResolvedValue(null);
+    mockGetUserByGoogleId.mockResolvedValue(null);
+    mockUpdateLastLogin.mockResolvedValue(undefined);
+  });
+
+  describe('ログイン時（account && user）', () => {
+    it('rolesRefreshedAt が設定される', async () => {
+      const now = Date.now();
+      mockGetUserByGoogleId.mockResolvedValueOnce({ userId: 'u1', roles: ['admin'] });
+      mockUpdateLastLogin.mockResolvedValueOnce(undefined);
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {};
+      const result = await capturedCallbacks.jwt!({
+        token,
+        user: { email: 'test@example.com', name: 'Test' },
+        account: { providerAccountId: 'google-123' },
+      });
+
+      expect(typeof result.rolesRefreshedAt).toBe('number');
+      expect(result.rolesRefreshedAt as number).toBeGreaterThanOrEqual(now);
+    });
+
+    it('ログイン時は roles も設定される', async () => {
+      mockGetUserByGoogleId.mockResolvedValueOnce({ userId: 'u1', roles: ['admin', 'viewer'] });
+      mockUpdateLastLogin.mockResolvedValueOnce(undefined);
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {};
+      const result = await capturedCallbacks.jwt!({
+        token,
+        user: { email: 'test@example.com', name: 'Test' },
+        account: { providerAccountId: 'google-123' },
+      });
+
+      expect(result.roles).toEqual(['admin', 'viewer']);
+      expect(result.userId).toBe('u1');
+    });
+  });
+
+  describe('ログイン以外の呼び出し - TTL ゲート', () => {
+    it('rolesRefreshedAt が TTL より古い場合、getUserByGoogleId が呼ばれ roles が更新される', async () => {
+      const oldTimestamp = Date.now() - TTL_MS - 1000;
+      const mockDbUser = { userId: 'u2', roles: ['manager'] };
+      mockGetUserByGoogleId.mockResolvedValueOnce(mockDbUser);
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {
+        googleId: 'google-456',
+        roles: ['old-role'],
+        rolesRefreshedAt: oldTimestamp,
+      };
+      const result = await capturedCallbacks.jwt!({ token });
+
+      expect(mockGetUserByGoogleId).toHaveBeenCalledWith('google-456');
+      expect(result.roles).toEqual(['manager']);
+      expect(result.userId).toBe('u2');
+      expect(typeof result.rolesRefreshedAt).toBe('number');
+      expect(result.rolesRefreshedAt as number).toBeGreaterThan(oldTimestamp);
+    });
+
+    it('rolesRefreshedAt が TTL 内（新しい）かつ trigger なしの場合、再取得されない', async () => {
+      const recentTimestamp = Date.now() - 1000; // 1 秒前（TTL 5 分以内）
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {
+        googleId: 'google-789',
+        roles: ['existing-role'],
+        rolesRefreshedAt: recentTimestamp,
+      };
+      const result = await capturedCallbacks.jwt!({ token });
+
+      expect(mockGetUserByGoogleId).not.toHaveBeenCalled();
+      expect(result.roles).toEqual(['existing-role']);
+    });
+
+    it('rolesRefreshedAt が未設定の場合（初回 TTL チェック）、再取得される', async () => {
+      mockGetUserByGoogleId.mockResolvedValueOnce({ userId: 'u3', roles: ['viewer'] });
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      // rolesRefreshedAt なし → Date.now() - 0 > TTL_MS → 再取得される
+      const token = { googleId: 'google-000' };
+      const result = await capturedCallbacks.jwt!({ token });
+
+      expect(mockGetUserByGoogleId).toHaveBeenCalledWith('google-000');
+      expect(result.roles).toEqual(['viewer']);
+    });
+  });
+
+  describe('trigger === "update"（強制リフレッシュ）', () => {
+    it('trigger が "update" のとき TTL に関わらず getUserByGoogleId が呼ばれる', async () => {
+      const recentTimestamp = Date.now() - 1000; // TTL 内でも強制再取得される
+      mockGetUserByGoogleId.mockResolvedValueOnce({ userId: 'u4', roles: ['super-admin'] });
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {
+        googleId: 'google-999',
+        roles: ['old-role'],
+        rolesRefreshedAt: recentTimestamp,
+      };
+      const result = await capturedCallbacks.jwt!({ token, trigger: 'update' });
+
+      expect(mockGetUserByGoogleId).toHaveBeenCalledWith('google-999');
+      expect(result.roles).toEqual(['super-admin']);
+    });
+
+    it('trigger が "update" のとき rolesRefreshedAt が更新される', async () => {
+      const recentTimestamp = Date.now() - 1000;
+      mockGetUserByGoogleId.mockResolvedValueOnce({ userId: 'u5', roles: [] });
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {
+        googleId: 'google-111',
+        roles: ['old-role'],
+        rolesRefreshedAt: recentTimestamp,
+      };
+      const result = await capturedCallbacks.jwt!({ token, trigger: 'update' });
+
+      expect(result.rolesRefreshedAt as number).toBeGreaterThan(recentTimestamp);
+    });
+  });
+
+  describe('DB ユーザーが見つからない場合', () => {
+    it('dbUser が null でも rolesRefreshedAt だけ更新し例外を投げない', async () => {
+      const oldTimestamp = Date.now() - TTL_MS - 1000;
+      mockGetUserByGoogleId.mockResolvedValueOnce(null);
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {
+        googleId: 'google-404',
+        roles: ['existing-role'],
+        rolesRefreshedAt: oldTimestamp,
+      };
+      const result = await capturedCallbacks.jwt!({ token });
+
+      // 既存 roles は変わらない
+      expect(result.roles).toEqual(['existing-role']);
+      // rolesRefreshedAt は更新される（次回の無駄な再取得を防ぐ）
+      expect(result.rolesRefreshedAt as number).toBeGreaterThan(oldTimestamp);
+      // 例外なし
+    });
+  });
+
+  describe('DB エラー時', () => {
+    it('DB エラー時は例外を投げず既存 token をそのまま返す', async () => {
+      const oldTimestamp = Date.now() - TTL_MS - 1000;
+      mockGetUserByGoogleId.mockRejectedValueOnce(new Error('DynamoDB 接続エラー'));
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {
+        googleId: 'google-err',
+        roles: ['safe-role'],
+        rolesRefreshedAt: oldTimestamp,
+      };
+
+      await expect(capturedCallbacks.jwt!({ token })).resolves.not.toThrow();
+
+      const result = await capturedCallbacks.jwt!({
+        token: { ...token },
+        // 2 回目は createUserRepository を再設定する必要があるため、
+        // 上記 resolves で検証済みのため、別途エラーなく返却されたことのみ確認する
+      });
+
+      // googleId がなければ再取得ロジックに入らない（token をそのまま返す）
+      expect(result).toMatchObject({ googleId: 'google-err', roles: ['safe-role'] });
+    });
+
+    it('DB エラー時は reportErrorEvent が呼ばれる', async () => {
+      const oldTimestamp = Date.now() - TTL_MS - 1000;
+      const dbError = new Error('DynamoDB タイムアウト');
+      mockGetUserByGoogleId.mockRejectedValueOnce(dbError);
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {
+        googleId: 'google-err2',
+        roles: ['current-role'],
+        rolesRefreshedAt: oldTimestamp,
+      };
+
+      await capturedCallbacks.jwt!({ token });
+
+      expect(reportErrorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: 'auth',
+          severity: 'error',
+        })
+      );
+    });
+
+    it('DB エラー時は既存の roles が維持される', async () => {
+      const oldTimestamp = Date.now() - TTL_MS - 1000;
+      mockGetUserByGoogleId.mockRejectedValueOnce(new Error('DB unavailable'));
+
+      const { createUserRepository } = await import('../../../src/repositories/factory');
+      (createUserRepository as jest.Mock).mockReturnValueOnce({
+        getUserByGoogleId: mockGetUserByGoogleId,
+        updateLastLogin: mockUpdateLastLogin,
+      });
+
+      const token = {
+        googleId: 'google-err3',
+        roles: ['preserved-role'],
+        rolesRefreshedAt: oldTimestamp,
+      };
+
+      const result = await capturedCallbacks.jwt!({ token });
+
+      expect(result.roles).toEqual(['preserved-role']);
+    });
+  });
+
+  describe('googleId がない場合', () => {
+    it('googleId がなければ再取得ロジックに入らず token をそのまま返す', async () => {
+      const token = { roles: ['some-role'], email: 'test@example.com' };
+      const result = await capturedCallbacks.jwt!({ token });
+
+      expect(mockGetUserByGoogleId).not.toHaveBeenCalled();
+      expect(result).toEqual(token);
+    });
+  });
+});

--- a/services/auth/web/jest.config.ts
+++ b/services/auth/web/jest.config.ts
@@ -34,6 +34,9 @@ const config: Config = {
     '!src/app/**/layout.tsx',
     '!src/app/**/page.tsx',
     '!src/app/api/**', // Exclude API routes from coverage for now
+    '!src/middleware.ts', // ミドルウェアは NextAuth 依存が強く単体テスト困難
+    '!src/components/SessionProviderWrapper.tsx', // SessionProvider の薄いラッパー（JSX のみ）
+    '!src/lib/navigate.ts', // window.location.assign の薄いラッパー（jsdom でテスト困難）
   ],
   // Coverage thresholds (fail if below 80%)
   coverageThreshold: {

--- a/services/auth/web/jest.config.ts
+++ b/services/auth/web/jest.config.ts
@@ -34,7 +34,6 @@ const config: Config = {
     '!src/app/**/layout.tsx',
     '!src/app/**/page.tsx',
     '!src/app/api/**', // Exclude API routes from coverage for now
-    '!src/middleware.ts', // ミドルウェアは NextAuth 依存が強く単体テスト困難
     '!src/components/SessionProviderWrapper.tsx', // SessionProvider の薄いラッパー（JSX のみ）
     '!src/lib/navigate.ts', // window.location.assign の薄いラッパー（jsdom でテスト困難）
   ],

--- a/services/auth/web/src/app/refresh/page.tsx
+++ b/services/auth/web/src/app/refresh/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useSearchParams } from 'next/navigation';
+import { Box, Container, CircularProgress, Typography } from '@mui/material';
+import SessionProviderWrapper from '../../components/SessionProviderWrapper';
+import { resolveRefreshCallbackUrl } from '../../lib/refresh-callback';
+import { navigateTo } from '../../lib/navigate';
+
+/**
+ * アクセス権限のリフレッシュを行う内部コンポーネント。
+ * useSession の update() を呼んで jwt callback を trigger:'update' で起動し、
+ * ロールを強制再取得したうえで callbackUrl へリダイレクトする。
+ */
+function RefreshContent() {
+  const { update } = useSession();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<'refreshing' | 'done' | 'error'>('refreshing');
+
+  useEffect(() => {
+    const rawCallbackUrl = searchParams.get('callbackUrl');
+    const baseUrl = window.location.origin;
+    const callbackUrl = resolveRefreshCallbackUrl(rawCallbackUrl, baseUrl);
+
+    update()
+      .then(() => {
+        setStatus('done');
+        navigateTo(callbackUrl);
+      })
+      .catch(() => {
+        setStatus('error');
+        navigateTo(callbackUrl);
+      });
+    // update と searchParams は安定した参照のため依存配列に含めるが、
+    // マウント時に一度だけ実行することが意図された処理。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          minHeight: '50vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 2,
+        }}
+      >
+        {status === 'refreshing' && (
+          <>
+            <CircularProgress />
+            <Typography variant="body1" color="text.secondary">
+              アクセス権限を更新しています…
+            </Typography>
+          </>
+        )}
+        {status === 'done' && (
+          <Typography variant="body1" color="text.secondary">
+            アクセス権限を更新しました。リダイレクト中…
+          </Typography>
+        )}
+        {status === 'error' && (
+          <Typography variant="body1" color="text.secondary">
+            更新中にエラーが発生しましたが、リダイレクト先へ移動します…
+          </Typography>
+        )}
+      </Box>
+    </Container>
+  );
+}
+
+/**
+ * /refresh ページ。
+ * クエリ callbackUrl を受け取り、ロールを強制再取得したうえで遷移する。
+ * Phase 4 の 403 画面からバウンスされる想定。
+ */
+export default function RefreshPage() {
+  return (
+    <SessionProviderWrapper>
+      <RefreshContent />
+    </SessionProviderWrapper>
+  );
+}

--- a/services/auth/web/src/app/refresh/page.tsx
+++ b/services/auth/web/src/app/refresh/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { Box, Container, CircularProgress, Typography } from '@mui/material';
@@ -78,9 +78,13 @@ function RefreshContent() {
  * Phase 4 の 403 画面からバウンスされる想定。
  */
 export default function RefreshPage() {
+  // useSearchParams を使う RefreshContent は Suspense 境界の内側に置く
+  // （App Router の prerender 要件。境界が無いと next build が失敗する）。
   return (
     <SessionProviderWrapper>
-      <RefreshContent />
+      <Suspense fallback={null}>
+        <RefreshContent />
+      </Suspense>
     </SessionProviderWrapper>
   );
 }

--- a/services/auth/web/src/components/SessionProviderWrapper.tsx
+++ b/services/auth/web/src/components/SessionProviderWrapper.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+
+/**
+ * /refresh ページ用の SessionProvider ラッパー。
+ * useSession（update 含む）を利用するクライアントコンポーネントを包む。
+ * dashboard など server component の getServerSession を使うページには影響を与えない。
+ */
+export default function SessionProviderWrapper({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/services/auth/web/src/lib/navigate.ts
+++ b/services/auth/web/src/lib/navigate.ts
@@ -1,0 +1,11 @@
+/**
+ * ブラウザナビゲーションのユーティリティ。
+ * テスト環境でモック可能なようにモジュールとして分離する。
+ */
+
+/**
+ * 指定 URL に移動する。window.location.assign のラッパー。
+ */
+export function navigateTo(url: string): void {
+  window.location.assign(url);
+}

--- a/services/auth/web/src/lib/refresh-callback.ts
+++ b/services/auth/web/src/lib/refresh-callback.ts
@@ -1,10 +1,13 @@
 /**
  * /refresh ページの callbackUrl 解決ロジック
  *
- * auth の redirect コールバック（auth.ts）と同じ許可基準を適用する:
- *   - 同一オリジン（baseUrl で始まる URL）
- *   - *.nagiyu.com 配下の URL
+ * 許可基準:
+ *   - 同一オリジン（baseUrl と同一 origin）
+ *   - nagiyu.com 本体、またはそのサブドメイン（*.nagiyu.com）
  * 許可されない URL は baseUrl（auth のトップ）にフォールバックする。
+ *
+ * 判定は文字列の前方一致ではなく URL パース＋ホスト名一致で行う
+ * （前方一致だと `https://auth.nagiyu.com.evil.com` 等のオープンリダイレクトを許すため）。
  */
 
 // エラーメッセージ定数
@@ -29,13 +32,30 @@ export function resolveRefreshCallbackUrl(
     return baseUrl;
   }
 
-  // 同一オリジン（baseUrl で始まる URL）は許可
-  if (rawCallbackUrl.startsWith(baseUrl)) {
-    return rawCallbackUrl;
+  let parsed: URL;
+  try {
+    parsed = new URL(rawCallbackUrl);
+  } catch {
+    // 相対パスやスキーム不正など、絶対 URL としてパースできないものはフォールバック
+    return baseUrl;
   }
 
-  // *.nagiyu.com 配下の URL は許可
-  if (rawCallbackUrl.match(/^https?:\/\/[^/]*\.nagiyu\.com/)) {
+  // http / https 以外（javascript:, data: 等）はフォールバック
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return baseUrl;
+  }
+
+  // 同一オリジンは許可
+  try {
+    if (parsed.origin === new URL(baseUrl).origin) {
+      return rawCallbackUrl;
+    }
+  } catch {
+    // baseUrl 自体が不正な場合は下のホスト名判定に委ねる
+  }
+
+  // nagiyu.com 本体、またはそのサブドメイン（ホスト名の完全一致 / 末尾一致）のみ許可
+  if (parsed.hostname === 'nagiyu.com' || parsed.hostname.endsWith('.nagiyu.com')) {
     return rawCallbackUrl;
   }
 

--- a/services/auth/web/src/lib/refresh-callback.ts
+++ b/services/auth/web/src/lib/refresh-callback.ts
@@ -1,0 +1,44 @@
+/**
+ * /refresh ページの callbackUrl 解決ロジック
+ *
+ * auth の redirect コールバック（auth.ts）と同じ許可基準を適用する:
+ *   - 同一オリジン（baseUrl で始まる URL）
+ *   - *.nagiyu.com 配下の URL
+ * 許可されない URL は baseUrl（auth のトップ）にフォールバックする。
+ */
+
+// エラーメッセージ定数
+export const ERROR_MESSAGES = {
+  INVALID_CALLBACK_URL:
+    'callbackUrl が許可されていない URL のため、トップページにフォールバックしました。',
+} as const;
+
+/**
+ * callbackUrl を検証し、許可された URL を返す。
+ * 許可されない場合は baseUrl（auth のトップ）を返す。
+ *
+ * @param rawCallbackUrl - クエリパラメータから受け取った生の callbackUrl
+ * @param baseUrl - auth サービスのベース URL（例: https://auth.nagiyu.com）
+ * @returns 遷移先として安全な URL 文字列
+ */
+export function resolveRefreshCallbackUrl(
+  rawCallbackUrl: string | null | undefined,
+  baseUrl: string
+): string {
+  if (!rawCallbackUrl) {
+    return baseUrl;
+  }
+
+  // 同一オリジン（baseUrl で始まる URL）は許可
+  if (rawCallbackUrl.startsWith(baseUrl)) {
+    return rawCallbackUrl;
+  }
+
+  // *.nagiyu.com 配下の URL は許可
+  if (rawCallbackUrl.match(/^https?:\/\/[^/]*\.nagiyu\.com/)) {
+    return rawCallbackUrl;
+  }
+
+  // それ以外は baseUrl にフォールバック
+  return baseUrl;
+}

--- a/services/auth/web/src/lib/refresh-callback.ts
+++ b/services/auth/web/src/lib/refresh-callback.ts
@@ -10,6 +10,8 @@
  * （前方一致だと `https://auth.nagiyu.com.evil.com` 等のオープンリダイレクトを許すため）。
  */
 
+import { isAllowedNagiyuRedirectUrl } from '@nagiyu/common';
+
 // エラーメッセージ定数
 export const ERROR_MESSAGES = {
   INVALID_CALLBACK_URL:
@@ -32,33 +34,7 @@ export function resolveRefreshCallbackUrl(
     return baseUrl;
   }
 
-  let parsed: URL;
-  try {
-    parsed = new URL(rawCallbackUrl);
-  } catch {
-    // 相対パスやスキーム不正など、絶対 URL としてパースできないものはフォールバック
-    return baseUrl;
-  }
-
-  // http / https 以外（javascript:, data: 等）はフォールバック
-  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-    return baseUrl;
-  }
-
-  // 同一オリジンは許可
-  try {
-    if (parsed.origin === new URL(baseUrl).origin) {
-      return rawCallbackUrl;
-    }
-  } catch {
-    // baseUrl 自体が不正な場合は下のホスト名判定に委ねる
-  }
-
-  // nagiyu.com 本体、またはそのサブドメイン（ホスト名の完全一致 / 末尾一致）のみ許可
-  if (parsed.hostname === 'nagiyu.com' || parsed.hostname.endsWith('.nagiyu.com')) {
-    return rawCallbackUrl;
-  }
-
-  // それ以外は baseUrl にフォールバック
-  return baseUrl;
+  // 許可判定（同一オリジン / *.nagiyu.com、オープンリダイレクト対策）は
+  // @nagiyu/common の共通バリデータに委譲する。
+  return isAllowedNagiyuRedirectUrl(rawCallbackUrl, baseUrl) ? rawCallbackUrl : baseUrl;
 }

--- a/services/auth/web/tests/unit/app/refresh/page.test.tsx
+++ b/services/auth/web/tests/unit/app/refresh/page.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * /refresh ページのユニットテスト
+ *
+ * callbackUrl 解決ロジックは refresh-callback.test.ts でテスト済みのため、
+ * ここでは「update() が呼ばれ、その後 navigateTo が正しい URL で呼ばれる」
+ * 呼び出し順と引数を検証する。
+ *
+ * jsdom の navigation 制約: window.location は configurable: false のため
+ * Object.defineProperty での置き換えが不可能。navigateTo モジュールをモックし、
+ * テスト内では jsdom の実際の origin（'http://localhost'）を期待値に使う。
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// navigateTo のモック（window.location.assign のラッパー。jsdom では assign を直接モックできないため分離）
+const mockNavigateTo = jest.fn();
+jest.mock('../../../../src/lib/navigate', () => ({
+  navigateTo: (url: string) => mockNavigateTo(url),
+}));
+
+// next-auth/react のモック
+const mockUpdate = jest.fn();
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(() => ({ update: mockUpdate })),
+  SessionProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+// next/navigation のモック
+const mockGet = jest.fn();
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(() => ({ get: mockGet })),
+}));
+
+// SessionProviderWrapper のモック（実体の SessionProvider 依存を回避）
+jest.mock('../../../../src/components/SessionProviderWrapper', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+// MUI コンポーネントのモック（jsdom でのレンダリングを簡略化）
+jest.mock('@mui/material', () => ({
+  Box: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+  Container: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  CircularProgress: () => React.createElement('div', { role: 'progressbar' }),
+  Typography: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('p', null, children),
+}));
+
+// jsdom での window.location.origin（テスト内で baseUrl として利用される値）
+const JSDOM_ORIGIN = 'http://localhost';
+
+// ページコンポーネントのインポートはモック設定後に行う
+let RefreshPage: React.ComponentType;
+
+describe('/refresh ページ', () => {
+  beforeAll(async () => {
+    ({ default: RefreshPage } = await import('../../../../src/app/refresh/page'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('マウント時に「アクセス権限を更新しています」テキストを表示する', () => {
+    mockUpdate.mockImplementation(() => new Promise(() => {})); // 永続的に pending
+    mockGet.mockReturnValue(null);
+
+    render(<RefreshPage />);
+
+    expect(screen.getByText('アクセス権限を更新しています…')).toBeInTheDocument();
+  });
+
+  it('マウント時に update() が呼ばれる', async () => {
+    mockUpdate.mockResolvedValue(undefined);
+    mockGet.mockReturnValue(null);
+
+    render(<RefreshPage />);
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('update() 完了後、*.nagiyu.com の callbackUrl へ navigateTo を呼ぶ', async () => {
+    mockUpdate.mockResolvedValue(undefined);
+    // *.nagiyu.com は許可 URL のため、そのまま使われる
+    const callbackUrl = 'https://admin.nagiyu.com/dashboard';
+    mockGet.mockReturnValue(callbackUrl);
+
+    render(<RefreshPage />);
+
+    await waitFor(() => {
+      expect(mockNavigateTo).toHaveBeenCalledWith(callbackUrl);
+    });
+  });
+
+  it('callbackUrl が null のとき jsdom origin（baseUrl）へ navigateTo を呼ぶ', async () => {
+    mockUpdate.mockResolvedValue(undefined);
+    mockGet.mockReturnValue(null);
+
+    render(<RefreshPage />);
+
+    await waitFor(() => {
+      // callbackUrl が null → resolveRefreshCallbackUrl は baseUrl（window.location.origin）を返す
+      expect(mockNavigateTo).toHaveBeenCalledWith(JSDOM_ORIGIN);
+    });
+  });
+
+  it('外部 URL の callbackUrl は origin（baseUrl）へフォールバックして navigateTo を呼ぶ', async () => {
+    mockUpdate.mockResolvedValue(undefined);
+    mockGet.mockReturnValue('https://evil.example.com/');
+
+    render(<RefreshPage />);
+
+    await waitFor(() => {
+      // 外部 URL → resolveRefreshCallbackUrl は baseUrl（window.location.origin）を返す
+      expect(mockNavigateTo).toHaveBeenCalledWith(JSDOM_ORIGIN);
+    });
+  });
+
+  it('update() がエラーを返しても navigateTo は呼ばれる（エラー時もリダイレクトする）', async () => {
+    mockUpdate.mockRejectedValue(new Error('セッション更新エラー'));
+    mockGet.mockReturnValue(null);
+
+    render(<RefreshPage />);
+
+    await waitFor(() => {
+      expect(mockNavigateTo).toHaveBeenCalled();
+    });
+  });
+
+  it('update() の後に navigateTo が呼ばれる（呼び出し順の検証）', async () => {
+    const callOrder: string[] = [];
+    mockUpdate.mockImplementation(async () => {
+      callOrder.push('update');
+    });
+    mockNavigateTo.mockImplementation(() => {
+      callOrder.push('navigate');
+    });
+    mockGet.mockReturnValue(null);
+
+    render(<RefreshPage />);
+
+    await waitFor(() => {
+      expect(callOrder).toEqual(['update', 'navigate']);
+    });
+  });
+});

--- a/services/auth/web/tests/unit/lib/refresh-callback.test.ts
+++ b/services/auth/web/tests/unit/lib/refresh-callback.test.ts
@@ -87,6 +87,39 @@ describe('resolveRefreshCallbackUrl', () => {
     });
   });
 
+  describe('オープンリダイレクト対策（ホスト名の途中に nagiyu.com を含む攻撃 URL）', () => {
+    it('https://auth.nagiyu.com.evil.com はフォールバックする', () => {
+      const result = resolveRefreshCallbackUrl('https://auth.nagiyu.com.evil.com/phish', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('https://evil.nagiyu.com.attacker.com はフォールバックする', () => {
+      const result = resolveRefreshCallbackUrl(
+        'https://evil.nagiyu.com.attacker.com/steal',
+        BASE_URL
+      );
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('https://x.nagiyu.como（末尾に別 TLD が続く）はフォールバックする', () => {
+      const result = resolveRefreshCallbackUrl('https://x.nagiyu.como/', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('nagiyu.com を含む別ドメイン（nagiyu.com.evil.example.com）はフォールバックする', () => {
+      const result = resolveRefreshCallbackUrl('https://nagiyu.com.evil.example.com/', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+  });
+
+  describe('apex ドメイン', () => {
+    it('https://nagiyu.com（本体）は許可する', () => {
+      const url = 'https://nagiyu.com/';
+      const result = resolveRefreshCallbackUrl(url, BASE_URL);
+      expect(result).toBe(url);
+    });
+  });
+
   describe('空 / 未指定のフォールバック', () => {
     it('null のとき baseUrl を返す', () => {
       const result = resolveRefreshCallbackUrl(null, BASE_URL);

--- a/services/auth/web/tests/unit/lib/refresh-callback.test.ts
+++ b/services/auth/web/tests/unit/lib/refresh-callback.test.ts
@@ -1,0 +1,106 @@
+/**
+ * resolveRefreshCallbackUrl のユニットテスト
+ *
+ * auth の redirect コールバックと同じ許可基準を検証:
+ *   - 同一オリジン（baseUrl で始まる URL）は許可
+ *   - *.nagiyu.com 配下の URL は許可
+ *   - 外部 URL は baseUrl にフォールバック
+ *   - 空 / 未指定のフォールバック
+ */
+
+import { resolveRefreshCallbackUrl } from '../../../src/lib/refresh-callback';
+
+const BASE_URL = 'https://auth.nagiyu.com';
+
+describe('resolveRefreshCallbackUrl', () => {
+  describe('同一オリジン（baseUrl で始まる URL）', () => {
+    it('baseUrl そのものは許可する', () => {
+      const result = resolveRefreshCallbackUrl(BASE_URL, BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('baseUrl で始まるパス付き URL は許可する', () => {
+      const url = `${BASE_URL}/dashboard`;
+      const result = resolveRefreshCallbackUrl(url, BASE_URL);
+      expect(result).toBe(url);
+    });
+
+    it('baseUrl で始まるネストされたパスも許可する', () => {
+      const url = `${BASE_URL}/dashboard/users?page=2`;
+      const result = resolveRefreshCallbackUrl(url, BASE_URL);
+      expect(result).toBe(url);
+    });
+  });
+
+  describe('*.nagiyu.com 配下の URL', () => {
+    it('https://admin.nagiyu.com は許可する', () => {
+      const url = 'https://admin.nagiyu.com/';
+      const result = resolveRefreshCallbackUrl(url, BASE_URL);
+      expect(result).toBe(url);
+    });
+
+    it('https://stock-tracker.nagiyu.com のパス付き URL は許可する', () => {
+      const url = 'https://stock-tracker.nagiyu.com/portfolio';
+      const result = resolveRefreshCallbackUrl(url, BASE_URL);
+      expect(result).toBe(url);
+    });
+
+    it('http スキームの *.nagiyu.com も許可する', () => {
+      const url = 'http://dev-admin.nagiyu.com/';
+      const result = resolveRefreshCallbackUrl(url, BASE_URL);
+      expect(result).toBe(url);
+    });
+
+    it('dev-*.nagiyu.com も許可する', () => {
+      const url = 'https://dev-stock-tracker.nagiyu.com/';
+      const result = resolveRefreshCallbackUrl(url, BASE_URL);
+      expect(result).toBe(url);
+    });
+  });
+
+  describe('外部 URL（フォールバック）', () => {
+    it('全く別のドメインは baseUrl にフォールバックする', () => {
+      const result = resolveRefreshCallbackUrl('https://evil.example.com/', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('nagiyu.com が含まれていても subdomain でなければフォールバックする', () => {
+      // 例: nagiyu.com.evil.example.com
+      const result = resolveRefreshCallbackUrl('https://nagiyu.com.attacker.com/', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('javascript: スキームはフォールバックする', () => {
+      const result = resolveRefreshCallbackUrl('javascript:alert(1)', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('data: スキームはフォールバックする', () => {
+      const result = resolveRefreshCallbackUrl('data:text/html,<h1>XSS</h1>', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('相対パスはフォールバックする', () => {
+      // 相対パスは baseUrl で始まらず *.nagiyu.com にもマッチしない
+      const result = resolveRefreshCallbackUrl('/relative/path', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+  });
+
+  describe('空 / 未指定のフォールバック', () => {
+    it('null のとき baseUrl を返す', () => {
+      const result = resolveRefreshCallbackUrl(null, BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('undefined のとき baseUrl を返す', () => {
+      const result = resolveRefreshCallbackUrl(undefined, BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+
+    it('空文字列のとき baseUrl を返す', () => {
+      const result = resolveRefreshCallbackUrl('', BASE_URL);
+      expect(result).toBe(BASE_URL);
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

親 Issue #3593 の Phase 3（根治）。ステートレス JWT のためロールがログイン時に焼き込まれ、再ログインまで更新されない問題に対し、**auth サービス側でロールを定期リフレッシュ**する仕組みを追加する。方針は「auth 集約リフレッシュ＋403 バウンス」（DB アクセスは auth に閉じ、consumer は触らない）。

- **auth jwt callback の TTL リフレッシュ**: ログイン以外の呼び出しでも、`trigger==='update'` または最終取得から `ROLES_REFRESH_TTL_MS`（5 分）超過時に DynamoDB からロールを再取得し token を更新。auth ドメインを通過するたびに最新ロールが共有 cookie（`.nagiyu.com`）へ再発行され、全サービスに伝播する。
- **auth `/refresh` ページ**: `useSession().update()` で強制リフレッシュ後、検証済み `callbackUrl` へ遷移。Phase 4 の 403 画面の「アクセスを更新」ボタンのバウンス先になる。
- **退会・削除済みユーザーの権限剥奪**: リフレッシュ時に `dbUser` が `null`（DB 不在＝退会等。DB エラーは throw→旧ロール維持と区別）なら `roles` を空にする。
- **オープンリダイレクト対策の共通化**: `isAllowedNagiyuRedirectUrl` を `@nagiyu/common` に新設（URL パース＋ホスト名の完全/末尾一致）。`/refresh` の callbackUrl 検証と、**既存の `auth.ts` redirect コールバック**（同じ前方一致欠陥があった）の両方をこの共通バリデータへ寄せ、`https://auth.nagiyu.com.evil.com` 等を確実に拒否。

## 関連 Issue

親 Issue: #3593（作業ブランチ → integration のため `Closes #` は付けない）

## 変更種別

- [x] 新規機能
- [x] バグ修正（オープンリダイレクト）
- [x] セキュリティ

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ閾値維持）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラー・フォーマットエラーがないことを確認した

## テスト内容

- `@nagiyu/common` `isAllowedNagiyuRedirectUrl`: 12 件（同一オリジン・`*.nagiyu.com`・apex 許可／攻撃ベクタ `*.nagiyu.com.evil.com`・`nagiyu.como`・javascript:/data:・相対パス拒否）。common 全 323 件グリーン
- auth-core: 102 件グリーン（jwt TTL リフレッシュ／`trigger:update` 強制／TTL 内スキップ／DB エラー時の旧ロール維持／null 時のロール剥奪）
- auth-web: 54 件グリーン、カバレッジ 89.71%（`/refresh` ページ・`resolveRefreshCallbackUrl`）
- `tsc --noEmit`（auth-core / auth-web）エラーなし、prettier 整形済み

## レビューポイント

- 本 PR は fresh-eyes レビュー（Opus）を実施。検出した**クリティカル（オープンリダイレクト）を修正**し、既存 `auth.ts` の同欠陥も承認のうえ共通化で是正。退会ユーザーのロール剥奪ポリシーも合意のうえ実装。
- ロール伝播は共有 cookie（`.nagiyu.com`、同一 AUTH_SECRET）前提。auth の jwt callback が token を書き換え cookie をローテーションすることで consumer 側へ反映される。TTL 経路は「auth ドメイン通過時」、明示更新は `/refresh` 経由。
- `ROLES_REFRESH_TTL_MS = 5 分`（DynamoDB 読み取り頻度と反映遅延のバランス。定数で固定）。
- consumer 側の自動 403 バウンス配線は Phase 4（401/403 画面に `/refresh` ボタン）に委ねるため本 PR スコープ外。
- 補足: 実装中に検出した「無関係な `middleware.ts` のカバレッジ除外」は取り消し済み（除外なしで閾値超過）。

## スクリーンショット

`/refresh` は遷移用の最小画面。dev 反映後に実機でロール反映フローを確認予定。

https://claude.ai/code/session_015mjPyhPKqKqiW1MjZGJqk3

---
_Generated by [Claude Code](https://claude.ai/code/session_015mjPyhPKqKqiW1MjZGJqk3)_