### PR TITLE
認証フロー改善 Phase 4: 403 の導線付き画面（AccessDeniedView）と livetalk /forbidden

### DIFF
--- a/libs/ui/src/components/feedback/AccessDeniedView.tsx
+++ b/libs/ui/src/components/feedback/AccessDeniedView.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { Box, Container, Typography } from '@mui/material';
+
+import Button from '../Button';
+import { buildRefreshUrl } from '../../utils/auth';
+import { buildSignOutUrl } from '../../utils/auth';
+
+/**
+ * AccessDeniedView に表示するテキストの定数。
+ *
+ * 表示文言を一箇所に集約して変更を容易にする。
+ */
+export const ACCESS_DENIED_VIEW_MESSAGES = {
+  DEFAULT_TITLE: 'アクセス権限がありません',
+  DEFAULT_DESCRIPTION:
+    'この機能を利用する権限がありません。管理者の承認後、下のボタンでアクセスを更新してください。',
+  REFRESH_BUTTON: 'アクセスを更新',
+  SIGN_OUT_BUTTON: '再ログイン',
+} as const;
+
+/**
+ * AccessDeniedView のプロパティ。
+ */
+export interface AccessDeniedViewProps {
+  /**
+   * auth サービスのベース URL（例: "https://auth.nagiyu.com"）
+   */
+  authUrl: string;
+  /**
+   * 更新・再ログイン後のリダイレクト先 URL。
+   * 未指定時は callbackUrl クエリパラメータを付与しない。
+   */
+  callbackUrl?: string;
+  /**
+   * 画面タイトル。デフォルト: "アクセス権限がありません"
+   */
+  title?: string;
+  /**
+   * 説明文。デフォルト: "この機能を利用する権限がありません。管理者の承認後、下のボタンでアクセスを更新してください。"
+   */
+  description?: string;
+  /**
+   * 「アクセスを更新」ボタン押下時の遷移処理。
+   * デフォルトは `window.location.assign(buildRefreshUrl(authUrl, callbackUrl))`。
+   * テストや特殊なナビゲーション要件がある場合に上書き可能。
+   */
+  onRefresh?: (url: string) => void;
+  /**
+   * 「再ログイン」ボタン押下時の遷移処理。
+   * デフォルトは `window.location.assign(buildSignOutUrl(authUrl, callbackUrl))`。
+   * テストや特殊なナビゲーション要件がある場合に上書き可能。
+   */
+  onSignOut?: (url: string) => void;
+}
+
+/**
+ * アクセス権限なし（403）時の導線付き画面コンポーネント。
+ *
+ * - 「アクセスを更新」ボタン: auth サービスの /refresh エンドポイントへリダイレクトし、
+ *   セッションを更新後に callbackUrl へ戻る（管理者によるロール付与後の利用を想定）。
+ * - 「再ログイン」ボタン: auth サービスのサインアウトエンドポイントへリダイレクトし、
+ *   再ログインを促す。
+ *
+ * libs 内のため、パスエイリアス（@/）は使用せず相対 import のみを使用する。
+ */
+export default function AccessDeniedView({
+  authUrl,
+  callbackUrl,
+  title = ACCESS_DENIED_VIEW_MESSAGES.DEFAULT_TITLE,
+  description = ACCESS_DENIED_VIEW_MESSAGES.DEFAULT_DESCRIPTION,
+  onRefresh,
+  onSignOut,
+}: AccessDeniedViewProps) {
+  const handleRefresh = () => {
+    const url = buildRefreshUrl(authUrl, callbackUrl);
+    if (onRefresh) {
+      onRefresh(url);
+    } else {
+      window.location.assign(url);
+    }
+  };
+
+  const handleSignOut = () => {
+    const url = buildSignOutUrl(authUrl, callbackUrl);
+    if (onSignOut) {
+      onSignOut(url);
+    } else {
+      window.location.assign(url);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        role="main"
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: 400,
+          gap: 3,
+          py: 4,
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="h5" component="h1">
+          {title}
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          {description}
+        </Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            width: '100%',
+            maxWidth: 320,
+          }}
+        >
+          <Button
+            variant="solid"
+            color="primary"
+            onClick={handleRefresh}
+            aria-label={ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON}
+          >
+            {ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON}
+          </Button>
+          <Button
+            variant="outline"
+            color="neutral"
+            onClick={handleSignOut}
+            aria-label={ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON}
+          >
+            {ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON}
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -47,4 +47,8 @@ export { termSections } from './data/termsOfServiceData';
 export type { TermSection, TermContent } from './data/termsOfServiceData';
 
 // Export utils
-export { buildSignOutUrl } from './utils/auth';
+export { buildSignOutUrl, buildRefreshUrl } from './utils/auth';
+
+// Export feedback components
+export { default as AccessDeniedView } from './components/feedback/AccessDeniedView';
+export type { AccessDeniedViewProps } from './components/feedback/AccessDeniedView';

--- a/libs/ui/src/utils/auth.ts
+++ b/libs/ui/src/utils/auth.ts
@@ -6,6 +6,26 @@
  */
 
 /**
+ * auth サービスの指定エンドポイント URL を生成する内部ヘルパー。
+ *
+ * @param authUrl - auth サービスのベース URL
+ * @param endpointPath - エンドポイントのパス（例: "/api/auth/signout"）
+ * @param callbackUrl - リダイレクト後の戻り先 URL（省略時はクエリパラメータなし）
+ * @returns 完全な URL 文字列
+ */
+function buildAuthUrl(authUrl: string, endpointPath: string, callbackUrl?: string): string {
+  // 末尾スラッシュを正規化して二重スラッシュを防ぐ
+  const base = authUrl.replace(/\/+$/, '');
+  const endpoint = `${base}${endpointPath}`;
+
+  if (callbackUrl === undefined || callbackUrl === '') {
+    return endpoint;
+  }
+
+  return `${endpoint}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+}
+
+/**
  * auth サービスのサインアウト URL を生成する。
  *
  * サインアウト処理は Cookie 発行元である auth サービスに集約する方針のため、
@@ -17,13 +37,20 @@
  * @returns auth サービスの signout エンドポイント URL
  */
 export function buildSignOutUrl(authUrl: string, callbackUrl?: string): string {
-  // 末尾スラッシュを正規化して二重スラッシュを防ぐ
-  const base = authUrl.replace(/\/+$/, '');
-  const endpoint = `${base}/api/auth/signout`;
+  return buildAuthUrl(authUrl, '/api/auth/signout', callbackUrl);
+}
 
-  if (callbackUrl === undefined || callbackUrl === '') {
-    return endpoint;
-  }
-
-  return `${endpoint}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+/**
+ * auth サービスのセッションリフレッシュ URL を生成する。
+ *
+ * 管理者によるロール付与後などに、ユーザーが最新のセッション情報を取得するために
+ * auth サービスの refresh エンドポイントへリダイレクトする。
+ * リフレッシュ完了後は callbackUrl に指定した URL へ戻る。
+ *
+ * @param authUrl - auth サービスのベース URL（例: "https://auth.nagiyu.com"）
+ * @param callbackUrl - リフレッシュ後のリダイレクト先 URL（省略時は付与しない）
+ * @returns auth サービスの refresh エンドポイント URL
+ */
+export function buildRefreshUrl(authUrl: string, callbackUrl?: string): string {
+  return buildAuthUrl(authUrl, '/refresh', callbackUrl);
 }

--- a/libs/ui/tests/unit/components/feedback/AccessDeniedView.test.tsx
+++ b/libs/ui/tests/unit/components/feedback/AccessDeniedView.test.tsx
@@ -1,0 +1,232 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import AccessDeniedView, {
+  ACCESS_DENIED_VIEW_MESSAGES,
+} from '../../../../src/components/feedback/AccessDeniedView';
+
+/**
+ * AccessDeniedView のユニットテスト。
+ *
+ * `window.location.assign` は jsdom 環境では再定義不可のため、コンポーネントは
+ * `onRefresh`/`onSignOut` コールバック props でナビゲーション処理を注入可能にしている。
+ * テストではこれらのモック関数を渡し、ボタン押下時に正しい URL で遷移が試みられることを検証する。
+ * URL 生成ロジック（buildRefreshUrl / buildSignOutUrl）自体は `utils/auth.test.ts` でテスト済み。
+ */
+
+describe('AccessDeniedView', () => {
+  describe('デフォルト表示', () => {
+    it('デフォルトのタイトルが表示される', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" />);
+      expect(screen.getByText(ACCESS_DENIED_VIEW_MESSAGES.DEFAULT_TITLE)).toBeInTheDocument();
+    });
+
+    it('デフォルトの説明文が表示される', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" />);
+      expect(screen.getByText(ACCESS_DENIED_VIEW_MESSAGES.DEFAULT_DESCRIPTION)).toBeInTheDocument();
+    });
+
+    it('「アクセスを更新」ボタンが表示される', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" />);
+      expect(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON })
+      ).toBeInTheDocument();
+    });
+
+    it('「再ログイン」ボタンが表示される', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" />);
+      expect(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('カスタム Props', () => {
+    it('title prop でタイトルを上書きできる', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" title="カスタムタイトル" />);
+      expect(screen.getByText('カスタムタイトル')).toBeInTheDocument();
+      expect(screen.queryByText(ACCESS_DENIED_VIEW_MESSAGES.DEFAULT_TITLE)).not.toBeInTheDocument();
+    });
+
+    it('description prop で説明文を上書きできる', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" description="カスタム説明文" />);
+      expect(screen.getByText('カスタム説明文')).toBeInTheDocument();
+      expect(
+        screen.queryByText(ACCESS_DENIED_VIEW_MESSAGES.DEFAULT_DESCRIPTION)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('「アクセスを更新」ボタンの遷移（onRefresh）', () => {
+    it('callbackUrl なしのとき /refresh エンドポイント URL で onRefresh が呼ばれる', () => {
+      const mockOnRefresh = jest.fn();
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" onRefresh={mockOnRefresh} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON })
+      );
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1);
+      expect(mockOnRefresh).toHaveBeenCalledWith('https://auth.nagiyu.com/refresh');
+    });
+
+    it('callbackUrl あり のとき encodeURIComponent 済みクエリ付き URL で onRefresh が呼ばれる', () => {
+      const mockOnRefresh = jest.fn();
+      render(
+        <AccessDeniedView
+          authUrl="https://auth.nagiyu.com"
+          callbackUrl="https://live-talk.nagiyu.com"
+          onRefresh={mockOnRefresh}
+        />
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON })
+      );
+      expect(mockOnRefresh).toHaveBeenCalledWith(
+        'https://auth.nagiyu.com/refresh?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com'
+      );
+    });
+
+    it('callbackUrl にパスが含まれる場合も正しく encode した URL で onRefresh が呼ばれる', () => {
+      const mockOnRefresh = jest.fn();
+      render(
+        <AccessDeniedView
+          authUrl="https://auth.nagiyu.com"
+          callbackUrl="https://live-talk.nagiyu.com/notes"
+          onRefresh={mockOnRefresh}
+        />
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON })
+      );
+      expect(mockOnRefresh).toHaveBeenCalledWith(
+        'https://auth.nagiyu.com/refresh?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com%2Fnotes'
+      );
+    });
+
+    it('authUrl の末尾スラッシュを正規化した URL で onRefresh が呼ばれる', () => {
+      const mockOnRefresh = jest.fn();
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com/" onRefresh={mockOnRefresh} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON })
+      );
+      expect(mockOnRefresh).toHaveBeenCalledWith('https://auth.nagiyu.com/refresh');
+    });
+  });
+
+  describe('「再ログイン」ボタンの遷移（onSignOut）', () => {
+    it('callbackUrl なしのとき /api/auth/signout エンドポイント URL で onSignOut が呼ばれる', () => {
+      const mockOnSignOut = jest.fn();
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" onSignOut={mockOnSignOut} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON })
+      );
+      expect(mockOnSignOut).toHaveBeenCalledTimes(1);
+      expect(mockOnSignOut).toHaveBeenCalledWith('https://auth.nagiyu.com/api/auth/signout');
+    });
+
+    it('callbackUrl あり のとき encodeURIComponent 済みクエリ付き URL で onSignOut が呼ばれる', () => {
+      const mockOnSignOut = jest.fn();
+      render(
+        <AccessDeniedView
+          authUrl="https://auth.nagiyu.com"
+          callbackUrl="https://live-talk.nagiyu.com"
+          onSignOut={mockOnSignOut}
+        />
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON })
+      );
+      expect(mockOnSignOut).toHaveBeenCalledWith(
+        'https://auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com'
+      );
+    });
+
+    it('callbackUrl にパスが含まれる場合も正しく encode した URL で onSignOut が呼ばれる', () => {
+      const mockOnSignOut = jest.fn();
+      render(
+        <AccessDeniedView
+          authUrl="https://auth.nagiyu.com"
+          callbackUrl="https://live-talk.nagiyu.com/notes"
+          onSignOut={mockOnSignOut}
+        />
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON })
+      );
+      expect(mockOnSignOut).toHaveBeenCalledWith(
+        'https://auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com%2Fnotes'
+      );
+    });
+
+    it('authUrl の末尾スラッシュを正規化した URL で onSignOut が呼ばれる', () => {
+      const mockOnSignOut = jest.fn();
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com/" onSignOut={mockOnSignOut} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON })
+      );
+      expect(mockOnSignOut).toHaveBeenCalledWith('https://auth.nagiyu.com/api/auth/signout');
+    });
+  });
+
+  describe('ボタンの独立性', () => {
+    it('「アクセスを更新」と「再ログイン」はそれぞれ異なる URL でコールバックを呼ぶ', () => {
+      const mockOnRefresh = jest.fn();
+      const mockOnSignOut = jest.fn();
+      render(
+        <AccessDeniedView
+          authUrl="https://auth.nagiyu.com"
+          callbackUrl="https://live-talk.nagiyu.com"
+          onRefresh={mockOnRefresh}
+          onSignOut={mockOnSignOut}
+        />
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON })
+      );
+      expect(mockOnRefresh).toHaveBeenCalledWith(
+        'https://auth.nagiyu.com/refresh?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com'
+      );
+      expect(mockOnSignOut).not.toHaveBeenCalled();
+
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON })
+      );
+      expect(mockOnSignOut).toHaveBeenCalledWith(
+        'https://auth.nagiyu.com/api/auth/signout?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com'
+      );
+      expect(mockOnRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('「アクセスを更新」ボタンに aria-label が設定されている', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" />);
+      const refreshButton = screen.getByRole('button', {
+        name: ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON,
+      });
+      expect(refreshButton).toHaveAttribute(
+        'aria-label',
+        ACCESS_DENIED_VIEW_MESSAGES.REFRESH_BUTTON
+      );
+    });
+
+    it('「再ログイン」ボタンに aria-label が設定されている', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" />);
+      const signOutButton = screen.getByRole('button', {
+        name: ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON,
+      });
+      expect(signOutButton).toHaveAttribute(
+        'aria-label',
+        ACCESS_DENIED_VIEW_MESSAGES.SIGN_OUT_BUTTON
+      );
+    });
+
+    it('main コンテンツに role="main" が設定されている', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" />);
+      expect(screen.getByRole('main')).toBeInTheDocument();
+    });
+
+    it('タイトルが h1 要素として描画されている', () => {
+      render(<AccessDeniedView authUrl="https://auth.nagiyu.com" />);
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+  });
+});

--- a/libs/ui/tests/unit/utils/auth.test.ts
+++ b/libs/ui/tests/unit/utils/auth.test.ts
@@ -1,4 +1,4 @@
-import { buildSignOutUrl } from '../../../src/utils/auth';
+import { buildSignOutUrl, buildRefreshUrl } from '../../../src/utils/auth';
 
 describe('buildSignOutUrl', () => {
   describe('callbackUrl なし', () => {
@@ -80,6 +80,90 @@ describe('buildSignOutUrl', () => {
     it('authUrl が空文字の場合でも例外を投げずに処理する（未設定フォールバック対応）', () => {
       const result = buildSignOutUrl('');
       expect(result).toBe('/api/auth/signout');
+    });
+  });
+});
+
+describe('buildRefreshUrl', () => {
+  describe('callbackUrl なし', () => {
+    it('基本的な authUrl からリフレッシュ URL を生成する', () => {
+      const result = buildRefreshUrl('https://auth.nagiyu.com');
+      expect(result).toBe('https://auth.nagiyu.com/refresh');
+    });
+
+    it('callbackUrl が undefined の場合クエリパラメータを付与しない', () => {
+      const result = buildRefreshUrl('https://auth.nagiyu.com', undefined);
+      expect(result).toBe('https://auth.nagiyu.com/refresh');
+    });
+
+    it('callbackUrl が空文字の場合クエリパラメータを付与しない', () => {
+      const result = buildRefreshUrl('https://auth.nagiyu.com', '');
+      expect(result).toBe('https://auth.nagiyu.com/refresh');
+    });
+  });
+
+  describe('callbackUrl あり', () => {
+    it('callbackUrl を encodeURIComponent してクエリパラメータに付与する', () => {
+      const result = buildRefreshUrl('https://auth.nagiyu.com', 'https://live-talk.nagiyu.com');
+      expect(result).toBe(
+        'https://auth.nagiyu.com/refresh?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com'
+      );
+    });
+
+    it('callbackUrl にパスが含まれる場合も正しく encode する', () => {
+      const result = buildRefreshUrl(
+        'https://auth.nagiyu.com',
+        'https://live-talk.nagiyu.com/notes'
+      );
+      expect(result).toBe(
+        'https://auth.nagiyu.com/refresh?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com%2Fnotes'
+      );
+    });
+
+    it('callbackUrl に特殊文字が含まれる場合も正しく encode する', () => {
+      const result = buildRefreshUrl(
+        'https://auth.nagiyu.com',
+        'https://example.com/page?foo=bar&baz=qux'
+      );
+      expect(result).toBe(
+        'https://auth.nagiyu.com/refresh?callbackUrl=https%3A%2F%2Fexample.com%2Fpage%3Ffoo%3Dbar%26baz%3Dqux'
+      );
+    });
+  });
+
+  describe('authUrl の末尾スラッシュ正規化', () => {
+    it('authUrl の末尾スラッシュを除去して二重スラッシュを防ぐ', () => {
+      const result = buildRefreshUrl('https://auth.nagiyu.com/');
+      expect(result).toBe('https://auth.nagiyu.com/refresh');
+    });
+
+    it('authUrl の複数の末尾スラッシュも除去する', () => {
+      const result = buildRefreshUrl('https://auth.nagiyu.com///');
+      expect(result).toBe('https://auth.nagiyu.com/refresh');
+    });
+
+    it('末尾スラッシュ正規化後も callbackUrl を正しく付与する', () => {
+      const result = buildRefreshUrl('https://auth.nagiyu.com/', 'https://live-talk.nagiyu.com');
+      expect(result).toBe(
+        'https://auth.nagiyu.com/refresh?callbackUrl=https%3A%2F%2Flive-talk.nagiyu.com'
+      );
+    });
+  });
+
+  describe('開発環境 URL の対応', () => {
+    it('dev 環境のサブドメインでも正しく URL を生成する', () => {
+      const result = buildRefreshUrl(
+        'https://dev-auth.nagiyu.com',
+        'https://dev-live-talk.nagiyu.com'
+      );
+      expect(result).toBe(
+        'https://dev-auth.nagiyu.com/refresh?callbackUrl=https%3A%2F%2Fdev-live-talk.nagiyu.com'
+      );
+    });
+
+    it('authUrl が空文字の場合でも例外を投げずに処理する（未設定フォールバック対応）', () => {
+      const result = buildRefreshUrl('');
+      expect(result).toBe('/refresh');
     });
   });
 });

--- a/services/livetalk/web/src/app/forbidden/page.tsx
+++ b/services/livetalk/web/src/app/forbidden/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { AccessDeniedView } from '@nagiyu/ui';
+import { getOrigin } from '../../lib/navigation';
+
+/**
+ * `from` クエリパラメータを読み取り、callbackUrl を解決するコンポーネント。
+ *
+ * `useSearchParams` は Suspense 境界でラップする必要があるため、親の
+ * ForbiddenPage から分離している。
+ */
+function ForbiddenContent({ resolveOrigin = getOrigin }: { resolveOrigin?: () => string }) {
+  const searchParams = useSearchParams();
+  const [callbackUrl, setCallbackUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const from = searchParams.get('from');
+    const origin = resolveOrigin();
+    if (from) {
+      // `from` は pathname（例: "/notes"）のため、origin と結合して絶対 URL にする
+      setCallbackUrl(`${origin}${from}`);
+    } else {
+      // `from` 未指定時はサービスのトップ（origin）を戻り先とする
+      setCallbackUrl(origin);
+    }
+  }, [searchParams, resolveOrigin]);
+
+  return (
+    <AccessDeniedView authUrl={process.env.NEXT_PUBLIC_AUTH_URL ?? ''} callbackUrl={callbackUrl} />
+  );
+}
+
+/**
+ * 403（権限なし）時の導線付きページ（/forbidden）。
+ *
+ * ミドルウェアが認証済みユーザーの権限不足を検出したとき、このページへリダイレクトする。
+ * `from` クエリパラメータには元のパス（pathname + search）が格納される。
+ * ユーザーは「アクセスを更新」または「再ログイン」で権限取得後の利用再開が可能。
+ *
+ * `useSearchParams` を使うため Suspense 境界でラップしている。
+ */
+export default function ForbiddenPage() {
+  return (
+    <Suspense>
+      <ForbiddenContent />
+    </Suspense>
+  );
+}

--- a/services/livetalk/web/src/lib/navigation.ts
+++ b/services/livetalk/web/src/lib/navigation.ts
@@ -1,0 +1,9 @@
+/**
+ * ブラウザの現在の origin（スキーム + ホスト + ポート）を返す。
+ *
+ * `window.location.origin` は jsdom 環境でモック不可のため、
+ * テスト時に差し替え可能なように独立した関数として切り出している。
+ */
+export function getOrigin(): string {
+  return window.location.origin;
+}

--- a/services/livetalk/web/src/middleware.ts
+++ b/services/livetalk/web/src/middleware.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server';
 import { auth } from './auth';
 import { createAuthMiddleware } from '@nagiyu/nextjs/middleware';
 
@@ -6,7 +7,7 @@ import { createAuthMiddleware } from '@nagiyu/nextjs/middleware';
  *
  * Auth サービスから発行された JWT を検証し、`livetalk:chat` permission を持つ
  * ユーザーのみアクセスを許可する。未認証ユーザーは Auth サービスのサインインへ
- * リダイレクトし、認証済みでも permission がない場合は 403 を返す。
+ * リダイレクトし、認証済みでも permission がない場合は /forbidden へリダイレクトする。
  *
  * 開発・テスト環境では、SKIP_AUTH_CHECK=true を設定することで
  * 認証チェックをスキップできます。
@@ -15,7 +16,17 @@ export default auth(
   createAuthMiddleware({
     getSignInBaseUrl: () => process.env.NEXT_PUBLIC_AUTH_URL || process.env.NEXTAUTH_URL,
     requiredPermission: 'livetalk:chat',
-    isPublicPath: (pathname) => pathname.startsWith('/legal/'),
+    isPublicPath: (pathname) => pathname.startsWith('/legal/') || pathname === '/forbidden',
+    onForbidden: (request) => {
+      // 元のパスを from クエリパラメータとして /forbidden へリダイレクトする
+      // APP_URL が未設定の場合は request.url からオリジンを取得する
+      const appUrl = process.env.APP_URL ?? new URL(request.url).origin;
+      const forbiddenUrl = new URL('/forbidden', appUrl);
+      // searchParams.set は値を自動でパーセントエンコードするため、
+      // encodeURIComponent は不要（二重エンコードになる）
+      forbiddenUrl.searchParams.set('from', request.nextUrl.pathname + request.nextUrl.search);
+      return NextResponse.redirect(forbiddenUrl);
+    },
   })
 );
 

--- a/services/livetalk/web/tests/unit/app/forbidden/page.test.tsx
+++ b/services/livetalk/web/tests/unit/app/forbidden/page.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import ForbiddenPage from '@/app/forbidden/page';
+
+/**
+ * /forbidden ページのユニットテスト。
+ *
+ * AccessDeniedView の描画ロジックおよびクエリパラメータ `from` による
+ * callbackUrl の解決を検証する。
+ *
+ * - `useSearchParams` は next/navigation からモック化
+ * - `getOrigin` は @/lib/navigation からモック化（window.location.origin の代替）
+ * - `AccessDeniedView` は @nagiyu/ui からモック化（UI ロジックは libs/ui 側でテスト済み）
+ */
+
+// next/navigation の useSearchParams をモック化
+const mockSearchParamsGet = jest.fn();
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(() => ({
+    get: mockSearchParamsGet,
+  })),
+}));
+
+// @/lib/navigation の getOrigin をモック化
+jest.mock('@/lib/navigation', () => ({
+  getOrigin: jest.fn(() => 'https://live-talk.nagiyu.com'),
+}));
+
+// @nagiyu/ui の AccessDeniedView をモック化
+// Props を data-testid で露出し、受け取った値を検証できるようにする
+jest.mock('@nagiyu/ui', () => ({
+  AccessDeniedView: jest.fn(
+    ({ authUrl, callbackUrl }: { authUrl: string; callbackUrl?: string }) => (
+      <div data-testid="access-denied-view">
+        <span data-testid="auth-url">{authUrl}</span>
+        <span data-testid="callback-url">{callbackUrl ?? ''}</span>
+      </div>
+    )
+  ),
+}));
+
+beforeEach(() => {
+  // NEXT_PUBLIC_AUTH_URL をモック
+  process.env.NEXT_PUBLIC_AUTH_URL = 'https://auth.nagiyu.com';
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  delete process.env.NEXT_PUBLIC_AUTH_URL;
+  // クエリなし状態に戻す
+  mockSearchParamsGet.mockReturnValue(null);
+});
+
+describe('ForbiddenPage', () => {
+  describe('AccessDeniedView への authUrl 受け渡し', () => {
+    it('NEXT_PUBLIC_AUTH_URL を authUrl として渡す', async () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      render(<ForbiddenPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('access-denied-view')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('auth-url')).toHaveTextContent('https://auth.nagiyu.com');
+    });
+
+    it('NEXT_PUBLIC_AUTH_URL が未設定のとき空文字列を渡す', async () => {
+      delete process.env.NEXT_PUBLIC_AUTH_URL;
+      mockSearchParamsGet.mockReturnValue(null);
+      render(<ForbiddenPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('access-denied-view')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('auth-url')).toHaveTextContent('');
+    });
+  });
+
+  describe('callbackUrl の解決（from クエリパラメータ）', () => {
+    it('from がない場合は origin をそのまま callbackUrl にする', async () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      render(<ForbiddenPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('callback-url')).toHaveTextContent(
+          'https://live-talk.nagiyu.com'
+        );
+      });
+    });
+
+    it('from = "/notes" のとき origin + pathname を callbackUrl にする', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'from') return '/notes';
+        return null;
+      });
+
+      render(<ForbiddenPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('callback-url')).toHaveTextContent(
+          'https://live-talk.nagiyu.com/notes'
+        );
+      });
+    });
+
+    it('from = "/memory?page=2" のとき origin + pathname + search を callbackUrl にする', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'from') return '/memory?page=2';
+        return null;
+      });
+
+      render(<ForbiddenPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('callback-url')).toHaveTextContent(
+          'https://live-talk.nagiyu.com/memory?page=2'
+        );
+      });
+    });
+
+    it('from = "/" のとき origin + "/" を callbackUrl にする', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        if (key === 'from') return '/';
+        return null;
+      });
+
+      render(<ForbiddenPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('callback-url')).toHaveTextContent(
+          'https://live-talk.nagiyu.com/'
+        );
+      });
+    });
+  });
+
+  describe('Suspense 境界', () => {
+    it('AccessDeniedView がレンダリングされる', async () => {
+      mockSearchParamsGet.mockReturnValue(null);
+      render(<ForbiddenPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('access-denied-view')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/services/livetalk/web/tests/unit/middleware/middleware.test.ts
+++ b/services/livetalk/web/tests/unit/middleware/middleware.test.ts
@@ -1,0 +1,156 @@
+/**
+ * ミドルウェアの onForbidden 設定テスト。
+ *
+ * `services/livetalk/web/src/middleware.ts` は `auth()` でラップされており、
+ * `NextResponse` は Edge Runtime API に依存するため、jsdom 環境では直接テストできない。
+ * そのため、`createAuthMiddleware` に渡しているロジック（`isPublicPath` と
+ * `onForbidden` の URL 構築）を同じ仕様で個別にテストする。
+ *
+ * これにより:
+ * - `isPublicPath` が /legal/ と /forbidden を公開パスとして扱うこと
+ * - `onForbidden` が正しい /forbidden?from=... URL を構築すること
+ * を保証する。
+ */
+
+// next/server を直接 import すると Edge Runtime API（Request 等）が必要になるため、
+// ミドルウェアのビジネスロジックを純粋関数として再実装してテストする。
+
+/**
+ * middleware.ts の isPublicPath と同一ロジック。
+ */
+function buildIsPublicPath() {
+  return (pathname: string): boolean => pathname.startsWith('/legal/') || pathname === '/forbidden';
+}
+
+/**
+ * middleware.ts の onForbidden における URL 構築ロジックと同一ロジック。
+ *
+ * NextResponse を使わず、最終的に遷移先となる URL 文字列のみを検証する。
+ * `searchParams.set` は値を自動でパーセントエンコードするため、`encodeURIComponent` は使わない。
+ */
+function buildForbiddenUrl(
+  requestUrl: string,
+  pathname: string,
+  search: string,
+  appUrl?: string
+): string {
+  const baseUrl = appUrl ?? new URL(requestUrl).origin;
+  const forbiddenUrl = new URL('/forbidden', baseUrl);
+  forbiddenUrl.searchParams.set('from', pathname + search);
+  return forbiddenUrl.toString();
+}
+
+describe('isPublicPath', () => {
+  const isPublicPath = buildIsPublicPath();
+
+  it('/legal/ は公開パスとして扱う', () => {
+    expect(isPublicPath('/legal/')).toBe(true);
+    expect(isPublicPath('/legal/terms')).toBe(true);
+    expect(isPublicPath('/legal/privacy')).toBe(true);
+  });
+
+  it('/forbidden は公開パスとして扱う（リダイレクトループ防止）', () => {
+    expect(isPublicPath('/forbidden')).toBe(true);
+  });
+
+  it('/forbidden/ はサブパスなので公開パスではない（/forbidden 完全一致のみ）', () => {
+    expect(isPublicPath('/forbidden/')).toBe(false);
+    expect(isPublicPath('/forbidden/something')).toBe(false);
+  });
+
+  it('その他のパスは公開パスではない', () => {
+    expect(isPublicPath('/')).toBe(false);
+    expect(isPublicPath('/notes')).toBe(false);
+    expect(isPublicPath('/memory')).toBe(false);
+    expect(isPublicPath('/api/chat')).toBe(false);
+  });
+});
+
+describe('onForbidden の URL 構築', () => {
+  describe('APP_URL ありの場合', () => {
+    it('/notes へのアクセスを /forbidden?from=%2Fnotes に変換する', () => {
+      const result = buildForbiddenUrl(
+        'https://live-talk.nagiyu.com/notes',
+        '/notes',
+        '',
+        'https://live-talk.nagiyu.com'
+      );
+      expect(result).toBe('https://live-talk.nagiyu.com/forbidden?from=%2Fnotes');
+    });
+
+    it('search 付きパスの場合は pathname + search をまとめて from に含める', () => {
+      const result = buildForbiddenUrl(
+        'https://live-talk.nagiyu.com/memory?page=2',
+        '/memory',
+        '?page=2',
+        'https://live-talk.nagiyu.com'
+      );
+      expect(result).toBe('https://live-talk.nagiyu.com/forbidden?from=%2Fmemory%3Fpage%3D2');
+    });
+
+    it('ルートパス / を /forbidden?from=%2F に変換する', () => {
+      const result = buildForbiddenUrl(
+        'https://live-talk.nagiyu.com/',
+        '/',
+        '',
+        'https://live-talk.nagiyu.com'
+      );
+      expect(result).toBe('https://live-talk.nagiyu.com/forbidden?from=%2F');
+    });
+
+    it('深いパスも正しく encode される', () => {
+      const result = buildForbiddenUrl(
+        'https://live-talk.nagiyu.com/memory/123',
+        '/memory/123',
+        '',
+        'https://live-talk.nagiyu.com'
+      );
+      expect(result).toBe('https://live-talk.nagiyu.com/forbidden?from=%2Fmemory%2F123');
+    });
+  });
+
+  describe('APP_URL なし（origin フォールバック）の場合', () => {
+    it('request.url からオリジンを取り出して /forbidden へのリダイレクト URL を構築する', () => {
+      const result = buildForbiddenUrl(
+        'https://live-talk.nagiyu.com/notes',
+        '/notes',
+        '',
+        undefined
+      );
+      expect(result).toBe('https://live-talk.nagiyu.com/forbidden?from=%2Fnotes');
+    });
+
+    it('ポート番号付きの URL でもオリジンを正しく取り出す', () => {
+      const result = buildForbiddenUrl('http://localhost:3000/notes', '/notes', '', undefined);
+      expect(result).toBe('http://localhost:3000/forbidden?from=%2Fnotes');
+    });
+  });
+
+  describe('from パラメータの encodeURIComponent', () => {
+    it('pathname が空の場合は from=%20 にならず from= になる', () => {
+      const result = buildForbiddenUrl(
+        'https://live-talk.nagiyu.com/',
+        '',
+        '',
+        'https://live-talk.nagiyu.com'
+      );
+      // 空文字列の encodeURIComponent は '' のまま
+      expect(result).toBe('https://live-talk.nagiyu.com/forbidden?from=');
+    });
+
+    it('特殊文字を含むクエリパラメータが正しく encode される', () => {
+      const result = buildForbiddenUrl(
+        'https://live-talk.nagiyu.com/search',
+        '/search',
+        '?q=hello world',
+        'https://live-talk.nagiyu.com'
+      );
+      // URLSearchParams は application/x-www-form-urlencoded 形式のため
+      // スペースは %20 ではなく + に encode される
+      // "?q=hello world" → "%3Fq%3Dhello+world"
+      expect(result).toBe(
+        'https://live-talk.nagiyu.com/forbidden?from=%2Fsearch%3Fq%3Dhello+world'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 変更の概要

親 Issue #3593 の Phase 4（最終）。初回利用時、ロール未付与のユーザーが受け取る 403 を**導線付きの画面**にする。**本 PR は #3596（Phase 1）の上に stack**（base = Phase 1 ブランチ。`buildSignOutUrl` を利用）。`/refresh` への導線は Phase 3（#3598）の auth `/refresh` ページを URL で参照する。

- **`@nagiyu/ui` に `AccessDeniedView`**: 「アクセスを更新」（→ `${authUrl}/refresh?callbackUrl=...`）と「再ログイン」（→ サインアウト）の 2 導線を持つ 403 画面。`buildRefreshUrl`/`buildSignOutUrl` で URL 生成。`onRefresh`/`onSignOut` props で遷移処理を差し替え可能（既定は `window.location.assign`）。
- **`@nagiyu/ui` に `buildRefreshUrl`**: `buildSignOutUrl` と対称のヘルパー（`${authUrl}/refresh?callbackUrl=...`）。
- **livetalk `/forbidden` ページ**: `AccessDeniedView` を描画。`from` クエリ（元のパス）から戻り先 `callbackUrl` を解決（`useSearchParams` は Suspense 境界でラップ）。
- **livetalk middleware**: `onForbidden` で権限不足のページアクセスを `/forbidden?from=<元パス>` へリダイレクト。`isPublicPath` に `/forbidden` を追加しループを防止。

これで「初回 403 → アクセス更新（Phase 3 の /refresh でロール再取得）→ 元の画面へ復帰」または「再ログイン」の導線が揃う。

## 関連 Issue

親 Issue: #3593（作業ブランチ → integration のため `Closes #` は付けない）

## 変更種別

- [x] 新規機能
- [x] UI 改善

## 実装チェックリスト

- [x] コーディング規約に従って実装した
- [x] テストを追加・更新した（カバレッジ閾値維持）
- [x] ローカルでテストが全て通ることを確認した
- [x] ビルドエラー・フォーマットエラーがないことを確認した

## テスト内容

- `@nagiyu/ui`: 382 件グリーン（`AccessDeniedView` 19 件 / `buildRefreshUrl` 追加分含む）。`window.location` の jsdom 制約は `onRefresh`/`onSignOut` props 注入で回避し、ボタン押下時の生成 URL を検証
- livetalk web: 758 件グリーン（`/forbidden` ページ 7 件 / middleware の `isPublicPath`・`onForbidden` URL 構築 12 件）。`NextResponse` は Edge Runtime 依存のためコアロジックを純粋関数として検証
- `/forbidden` は `useSearchParams` を Suspense 境界でラップ（Phase 3 で発生した prerender 失敗の予防）
- 共通ライブラリを依存順にビルド、tsc・lint・prettier 通過

## レビューポイント

- 403 の見せ方: ミドルウェアの `onForbidden` でページリダイレクト（`/forbidden` を public パス化してループ防止）。API ルートは matcher 除外のため従来通り
- `from` の受け渡しは `URL.searchParams.set`（自動エンコード。`encodeURIComponent` 併用は二重エンコードになるため不使用）
- `AccessDeniedView` は他サービスでも再利用可能な共通部品。今回の配線は livetalk のみ（他サービス展開は follow-up）

## スクリーンショット

403 画面（タイトル「アクセス権限がありません」＋「アクセスを更新」「再ログイン」）。dev 反映後に初回利用フローを実機確認予定。

https://claude.ai/code/session_015mjPyhPKqKqiW1MjZGJqk3

---
_Generated by [Claude Code](https://claude.ai/code/session_015mjPyhPKqKqiW1MjZGJqk3)_